### PR TITLE
fix: Retry bootstrap nodes if they fail to connect at startup

### DIFF
--- a/.changeset/quick-donuts-shave.md
+++ b/.changeset/quick-donuts-shave.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Retry bootstrap nodes if all fail to connect

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -403,6 +403,8 @@ export class Hub implements HubInterface {
     this.pruneMessagesJobScheduler.stop();
     this.periodSyncJobScheduler.stop();
     this.pruneEventsJobScheduler.stop();
+    this.testDataJobScheduler?.stop();
+    this.updateNameRegistryEventExpiryJobWorker?.stop();
 
     // Stop the ETH registry provider
     if (this.ethRegistryProvider) {

--- a/apps/hubble/src/network/p2p/periodicPeerCheck.ts
+++ b/apps/hubble/src/network/p2p/periodicPeerCheck.ts
@@ -1,0 +1,49 @@
+import { Multiaddr } from '@multiformats/multiaddr';
+import { logger } from '~/utils/logger';
+import cron from 'node-cron';
+import { GossipNode } from './gossipNode';
+
+const log = logger.child({
+  component: 'PeriodicSyncJob',
+});
+
+type SchedulerStatus = 'started' | 'stopped';
+
+// Every 2 minutes, at 00:45 seconds, to avoid clashing with the prune job
+const DEFAULT_PERIODIC_PEER_CHECK_CRON = '*/5 * * * *';
+
+export class PeriodicPeerCheckScheduler {
+  private _bootstrapPeers: Multiaddr[];
+  private _gossipNode: GossipNode;
+
+  private _cronTask?: cron.ScheduledTask;
+
+  constructor(_gossipNode: GossipNode, _bootstrapPeers: Multiaddr[]) {
+    this._bootstrapPeers = _bootstrapPeers;
+    this._gossipNode = _gossipNode;
+  }
+
+  start(cronSchedule?: string) {
+    this._cronTask = cron.schedule(cronSchedule ?? DEFAULT_PERIODIC_PEER_CHECK_CRON, () => {
+      return this.doJobs();
+    });
+  }
+
+  stop() {
+    if (this._cronTask) {
+      return this._cronTask.stop();
+    }
+  }
+
+  status(): SchedulerStatus {
+    return this._cronTask ? 'started' : 'stopped';
+  }
+
+  async doJobs() {
+    // If there are no peers, try to connect to the bootstrap peers
+    const result = await this._gossipNode.bootstrap(this._bootstrapPeers);
+    if (result.isErr()) {
+      log.warn({ err: result.error }, 'No Connected Peers');
+    }
+  }
+}

--- a/apps/hubble/src/network/sync/periodicSyncJob.ts
+++ b/apps/hubble/src/network/sync/periodicSyncJob.ts
@@ -11,7 +11,7 @@ const log = logger.child({
 type SchedulerStatus = 'started' | 'stopped';
 
 // Every 2 minutes, at 00:45 seconds, to avoid clashing with the prune job
-const DEFAULT_PERIODIC_JOB_CRON = '45 */2 * * * *';
+const DEFAULT_PERIODIC_SYNC_JOB_CRON = '45 */2 * * * *';
 
 export class PeriodicSyncJobScheduler {
   private _hub: Hub;
@@ -26,7 +26,7 @@ export class PeriodicSyncJobScheduler {
   }
 
   start(cronSchedule?: string) {
-    this._cronTask = cron.schedule(cronSchedule ?? DEFAULT_PERIODIC_JOB_CRON, () => {
+    this._cronTask = cron.schedule(cronSchedule ?? DEFAULT_PERIODIC_SYNC_JOB_CRON, () => {
       return this.doJobs();
     });
   }


### PR DESCRIPTION
## Motivation

If all bootstrap nodes fail to connect, we should retry them 

## Change Summary

- Retry bootstrap nodes if no connections
- Check if we have peers every 5 minutes

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
