### PR TITLE
feat: add benchmark suite for MerkleTrie

### DIFF
--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/farcasterxyz/hub#readme",
   "type": "module",
   "scripts": {
-    "bench": "tsx src/test/perf/bench.ts",
+    "bench": "NODE_OPTIONS='--max-old-space-size=8192' tsx src/test/bench",
     "build": "yarn clean && tsc --project ./tsconfig.json",
     "clean": "rimraf ./build",
     "dev": "yarn start | yarn pino-pretty",
@@ -30,8 +30,11 @@
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
     "@libp2p/interface-mocks": "^7.0.1",
+    "@types/chance": "^1.1.3",
     "@types/pino": "^7.0.5",
     "@types/progress": "^2.0.5",
+    "chance": "^1.1.9",
+    "csv-stringify": "^6.2.3",
     "eslint-config-custom": "*",
     "fishery": "^2.2.2",
     "pino-pretty": "^9.1.1",

--- a/apps/hubble/src/test/bench/helpers.ts
+++ b/apps/hubble/src/test/bench/helpers.ts
@@ -1,0 +1,50 @@
+import Chance from 'chance';
+
+import { Message } from '@farcaster/protobufs';
+import { SyncId } from '~/network/sync/syncId';
+
+/**
+ * Generate `n` SyncId. The SyncIds are sampled from FIDs between 1 to `numFids`.  Timestamp in
+ * returned SyncIds are strictly increasing by a uniformly random number between 1 to `maxTsDelta`.
+ * The generated result set is repeatable.
+ *
+ * @param n the total number of SyncId
+ * @param numFids number of FIDs
+ * @param maxTimeShift generate timestamp between 1 to maxTsDelta
+ */
+export const generateSyncIds = (n: number, numFids = 1, maxTimeShift = 1): SyncId[] => {
+  const chance = new Chance(1); // use constant seed for repeatable data
+  const fids: number[] = [];
+  for (let i = 1; i <= numFids; i++) {
+    fids.push(i);
+  }
+  const syncIds: SyncId[] = [];
+  let ts = 1;
+  for (let i = 0; i < n; i++) {
+    const fid = chance.pickone(fids);
+    const hash = chance.hash({ length: 40 });
+    const syncId = fastSyncId(fid, Buffer.from(hash, 'hex'), ts, 1);
+    syncIds.push(syncId);
+    ts += chance.integer({ min: 1, max: maxTimeShift });
+  }
+  return syncIds;
+};
+
+/**
+ * Create SyncId quickly for test cases.
+ * @param fid
+ * @param tsHash
+ * @param timestamp
+ * @param type
+ */
+export const fastSyncId = (fid: number, hash: Uint8Array, timestamp: number, type: number) => {
+  // Ducktyping message model to avoid creating the whole message.
+  return new SyncId({
+    data: {
+      fid,
+      timestamp,
+      type,
+    },
+    hash,
+  } as Message);
+};

--- a/apps/hubble/src/test/bench/index.ts
+++ b/apps/hubble/src/test/bench/index.ts
@@ -1,0 +1,47 @@
+import { Command } from 'commander';
+
+import { benchMerkleTrie } from './merkleTrie';
+import { outputWriter, waitForPromise } from './utils';
+
+const app = new Command();
+app
+  .name('farcaster-bench')
+  .description('Farcaster unit benchmark suites')
+  .version(process.env['npm_package_version'] ?? '1.0.0');
+
+app
+  .usage('--benchmark <suite> [options]')
+  .requiredOption('-b --benchmark <suite>', 'the benchmarking suite to run')
+  .option('-n, --count <count>', 'size of input')
+  .option('-c, --cycle <cycles>', 'run at least <cycle> times before taking measurements')
+  .option('-o, --output <file>', 'path of the output file (default STDOUT)')
+  .option('-s, --write-heap-snapshot', 'write V8 heap snapshot after each cycle', false)
+  .showHelpAfterError();
+
+app.parse(process.argv);
+const opts = app.opts();
+
+const writer = outputWriter(opts['output'] ?? process.stdout);
+
+const args = {
+  count: parseInt(opts['count']),
+  cycle: parseInt(opts['cycle']),
+  writer,
+  writeHeapSnapshot: opts['writeHeapSnapshot'],
+};
+
+let promise;
+
+switch (opts['benchmark'].toLowerCase()) {
+  case 'merkletrie':
+    promise = benchMerkleTrie(args);
+    break;
+  default:
+    process.stderr.write('Error: unknown benchmark suite\n');
+    app.help();
+}
+
+if (promise) {
+  // Wait for the job to finish
+  waitForPromise(promise);
+}

--- a/apps/hubble/src/test/bench/merkleTrie.ts
+++ b/apps/hubble/src/test/bench/merkleTrie.ts
@@ -1,0 +1,113 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable prefer-arrow-functions/prefer-arrow-functions */
+/* eslint-disable no-console */
+
+import { performance } from 'node:perf_hooks';
+import { Writable } from 'node:stream';
+import v8 from 'v8';
+
+import ProgressBar from 'progress';
+
+import { MerkleTrie } from '~/network/sync/merkleTrie';
+
+import { generateSyncIds } from './helpers';
+import { yieldToEventLoop } from './utils';
+
+/**
+ * Benchmark MerkleTrie. This is a CPU bound test (no disk operations). The test focuses on the
+ * MerkleTrie implementation; Protobuf messages encoding/decoding are avoided as much as possible.
+ *
+ * Methodology
+ *
+ * 1. Pre-generates `count` SyncIds with sequential timestamps (delta between 1 to 300 seconds) and
+ *    FIDs drew from 100,000 pre-generated set.
+ * 2. Call insert `count` times, then measure time and memory
+ * 3. Call getSnapshot `count` times, then measure time and memory
+ * 4. Yield to NodeJS event loop
+ * 5. Repeat 2-4 until all SyncIds are inserted
+ *
+ * @param args.count Target number of entries to be inserted.
+ * @param args.cycle Take measurements after every this number of cycle.
+ * @param args.writer Output writer
+ * @param args.writeHeapSnapshot Write V8 heap snapshot after every cycle
+ */
+export const benchMerkleTrie = async ({
+  count,
+  cycle,
+  writer,
+  writeHeapSnapshot,
+}: {
+  count: number;
+  cycle: number;
+  writer: Writable;
+  writeHeapSnapshot: boolean;
+}) => {
+  if (isNaN(count) || count < 1) {
+    count = 100_000;
+  }
+  if (isNaN(cycle) || cycle < 1) {
+    cycle = 10_000;
+  }
+  count = Math.ceil(count / cycle) * cycle;
+
+  const progress = new ProgressBar('benchmarking MerkleTrie :bar :current/:total ', {
+    total: count,
+  });
+
+  const syncIds = generateSyncIds(count, 100_000, 300);
+  const trie = new MerkleTrie();
+
+  let i = 0;
+  progress.tick(0);
+  const memoryUsage = process.memoryUsage();
+  writer.write([
+    0,
+    '',
+    '',
+    memoryUsage.heapUsed / 1048576,
+    memoryUsage.external / 1048576,
+    memoryUsage.rss / 1048576,
+    memoryUsage.arrayBuffers / 1048576,
+  ]);
+
+  // Yield before starting the test
+  await yieldToEventLoop();
+
+  while (i < syncIds.length) {
+    let start = performance.now();
+    for (let j = 0; j < cycle; j++) {
+      trie.insert(syncIds[(i + j) % syncIds.length]!);
+    }
+    const insertDuration = performance.now() - start;
+
+    i += cycle;
+
+    start = performance.now();
+    for (let j = 0; j < cycle; j++) {
+      trie.getSnapshot(syncIds[(i - 1) % syncIds.length]!.syncId().slice(0, 10));
+    }
+    const snapshotDuration = performance.now() - start;
+
+    const memoryUsage = process.memoryUsage();
+    writer.write([
+      i,
+      insertDuration / cycle,
+      snapshotDuration / cycle,
+      memoryUsage.heapUsed / 1048576,
+      memoryUsage.external / 1048576,
+      memoryUsage.rss / 1048576,
+      memoryUsage.arrayBuffers / 1048576,
+    ]);
+
+    if (writeHeapSnapshot) {
+      v8.writeHeapSnapshot();
+    }
+
+    progress.tick(cycle);
+
+    // Yield every cycle count
+    await yieldToEventLoop();
+  }
+
+  process.stderr.write('finished\n');
+};

--- a/apps/hubble/src/test/bench/utils.ts
+++ b/apps/hubble/src/test/bench/utils.ts
@@ -1,0 +1,38 @@
+/* eslint-disable security/detect-non-literal-fs-filename */
+import * as fs from 'node:fs';
+
+import { stringify } from 'csv-stringify';
+import { Writable } from 'node:stream';
+
+export const outputWriter = (f: string | fs.WriteStream): Writable => {
+  let stream: fs.WriteStream;
+  if (typeof f === 'string') {
+    stream = fs.createWriteStream(f);
+  } else {
+    stream = f as fs.WriteStream;
+  }
+
+  const stringifier = stringify({});
+  stringifier.pipe(stream);
+
+  return stringifier;
+};
+
+export const yieldToEventLoop = (): Promise<void> => {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+};
+
+export const waitForPromise = (promise: Promise<unknown>) => {
+  let finished = false;
+  promise.finally(() => (finished = true));
+
+  const pollToFinish = () => {
+    if (!finished) {
+      setTimeout(pollToFinish, 1000);
+    }
+  };
+
+  pollToFinish();
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2377,6 +2377,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/chance@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/@types/chance/-/chance-1.1.3.tgz#d19fe9391288d60fdccd87632bfc9ab2b4523fea"
+  integrity sha512-X6c6ghhe4/sQh4XzcZWSFaTAUOda38GQHmq9BUanYkOE/EO7ZrkazwKmtsj3xzTjkLWmwULE++23g3d3CCWaWw==
+
 "@types/connect@^3.4.33":
   version "3.4.35"
   resolved "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"
@@ -3083,6 +3088,11 @@ chalk@^4.0.0, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chance@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.npmjs.org/chance/-/chance-1.1.9.tgz#fbf409726a956415b4bde0e8db010f60b60fc01b"
+  integrity sha512-TfxnA/DcZXRTA4OekA2zL9GH8qscbbl6X0ZqU4tXhGveVY/mXWvEQLt5GwZcYXTEyEFflVtj+pG8nc8EwSm1RQ==
+
 char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
@@ -3313,6 +3323,11 @@ csv-stringify@^5.6.5:
   version "5.6.5"
   resolved "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.5.tgz#c6d74badda4b49a79bf4e72f91cce1e33b94de00"
   integrity sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A==
+
+csv-stringify@^6.2.3:
+  version "6.2.3"
+  resolved "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.2.3.tgz#fefd25e66fd48f8f42f43b85a66a4663a2c3e796"
+  integrity sha512-4qGjUMwnlaRc00gc2jrIYh2w/h1fo25B0mTuY9K8fBiIgtmCX3LcgUbrEGViL98Ci4Se/F5LFEtu8k+dItJVZQ==
 
 csv@^5.5.0:
   version "5.5.3"


### PR DESCRIPTION
## Motivation

Add benchmarking scripts for MerkleTrie (#445)

## Change Summary

The change add a simple cli script that run benchmarking suites. The command takes parameters that can be useful for experimenting with different configuration.

An initial benchmark for MerkleTrie is implemented. It measures the time and memory usage of insert and getSnapshot operations in the MerkleTrie implementation.

To run the benchmark, run `yarn bench` under `apps/hubble` folder.

```
$ yarn bench -h
Usage: farcaster-bench --benchmark <suite> [options]

Farcaster unit benchmark suites

Options:
  -V, --version              output the version number
  -b --benchmark <suite>     the benchmarking suite to run
  -n, --count <count>        size of input
  -c, --cycle <cycles>       run at least <cycle> times before taking measurements
  -o, --output <file>        path of the output file (default STDOUT)
  -s, --write-heap-snapshot  write V8 heap snapshot after each cycle (default: false)
  -h, --help                 display help for command
```

For example, running a MerkleTrie benchmark of 5M items:

```
yarn bench -b merkletrie -n 5000000 -o output.csv
```

The `--write-heap-snapshot`  write V8 heap snapshot after each cycle which is useful for debugging memory leak.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)

## Additional Context

Some preliminary benchmark results can be found here: https://gist.github.com/kcchu/03c07ce4c7a582c04bb6678e3fa8b275