### PR TITLE
fix: map grpc error codes to hub error codes

### DIFF
--- a/.changeset/light-gifts-remember.md
+++ b/.changeset/light-gifts-remember.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hub-web': patch
+---
+
+map grpc codes to hub error codes in client


### PR DESCRIPTION
## Change Summary

Small fix to the hub-web client to ensure we're mapping grpc codes to valid hub error codes

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
