### PR TITLE
fix: tests hanging with yarn test

### DIFF
--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -1,5 +1,6 @@
 import * as protobufs from '@farcaster/protobufs';
 import { Ed25519Signer, Factories, getInsecureHubRpcClient, HubRpcClient } from '@farcaster/utils';
+import { jest } from '@jest/globals';
 import { APP_NICKNAME, APP_VERSION } from '~/hubble';
 import SyncEngine from '~/network/sync/syncEngine';
 import { SyncId } from '~/network/sync/syncId';
@@ -270,6 +271,7 @@ describe('Multi peer sync engine', () => {
     expect(await syncEngine2.trie.rootHash()).toEqual(beforeRootHash);
   });
 
+  jest.setTimeout(10000);
   test('Merge with multiple signers', async () => {
     await engine1.mergeIdRegistryEvent(custodyEvent);
 

--- a/apps/hubble/src/utils/crypto.ts
+++ b/apps/hubble/src/utils/crypto.ts
@@ -15,11 +15,11 @@ export const sleepWhile = (condition: () => boolean, timeoutMs: number): Promise
         clearInterval(interval);
         resolve(false);
       }
-    }, 10);
+    }, 10).unref();
     setTimeout(() => {
       clearInterval(interval);
       resolve(true);
-    }, timeoutMs);
+    }, timeoutMs).unref();
   });
 };
 


### PR DESCRIPTION
## Motivation

This fixes issue #631. `yarn test` was hanging due to open handles and limitations with the default time for jest tests. This is put forward as a draft as I'm unsure if the addition of `.unref()` may have adverse consequences and need someone more familiar with the codebase to verify it does not 

## Change Summary

- Increase the time in `MultiPeerSyncEngine.test` for `Merge with multiple signers`
- add `unref()` to sleepWhile in functions timeouts in `utils/crypto.ts`.

Tested locally and fixes the issue.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] Changes to the protocol specification have been merged

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
