### PR TITLE
Update envoy.yaml to fix Python gRPC error

### DIFF
--- a/apps/hubble/envoy/envoy.yaml
+++ b/apps/hubble/envoy/envoy.yaml
@@ -62,3 +62,8 @@ static_resources:
                       address: 0.0.0.0
                       # update the value to the port of rpc server
                       port_value: 2283
+      tls_context:
+        common_tls_context:
+          # https://stackoverflow.com/questions/69444526/python-grpc-failed-to-pick-subchannel
+          tls_certificates:
+            alpn_protocols: ["h2"]


### PR DESCRIPTION
## Motivation

Using gRPC 1.53.0 I get this error while trying to connect to testnet1.farcaster.xyz:2283:
```
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
        status = StatusCode.UNAVAILABLE
        details = "failed to connect to all addresses; last error: UNKNOWN: ipv4:52.207.28.61:2283: Cannot check peer: missing selected ALPN property."
        debug_error_string = "UNKNOWN:failed to connect to all addresses; last error: UNKNOWN: ipv4:52.207.28.61:2283: Cannot check peer: missing selected ALPN property. {grpc_status:14, created_time:"2023-04-05T20:42:06.658276-07:00"}"
```

## Change Summary

I'm implementing the fix described in this StackOverflow thread: 
https://stackoverflow.com/questions/69444526/python-grpc-failed-to-pick-subchannel

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)