### PR TITLE
docs: update docs to close() grpc connection

### DIFF
--- a/.changeset/thick-tips-invite.md
+++ b/.changeset/thick-tips-invite.md
@@ -1,0 +1,7 @@
+---
+'@farcaster/hub-nodejs': patch
+'@farcaster/utils': patch
+'@farcaster/hubble': patch
+---
+
+Update docs to close grpc connections after use

--- a/apps/hubble/src/network/p2p/gossipNode.test.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.test.ts
@@ -144,7 +144,7 @@ describe('GossipNode', () => {
       await hub.submitMessage(castAdd2);
       expect(numMessagesGossiped).toEqual(0);
 
-      client.$.close();
+      client.close();
       await server.stop();
       await syncEngine.stop();
     });

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -96,7 +96,7 @@ describe('Multi peer sync engine', () => {
 
   afterEach(async () => {
     // Cleanup
-    clientForServer1.$.close();
+    clientForServer1.close();
     await server1.stop();
     await syncEngine1.stop();
     await engine1.stop();
@@ -252,7 +252,7 @@ describe('Multi peer sync engine', () => {
 
       expect(await syncEngine1.trie.rootHash()).toEqual(engine1RootHashBefore);
 
-      clientForServer2.$.close();
+      clientForServer2.close();
       await server2.stop();
     }
 

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -251,7 +251,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
       return;
     } finally {
       const closeResult = Result.fromThrowable(
-        () => rpcClient.$.close(),
+        () => rpcClient.close(),
         (e) => e as Error
       )();
       if (closeResult.isErr()) {

--- a/apps/hubble/src/rpc/test/bulkService.test.ts
+++ b/apps/hubble/src/rpc/test/bulkService.test.ts
@@ -21,7 +21,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  client.$.close();
+  client.close();
   await server.stop();
   await engine.stop();
 });

--- a/apps/hubble/src/rpc/test/castService.test.ts
+++ b/apps/hubble/src/rpc/test/castService.test.ts
@@ -21,7 +21,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  client.$.close();
+  client.close();
   await server.stop();
   await engine.stop();
 });

--- a/apps/hubble/src/rpc/test/concurrency.test.ts
+++ b/apps/hubble/src/rpc/test/concurrency.test.ts
@@ -26,9 +26,9 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  client1.$.close();
-  client2.$.close();
-  client3.$.close();
+  client1.close();
+  client2.close();
+  client3.close();
   await server.stop();
   await engine.stop();
 });

--- a/apps/hubble/src/rpc/test/reactionService.test.ts
+++ b/apps/hubble/src/rpc/test/reactionService.test.ts
@@ -21,7 +21,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  client.$.close();
+  client.close();
   await server.stop();
   await engine.stop();
 });

--- a/apps/hubble/src/rpc/test/rpcAuth.test.ts
+++ b/apps/hubble/src/rpc/test/rpcAuth.test.ts
@@ -77,7 +77,7 @@ describe('auth tests', () => {
     expect(result5.isOk()).toBeTruthy();
 
     await authServer.stop();
-    authClient.$.close();
+    authClient.close();
   });
 
   test('all submit methods require auth', async () => {
@@ -101,7 +101,7 @@ describe('auth tests', () => {
     expect(result2.isOk()).toBeTruthy();
 
     await authServer.stop();
-    authClient.$.close();
+    authClient.close();
   });
 
   test('test rate limiting', async () => {

--- a/apps/hubble/src/rpc/test/signerService.test.ts
+++ b/apps/hubble/src/rpc/test/signerService.test.ts
@@ -22,7 +22,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  client.$.close();
+  client.close();
   await server.stop();
   await engine.stop();
 });

--- a/apps/hubble/src/rpc/test/submitService.test.ts
+++ b/apps/hubble/src/rpc/test/submitService.test.ts
@@ -23,7 +23,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  client.$.close();
+  client.close();
   await server.stop();
   await engine.stop();
 });

--- a/apps/hubble/src/rpc/test/userDataService.test.ts
+++ b/apps/hubble/src/rpc/test/userDataService.test.ts
@@ -22,7 +22,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  client.$.close();
+  client.close();
   await server.stop();
   await engine.stop();
 });

--- a/apps/hubble/src/rpc/test/verificationService.test.ts
+++ b/apps/hubble/src/rpc/test/verificationService.test.ts
@@ -21,7 +21,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  client.$.close();
+  client.close();
   await server.stop();
   await engine.stop();
 });

