### PR TITLE
fix: Prevent slow subscribers from crashing the hub

### DIFF
--- a/.changeset/pretty-llamas-grow.md
+++ b/.changeset/pretty-llamas-grow.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Write events to subscribe() with a timeout to prevent slow clients from clogging up memory


### PR DESCRIPTION
## Motivation

When clients don't consume events from the subscribe() RPC fast enough, pending writes to the grpc stream can clog up memory, crashing the client. 

## Change Summary

- Write to subscribers with a timeout of 10s
- Close stream if a event subscriber is too slow. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
