### PR TITLE
fix: Hangup on peers when removing from address book

### DIFF
--- a/.changeset/tiny-pots-collect.md
+++ b/.changeset/tiny-pots-collect.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Hangup on peer when removing from address book.

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -321,7 +321,7 @@ export class Hub implements HubInterface {
       throw new HubError(
         'unavailable',
         `network mismatch: DB is ${dbNetworkResult.value}, but Hub is started with ${this.options.network}. ` +
-          `Please reset the DB with --db-reset if this is intentional.`
+          `Please reset the DB with the "dbreset" command if this is intentional.`
       );
     }
 

--- a/apps/hubble/src/network/p2p/gossipNode.test.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.test.ts
@@ -14,6 +14,7 @@ import { jestRocksDB } from '~/storage/db/jestUtils';
 import Engine from '~/storage/engine';
 import { MockHub } from '~/test/mocks';
 import SyncEngine from '../sync/syncEngine';
+import { PeerId } from '@libp2p/interface-peer-id';
 
 const TEST_TIMEOUT_SHORT = 10 * 1000;
 
@@ -91,6 +92,33 @@ describe('GossipNode', () => {
     },
     TEST_TIMEOUT_SHORT
   );
+
+  test('removing from addressbook hangs up connection', async () => {
+    const node1 = new GossipNode();
+    await node1.start([]);
+
+    const node2 = new GossipNode();
+    await node2.start([]);
+
+    try {
+      const dialResult = await node1.connect(node2);
+      expect(dialResult.isOk()).toBeTruthy();
+
+      let other = await node1.addressBook?.get(node2.peerId as PeerId);
+      expect(other?.length).toEqual(1);
+
+      await node1.removePeerFromAddressBook(node2.peerId as PeerId);
+
+      // Make sure the connection is closed
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      other = await node1.addressBook?.get(node2.peerId as PeerId);
+      expect(other).toEqual([]);
+    } finally {
+      await node1.stop();
+      await node2.stop();
+    }
+  });
 
   describe('gossip messages', () => {
     const db = jestRocksDB('protobufs.rpc.gossipMessageTest.test');

--- a/apps/hubble/src/network/p2p/gossipNode.test.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.test.ts
@@ -15,6 +15,7 @@ import Engine from '~/storage/engine';
 import { MockHub } from '~/test/mocks';
 import SyncEngine from '../sync/syncEngine';
 import { PeerId } from '@libp2p/interface-peer-id';
+import { sleep } from '~/utils/crypto';
 
 const TEST_TIMEOUT_SHORT = 10 * 1000;
 
@@ -109,9 +110,10 @@ describe('GossipNode', () => {
 
       await node1.removePeerFromAddressBook(node2.peerId as PeerId);
 
-      // Make sure the connection is closed
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      // Sleep to allow the connection to be closed
+      await sleep(1000);
 
+      // Make sure the connection is closed
       other = await node1.addressBook?.get(node2.peerId as PeerId);
       expect(other).toEqual([]);
 

--- a/apps/hubble/src/network/p2p/gossipNode.test.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.test.ts
@@ -114,6 +114,9 @@ describe('GossipNode', () => {
 
       other = await node1.addressBook?.get(node2.peerId as PeerId);
       expect(other).toEqual([]);
+
+      other = await node2.addressBook?.get(node1.peerId as PeerId);
+      expect(other).toEqual([]);
     } finally {
       await node1.stop();
       await node2.stop();


### PR DESCRIPTION
## Motivation
Add call to hangup() so we actually disconnect from peers when removing from our addressbook

## Change Summary

- Add hangup() when remove from address book 
- Test

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