--- a/apps/hubble/src/utils/periodicTestDataJob.ts
+++ b/apps/hubble/src/utils/periodicTestDataJob.ts
@@ -180,7 +180,7 @@ export class PeriodicTestDataJobScheduler {
     }
 
     const closeResult = Result.fromThrowable(
-      () => client.$.close(),
+      () => client.close(),
       (e) => e as Error
     )();
     if (closeResult.isErr()) {

--- a/packages/hub-nodejs/README.md
+++ b/packages/hub-nodejs/README.md
@@ -34,6 +34,8 @@ import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
   const castsResult = await client.getCastsByFid({ fid: 2 });
 
   castsResult.map((casts) => casts.messages.map((cast) => console.log(cast.data?.castAddBody?.text)));
+
+  client.close();
 })();
 ```
 

--- a/packages/hub-nodejs/docs/Client.md
+++ b/packages/hub-nodejs/docs/Client.md
@@ -15,13 +15,16 @@ getInsecureHubRpcClient returns a Hub RPC Client. Use getSSLHubRpcClient if the 
 #### Usage
 
 ```typescript
-import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
+import { geSSLHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
 
   // If the Hub does not use SSL, call the getInsecureHubRpcClient method instead
   // const insecureClient = getInsecureHubRpcClient('https://testnet1.farcaster.xyz:2283');
+
+  // After everything, close the RPC connection
+  client.close();
 })();
 ```
 
@@ -109,7 +112,7 @@ if (castResult.isOk()) {
 Methods that return multiple values support pagination in requests with a `pageSize` and `pageToken` property.
 
 ```typescript
-import { getInsecureHubRpcClient, HubResult, MessagesResponse } from '@farcaster/hub-nodejs';
+import { geSSLHubRpcClient, HubResult, MessagesResponse } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
@@ -134,6 +137,8 @@ import { getInsecureHubRpcClient, HubResult, MessagesResponse } from '@farcaster
     nextPageToken = castsResponse.nextPageToken;
     isNextPage = !!nextPageToken && nextPageToken.length > 0;
   }
+
+  client.close();
 })();
 ```
 
@@ -146,7 +151,7 @@ Returns an active signer message given an fid and the public key of the signer.
 #### Usage
 
 ```typescript
-import { getInsecureHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs';
+import { geSSLHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
@@ -161,6 +166,7 @@ import { getInsecureHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs
   });
 
   signerResult.map((signerAdd) => console.log(signerAdd));
+  client.close();
 })();
 ```
 
@@ -186,7 +192,7 @@ Returns all active signers created by an fid in reverse chronological order.
 #### Usage
 
 ```typescript
-import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
+import { geSSLHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
@@ -194,6 +200,7 @@ import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
   const signersResult = await client.getAllSignerMessagesByFid({ fid: 2 });
 
   signersResult.map((signers) => console.log(signers.messages));
+  client.close();
 })();
 ```
 
@@ -221,7 +228,7 @@ Returns all active and inactive signers created by an fid in reverse chronologic
 #### Usage
 
 ```typescript
-import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
+import { geSSLHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
@@ -229,6 +236,7 @@ import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
   const signersResult = await client.getAllSignerMessagesByFid({ fid: 2 });
 
   signersResult.map((signers) => console.log(signers.messages));
+  client.close();
 })();
 ```
 
@@ -256,7 +264,7 @@ Returns a specific piece of metadata about the user.
 #### Usage
 
 ```typescript
-import { getInsecureHubRpcClient, UserDataType } from '@farcaster/hub-nodejs';
+import { geSSLHubRpcClient, UserDataType } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
@@ -264,6 +272,7 @@ import { getInsecureHubRpcClient, UserDataType } from '@farcaster/hub-nodejs';
   const userDataResult = await client.getUserData({ fid: 2, userDataType: UserDataType.DISPLAY });
 
   userDataResult.map((userData) => console.log(userData));
+  client.close();
 })();
 ```
 
@@ -289,7 +298,7 @@ Returns all metadata about the user.
 #### Usage
 
 ```typescript
-import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
+import { geSSLHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
@@ -297,6 +306,7 @@ import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
   const userDataResult = await client.getAllUserDataMessagesByFid({ fid: 2 });
 
   userDataResult.map((userData) => userData.messages.map((message) => console.log(message)));
+  client.close();
 })();
 ```
 
@@ -328,7 +338,7 @@ Returns an active cast for a user.
 #### Usage
 
 ```typescript
-import { getInsecureHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs';
+import { geSSLHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
@@ -339,6 +349,7 @@ import { getInsecureHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs
   const castResult = await client.getCast({ fid: 2, hash: castHashBytes });
 
   castResult.map((cast) => console.log(cast));
+  client.close();
 })();
 ```
 
@@ -364,7 +375,7 @@ Returns active casts for a user in reverse chronological order.
 #### Usage
 
 ```typescript
-import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
+import { geSSLHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
@@ -372,6 +383,7 @@ import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
   const castsResult = await client.getCastsByFid({ fid: 2 });
 
   castsResult.map((casts) => console.log(casts.messages));
+  client.close();
 })();
 ```
 
@@ -399,7 +411,7 @@ Returns all active casts that mention an fid in reverse chronological order.
 #### Usage
 
 ```typescript
