### PR TITLE
docs: correct steps to reset db in hubble readme

### DIFF
--- a/apps/hubble/README.md
+++ b/apps/hubble/README.md
@@ -24,7 +24,7 @@ Hubble can be started in testnet mode where it peers with other hubs. The Farcas
 messages every 10 seconds to make testing easy. To connect to testnet:
 
 1. Run `yarn start -e <eth-rpc-url> -b /dns/testnet1.farcaster.xyz/tcp/2282 -n 2`
-2. Pass `--reset-db` flag on first run, if you've previously connected to devnet or mainnet
+2. If you've previously connected to devnet or mainnet, run `yarn dbreset` to clear the database before starting
 
 #### Connecting to Mainnet
 


### PR DESCRIPTION
## Motivation

Provide easy instructions on how to switch the network a hub is running on.

## Change Summary

Update the hubble readme with the correct instructions on how to reset a rocksdb instance.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
