### PR TITLE
feat: Include network id in gossip topics to keep networks isolated

### DIFF
--- a/.changeset/spotty-dryers-kneel.md
+++ b/.changeset/spotty-dryers-kneel.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': minor
+---
+
+Include network id in gossip topics to keep networks isolated

--- a/apps/hubble/src/network/p2p/protocol.ts
+++ b/apps/hubble/src/network/p2p/protocol.ts
@@ -1,16 +1,4 @@
 import { GossipVersion } from '@farcaster/hub-nodejs';
 
-// Network topic for Farcaster Messages
-export const NETWORK_TOPIC_PRIMARY = 'f_network_topic_primary';
-
-// Network topic for Gossip Node ContactInfo messages
-export const NETWORK_TOPIC_CONTACT = 'f_network_topic_contact';
-
-// The rate at which nodes republish ContactInfo
-export const GOSSIP_CONTACT_INTERVAL = 10_000;
-
-// List of all valid Gossip Topics
-export const GOSSIP_TOPICS = [NETWORK_TOPIC_CONTACT, NETWORK_TOPIC_PRIMARY];
-
 // Current gossip protocol version
 export const GOSSIP_PROTOCOL_VERSION = GossipVersion.V1;

--- a/apps/hubble/src/network/utils/factories.ts
+++ b/apps/hubble/src/network/utils/factories.ts
@@ -10,7 +10,6 @@ import {
 import { PeerId } from '@libp2p/interface-peer-id';
 import { createEd25519PeerId } from '@libp2p/peer-id-factory';
 import { Factory } from 'fishery';
-import { NETWORK_TOPIC_PRIMARY } from '~/network/p2p/protocol';
 import { HASH_LENGTH, SyncId } from '~/network/sync/syncId';
 
 const GossipAddressInfoFactory = Factory.define<GossipAddressInfo>(() => {
@@ -42,7 +41,7 @@ const GossipMessageFactory = Factory.define<GossipMessage, { peerId?: PeerId }, 
     return GossipMessage.create({
       peerId: transientParams.peerId ? transientParams.peerId.toBytes() : new Uint8Array(),
       message: Factories.Message.build(),
-      topics: [NETWORK_TOPIC_PRIMARY],
+      topics: ['f_network_0_primary'],
       version: GossipVersion.V1,
     });
   }

--- a/apps/hubble/src/test/e2e/gossipNetwork.test.ts
+++ b/apps/hubble/src/test/e2e/gossipNetwork.test.ts
@@ -1,5 +1,4 @@
 import { GossipNode } from '~/network/p2p/gossipNode';
-import { NETWORK_TOPIC_PRIMARY } from '~/network/p2p/protocol';
 import { sleep } from '~/utils/crypto';
 import { NetworkFactories } from '../../network/utils/factories';
 import { GossipMessage } from '@farcaster/hub-nodejs';
@@ -41,9 +40,9 @@ describe('gossip network tests', () => {
         const result = await n.connect(nodes[0] as GossipNode);
         expect(result.isOk()).toBeTruthy();
       }
-
+      const primaryTopic = nodes[0]!.primaryTopic();
       // Subscribe each node to the test topic
-      nodes.forEach((n) => n.gossip?.subscribe(NETWORK_TOPIC_PRIMARY));
+      nodes.forEach((n) => n.gossip?.subscribe(primaryTopic));
 
       // Sleep 5 heartbeats to let the gossipsub network form
       await sleep(PROPAGATION_DELAY);
@@ -82,8 +81,8 @@ describe('gossip network tests', () => {
       nonSenderNodes.map((n) => {
         const topics = messageStore.get(n.peerId?.toString() ?? '');
         expect(topics).toBeDefined();
-        expect(topics?.has(NETWORK_TOPIC_PRIMARY)).toBeTruthy();
-        const topicMessages = topics?.get(NETWORK_TOPIC_PRIMARY) ?? [];
+        expect(topics?.has(primaryTopic)).toBeTruthy();
+        const topicMessages = topics?.get(primaryTopic) ?? [];
         expect(topicMessages.length).toBe(1);
         expect(topicMessages[0]).toEqual(message);
       });


### PR DESCRIPTION
## Motivation

Fixes https://github.com/farcasterxyz/hub-monorepo/issues/860 and https://github.com/farcasterxyz/hub-monorepo/issues/849

## Change Summary

 - Adds the network id to all gossip topics the hubs subscribes to ensure we're only talking with peers on the same network

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

Tested manually. Bootstrapped the a node to testnet node and verified it's not receiving any messages from current testnet/mainnet nodes but can receive messages from another instance with the topic change.