-import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
+import { geSSLHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
@@ -407,6 +419,7 @@ import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
   const castsResult = await client.getCastsByMention({ fid: 2 });
 
   castsResult.map((casts) => console.log(casts.messages));
+  client.close();
 })();
 ```
 
@@ -434,7 +447,7 @@ Returns all active casts that are replies to a specific cast in reverse chronolo
 #### Usage
 
 ```typescript
-import { getInsecureHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs';
+import { geSSLHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
@@ -445,6 +458,7 @@ import { getInsecureHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs
   const castsResult = await client.getCastsByParent({ castId: { fid: 2, hash: castHashBytes } });
 
   castsResult.map((casts) => console.log(casts.messages));
+  client.close();
 })();
 ```
 
@@ -472,13 +486,14 @@ Returns all active and inactive casts for a user in reverse chronological order.
 #### Usage
 
 ```typescript
-import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
+import { geSSLHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
 
   const castsResult = await client.getAllCastMessagesByFid({ fid: 2 });
   castsResult.map((casts) => console.log(casts.messages));
+  client.close();
 })();
 ```
 
@@ -506,7 +521,7 @@ Returns an active reaction of a particular type made by a user to a cast.
 #### Usage
 
 ```typescript
-import { getInsecureHubRpcClient, hexStringToBytes, ReactionType } from '@farcaster/hub-nodejs';
+import { geSSLHubRpcClient, hexStringToBytes, ReactionType } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
@@ -524,6 +539,7 @@ import { getInsecureHubRpcClient, hexStringToBytes, ReactionType } from '@farcas
   });
 
   reactionsResult.map((reaction) => console.log(reaction));
+  client.close();
 })();
 ```
 
@@ -550,7 +566,7 @@ Returns all active reactions made by users to a cast.
 #### Usage
 
 ```typescript
-import { getInsecureHubRpcClient, hexStringToBytes, ReactionType } from '@farcaster/hub-nodejs';
+import { geSSLHubRpcClient, hexStringToBytes, ReactionType } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
@@ -567,6 +583,7 @@ import { getInsecureHubRpcClient, hexStringToBytes, ReactionType } from '@farcas
   });
 
   reactionsResult.map((reaction) => console.log(reaction.messages));
+  client.close();
 })();
 ```
 
@@ -595,7 +612,7 @@ Returns all active reactions made by a user in reverse chronological order.
 #### Usage
 
 ```typescript
-import { getInsecureHubRpcClient, ReactionType } from '@farcaster/hub-nodejs';
+import { geSSLHubRpcClient, ReactionType } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
@@ -603,6 +620,7 @@ import { getInsecureHubRpcClient, ReactionType } from '@farcaster/hub-nodejs';
   const reactionsResult = await client.getReactionsByFid({ fid: 2, reactionType: ReactionType.LIKE });
 
   reactionsResult.map((reaction) => console.log(reaction.messages));
+  client.close();
 })();
 ```
 
@@ -631,7 +649,7 @@ Returns all active and inactive reactions made by a user in reverse chronologica
 #### Usage
 
 ```typescript
-import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
+import { geSSLHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
@@ -639,6 +657,7 @@ import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
   const reactionsResult = await client.getAllReactionMessagesByFid({ fid: 2 });
 
   reactionsResult.map((reaction) => console.log(reaction.messages));
+  client.close();
 })();
 ```
 
@@ -666,7 +685,7 @@ Returns an active verification for a specific Ethereum address made by a user.
 #### Usage
 
 ```typescript
-import { getInsecureHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs';
+import { geSSLHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
@@ -677,6 +696,7 @@ import { getInsecureHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs
   const verificationResult = await client.getVerification({ fid: 2, address: addressBytes });
 
   verificationResult.map((verification) => console.log(verification));
+  client.close();
 })();
 ```
 
@@ -702,7 +722,7 @@ Returns all active verifications for Ethereum addresses made by a user in revers
 #### Usage
 
 ```typescript
-import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
+import { geSSLHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
@@ -714,6 +734,7 @@ import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
       console.log(v);
     })
   );
+  client.close();
 })();
 ```
 
@@ -741,7 +762,7 @@ Returns all active and inactive verifications for Ethereum addresses made by a u
 #### Usage
 
 ```typescript
-import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
+import { geSSLHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
@@ -753,6 +774,7 @@ import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
       console.log(v);
     })
   );
