### PR TITLE
feat: add ability to customize log level from the cli

### DIFF
--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -8,7 +8,7 @@ import { ResultAsync } from 'neverthrow';
 import { dirname, resolve } from 'path';
 import { exit } from 'process';
 import { APP_VERSION, Hub, HubOptions } from '~/hubble';
-import { logger } from '~/utils/logger';
+import { logger, loggerLevels } from '~/utils/logger';
 import { addressInfoFromParts, ipMultiAddrStrFromAddressInfo, parseAddress } from '~/utils/p2p';
 import { DEFAULT_RPC_CONSOLE, startConsole } from './console/console';
 import { DB_DIRECTORY } from './storage/db/rocksdb';
@@ -33,7 +33,8 @@ app.name('hub').description('Farcaster Hub').version(APP_VERSION);
 
 app
   .command('start')
-  .description('Start a Hub')
+  .description("Start a Hub\n")
+  .description('Set minimum log level with FARCASTER_LOG_LEVEL from ' + loggerLevels )
   .option('-e, --eth-rpc-url <url>', 'RPC URL of a Goerli Ethereum Node')
   .option('-c, --config <filepath>', 'Path to a config file with options', DEFAULT_CONFIG_FILE)
   .option('--fir-address <address>', 'The address of the Farcaster ID Registry contract')
@@ -63,6 +64,7 @@ app
   .option('--rebuild-sync-trie', 'Rebuilds the sync trie before starting')
   .option('-i, --id <filepath>', 'Path to the PeerId file')
   .option('-n --network <network>', 'Farcaster network ID', parseNetwork)
+  .option('-v --version', "Display Farcaster version")
   .action(async (cliOptions) => {
     const teardown = async (hub: Hub) => {
       await hub.stop();

--- a/apps/hubble/src/utils/logger.ts
+++ b/apps/hubble/src/utils/logger.ts
@@ -31,15 +31,20 @@ import { default as Pino } from 'pino';
  * More info on best practices:
  * https://betterstack.com/community/guides/logging/how-to-install-setup-and-use-pino-to-log-node-js-applications/
  */
-const defaultOptions: Pino.LoggerOptions = {};
+const loggerOptions: Pino.LoggerOptions = {};
 
 // Disable logging in tests and CI to reduce noise
 if (process.env['NODE_ENV'] === 'test' || process.env['CI']) {
-  // defaultOptions.level = 'debug';
-  defaultOptions.level = 'silent';
+  // loggerOptions.level = 'debug';
+  loggerOptions.level = 'silent';
 }
 
-export const logger = Pino(defaultOptions);
+if (process.env['FARCASTER_LOG_LEVEL']) {
+  loggerOptions.level = process.env['FARCASTER_LOG_LEVEL'];
+}
+
+export const logger = Pino(loggerOptions);
+export const loggerLevels = [ 'trace', 'debug', 'info', 'warn', 'error', 'fatal', 'silent'];
 
 export const messageTypeToName = (type?: protobufs.MessageType) => {
   if (!type) return '';


### PR DESCRIPTION
An environment variable is utilized for simplicity

Also, clarify that --version is available from the cli in the help menu

## Motivation

This allows users to configure the minimum log level they want outputted.

## Change Summary

Add FARCASTER_LOG_LEVEL to the environment variables utilized.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] Changes to the protocol specification have been merged

