### PR TITLE
chore: Check in mainnet allowed peers

### DIFF
--- a/.changeset/nervous-bats-help.md
+++ b/.changeset/nervous-bats-help.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Check in list of allowed peers on Mainnet

--- a/apps/hubble/src/allowedPeers.mainnet.ts
+++ b/apps/hubble/src/allowedPeers.mainnet.ts
@@ -1,0 +1,20 @@
+// List of peers that are allowed to connect to the mainnet
+export const MAINNET_ALLOWED_PEERS = [
+  '12D3KooWRnSZUxjVJjbSHhVKpXtvibMarSfLSKDBeMpfVaNm1Joo', // hoyt.farcaster.xyz
+  '12D3KooWJECuSHn5edaorpufE9ceAoqR5zcAuD4ThoyDzVaz77GV', // lamia.farcaster.xyz
+  '12D3KooWMQrf6unpGJfLBmTGy3eKTo4cGcXktWRbgMnfbZLXqBbn', // nemes.farcaster.xyz
+  '12D3KooWN9ztVoHYi26NwTDDLNjgBozz479br3pwBuy3oLQVQmhz', // @cassie
+  '12D3KooWHiyvASqvhGn9kqsLBemPTAF6UYEaFGaLUpPxnM54KFbG', // @deodad
+  '12D3KooWFbnaXtbD5fwbMGq2JRjPaj7C6EpZRgaxC8jdtcX7FJbZ', // @v
+  '12D3KooWMDdQaMWCkQ8Gf3C6zdJdMEfFs8R2pw8YQw2HgoY8qhzA', // @adityapk
+  '12D3KooWKwUpms7tgUoVsjQ2uV9g93hS2UiMRUfR8f4xjMtsk1Kq', // @pfh
+  '12D3KooWBWSxYTN1cdjyJqbKzvnaUHf5nEvAm4NfLHQg68QL1czp', // @df
+  '12D3KooWMnmYq2BDGKJ76w5pFyz2c1ZsK8pMvu6wxyg747j3p679', // @eddy
+  '12D3KooWFoPsstYWVH3a4uFpmxksF6nDEsgYizHnPpd9Atw9DRbH', // @gavi
+  '12D3KooWKYqmj1bQJChn4hCAhsneg9sRKRd6Zzp3DkVMUL2pjyAB', // @16
+  '12D3KooWReH654LePzAE4shSw6wuWqP3i9jSN2jBNswWJu2kiPQ5', // @vern
+  '12D3KooWRxgeFVLTAxeVgj4QHPzuT6HaV3Hj93LNZQeRi7gAwUVk', // @stout
+  '12D3KooWSii9GJheDmFRBzii43fpzvb3WkmPn62QSoJ8MjvGKMxr', // @mp
+  '12D3KooWHT3zEUaNtyDX4GKHa5WtfymAJpYS3qZ9vifvAKhMQ6kn', // @brianjckim
+  '12D3KooWRrFF356RALgsPwQQpg68reJL2y94VwKZFogUkM9der1V', // @lndnnft
+];

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -52,6 +52,7 @@ import { ensureAboveMinFarcasterVersion, VersionSchedule } from '~/utils/version
 import { CheckFarcasterVersionJobScheduler } from '~/storage/jobs/checkFarcasterVersionJob';
 import { ValidateOrRevokeMessagesJobScheduler } from '~/storage/jobs/validateOrRevokeMessagesJob';
 import { GossipContactInfoJobScheduler } from '~/storage/jobs/gossipContactInfoJob';
+import { MAINNET_ALLOWED_PEERS } from './allowedPeers.mainnet';
 
 export type HubSubmitSource = 'gossip' | 'rpc' | 'eth-provider';
 
@@ -349,12 +350,19 @@ export class Hub implements HubInterface {
       this.updateNameRegistryEventExpiryJobWorker.start();
     }
 
+    let allowedPeerIdStrs = this.options.allowedPeers;
+    if (this.options.network === FarcasterNetwork.MAINNET) {
+      // Mainnet is right now resitrcited to a few peers
+      // Append and de-dup the allowed peers
+      allowedPeerIdStrs = [...new Set([...(allowedPeerIdStrs ?? []), ...MAINNET_ALLOWED_PEERS])];
+    }
+
     await this.gossipNode.start(this.options.bootstrapAddrs ?? [], {
       peerId: this.options.peerId,
       ipMultiAddr: this.options.ipMultiAddr,
       announceIp: this.options.announceIp,
       gossipPort: this.options.gossipPort,
-      allowedPeerIdStrs: this.options.allowedPeers,
+      allowedPeerIdStrs,
     });
 
     this.registerEventHandlers();


### PR DESCRIPTION
## Motivation

Check in the list of allowed peers for Farcaster Mainnet

## Change Summary

- `allowedPeers.mainnet.ts` now contains a list of allowed mainnet peers

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
