### PR TITLE
Release v1.0.19 of hubble

### DIFF
--- a/.changeset/gold-points-leave.md
+++ b/.changeset/gold-points-leave.md
@@ -1,5 +1,0 @@
----
-'@farcaster/hubble': patch
----
-
-Close RPC connections to fix a memory leak

--- a/.changeset/honest-frogs-watch.md
+++ b/.changeset/honest-frogs-watch.md
@@ -1,5 +1,0 @@
----
-'@farcaster/hubble': patch
----
-
-Support multiple RPC users via comma-separted-list

--- a/.changeset/nervous-masks-camp.md
+++ b/.changeset/nervous-masks-camp.md
@@ -1,5 +1,0 @@
----
-'@farcaster/hubble': patch
----
-
-Refuse to startup if DB network is mismatched

--- a/.changeset/sour-experts-poke.md
+++ b/.changeset/sour-experts-poke.md
@@ -1,5 +1,0 @@
----
-'@farcaster/hubble': patch
----
-
-Gossip server listens on 0.0.0.0 by default

--- a/.changeset/tricky-suits-carry.md
+++ b/.changeset/tricky-suits-carry.md
@@ -1,5 +1,0 @@
----
-'@farcaster/hubble': patch
----
-
-Better grpc error messages when auth fails

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @farcaster/hubble
 
+## 1.0.19
+
+### Patch Changes
+
+- fe74a1e: Close RPC connections to fix a memory leak
+- 1025d3b: Support multiple RPC users via comma-separted-list
+- de25020: Refuse to startup if DB network is mismatched
+- 58cfbb9: Gossip server listens on 0.0.0.0 by default
+- 9ee1076: Better grpc error messages when auth fails
+
 ## 1.0.18
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",


### PR DESCRIPTION
## Motivation

Release v1.0.19 of hubble

## Change Summary

- Release

- fe74a1e: Close RPC connections to fix a memory leak
- 1025d3b: Support multiple RPC users via comma-separted-list
- de25020: Refuse to startup if DB network is mismatched
- 58cfbb9: Gossip server listens on 0.0.0.0 by default
- 9ee1076: Better grpc error messages when auth fails