### PR TITLE
fix: Start the rpc Server before the ethEventsProvider for smoke test

### DIFF
--- a/.changeset/chilled-cats-wave.md
+++ b/.changeset/chilled-cats-wave.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Start rpcServer before ethEventsProvider

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -327,6 +327,12 @@ export class Hub implements HubInterface {
 
     await this.engine.start();
 
+    // Start the RPC server
+    await this.rpcServer.start(this.options.rpcServerHost, this.options.rpcPort ? this.options.rpcPort : 0);
+    if (this.options.adminServerEnabled) {
+      await this.adminServer.start(this.options.adminServerHost ?? '127.0.0.1');
+    }
+
     // Start the ETH registry provider first
     if (this.ethRegistryProvider) {
       await this.ethRegistryProvider.start();
@@ -347,11 +353,6 @@ export class Hub implements HubInterface {
       allowedPeerIdStrs: this.options.allowedPeers,
     });
 
-    // Start the RPC server
-    await this.rpcServer.start(this.options.rpcServerHost, this.options.rpcPort ? this.options.rpcPort : 0);
-    if (this.options.adminServerEnabled) {
-      await this.adminServer.start(this.options.adminServerHost ?? '127.0.0.1');
-    }
     this.registerEventHandlers();
 
     // Start cron tasks


### PR DESCRIPTION
## Motivation

To enable the smoke test to run, we should start the rpcServer before the ethEventsProvider

## Change Summary

Change startup order
- rpcServer
- ethEventsProvider
- SyncEngine

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
