### PR TITLE
fix: Add merkle trie initialization test

### DIFF
--- a/app/src/network/sync/merkleTrie.test.ts
+++ b/app/src/network/sync/merkleTrie.test.ts
@@ -1,8 +1,7 @@
 import { blake3 } from '@noble/hashes/blake3';
 import Factories from '~/flatbuffers/factories';
 import { MerkleTrie } from '~/network/sync/merkleTrie';
-
-const emptyHash = Buffer.from(blake3('', { dkLen: 16 })).toString('hex');
+import { EMPTY_HASH } from './trieNode';
 
 describe('MerkleTrie', () => {
   const trieWithIds = async (timestamps: number[]) => {
@@ -85,7 +84,7 @@ describe('MerkleTrie', () => {
 
       trie.delete(syncId);
       expect(trie.items).toEqual(0);
-      expect(trie.rootHash).toEqual(emptyHash);
+      expect(trie.rootHash).toEqual(EMPTY_HASH);
       expect(trie.exists(syncId)).toBeFalsy();
     });
 
@@ -226,16 +225,16 @@ describe('MerkleTrie', () => {
           .digest()
       ).toString('hex');
       expect(snapshot.excludedHashes).toEqual([
-        emptyHash, // 1, these are empty because there are no other children at this level
-        emptyHash, // 6
-        emptyHash, // 6
-        emptyHash, // 5
-        emptyHash, // 1
-        emptyHash, // 8
-        emptyHash, // 2
-        emptyHash, // 3
+        EMPTY_HASH, // 1, these are empty because there are no other children at this level
+        EMPTY_HASH, // 6
+        EMPTY_HASH, // 6
+        EMPTY_HASH, // 5
+        EMPTY_HASH, // 1
+        EMPTY_HASH, // 8
+        EMPTY_HASH, // 2
+        EMPTY_HASH, // 3
         expectedHash, // 5 (hash of the 3 and 4 child node hashes)
-        emptyHash, // 1
+        EMPTY_HASH, // 1
       ]);
 
       snapshot = trie.getSnapshot('1665182343');
@@ -250,14 +249,14 @@ describe('MerkleTrie', () => {
           .digest()
       ).toString('hex');
       expect(snapshot.excludedHashes).toEqual([
-        emptyHash, // 1
-        emptyHash, // 6
-        emptyHash, // 6
-        emptyHash, // 5
-        emptyHash, // 1
-        emptyHash, // 8
-        emptyHash, // 2
-        emptyHash, // 3
+        EMPTY_HASH, // 1
+        EMPTY_HASH, // 6
+        EMPTY_HASH, // 6
+        EMPTY_HASH, // 5
+        EMPTY_HASH, // 1
+        EMPTY_HASH, // 8
+        EMPTY_HASH, // 2
+        EMPTY_HASH, // 3
         expectedPenultimateHash, // 4 (hash of the 3 and 5 child node hashes)
         expectedLastHash, // 3 (hash of the 5 child node hash)
       ]);

--- a/app/src/network/sync/trieNode.test.ts
+++ b/app/src/network/sync/trieNode.test.ts
@@ -1,10 +1,8 @@
-import { blake3 } from '@noble/hashes/blake3';
 import Factories from '~/flatbuffers/factories';
 import { TIMESTAMP_LENGTH } from '~/network/sync/syncId';
-import { TrieNode } from '~/network/sync/trieNode';
+import { EMPTY_HASH, TrieNode } from '~/network/sync/trieNode';
 
 const fid = Factories.FID.build();
-const emptyHash = Buffer.from(blake3('', { dkLen: 16 })).toString('hex');
 const sharedDate = new Date(1665182332000);
 const sharedPrefixHashA =
   '0x09bc3dad4e7f2a77bbb2cccbecb06febfc3f0cbe7ea6a774d2dc043fd45c2c9912f130bf502c88fdedf7bbc4cd20b47aab2079e2d5cbd0a35afd2deec86a4321';
@@ -116,7 +114,7 @@ describe('TrieNode', () => {
 
       root.delete(id.idString());
       expect(root.items).toEqual(0);
-      expect(root.hash).toEqual(emptyHash);
+      expect(root.hash).toEqual(EMPTY_HASH);
     });
 
     test('deleting a single item from a node with multiple items removes the item', async () => {

--- a/app/src/network/sync/trieNode.ts
+++ b/app/src/network/sync/trieNode.ts
@@ -2,6 +2,8 @@ import { HubError } from '@hub/errors';
 import { blake3 } from '@noble/hashes/blake3';
 import { TIMESTAMP_LENGTH } from '~/network/sync/syncId';
 
+export const EMPTY_HASH = Buffer.from(blake3('', { dkLen: 16 })).toString('hex');
+
 /**
  * A snapshot of the trie at a particular timestamp which can be used to determine if two
  * hubs are in sync

--- a/app/src/storage/stores/signerStore.ts
+++ b/app/src/storage/stores/signerStore.ts
@@ -9,7 +9,6 @@ import * as types from '~/flatbuffers/models/types';
 import RocksDB, { Transaction } from '~/storage/db/rocksdb';
 import StoreEventHandler from '~/storage/stores/storeEventHandler';
 import { eventCompare } from '~/utils/contractEvent';
-import { logger } from '~/utils/logger';
 
 const PRUNE_SIZE_LIMIT_DEFAULT = 100;
 
@@ -104,9 +103,7 @@ class SignerStore {
    * @returns the SignerAdd Model if it exists, throws Error otherwise
    */
   async getSignerAdd(fid: Uint8Array, signerPubKey: Uint8Array): Promise<types.SignerAddModel> {
-    logger.info(`Getting signer add for fid ${fid} and signer ${Buffer.from(signerPubKey).toString('hex')}...`);
     const messageTsHash = await this._db.get(SignerStore.signerAddsKey(fid, signerPubKey));
-    logger.info(`...: ${messageTsHash.toString('hex')}`);
 
     return MessageModel.get<types.SignerAddModel>(this._db, fid, types.UserPostfix.SignerMessage, messageTsHash);
   }


### PR DESCRIPTION
## Motivation

Add test to make sure the Merkle Trie can be loaded from the engine

## Change Summary

- Expand test to ensure `SyncEngine` can be initialized from an already-populated engine. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] Changes to the protocol specification have been merged

## Additional Context

