### PR TITLE
chore: enable getSSLHubRpcClient

### DIFF
--- a/.changeset/neat-dingos-fry.md
+++ b/.changeset/neat-dingos-fry.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hub-web': patch
+---
+
+enable getSSLHubRpcClient

--- a/packages/hub-web/src/client.ts
+++ b/packages/hub-web/src/client.ts
@@ -81,12 +81,9 @@ const wrapClient = <C extends object>(client: C) => {
 
 export type HubRpcClient = WrappedClient<HubService>;
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
 export const getSSLHubRpcClient = (address: string, isBrowser = true): HubRpcClient => {
-  throw new Error('getSSLHubRpcClient not implemented');
-  // return wrapClient(new HubServiceClientImpl(getRpcWebClient('https://' + address, isBrowser)));
+  return wrapClient(new HubServiceClientImpl(getRpcWebClient('https://' + address, isBrowser)));
 };
-/* eslint-enable @typescript-eslint/no-unused-vars */
 
 export const getInsecureHubRpcClient = (address: string, isBrowser = true): HubRpcClient => {
   return wrapClient(new HubServiceClientImpl(getRpcWebClient('http://' + address, isBrowser)));


### PR DESCRIPTION
## Motivation

enable getSSLHubRpcClient for hub-web

## Change Summary

enable getSSLHubRpcClient for hub-web

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

