### PR TITLE
chore: Test gRPC server is running in Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,31 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build Docker image
+        id: docker-image
         uses: docker/build-push-action@v4
         with:
           cache-from: type=gha
-          cache-to: type=gha
+          cache-to: type=gha,type=inline
+          load: true
+          tags: farcasterxyz/hubble:test
+
+      - name: Run Hubble
+        shell: bash
+        run: docker run --name hub --detach -p2282:2282 -p2283:2283 farcasterxyz/hubble:test sh -c 'yarn --cwd=apps/hubble identity create && yarn --cwd=apps/hubble start --rpc-port 2283 --ip 0.0.0.0 --gossip-port 2282 --eth-rpc-url "https://eth-goerli.g.alchemy.com/v2/IvjMoCKt1hT66f9OJoL_dMXypnvQYUdd" --network 3 --allowed-peers none -e ""'
+
+      - name: Download grpcurl
+        shell: bash
+        run: curl -L https://github.com/fullstorydev/grpcurl/releases/download/v1.8.7/grpcurl_1.8.7_linux_x86_64.tar.gz -o - | tar -xzf -
+
+      - name: Check that gRPC server is running
+        uses: nick-fields/retry@v2
+        with:
+          timeout_seconds: 10
+          retry_wait_seconds: 5
+          max_attempts: 10
+          shell: bash
+          command: ./grpcurl -plaintext -import-path packages/protobufs/src/schemas -proto packages/protobufs/src/schemas/rpc.proto 127.0.0.1:2283 HubService.GetInfo
+          on_retry_command: docker logs hub
 
   analyze:
     timeout-minutes: 10


### PR DESCRIPTION
## Motivation

Ensure we know if we accidentally break the gRPC service for the hub.

## Change Summary

Add a simple test to our build step that ensures the gRPC service is running.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
