### PR TITLE
fix: memory leak in MerkleTrie

### DIFF
--- a/apps/hubble/src/network/sync/trieNode.test.ts
+++ b/apps/hubble/src/network/sync/trieNode.test.ts
@@ -65,7 +65,7 @@ describe('TrieNode', () => {
       }
 
       expect(node.isLeaf).toEqual(true);
-      expect(node.value).toEqual(id.syncId());
+      expect(Buffer.from(node.value ?? [])).toEqual(id.syncId());
     });
 
     test('inserting another key with a common prefix splits the node', async () => {
@@ -99,12 +99,12 @@ describe('TrieNode', () => {
       // eslint-disable-next-line security/detect-object-injection
       expect(firstChild[0]).toEqual(hash1[firstDiffPos]);
       expect(firstChild[1].isLeaf).toBeTruthy();
-      expect(firstChild[1].value).toEqual(id1.syncId());
+      expect(Buffer.from(firstChild[1].value ?? [])).toEqual(id1.syncId());
       // hash2 node
       // eslint-disable-next-line security/detect-object-injection
       expect(secondChild[0]).toEqual(hash2[firstDiffPos]);
       expect(secondChild[1].isLeaf).toBeTruthy();
-      expect(secondChild[1].value).toEqual(id2.syncId());
+      expect(Buffer.from(secondChild[1].value ?? [])).toEqual(id2.syncId());
     });
   });
 

--- a/apps/hubble/src/utils/crypto.ts
+++ b/apps/hubble/src/utils/crypto.ts
@@ -1,5 +1,22 @@
+import { blake3 } from '@noble/hashes/blake3';
+
+export const BLAKE3TRUNCATE160_EMPTY_HASH = Buffer.from(blake3(new Uint8Array(), { dkLen: 20 }));
+
 export const sleep = (ms: number) => {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
+};
+
+/**
+ * Compute Blake3-Truncate-160 digest.
+ *
+ * @param msg Message to digest. undefined is treated as empty message.
+ * @return Blake3-Truncate-160 digest
+ */
+export const blake3Truncate160 = (msg: Uint8Array | undefined): Uint8Array => {
+  if (msg === undefined || msg.length === 0) {
+    return BLAKE3TRUNCATE160_EMPTY_HASH;
+  }
+  return blake3(msg, { dkLen: 20 });
 };


### PR DESCRIPTION
## Motivation

Fix memory leak in MerkleTrie that causes unproportional ArrayBuffer allocation

## Change Summary

Node's Buffer uses pooled memory chunk of 8KB by default. The memory pool won't be freed until all Buffers that reference the pool is freed. TrieNode creates a bunch of temporary Buffers during MerkleTrie.insert. And it has a long-lived Buffer that stores the key of an entry.

As a result, the short-lived Buffers creates a lot of holes in memory pools, but pools can’t be freed because part of them are referenced by long-lived TrieNodes.

The fix is to create new Uint8Array instances (which doesn't use shared memory pool) when TrieNodes store the keys. This change also improves the Buffer usage during TrieNode hash calculation.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)

## Additional Context

The bug is discovered in the benchmarking test introduced in #470.

Before the fix:

<img width="831" alt="image" src="https://user-images.githubusercontent.com/800071/216339905-0f0136cc-1d8a-4c93-a245-5f25321d5b9a.png">

<img width="509" alt="image" src="https://user-images.githubusercontent.com/800071/216340489-29c50393-c031-4854-b3d5-56829d5cb377.png">

After the fix:

<img width="831" alt="image" src="https://user-images.githubusercontent.com/800071/216340536-cb7c3b34-be29-4511-b59e-abb94002f3d4.png">

<img width="512" alt="image" src="https://user-images.githubusercontent.com/800071/216340556-03e67d1a-2a5b-4f84-9f23-af6873341b83.png">


