### PR TITLE
fix: Sync was sometimes off by 1

### DIFF
--- a/.changeset/kind-wasps-fly.md
+++ b/.changeset/kind-wasps-fly.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Fix issue where sync was off by 1

--- a/apps/hubble/src/utils/crypto.ts
+++ b/apps/hubble/src/utils/crypto.ts
@@ -8,10 +8,10 @@ export const sleep = (ms: number) => {
   });
 };
 
-export const sleepWhile = (condition: () => boolean, timeoutMs: number): Promise<boolean> => {
+export const sleepWhile = (condition: () => boolean | Promise<boolean>, timeoutMs: number): Promise<boolean> => {
   return new Promise((resolve, reject) => {
-    const interval = setInterval(() => {
-      if (!condition()) {
+    const interval = setInterval(async () => {
+      if (!(await condition())) {
         clearInterval(interval);
         resolve(false);
       }


### PR DESCRIPTION
## Motivation

Fix an issue with sync where sometimes a branch of the trie wouldn't sync if we had one more message than the other node. 

## Change Summary

- Recurse down the tree if the hashes mismatch, till we identify the mismatched node.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
