### PR TITLE
feat: add getIdRegistryEventByAddress method

### DIFF
--- a/.changeset/big-apricots-clean.md
+++ b/.changeset/big-apricots-clean.md
@@ -1,0 +1,6 @@
+---
+'@farcaster/protobufs': patch
+'@farcaster/hubble': patch
+---
+
+add getIdRegistryEventByAddress rpc and engine method

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -624,11 +624,22 @@ export default class Server {
       },
       getIdRegistryEvent: async (call, callback) => {
         const request = call.request;
-
-        const custodyEventResult = await this.engine?.getIdRegistryEvent(request.fid);
-        custodyEventResult?.match(
-          (custodyEvent: IdRegistryEvent) => {
-            callback(null, custodyEvent);
+        const idRegistryEventResult = await this.engine?.getIdRegistryEvent(request.fid);
+        idRegistryEventResult?.match(
+          (idRegistryEvent: IdRegistryEvent) => {
+            callback(null, idRegistryEvent);
+          },
+          (err: HubError) => {
+            callback(toServiceError(err));
+          }
+        );
+      },
+      getIdRegistryEventByAddress: async (call, callback) => {
+        const request = call.request;
+        const idRegistryEventResult = await this.engine?.getIdRegistryEventByAddress(request.address);
+        idRegistryEventResult?.match(
+          (idRegistryEvent: IdRegistryEvent) => {
+            callback(null, idRegistryEvent);
           },
           (err: HubError) => {
             callback(toServiceError(err));

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -554,6 +554,10 @@ class Engine {
     return ResultAsync.fromPromise(this._signerStore.getIdRegistryEvent(fid), (e) => e as HubError);
   }
 
+  async getIdRegistryEventByAddress(address: Uint8Array): HubAsyncResult<protobufs.IdRegistryEvent> {
+    return ResultAsync.fromPromise(this._signerStore.getIdRegistryEventByAddress(address), (e) => e as HubError);
+  }
+
   async getFids(pageOptions: PageOptions = {}): HubAsyncResult<{
     fids: number[];
     nextPageToken: Uint8Array | undefined;

--- a/apps/hubble/src/storage/stores/signerStore.test.ts
+++ b/apps/hubble/src/storage/stores/signerStore.test.ts
@@ -64,6 +64,17 @@ describe('getIdRegistryEvent', () => {
   });
 });
 
+describe('getIdRegistryEventByAddress', () => {
+  test('returns contract event if it exists', async () => {
+    await set.mergeIdRegistryEvent(custody1Event);
+    await expect(set.getIdRegistryEventByAddress(custody1Event.to)).resolves.toEqual(custody1Event);
+  });
+
+  test('fails if event is missing', async () => {
+    await expect(set.getIdRegistryEventByAddress(custody1Event.to)).rejects.toThrow(HubError);
+  });
+});
+
 describe('getSignerAdd', () => {
   test('fails if missing', async () => {
     await expect(set.getSignerAdd(fid, signerKey)).rejects.toThrow(HubError);

--- a/apps/hubble/src/storage/stores/signerStore.ts
+++ b/apps/hubble/src/storage/stores/signerStore.ts
@@ -2,7 +2,11 @@ import * as protobufs from '@farcaster/protobufs';
 import { bytesCompare, HubAsyncResult, HubError, isHubError } from '@farcaster/utils';
 import AsyncLock from 'async-lock';
 import { err, ok, ResultAsync } from 'neverthrow';
-import { getIdRegistryEvent, putIdRegistryEventTransaction } from '~/storage/db/idRegistryEvent';
+import {
+  getIdRegistryEvent,
+  getIdRegistryEventByCustodyAddress,
+  putIdRegistryEventTransaction,
+} from '~/storage/db/idRegistryEvent';
 import {
   deleteMessageTransaction,
   getMessage,
@@ -104,6 +108,10 @@ class SignerStore {
   /** Returns the most recent event from the IdRegistry contract that affected the fid  */
   async getIdRegistryEvent(fid: number): Promise<protobufs.IdRegistryEvent> {
     return getIdRegistryEvent(this._db, fid);
+  }
+
+  async getIdRegistryEventByAddress(address: Uint8Array): Promise<protobufs.IdRegistryEvent> {
+    return getIdRegistryEventByCustodyAddress(this._db, address);
   }
 
   /**

--- a/packages/protobufs/src/generated/rpc.ts
+++ b/packages/protobufs/src/generated/rpc.ts
@@ -141,6 +141,14 @@ export interface SignerRequest {
   signer: Uint8Array;
 }
 
+export interface IdRegistryEventRequest {
+  fid: number;
+}
+
+export interface IdRegistryEventByAddressRequest {
+  address: Uint8Array;
+}
+
 function createBaseEmpty(): Empty {
   return {};
 }
@@ -1542,6 +1550,111 @@ export const SignerRequest = {
   },
 };
 
+function createBaseIdRegistryEventRequest(): IdRegistryEventRequest {
+  return { fid: 0 };
+}
+
+export const IdRegistryEventRequest = {
+  encode(message: IdRegistryEventRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.fid !== 0) {
+      writer.uint32(8).uint64(message.fid);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): IdRegistryEventRequest {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseIdRegistryEventRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.fid = longToNumber(reader.uint64() as Long);
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): IdRegistryEventRequest {
+    return { fid: isSet(object.fid) ? Number(object.fid) : 0 };
+  },
+
+  toJSON(message: IdRegistryEventRequest): unknown {
+    const obj: any = {};
+    message.fid !== undefined && (obj.fid = Math.round(message.fid));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<IdRegistryEventRequest>, I>>(base?: I): IdRegistryEventRequest {
+    return IdRegistryEventRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<IdRegistryEventRequest>, I>>(object: I): IdRegistryEventRequest {
+    const message = createBaseIdRegistryEventRequest();
+    message.fid = object.fid ?? 0;
+    return message;
+  },
+};
+
+function createBaseIdRegistryEventByAddressRequest(): IdRegistryEventByAddressRequest {
+  return { address: new Uint8Array() };
+}
+
+export const IdRegistryEventByAddressRequest = {
+  encode(message: IdRegistryEventByAddressRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.address.length !== 0) {
+      writer.uint32(10).bytes(message.address);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): IdRegistryEventByAddressRequest {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseIdRegistryEventByAddressRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.address = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): IdRegistryEventByAddressRequest {
+    return { address: isSet(object.address) ? bytesFromBase64(object.address) : new Uint8Array() };
+  },
+
+  toJSON(message: IdRegistryEventByAddressRequest): unknown {
+    const obj: any = {};
+    message.address !== undefined &&
+      (obj.address = base64FromBytes(message.address !== undefined ? message.address : new Uint8Array()));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<IdRegistryEventByAddressRequest>, I>>(base?: I): IdRegistryEventByAddressRequest {
+    return IdRegistryEventByAddressRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<IdRegistryEventByAddressRequest>, I>>(
+    object: I
+  ): IdRegistryEventByAddressRequest {
+    const message = createBaseIdRegistryEventByAddressRequest();
+    message.address = object.address ?? new Uint8Array();
+    return message;
+  },
+};
+
 export type HubServiceService = typeof HubServiceService;
 export const HubServiceService = {
   /** Submit Methods */
@@ -1708,8 +1821,18 @@ export const HubServiceService = {
     path: '/HubService/GetIdRegistryEvent',
     requestStream: false,
     responseStream: false,
-    requestSerialize: (value: FidRequest) => Buffer.from(FidRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer) => FidRequest.decode(value),
+    requestSerialize: (value: IdRegistryEventRequest) => Buffer.from(IdRegistryEventRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => IdRegistryEventRequest.decode(value),
+    responseSerialize: (value: IdRegistryEvent) => Buffer.from(IdRegistryEvent.encode(value).finish()),
+    responseDeserialize: (value: Buffer) => IdRegistryEvent.decode(value),
+  },
+  getIdRegistryEventByAddress: {
+    path: '/HubService/GetIdRegistryEventByAddress',
+    requestStream: false,
+    responseStream: false,
+    requestSerialize: (value: IdRegistryEventByAddressRequest) =>
+      Buffer.from(IdRegistryEventByAddressRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => IdRegistryEventByAddressRequest.decode(value),
     responseSerialize: (value: IdRegistryEvent) => Buffer.from(IdRegistryEvent.encode(value).finish()),
     responseDeserialize: (value: Buffer) => IdRegistryEvent.decode(value),
   },
@@ -1843,7 +1966,8 @@ export interface HubServiceServer extends UntypedServiceImplementation {
   /** Signer */
   getSigner: handleUnaryCall<SignerRequest, Message>;
   getSignersByFid: handleUnaryCall<FidRequest, MessagesResponse>;
-  getIdRegistryEvent: handleUnaryCall<FidRequest, IdRegistryEvent>;
+  getIdRegistryEvent: handleUnaryCall<IdRegistryEventRequest, IdRegistryEvent>;
+  getIdRegistryEventByAddress: handleUnaryCall<IdRegistryEventByAddressRequest, IdRegistryEvent>;
   getFids: handleUnaryCall<FidsRequest, FidsResponse>;
   /** Bulk Methods */
   getAllCastMessagesByFid: handleUnaryCall<FidRequest, MessagesResponse>;
@@ -2102,16 +2226,31 @@ export interface HubServiceClient extends Client {
     callback: (error: ServiceError | null, response: MessagesResponse) => void
   ): ClientUnaryCall;
   getIdRegistryEvent(
-    request: FidRequest,
+    request: IdRegistryEventRequest,
     callback: (error: ServiceError | null, response: IdRegistryEvent) => void
   ): ClientUnaryCall;
   getIdRegistryEvent(
-    request: FidRequest,
+    request: IdRegistryEventRequest,
     metadata: Metadata,
     callback: (error: ServiceError | null, response: IdRegistryEvent) => void
   ): ClientUnaryCall;
   getIdRegistryEvent(
-    request: FidRequest,
+    request: IdRegistryEventRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: IdRegistryEvent) => void
+  ): ClientUnaryCall;
+  getIdRegistryEventByAddress(
+    request: IdRegistryEventByAddressRequest,
+    callback: (error: ServiceError | null, response: IdRegistryEvent) => void
+  ): ClientUnaryCall;
+  getIdRegistryEventByAddress(
+    request: IdRegistryEventByAddressRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: IdRegistryEvent) => void
+  ): ClientUnaryCall;
+  getIdRegistryEventByAddress(
+    request: IdRegistryEventByAddressRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: IdRegistryEvent) => void

--- a/packages/protobufs/src/schemas/rpc.proto
+++ b/packages/protobufs/src/schemas/rpc.proto
@@ -117,6 +117,14 @@ message SignerRequest {
   bytes signer = 2;
 }
 
+message IdRegistryEventRequest {
+  uint64 fid = 1;
+}
+
+message IdRegistryEventByAddressRequest {
+  bytes address = 1;
+}
+
 service HubService {
   // Submit Methods
   rpc SubmitMessage(Message) returns (Message);
@@ -148,7 +156,8 @@ service HubService {
   // Signer
   rpc GetSigner(SignerRequest) returns (Message);
   rpc GetSignersByFid(FidRequest) returns (MessagesResponse);
-  rpc GetIdRegistryEvent(FidRequest) returns (IdRegistryEvent);
+  rpc GetIdRegistryEvent(IdRegistryEventRequest) returns (IdRegistryEvent);
+  rpc GetIdRegistryEventByAddress(IdRegistryEventByAddressRequest) returns (IdRegistryEvent);
   rpc GetFids(FidsRequest) returns (FidsResponse);
 
   // Bulk Methods


### PR DESCRIPTION
## Motivation

Right now if you only know a custody address, it's hard to retrieve an fid via gRPC.

## Change Summary

* Add a `getIdRegistryEventByAddress` method to `rpc.proto` and hubble (this was already implemented, just not connected to rpc)

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
