### PR TITLE
fix: Make dbreset its own command

### DIFF
--- a/.changeset/modern-houses-matter.md
+++ b/.changeset/modern-houses-matter.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Make dbreset its own command

--- a/apps/hubble/.config/hub.config.ts
+++ b/apps/hubble/.config/hub.config.ts
@@ -39,8 +39,6 @@ export const Config = {
   rpcRateLimit: 20000,
   /** The name of the RocksDB instance */
   dbName: 'rocks.hub._default',
-  /** Clear the RocksDB instance before starting */
-  dbReset: false,
   /** Rebuild the sync trie before starting */
   rebuildSyncTrie: false,
   /** Farcaster network */

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -23,6 +23,7 @@
     "lint:fix": "yarn run lint -- --fix",
     "start": "tsx src/cli.ts start",
     "identity": "tsx src/cli.ts identity",
+    "dbreset": "tsx src/cli.ts dbreset",
     "console": "tsx src/cli.ts console",
     "test": "yarn build && NODE_OPTIONS=--experimental-vm-modules jest",
     "test:ci": "ENVIRONMENT=test NODE_OPTIONS=--experimental-vm-modules jest --ci --forceExit --coverage"


### PR DESCRIPTION
## Motivation

make dbreset its own command

## Change Summary

Remove --db-reset arg
Add dbreset command

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
