### PR TITLE
fix: handle invalid version strings

### DIFF
--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -48,7 +48,7 @@ import {
   p2pMultiAddrStr,
 } from '~/utils/p2p';
 import { PeriodicTestDataJobScheduler, TestUser } from '~/utils/periodicTestDataJob';
-import { isBelowMinFarcasterVersion, VersionSchedule } from '~/utils/versions';
+import { ensureAboveMinFarcasterVersion, VersionSchedule } from '~/utils/versions';
 import { CheckFarcasterVersionJobScheduler } from '~/storage/jobs/checkFarcasterVersionJob';
 import { ValidateOrRevokeMessagesJobScheduler } from '~/storage/jobs/validateOrRevokeMessagesJob';
 import { GossipContactInfoJobScheduler } from '~/storage/jobs/gossipContactInfoJob';
@@ -545,9 +545,9 @@ export class Hub implements HubInterface {
 
       // Ignore peers that are below the minimum supported version.
       const theirVersion = message.hubVersion;
-      const versionCheckResult = isBelowMinFarcasterVersion(theirVersion);
-      if (versionCheckResult.isErr() || (versionCheckResult.isOk() && !versionCheckResult.value)) {
-        log.warn({ peerId, theirVersion }, 'Peer is running an outdated version, ignoring');
+      const versionCheckResult = ensureAboveMinFarcasterVersion(theirVersion);
+      if (versionCheckResult.isErr()) {
+        log.warn({ peerId, theirVersion }, 'Peer is running an invalid or outdated version, ignoring');
         await this.gossipNode.removePeerFromAddressBook(peerId);
         this.syncEngine.removeContactInfoForPeerId(peerId.toString());
         return;

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -545,7 +545,8 @@ export class Hub implements HubInterface {
 
       // Ignore peers that are below the minimum supported version.
       const theirVersion = message.hubVersion;
-      if (isBelowMinFarcasterVersion(theirVersion)) {
+      const versionCheckResult = isBelowMinFarcasterVersion(theirVersion);
+      if (versionCheckResult.isErr() || (versionCheckResult.isOk() && !versionCheckResult.value)) {
         log.warn({ peerId, theirVersion }, 'Peer is running an outdated version, ignoring');
         await this.gossipNode.removePeerFromAddressBook(peerId);
         this.syncEngine.removeContactInfoForPeerId(peerId.toString());

--- a/apps/hubble/src/utils/versions.test.ts
+++ b/apps/hubble/src/utils/versions.test.ts
@@ -1,30 +1,31 @@
 import semver from 'semver';
-import { getMinFarcasterVersion, isBelowMinFarcasterVersion } from '~/utils/versions';
+import { getMinFarcasterVersion, ensureAboveMinFarcasterVersion } from '~/utils/versions';
 import { ok } from 'neverthrow';
 
 describe('versions tests', () => {
   describe('isBelowMinFarcasterVersion', () => {
-    test('returns false if version is equal to min version', () => {
+    test('returns ok if version is equal to min version', () => {
       const minVersion = getMinFarcasterVersion();
-      const result = isBelowMinFarcasterVersion(minVersion._unsafeUnwrap());
-      expect(result).toEqual(ok(false));
+      const result = ensureAboveMinFarcasterVersion(minVersion._unsafeUnwrap());
+      expect(result).toEqual(ok(undefined));
     });
 
-    test('returns false if version is greater than min version', () => {
+    test('returns ok if version is greater than min version', () => {
       const minVersion = getMinFarcasterVersion();
       const higherVersion = semver.inc(minVersion._unsafeUnwrap(), 'patch');
-      const result = isBelowMinFarcasterVersion(higherVersion!);
-      expect(result).toEqual(ok(false));
+      const result = ensureAboveMinFarcasterVersion(higherVersion!);
+      expect(result).toEqual(ok(undefined));
     });
 
-    test('returns true if version is below min version', () => {
+    test('returns err if version is below min version', () => {
       const theirVersion = '2023.1.1';
-      const result = isBelowMinFarcasterVersion(theirVersion);
-      expect(result).toEqual(ok(true));
+      const result = ensureAboveMinFarcasterVersion(theirVersion);
+      expect(result.isErr()).toBeTruthy();
+      expect(result._unsafeUnwrapErr().message).toEqual('version too low');
     });
 
     test('returns err if version is empty', () => {
-      const result = isBelowMinFarcasterVersion('');
+      const result = ensureAboveMinFarcasterVersion('');
       expect(result.isErr()).toBeTruthy();
       expect(result._unsafeUnwrapErr().message).toEqual('invalid version');
     });

--- a/apps/hubble/src/utils/versions.test.ts
+++ b/apps/hubble/src/utils/versions.test.ts
@@ -22,5 +22,11 @@ describe('versions tests', () => {
       const result = isBelowMinFarcasterVersion(theirVersion);
       expect(result).toEqual(ok(true));
     });
+
+    test('returns err if version is empty', () => {
+      const result = isBelowMinFarcasterVersion('');
+      expect(result.isErr()).toBeTruthy();
+      expect(result._unsafeUnwrapErr().message).toEqual('invalid version');
+    });
   });
 });

--- a/apps/hubble/src/utils/versions.ts
+++ b/apps/hubble/src/utils/versions.ts
@@ -17,7 +17,7 @@ export const getMinFarcasterVersion = (): HubResult<string> => {
   return err(new HubError('unavailable', 'no minimum Farcaster version available'));
 };
 
-export const isBelowMinFarcasterVersion = (version: string): HubResult<boolean> => {
+export const ensureAboveMinFarcasterVersion = (version: string): HubResult<void> => {
   const minVersion = getMinFarcasterVersion();
   if (minVersion.isErr()) {
     return err(minVersion.error);
@@ -27,5 +27,8 @@ export const isBelowMinFarcasterVersion = (version: string): HubResult<boolean> 
     return err(new HubError('bad_request.invalid_param', 'invalid version'));
   }
 
-  return ok(semver.lt(version, minVersion.value));
+  if (semver.lt(version, minVersion.value)) {
+    return err(new HubError('bad_request.validation_failure', 'version too low'));
+  }
+  return ok(undefined);
 };

--- a/apps/hubble/src/utils/versions.ts
+++ b/apps/hubble/src/utils/versions.ts
@@ -23,5 +23,9 @@ export const isBelowMinFarcasterVersion = (version: string): HubResult<boolean> 
     return err(minVersion.error);
   }
 
+  if (!semver.valid(version)) {
+    return err(new HubError('bad_request.invalid_param', 'invalid version'));
+  }
+
   return ok(semver.lt(version, minVersion.value));
 };


### PR DESCRIPTION
## Motivation

Fixes hub crashing when version is empty

## Change Summary

Version can be empty for older hub versions.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
