### PR TITLE
ci: auto-label all new issues with s-triage

### DIFF
--- a/.github/workflows/label_issues.yml
+++ b/.github/workflows/label_issues.yml
@@ -1,0 +1,19 @@
+name: Label Issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add label
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issueNumber = context.issue.number;
+            const repo = context.repo;
+            const labelToAdd = "s-triage";
+            github.issues.addLabels({...repo, issue_number: issueNumber, labels: [labelToAdd]});


### PR DESCRIPTION
## Motivation

Ensures all inbound issues are tagged with a label so that they can be triaged easily. 

## Change Summary

Applies s-triage label to any new issue observed

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a type (i.e. docs, perf, feat, bug, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
