### PR TITLE
chore: Add test to ensure verification and claim must have same network

### DIFF
--- a/packages/core/src/factories.ts
+++ b/packages/core/src/factories.ts
@@ -378,15 +378,12 @@ const VerificationAddEthAddressBodyFactory = Factory.define<
       const fid = transientParams.fid ?? FidFactory.build();
       const network = transientParams.network ?? FarcasterNetworkFactory.build();
       const blockHash = bytesToHexString(body.blockHash);
-      const claim = VerificationEthAddressClaimFactory.build(
-        {
-          fid: BigInt(fid),
-          network,
-          blockHash: blockHash.isOk() ? blockHash.value : '0x',
-          address: bytesToHexString(body.address)._unsafeUnwrap(),
-        },
-        { transient: { signer: ethSigner } }
-      );
+      const claim = VerificationEthAddressClaimFactory.build({
+        fid: BigInt(fid),
+        network,
+        blockHash: blockHash.isOk() ? blockHash.value : '0x',
+        address: bytesToHexString(body.address)._unsafeUnwrap(),
+      });
       body.ethSignature = (await ethSigner.signVerificationEthAddressClaim(claim))._unsafeUnwrap();
     }
 


### PR DESCRIPTION
## Motivation

Closes https://github.com/farcasterxyz/hub-monorepo/issues/737

## Change Summary

Add a test to make sure it's not possible to pass in a different network in the claim vs the verification and have it pass.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
