### PR TITLE
fix: Fetch missing IdRegistry from the contract instead of the peer

### DIFF
--- a/.changeset/light-hounds-arrive.md
+++ b/.changeset/light-hounds-arrive.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Retry missing IdRegistry events from Eth node instead of peer

--- a/apps/hubble/src/eth/ethEventsProvider.ts
+++ b/apps/hubble/src/eth/ethEventsProvider.ts
@@ -235,6 +235,34 @@ export class EthEventsProvider {
   }
 
   /**
+   * Retry events from a specific block number
+   *
+   * @param blockNumber
+   */
+  public async retryEventsFromBlock(blockNumber: number) {
+    await this.syncHistoricalIdEvents(
+      protobufs.IdRegistryEventType.REGISTER,
+      blockNumber,
+      blockNumber,
+      this._chunkSize
+    );
+    await this.syncHistoricalIdEvents(
+      protobufs.IdRegistryEventType.TRANSFER,
+      blockNumber,
+      blockNumber,
+      this._chunkSize
+    );
+
+    // Sync old Name Transfer events
+    await this.syncHistoricalNameEvents(
+      protobufs.NameRegistryEventType.TRANSFER,
+      blockNumber,
+      blockNumber,
+      this._chunkSize
+    );
+  }
+
+  /**
    * Sync old Id events that may have happened before hub was started. We'll put them all
    * in the sync queue to be processed later, to make sure we don't process any unconfirmed events.
    */

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -148,6 +148,9 @@ describe('Multi peer sync engine', () => {
       const engine2 = new Engine(testDb2, network);
       const syncEngine2 = new SyncEngine(engine2, testDb2);
 
+      // Add the signer custody event to engine 2
+      await engine2.mergeIdRegistryEvent(custodyEvent);
+
       // Engine 2 should sync with engine1
       expect(
         (await syncEngine2.shouldSync((await syncEngine1.getSnapshot())._unsafeUnwrap()))._unsafeUnwrap()
@@ -205,6 +208,9 @@ describe('Multi peer sync engine', () => {
 
     const engine2 = new Engine(testDb2, network);
     const syncEngine2 = new SyncEngine(engine2, testDb2);
+
+    // Add the signer custody event to engine 2
+    await engine2.mergeIdRegistryEvent(custodyEvent);
 
     // Sync engine 2 with engine 1
     await syncEngine2.performSync((await syncEngine1.getSnapshot())._unsafeUnwrap(), clientForServer1);
@@ -313,6 +319,8 @@ describe('Multi peer sync engine', () => {
 
     // Create a new sync engine with a new test db
     const engine2 = new Engine(testDb2, network);
+    await engine2.mergeIdRegistryEvent(custodyEvent);
+
     const syncEngine2 = new SyncEngine(engine2, testDb2);
     await syncEngine2.initialize();
 


### PR DESCRIPTION
## Motivation

Missing IdRegistry events during sync should be retried from the RPC provider instead of fetching it unverified from the peer. 

Fixes #767 

## Change Summary

- If a missing IdRegistryEvent is detected, fetch it from the RPC provider
- Verify peer's IP address (and don't crash)

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
