### PR TITLE
feat: ignore hubs below minimum version for sync

### DIFF
--- a/.changeset/tasty-grapes-decide.md
+++ b/.changeset/tasty-grapes-decide.md
@@ -1,0 +1,6 @@
+---
+'@farcaster/protobufs': patch
+'@farcaster/hubble': patch
+---
+
+Ignore outdated hubs for sync

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -50,7 +50,7 @@ import {
   p2pMultiAddrStr,
 } from '~/utils/p2p';
 import { PeriodicTestDataJobScheduler, TestUser } from '~/utils/periodicTestDataJob';
-import { VersionSchedule } from '~/utils/versions';
+import { isBelowMinFarcasterVersion, VersionSchedule } from '~/utils/versions';
 import { CheckFarcasterVersionJobScheduler } from '~/storage/jobs/checkFarcasterVersionJob';
 import { ValidateOrRevokeMessagesJobScheduler } from '~/storage/jobs/validateOrRevokeMessagesJob';
 
@@ -394,6 +394,7 @@ export class Hub implements HubInterface {
         rpcAddress: rpcAddressContactInfo,
         excludedHashes: snapshot.excludedHashes,
         count: snapshot.numMessages,
+        hubVersion: FARCASTER_VERSION,
       });
     });
   }
@@ -519,6 +520,13 @@ export class Hub implements HubInterface {
           { error: p2pMultiAddrResult.value.error, message, address: addressInfo.value },
           'failed to parse multiaddr'
         );
+        return;
+      }
+
+      // Ignore peers that are below the minimum supported version.
+      const theirVersion = message.hubVersion;
+      if (isBelowMinFarcasterVersion(theirVersion)) {
+        log.warn({ peerId, theirVersion }, 'Peer is running an outdated version, ignoring');
         return;
       }
 