+  client.close();
 })();
 ```
 
@@ -784,7 +806,7 @@ which helps with recovery when clients get disconnected temporarily.
 #### Usage
 
 ```typescript
-import { getInsecureHubRpcClient, HubEventType } from '@farcaster/hub-nodejs';
+import { geSSLHubRpcClient, HubEventType } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
@@ -800,6 +822,7 @@ import { getInsecureHubRpcClient, HubEventType } from '@farcaster/hub-nodejs';
       console.log(event);
     }
   }
+  client.close();
 })();
 ```
 
@@ -825,7 +848,7 @@ Submits a new message to the Hub. A Hub can choose to require basic authenticati
 #### Usage
 
 ```typescript
-import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
+import { geSSLHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
@@ -837,6 +860,8 @@ import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
 
   const submitResult = await client.submitMessage(message);
   console.log(submitResult);
+
+  client.close();
 })();
 ```
 
@@ -862,7 +887,7 @@ Returns the on-chain event most recently associated with changing an fid's owner
 #### Usage
 
 ```typescript
-import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
+import { geSSLHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
@@ -870,6 +895,7 @@ import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
   const idrResult = await client.getIdRegistryEvent({ fid: 2 });
 
   idrResult.map((event) => console.log(event));
+  client.close();
 })();
 ```
 
@@ -894,7 +920,7 @@ Returns the on-chain event most recently associated with changing an fname's own
 #### Usage
 
 ```typescript
-import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
+import { geSSLHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
@@ -903,6 +929,7 @@ import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
   const nrResult = await client.getNameRegistryEvent({ name: fnameBytes });
 
   nrResult.map((event) => console.log(event));
+  client.close();
 })();
 ```
 

--- a/packages/hub-nodejs/examples/chron-feed/index.ts
+++ b/packages/hub-nodejs/examples/chron-feed/index.ts
@@ -112,4 +112,7 @@ const castToString = (cast: CastAddMessage, nameMapping: Map<number, string>) =>
   for (const outputCast of stringifiedCasts) {
     console.log(outputCast);
   }
+
+  // 3. Close the connection
+  client.close();
 })();

--- a/packages/hub-nodejs/examples/make-cast/index.ts
+++ b/packages/hub-nodejs/examples/make-cast/index.ts
@@ -1,4 +1,4 @@
-import { FarcasterNetwork, NobleEd25519Signer, getHubRpcClient, makeCastAdd } from '@farcaster/hub-nodejs';
+import { FarcasterNetwork, NobleEd25519Signer, getInsecureHubRpcClient, makeCastAdd } from '@farcaster/hub-nodejs';
 import * as ed from '@noble/ed25519';
 
 /**
@@ -146,6 +146,10 @@ const HUB_URL = process.env['HUB_ADDR'] || ''; // URL of the Hub
   castResults.push(castWithEmojiLinkAttachmnent);
 
   // Submit Casts to the Hub
-  const client = await getHubRpcClient(HUB_URL);
+  const client = getInsecureHubRpcClient(HUB_URL);
+  // If your Hub is using SSL, use getSSLHubRpcClient instead
+
   castResults.map((castAddResult) => castAddResult.map((castAdd) => client.submitMessage(castAdd)));
+
+  client.close();
 })();

--- a/packages/hub-nodejs/examples/write-data/index.ts
+++ b/packages/hub-nodejs/examples/write-data/index.ts
@@ -91,4 +91,6 @@ const HUB_URL = process.env['HUB_ADDR'] || ''; // URL of the Hub
   }
 
   console.log('UserDataAdd was published successfully!');
+
+  client.close();
 })();

--- a/packages/utils/src/client.ts
+++ b/packages/utils/src/client.ts
@@ -54,7 +54,7 @@ type PromisifiedStream<T, U> = (
   options?: Partial<CallOptions>
 ) => Promise<HubResult<ClientReadableStream<U>>>;
 
-type PromisifiedClient<C> = { $: C } & {
+type PromisifiedClient<C> = { $: C; close: () => void } & {
   [prop in Exclude<keyof C, keyof Client>]: C[prop] extends OriginalStream<infer T, infer U>
     ? PromisifiedStream<T, U>
     : C[prop] extends OriginalUnaryCall<infer T, infer U>
@@ -68,6 +68,8 @@ const promisifyClient = <C extends Client>(client: C) => {
       const key = descriptor as keyof PromisifiedClient<C>;
 
       if (key === '$') return target;
+
+      if (key === 'close') return () => target.close;
 
       // eslint-disable-next-line security/detect-object-injection
       const func = target[key];


### PR DESCRIPTION
## Motivation

Update docs to encourage users to close the grpc client connection after use

## Change Summary

- add close() method directly on client
- Update docs to close() connection after every use.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
