### PR TITLE
docs: update examples for making casts and writing data

### DIFF
--- a/packages/hub-nodejs/examples/make-cast/index.ts
+++ b/packages/hub-nodejs/examples/make-cast/index.ts
@@ -7,16 +7,20 @@ import * as ed from '@noble/ed25519';
 
 const HUB_URL = process.env['HUB_ADDR'] || ''; // URL of the Hub
 
+// If the Hub requests authentication, set the following constants
+// const HUB_USERNAME = process.env['HUB_USERNAME'] || '';
+// const HUB_PASSWORD = process.env['HUB_PASSWORD'] || '';
+
 (async () => {
   /**
    * This should be set to the private key of a known signer for the user, instead of randomly generating
-   * one, or the Hubs will reject the message. See the make-data tutorial for examples of how to do this.
+   * one, or the Hubs will reject the message. See the write-data tutorial for examples of how to do this.
    */
   const privateKey = ed.utils.randomPrivateKey();
   const ed25519Signer = new NobleEd25519Signer(privateKey);
 
   const dataOptions = {
-    fid: 1,
+    fid: 1, // Set to your fid.
     network: FarcasterNetwork.DEVNET,
   };
 
@@ -150,6 +154,10 @@ const HUB_URL = process.env['HUB_ADDR'] || ''; // URL of the Hub
   // If your Hub is using SSL, use getSSLHubRpcClient instead
 
   castResults.map((castAddResult) => castAddResult.map((castAdd) => client.submitMessage(castAdd)));
+
+  // If your Hub requires authentication, use the following instead:
+  // const authMetadata = getAuthMetadata(HUB_USERNAME, HUB_PASSWORD);
+  // castResults.map((castAddResult) => castAddResult.map((castAdd) => client.submitMessage(castAdd, authMetadata)));
 
   client.close();
 })();

--- a/packages/hub-nodejs/examples/write-data/index.ts
+++ b/packages/hub-nodejs/examples/write-data/index.ts
@@ -16,7 +16,11 @@ import { Wallet } from 'ethers';
  * Populate the following constants with your own values
  */
 
-const HUB_URL = process.env['HUB_ADDR'] || ''; // URL of the Hub
+const HUB_URL = process.env['HUB_ADDR'] || ''; // URL of the Hub - make sure to include port 2283
+
+// If the Hub requests authentication, set the following constants
+// const HUB_USERNAME = process.env['HUB_USERNAME'] || '';
+// const HUB_PASSWORD = process.env['HUB_PASSWORD'] || '';
 
 (async () => {
   /**
@@ -58,6 +62,10 @@ const HUB_URL = process.env['HUB_ADDR'] || ''; // URL of the Hub
 
   const client = getInsecureHubRpcClient(HUB_URL);
   // const client = getSSLHubRpcClient(HUB_URL); if you want to use SSL
+
+  // If your Hub requires authentication, use the following instead:
+  // const authMetadata = getAuthMetadata(HUB_USERNAME, HUB_PASSWORD);
+  // const result = await client.submitMessage(signerAdd);
 
   const result = await client.submitMessage(signerAdd);
   result.isOk() ? console.log('SignerAdd was published successfully!') : console.log(result.error);


### PR DESCRIPTION
## Motivation

Update example code `make-cast/index.ts` and `write-data/index.ts` to support reaching hubs with authentication

## Change Summary

When hubs require username and password, `client.submitMessage` requires an `authMetadata` object. It isn't obvious in the samples how to do this, but it would make it a lot easier if the samples included this. 

I commented out any `authMetadata` code but it can sit there in case someone needs to reference it when they try and replicate the `write-data` process, but not sure if the commented code is a problematic way to add this documentation

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

N/A
