### PR TITLE
chore: shift timing of sync job

### DIFF
--- a/apps/hubble/src/network/sync/periodicSyncJob.ts
+++ b/apps/hubble/src/network/sync/periodicSyncJob.ts
@@ -10,7 +10,8 @@ const log = logger.child({
 
 type SchedulerStatus = 'started' | 'stopped';
 
-const DEFAULT_PERIODIC_JOB_CRON = '*/2 * * * *'; // Every 2 minutes
+// Every 2 minutes, at 00:45 seconds, to avoid clashing with the prune job
+const DEFAULT_PERIODIC_JOB_CRON = '45 */2 * * * *';
 
 export class PeriodicSyncJobScheduler {
   private _hub: Hub;


### PR DESCRIPTION
## Motivation
Start the sync job at :45 seconds, so as to not clash with the prune job at the top of the hour

## Change Summary

- Start sync job slightly after prune job

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
