### PR TITLE
chore: separate build step into typecheck and transpile

### DIFF
--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -16,7 +16,8 @@
   "type": "module",
   "scripts": {
     "bench": "NODE_OPTIONS='--max-old-space-size=8192' tsx src/test/bench",
-    "build": "yarn clean && tsc --project ./tsconfig.json",
+    "build": "yarn clean && swc src -d dist",
+    "typecheck": "tsc --noEmit",
     "clean": "rimraf ./build",
     "dev": "yarn start | yarn pino-pretty",
     "lint": "eslint  src/ --color --ext .ts",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test": "./node_modules/.bin/turbo run test",
     "test:ci": "./node_modules/.bin/turbo run test:ci -- --passWithNoTests",
     "lint": "./node_modules/.bin/turbo run lint --parallel",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "typecheck": "./node_modules/.bin/turbo run typecheck"
   },
   "engines": {
     "npm": ">=8.0.0",

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -23,12 +23,13 @@
     "neverthrow": "^6.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
+    "build": "swc src -d dist",
     "clean": "rimraf ./dist",
     "lint": "eslint  src/ --color --ext .ts",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:ci": "ENVIRONMENT=test NODE_OPTIONS=--experimental-vm-modules jest --ci --forceExit --coverage",
-    "prepublishOnly": "yarn run build"
+    "prepublishOnly": "yarn run build",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",

--- a/packages/protobufs/package.json
+++ b/packages/protobufs/package.json
@@ -16,12 +16,13 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "tsup --config tsup.config.ts",
+    "build": "swc src -d dist",
     "clean": "rimraf ./dist",
     "protoc": "protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=./src/generated/ --ts_proto_opt=esModuleInterop=true,exportCommonSymbols=false,outputServices=grpc-js,useOptionals=none,unrecognizedEnum=false,removeEnumPrefix=true --proto_path=./src/schemas ./src/schemas/*",
     "lint": "eslint  src/ --color --ext .ts",
     "lint:fix": "yarn run lint -- --fix",
-    "prepublishOnly": "yarn run build"
+    "prepublishOnly": "yarn run build",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "eslint-config-custom": "*",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -24,12 +24,13 @@
     "neverthrow": "^6.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
+    "build": "swc src -d dist",
     "clean": "rimraf ./dist",
     "lint": "eslint  src/ --color --ext .ts",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:ci": "ENVIRONMENT=test NODE_OPTIONS=--experimental-vm-modules jest --ci --forceExit --coverage",
-    "prepublishOnly": "yarn run build"
+    "prepublishOnly": "yarn run build",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@farcaster/fishery": "2.2.3",

--- a/turbo.json
+++ b/turbo.json
@@ -1,8 +1,12 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
+    "typecheck": {
+      "cache": true,
+      "outputs": []
+    },
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["typecheck", "^typecheck", "^build"],
       "outputs": ["build/**", "dist/**"]
     },
     "clean": {


### PR DESCRIPTION
## Motivation

Fixes #346.

## Change Summary

Changes:
1. Build uses `swc`
2. Typecheck command: `tsc --noEmit`
3. `turbo build` depends on `turbo typecheck`

Some screenshots:

![Screenshot from 2023-03-18 13-36-29](https://user-images.githubusercontent.com/34117807/226089687-12b95e7a-fc5d-40ba-901c-4268c7650ff0.png)
![Screenshot from 2023-03-18 13-36-38](https://user-images.githubusercontent.com/34117807/226089689-b6a50209-a579-4023-8dc9-cf6148fc781d.png)
![Screenshot from 2023-03-18 13-38-28](https://user-images.githubusercontent.com/34117807/226089741-eda8c498-9fae-4564-8625-d05413a3ec34.png)


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

Read somewhere on docs Hubble doesn't use Turborepo caching because it's "not worth the risk" or something. (Forgot where it's located.) Both `typecheck` and `build` are cached in this PR. Is this an unwanted behavior?
