### PR TITLE
feat: ensure hub networks match when syncing with peers

### DIFF
--- a/.changeset/eighty-buckets-shout.md
+++ b/.changeset/eighty-buckets-shout.md
@@ -1,0 +1,6 @@
+---
+'@farcaster/core': patch
+'@farcaster/hubble': patch
+---
+
+Ensure hub networks match when syncing with peers

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -546,8 +546,11 @@ export class Hub implements HubInterface {
       // Ignore peers that are below the minimum supported version.
       const theirVersion = message.hubVersion;
       const versionCheckResult = ensureAboveMinFarcasterVersion(theirVersion);
-      if (versionCheckResult.isErr()) {
-        log.warn({ peerId, theirVersion }, 'Peer is running an invalid or outdated version, ignoring');
+      if (versionCheckResult.isErr() || message.network !== this.options.network) {
+        log.warn(
+          { peerId, theirVersion, theirNetwork: message.network },
+          'Peer is running an invalid or outdated version, ignoring'
+        );
         await this.gossipNode.removePeerFromAddressBook(peerId);
         this.syncEngine.removeContactInfoForPeerId(peerId.toString());
         return;

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -398,6 +398,7 @@ export class Hub implements HubInterface {
         excludedHashes: snapshot.excludedHashes,
         count: snapshot.numMessages,
         hubVersion: FARCASTER_VERSION,
+        network: this.options.network,
       });
     });
   }

--- a/packages/core/src/protobufs/generated/gossip.ts
+++ b/packages/core/src/protobufs/generated/gossip.ts
@@ -1,7 +1,7 @@
 /* eslint-disable */
 import _m0 from 'protobufjs/minimal';
 import { IdRegistryEvent } from './id_registry_event';
-import { Message } from './message';
+import { FarcasterNetwork, farcasterNetworkFromJSON, farcasterNetworkToJSON, Message } from './message';
 
 export enum GossipVersion {
   V1 = 0,
@@ -39,6 +39,7 @@ export interface ContactInfoContent {
   excludedHashes: string[];
   count: number;
   hubVersion: string;
+  network: FarcasterNetwork;
 }
 
 export interface GossipMessage {
@@ -148,7 +149,7 @@ export const GossipAddressInfo = {
 };
 
 function createBaseContactInfoContent(): ContactInfoContent {
-  return { gossipAddress: undefined, rpcAddress: undefined, excludedHashes: [], count: 0, hubVersion: '' };
+  return { gossipAddress: undefined, rpcAddress: undefined, excludedHashes: [], count: 0, hubVersion: '', network: 0 };
 }
 
 export const ContactInfoContent = {
@@ -167,6 +168,9 @@ export const ContactInfoContent = {
     }
     if (message.hubVersion !== '') {
       writer.uint32(42).string(message.hubVersion);
+    }
+    if (message.network !== 0) {
+      writer.uint32(48).int32(message.network);
     }
     return writer;
   },
@@ -213,6 +217,13 @@ export const ContactInfoContent = {
 
           message.hubVersion = reader.string();
           continue;
+        case 6:
+          if (tag != 48) {
+            break;
+          }
+
+          message.network = reader.int32() as any;
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -229,6 +240,7 @@ export const ContactInfoContent = {
       excludedHashes: Array.isArray(object?.excludedHashes) ? object.excludedHashes.map((e: any) => String(e)) : [],
       count: isSet(object.count) ? Number(object.count) : 0,
       hubVersion: isSet(object.hubVersion) ? String(object.hubVersion) : '',
+      network: isSet(object.network) ? farcasterNetworkFromJSON(object.network) : 0,
     };
   },
 
@@ -245,6 +257,7 @@ export const ContactInfoContent = {
     }
     message.count !== undefined && (obj.count = Math.round(message.count));
     message.hubVersion !== undefined && (obj.hubVersion = message.hubVersion);
+    message.network !== undefined && (obj.network = farcasterNetworkToJSON(message.network));
     return obj;
   },
 
@@ -265,6 +278,7 @@ export const ContactInfoContent = {
     message.excludedHashes = object.excludedHashes?.map((e) => e) || [];
     message.count = object.count ?? 0;
     message.hubVersion = object.hubVersion ?? '';
+    message.network = object.network ?? 0;
     return message;
   },
 };

--- a/protobufs/schemas/gossip.proto
+++ b/protobufs/schemas/gossip.proto
@@ -20,6 +20,7 @@ message ContactInfoContent {
   repeated string excluded_hashes = 3;
   uint32 count = 4;
   string hub_version = 5;
+  FarcasterNetwork network = 6;
 }
 
 message GossipMessage {


### PR DESCRIPTION
## Motivation

Fixes: https://github.com/farcasterxyz/hub-monorepo/issues/835. Prevents testnet hubs from accidentally syncing mainnet and vice versa

## Change Summary

Check the peer hubs network and make sure it matches ours before syncing

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
