### PR TITLE
fix: allow multiple passwords for a rpc user

### DIFF
--- a/apps/hubble/src/rpc/adminServer.ts
+++ b/apps/hubble/src/rpc/adminServer.ts
@@ -11,7 +11,7 @@ import * as net from 'net';
 import { err, ok } from 'neverthrow';
 import { HubInterface } from '~/hubble';
 import SyncEngine from '~/network/sync/syncEngine';
-import { authenticateUser, getRPCUsersFromAuthString, RPCUser, toServiceError } from '~/rpc/server';
+import { authenticateUser, getRPCUsersFromAuthString, RpcUsers, toServiceError } from '~/rpc/server';
 import RocksDB from '~/storage/db/rocksdb';
 import Engine from '~/storage/engine';
 import { logger } from '~/utils/logger';
@@ -26,7 +26,7 @@ export default class AdminServer {
   private syncEngine: SyncEngine;
   private grpcServer: GrpcServer;
 
-  private rpcUsers: RPCUser[] = [];
+  private rpcUsers: RpcUsers;
 
   constructor(hub: HubInterface, db: RocksDB, engine: Engine, syncEngine: SyncEngine, rpcAuth?: string) {
     this.hub = hub;
@@ -39,8 +39,8 @@ export default class AdminServer {
 
     this.rpcUsers = getRPCUsersFromAuthString(rpcAuth);
 
-    if (this.rpcUsers.length > 0) {
-      log.info({ num_users: this.rpcUsers.length }, 'RPC auth enabled');
+    if (this.rpcUsers.size > 0) {
+      log.info({ num_users: this.rpcUsers.size }, 'RPC auth enabled');
     }
   }
 

--- a/apps/hubble/src/utils/periodicTestDataJob.ts
+++ b/apps/hubble/src/utils/periodicTestDataJob.ts
@@ -87,8 +87,14 @@ export class PeriodicTestDataJobScheduler {
       const signerAdd = signerAddResult._unsafeUnwrap();
 
       const rpcUsers = this._server.auth;
-      const user = rpcUsers[0]?.username ?? '';
-      const password = rpcUsers[0]?.password ?? '';
+
+      let user = '';
+      let password = '';
+
+      if (rpcUsers.size > 0) {
+        user = rpcUsers.values().next().value as string;
+        password = rpcUsers.get(user)?.[0] as string;
+      }
 
       const result = await client.submitMessage(signerAdd, getAuthMetadata(user, password));
       if (result.isErr()) {
@@ -112,8 +118,14 @@ export class PeriodicTestDataJobScheduler {
     const targetCastIds = [];
 
     const rpcUsers = this._server.auth;
-    const rpcUsername = rpcUsers[0]?.username ?? '';
-    const rpcPassword = rpcUsers[0]?.password ?? '';
+
+    let rpcUsername = '';
+    let rpcPassword = '';
+
+    if (rpcUsers.size > 0) {
+      rpcUsername = rpcUsers.values().next().value as string;
+      rpcPassword = rpcUsers.get(rpcUsername)?.[0] as string;
+    }
 
     // Insert some casts
     for (const testUser of this._testDataUsers) {


### PR DESCRIPTION
## Motivation

Allow multiple passwords for a rpc user so that passwords can be rotated more easily. 

## Change Summary

- Allow multiple passwords per user.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
