### PR TITLE
fix: incorrect prefix used by SyncEngine.getSnapshot()

### DIFF
--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -258,4 +258,20 @@ describe('SyncEngine', () => {
     expect(await syncEngine.trie.exists(new SyncId(messages[1] as protobufs.Message))).toBeTruthy();
     expect(await syncEngine.trie.exists(new SyncId(messages[2] as protobufs.Message))).toBeTruthy();
   });
+
+  test('getSnapshot should use a prefix of 10-seconds resolution timestamp', async () => {
+    await engine.mergeIdRegistryEvent(custodyEvent);
+    await engine.mergeMessage(signerAdd);
+
+    await addMessagesWithTimestamps([30662167, 30662169, 30662172]);
+    const nowOrig = Date.now;
+    Date.now = () => 16409952e5 + 30662167 * 1000;
+    try {
+      const result = await syncEngine.getSnapshot();
+      const snapshot = result._unsafeUnwrap();
+      expect(snapshot.prefix).toEqual(Buffer.from('0030662160'));
+    } finally {
+      Date.now = nowOrig;
+    }
+  });
 });

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -260,7 +260,7 @@ class SyncEngine {
     return this.snapshotTimestamp.asyncMap((snapshotTimestamp) => {
       // Ignore the least significant digit when fetching the snapshot timestamp because
       // second resolution is too fine grained, and fall outside sync threshold anyway
-      return this._trie.getSnapshot(Buffer.from(timestampToPaddedTimestampPrefix(snapshotTimestamp / 10)));
+      return this._trie.getSnapshot(Buffer.from(timestampToPaddedTimestampPrefix(snapshotTimestamp)));
     });
   }
 


### PR DESCRIPTION

## Motivation

SyncEngine.getSnapshot() divides timestamp by 10 inadvertently and makes the prefix to be shifted right, causing the prefix to be mismatch with with messages in MerkleTrie.

## Change Summary

Change SyncEngine.getSnapshot() to not divide timestamp by 10.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)

## Additional Context

The function intents to use a 10-seconds resolution timestamp to give the messages a chance to settle before they are picked up by the sync algorithm. The timestamp rounding logic is implemented in `snapshotTimestamp` and dividing timestamp by 10 in SyncEngine.getSnapshot() is unnecessary and incorrect.
