### PR TITLE
fix: Support multiple RPC usernames

### DIFF
--- a/.changeset/honest-frogs-watch.md
+++ b/.changeset/honest-frogs-watch.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Support multiple RPC users via comma-separted-list

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -58,7 +58,7 @@ app
   .option('-g, --gossip-port <port>', 'The tcp port libp2p should gossip over. (default: 2282)')
   .option('-r, --rpc-port <port>', 'The tcp port that the rpc server should listen on.  (default: 2283)')
   .option(
-    '--rpc-auth <username:password>',
+    '--rpc-auth <username:password,...>',
     'Enable Auth for RPC submit methods with the username and password. (default: disabled)'
   )
   .option(

--- a/apps/hubble/src/utils/periodicTestDataJob.ts
+++ b/apps/hubble/src/utils/periodicTestDataJob.ts
@@ -86,8 +86,11 @@ export class PeriodicTestDataJobScheduler {
       );
       const signerAdd = signerAddResult._unsafeUnwrap();
 
-      const { user, password } = this._server.auth;
-      const result = await client.submitMessage(signerAdd, getAuthMetadata(user ?? '', password ?? ''));
+      const rpcUsers = this._server.auth;
+      const user = rpcUsers[0]?.username ?? '';
+      const password = rpcUsers[0]?.password ?? '';
+
+      const result = await client.submitMessage(signerAdd, getAuthMetadata(user, password));
       if (result.isErr()) {
         log.error({ error: result.error, dataOptions }, 'TestData: failed to submit SignerAdd message');
       }
@@ -108,6 +111,10 @@ export class PeriodicTestDataJobScheduler {
     const farcasterTimestamp = toFarcasterTime(Date.now())._unsafeUnwrap();
     const targetCastIds = [];
 
+    const rpcUsers = this._server.auth;
+    const rpcUsername = rpcUsers[0]?.username ?? '';
+    const rpcPassword = rpcUsers[0]?.password ?? '';
+
     // Insert some casts
     for (const testUser of this._testDataUsers) {
       const dataOptions = {
@@ -124,8 +131,7 @@ export class PeriodicTestDataJobScheduler {
           signer
         );
 
-        const { user, password } = this._server.auth;
-        const result = await client.submitMessage(castAdd._unsafeUnwrap(), getAuthMetadata(user ?? '', password ?? ''));
+        const result = await client.submitMessage(castAdd._unsafeUnwrap(), getAuthMetadata(rpcUsername, rpcPassword));
         if (result.isErr()) {
           log.error({ error: result.error, dataOptions }, 'TestData: failed to submit CastAdd message');
         }
@@ -148,10 +154,9 @@ export class PeriodicTestDataJobScheduler {
           if (targetCastId.fid !== testUser.fid) {
             const reactionAdd = await makeReactionAdd({ type: ReactionType.LIKE, targetCastId }, dataOptions, signer);
 
-            const { user, password } = this._server.auth;
             const result = await client.submitMessage(
               reactionAdd._unsafeUnwrap(),
-              getAuthMetadata(user ?? '', password ?? '')
+              getAuthMetadata(rpcUsername, rpcPassword)
             );
             if (result.isErr()) {
               log.error({ error: result.error, dataOptions }, 'TestData: failed to submit ReactionAdd message');


### PR DESCRIPTION
## Motivation

We need to support multiple usernames and passwords for RPC Authentication

## Change Summary

- RPC_AUTH now accepts a series of usernames and passwords, separated by commas

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
