### PR TITLE
chore: log sync status for better visibility

### DIFF
--- a/.changeset/wicked-planets-walk.md
+++ b/.changeset/wicked-planets-walk.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+log sync status for better visibility

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -164,7 +164,7 @@ describe('Multi peer sync engine', () => {
 
       // Engine 2 should sync with engine1
       expect(
-        (await syncEngine2.shouldSync((await syncEngine1.getSnapshot())._unsafeUnwrap()))._unsafeUnwrap()
+        (await syncEngine2.syncStatus((await syncEngine1.getSnapshot())._unsafeUnwrap()))._unsafeUnwrap().shouldSync
       ).toBeTruthy();
 
       // Sync engine 2 with engine 1
@@ -175,7 +175,7 @@ describe('Multi peer sync engine', () => {
 
       // Should sync should now be false with the new excluded hashes
       expect(
-        (await syncEngine2.shouldSync((await syncEngine1.getSnapshot())._unsafeUnwrap()))._unsafeUnwrap()
+        (await syncEngine2.syncStatus((await syncEngine1.getSnapshot())._unsafeUnwrap()))._unsafeUnwrap().shouldSync
       ).toBeFalsy();
 
       // Add more messages
@@ -194,7 +194,7 @@ describe('Multi peer sync engine', () => {
       expect(await syncEngine1.trie.rootHash()).toEqual(newSnapshot.rootHash);
 
       // Should sync should now be true
-      expect((await syncEngine2.shouldSync(newSnapshot))._unsafeUnwrap()).toBeTruthy();
+      expect((await syncEngine2.syncStatus(newSnapshot))._unsafeUnwrap().shouldSync).toBeTruthy();
 
       // Do the sync again
       await syncEngine2.performSync(newSnapshot, clientForServer1);
@@ -512,7 +512,7 @@ describe('Multi peer sync engine', () => {
 
       // Engine 2 should sync with engine1
       expect(
-        (await syncEngine2.shouldSync((await syncEngine1.getSnapshot())._unsafeUnwrap()))._unsafeUnwrap()
+        (await syncEngine2.syncStatus((await syncEngine1.getSnapshot())._unsafeUnwrap()))._unsafeUnwrap().shouldSync
       ).toBeTruthy();
 
       await engine2.mergeIdRegistryEvent(custodyEvent);

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -265,10 +265,12 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
       log.info(
         {
           peerId,
-          shouldSync: syncStatus.shouldSync,
+          inSync: syncStatus.isSyncing ? 'unknown' : !syncStatus.shouldSync,
           isSyncing: syncStatus.isSyncing,
           theirMessages: syncStatus.theirSnapshot.numMessages,
           ourMessages: syncStatus.ourSnapshot?.numMessages,
+          peerNetwork: peerContact.network,
+          peerVersion: peerContact.hubVersion,
         },
         'SyncStatus' // Search for this string in the logs to get summary of sync status
       );

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -51,6 +51,13 @@ type PeerContact = {
   peerId: PeerId;
 };
 
+type SyncStatus = {
+  isSyncing: boolean;
+  shouldSync: boolean;
+  theirSnapshot: TrieSnapshot;
+  ourSnapshot?: TrieSnapshot;
+};
+
 class SyncEngine extends TypedEmitter<SyncEvents> {
   private readonly _trie: MerkleTrie;
 
@@ -246,14 +253,27 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
       }
 
       const peerState = peerStateResult.value;
-      const shouldSync = await this.shouldSync(peerState);
-      if (shouldSync.isErr()) {
+      const syncStatusResult = await this.syncStatus(peerState);
+      if (syncStatusResult.isErr()) {
         log.warn(`Diffsync: Failed to get shouldSync`);
         this.emit('syncComplete', false);
         return;
       }
 
-      if (shouldSync.value === true) {
+      // Log sync status for visibility
+      const syncStatus = syncStatusResult.value;
+      log.info(
+        {
+          peerId,
+          shouldSync: syncStatus.shouldSync,
+          isSyncing: syncStatus.isSyncing,
+          theirMessages: syncStatus.theirSnapshot.numMessages,
+          ourMessages: syncStatus.ourSnapshot?.numMessages,
+        },
+        'SyncStatus' // Search for this string in the logs to get summary of sync status
+      );
+
+      if (syncStatus.shouldSync === true) {
         log.info({ peerId }, `Diffsync: Syncing with peer`);
         await this.performSync(peerState, rpcClient);
       } else {
@@ -276,22 +296,27 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     }
   }
 
-  public async shouldSync(otherSnapshot: TrieSnapshot): HubAsyncResult<boolean> {
+  public async syncStatus(theirSnapshot: TrieSnapshot): HubAsyncResult<SyncStatus> {
     if (this._isSyncing) {
       log.info('shouldSync: already syncing');
-      return ok(false);
+      return ok({ isSyncing: true, shouldSync: false, theirSnapshot });
     }
 
-    return (await this.getSnapshot(otherSnapshot.prefix)).map((ourSnapshot) => {
+    const ourSnapshotResult = await this.getSnapshot(theirSnapshot.prefix);
+    if (ourSnapshotResult.isErr()) {
+      return err(ourSnapshotResult.error);
+    } else {
+      const ourSnapshot = ourSnapshotResult.value;
       const excludedHashesMatch =
-        ourSnapshot.excludedHashes.length === otherSnapshot.excludedHashes.length &&
+        ourSnapshot.excludedHashes.length === theirSnapshot.excludedHashes.length &&
         // NOTE: `index` is controlled by `every` and so not at risk of object injection.
         // eslint-disable-next-line security/detect-object-injection
-        ourSnapshot.excludedHashes.every((value, index) => value === otherSnapshot.excludedHashes[index]);
+        ourSnapshot.excludedHashes.every((value, index) => value === theirSnapshot.excludedHashes[index]);
 
       log.info({ excludedHashesMatch }, `shouldSync: excluded hashes`);
-      return !excludedHashesMatch;
-    });
+
+      return ok({ isSyncing: false, shouldSync: !excludedHashesMatch, ourSnapshot, theirSnapshot });
+    }
   }
 
   async performSync(otherSnapshot: TrieSnapshot, rpcClient: HubRpcClient): Promise<boolean> {
@@ -306,7 +331,13 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
       } else {
         const ourSnapshot = snapshot.value;
         const divergencePrefix = await this.getDivergencePrefix(ourSnapshot, otherSnapshot.excludedHashes);
-        log.info({ divergencePrefix, prefix: ourSnapshot.prefix }, 'Divergence prefix');
+        log.info(
+          {
+            divergencePrefix: Buffer.from(divergencePrefix).toString('ascii'),
+            prefix: Buffer.from(ourSnapshot.prefix).toString('ascii'),
+          },
+          'Divergence prefix'
+        );
 
         let missingCount = 0;
         await this.fetchMissingHashesByPrefix(divergencePrefix, rpcClient, async (missingIds: Uint8Array[]) => {

--- a/apps/hubble/src/test/bench/syncEngine.ts
+++ b/apps/hubble/src/test/bench/syncEngine.ts
@@ -254,7 +254,7 @@ export const benchSyncEngine = async ({
           } while (theirSyncEngine === ourSyncEngine);
 
           const otherSnapshot = (await theirSyncEngine.getSnapshot())._unsafeUnwrap();
-          if ((await ourSyncEngine.shouldSync(otherSnapshot))._unsafeUnwrap()) {
+          if ((await ourSyncEngine.syncStatus(otherSnapshot))._unsafeUnwrap().shouldSync) {
             const rpcClient = new MockRpcClient((theirSyncEngine as any).engine, theirSyncEngine);
             await ourSyncEngine.performSync(otherSnapshot, rpcClient as unknown as HubRpcClient);
 


### PR DESCRIPTION
## Motivation

First step for https://github.com/farcasterxyz/hub-monorepo/issues/851

## Change Summary

Adds a greppable log line that gives us visibility into the hubs sync status. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
