### PR TITLE
feat: allow client to subscribe from 0 fromId

### DIFF
--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -777,7 +777,7 @@ export default class Server {
         });
 
         // If the user wants to start from a specific event, we'll start from there first
-        if (this.engine && request.fromId) {
+        if (this.engine && request.fromId !== undefined && request.fromId >= 0) {
           const eventsIterator = this.engine.eventHandler.getEventsIterator({ fromId: request.fromId });
           if (eventsIterator.isErr()) {
             stream.destroy(eventsIterator.error);

--- a/apps/hubble/src/rpc/test/eventService.test.ts
+++ b/apps/hubble/src/rpc/test/eventService.test.ts
@@ -194,6 +194,18 @@ describe('subscribe', () => {
         [HubEventType.MERGE_MESSAGE, Message.toJSON(signerAdd)],
       ]);
     });
+
+    test('emits events with fromId of 0', async () => {
+      await engine.mergeIdRegistryEvent(custodyEvent);
+      await engine.mergeMessage(signerAdd);
+
+      stream = await setupSubscription(events, { fromId: 0 });
+
+      expect(events).toEqual([
+        [HubEventType.MERGE_ID_REGISTRY_EVENT, IdRegistryEvent.toJSON(custodyEvent)],
+        [HubEventType.MERGE_MESSAGE, Message.toJSON(signerAdd)],
+      ]);
+    });
   });
 
   describe('with fromId and type filters', () => {


### PR DESCRIPTION
## Motivation

It's annoying right now that you have to start with `fromId: 1` to get all hub events.

## Change Summary

* Support `fromId` of 0 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
