### PR TITLE
fix: End iterator if returning early from forEachMessage

### DIFF
--- a/.changeset/little-bats-lick.md
+++ b/.changeset/little-bats-lick.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+End iterator in while rebulding trie

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -301,9 +301,11 @@ class Engine {
 
   async forEachMessage(callback: (message: protobufs.Message, key: Buffer) => Promise<boolean | void>): Promise<void> {
     const allUserPrefix = Buffer.from([RootPrefix.User]);
+    const iterator = this._db.iteratorByPrefix(allUserPrefix, { keys: true });
 
-    for await (const [key, value] of this._db.iteratorByPrefix(allUserPrefix, { keys: true })) {
+    for await (const [key, value] of iterator) {
       if (!key || !value) {
+        await iterator.end();
         break;
       }
 
@@ -334,6 +336,7 @@ class Engine {
       if (message.isOk()) {
         const done = await callback(message.value, key);
         if (done) {
+          await iterator.end();
           break;
         }
       }


### PR DESCRIPTION
## Motivation

Fix issue where iterator was not ended

## Change Summary

end iterator if returning early from forEachMessage

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