--- a/apps/hubble/src/utils/versions.test.ts
+++ b/apps/hubble/src/utils/versions.test.ts
@@ -6,14 +6,14 @@ describe('versions tests', () => {
   describe('isBelowMinFarcasterVersion', () => {
     test('returns false if version is equal to min version', () => {
       const minVersion = getMinFarcasterVersion();
-      const result = isBelowMinFarcasterVersion(minVersion.value);
+      const result = isBelowMinFarcasterVersion(minVersion._unsafeUnwrap());
       expect(result).toEqual(ok(false));
     });
 
     test('returns false if version is greater than min version', () => {
       const minVersion = getMinFarcasterVersion();
-      const higherVersion = semver.inc(minVersion.value, 'patch');
-      const result = isBelowMinFarcasterVersion(higherVersion);
+      const higherVersion = semver.inc(minVersion._unsafeUnwrap(), 'patch');
+      const result = isBelowMinFarcasterVersion(higherVersion!);
       expect(result).toEqual(ok(false));
     });
 

--- a/apps/hubble/src/utils/versions.test.ts
+++ b/apps/hubble/src/utils/versions.test.ts
@@ -1,0 +1,26 @@
+import semver from 'semver';
+import { getMinFarcasterVersion, isBelowMinFarcasterVersion } from '~/utils/versions';
+import { ok } from 'neverthrow';
+
+describe('versions tests', () => {
+  describe('isBelowMinFarcasterVersion', () => {
+    test('returns false if version is equal to min version', () => {
+      const minVersion = getMinFarcasterVersion();
+      const result = isBelowMinFarcasterVersion(minVersion.value);
+      expect(result).toEqual(ok(false));
+    });
+
+    test('returns false if version is greater than min version', () => {
+      const minVersion = getMinFarcasterVersion();
+      const higherVersion = semver.inc(minVersion.value, 'patch');
+      const result = isBelowMinFarcasterVersion(higherVersion);
+      expect(result).toEqual(ok(false));
+    });
+
+    test('returns true if version is below min version', () => {
+      const theirVersion = '2023.1.1';
+      const result = isBelowMinFarcasterVersion(theirVersion);
+      expect(result).toEqual(ok(true));
+    });
+  });
+});

--- a/apps/hubble/src/utils/versions.ts
+++ b/apps/hubble/src/utils/versions.ts
@@ -1,4 +1,5 @@
 import { ok, err } from 'neverthrow';
+import semver from 'semver';
 import { HubError, HubResult } from '@farcaster/utils';
 import { FARCASTER_VERSIONS_SCHEDULE } from '~/hubble';
 
@@ -14,4 +15,13 @@ export const getMinFarcasterVersion = (): HubResult<string> => {
   }
 
   return err(new HubError('unavailable', 'no minimum Farcaster version available'));
+};
+
+export const isBelowMinFarcasterVersion = (version: string): HubResult<boolean> => {
+  const minVersion = getMinFarcasterVersion();
+  if (minVersion.isErr()) {
+    return err(minVersion.error);
+  }
+
+  return ok(semver.lt(version, minVersion.value));
 };

--- a/packages/protobufs/src/generated/gossip.ts
+++ b/packages/protobufs/src/generated/gossip.ts
@@ -38,6 +38,7 @@ export interface ContactInfoContent {
   rpcAddress: GossipAddressInfo | undefined;
   excludedHashes: string[];
   count: number;
+  hubVersion: string;
 }
 
 export interface GossipMessage {
@@ -130,7 +131,7 @@ export const GossipAddressInfo = {
 };
 
 function createBaseContactInfoContent(): ContactInfoContent {
-  return { gossipAddress: undefined, rpcAddress: undefined, excludedHashes: [], count: 0 };
+  return { gossipAddress: undefined, rpcAddress: undefined, excludedHashes: [], count: 0, hubVersion: '' };
 }
 
 export const ContactInfoContent = {
@@ -146,6 +147,9 @@ export const ContactInfoContent = {
     }
     if (message.count !== 0) {
       writer.uint32(32).uint32(message.count);
+    }
+    if (message.hubVersion !== '') {
+      writer.uint32(42).string(message.hubVersion);
     }
     return writer;
   },
@@ -169,6 +173,9 @@ export const ContactInfoContent = {
         case 4:
           message.count = reader.uint32();
           break;
+        case 5:
+          message.hubVersion = reader.string();
+          break;
         default:
           reader.skipType(tag & 7);
           break;
@@ -183,6 +190,7 @@ export const ContactInfoContent = {
       rpcAddress: isSet(object.rpcAddress) ? GossipAddressInfo.fromJSON(object.rpcAddress) : undefined,
       excludedHashes: Array.isArray(object?.excludedHashes) ? object.excludedHashes.map((e: any) => String(e)) : [],
       count: isSet(object.count) ? Number(object.count) : 0,
+      hubVersion: isSet(object.hubVersion) ? String(object.hubVersion) : '',
     };
   },
 
@@ -198,6 +206,7 @@ export const ContactInfoContent = {
       obj.excludedHashes = [];
     }
     message.count !== undefined && (obj.count = Math.round(message.count));
+    message.hubVersion !== undefined && (obj.hubVersion = message.hubVersion);
     return obj;
   },
 
@@ -217,6 +226,7 @@ export const ContactInfoContent = {
         : undefined;
     message.excludedHashes = object.excludedHashes?.map((e) => e) || [];
     message.count = object.count ?? 0;
+    message.hubVersion = object.hubVersion ?? '';
     return message;
   },
 };

--- a/packages/protobufs/src/schemas/gossip.proto
+++ b/packages/protobufs/src/schemas/gossip.proto
@@ -19,6 +19,7 @@ message ContactInfoContent {
   GossipAddressInfo rpc_address = 2;
   repeated string excluded_hashes = 3;
   uint32 count = 4;
+  string hub_version = 5;
 }
 
 message GossipMessage {


### PR DESCRIPTION
## Motivation

followup to [expire hubs](https://github.com/farcasterxyz/hub-monorepo/pull/795)


## Change Summary

Ignore outdated hubs when syncing

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
