### PR TITLE
fix: Make sure there are no duplicate rpc usernames

### DIFF
--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -162,6 +162,13 @@ export const getRPCUsersFromAuthString = (rpcAuth?: string): RPCUser[] => {
     }
   });
 
+  // Check for duplicate usernames
+  const usernames = rpcUsers.map((u) => u.username);
+  const uniqueUsernames = [...new Set(usernames)];
+  if (usernames.length !== uniqueUsernames.length) {
+    throw new Error('Duplicate usernames in rpcAuth');
+  }
+
   return rpcUsers;
 };
 


### PR DESCRIPTION
## Motivation

Make sure there are no duplicates in RPC_AUTH usernames

## Change Summary



## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
