### PR TITLE
fix: Fix off by one error when retrying id registry event on sync

### DIFF
--- a/.changeset/moody-rocks-greet.md
+++ b/.changeset/moody-rocks-greet.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Fix sync stalling because id registry events weren't retried correctly

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -78,6 +78,7 @@ app
   .option('--admin-server-host <host>', "The host the admin server should listen on. (default: '127.0.0.1')")
   .option('--db-name <name>', 'The name of the RocksDB instance')
   .option('--rebuild-sync-trie', 'Rebuilds the sync trie before starting')
+  .option('--resync-events', 'Resyncs events from the Farcaster contracts before starting')
   .option('--commit-lock-timeout <number>', 'Commit lock timeout in milliseconds (default: 500)', parseNumber)
   .option('--commit-lock-max-pending <number>', 'Commit lock max pending jobs (default: 1000)', parseNumber)
   .option('-i, --id <filepath>', 'Path to the PeerId file')
@@ -293,6 +294,7 @@ app
       rocksDBName: cliOptions.dbName ?? hubConfig.dbName,
       resetDB,
       rebuildSyncTrie,
+      resyncEvents: cliOptions.resyncEvents ?? hubConfig.resyncEvents ?? false,
       commitLockTimeout: cliOptions.commitLockTimeout ?? hubConfig.commitLockTimeout,
       commitLockMaxPending: cliOptions.commitLockMaxPending ?? hubConfig.commitLockMaxPending,
       adminServerEnabled: cliOptions.adminServerEnabled ?? hubConfig.adminServerEnabled,

--- a/apps/hubble/src/eth/ethEventsProvider.test.ts
+++ b/apps/hubble/src/eth/ethEventsProvider.test.ts
@@ -15,7 +15,7 @@ import { getIdRegistryEvent } from '~/storage/db/idRegistryEvent';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 import { getNameRegistryEvent } from '~/storage/db/nameRegistryEvent';
 import Engine from '~/storage/engine';
-import { MockHub } from '~/test/mocks';
+import { MockHub, MockRPCProvider } from '~/test/mocks';
 
 const db = jestRocksDB('flatbuffers.ethEventsProvider.test');
 const engine = new Engine(db, FarcasterNetwork.TESTNET);
@@ -32,22 +32,6 @@ let mockNameRegistry: Contract;
 const generateEthAddressHex = () => {
   return bytesToHexString(Factories.EthAddress.build())._unsafeUnwrap();
 };
-
-/** A Mock RPC provider */
-class MockRPCProvider extends AbstractProvider {
-  constructor() {
-    // The Goerli networkID is 5
-    super(5);
-  }
-
-  override async getLogs() {
-    return [];
-  }
-
-  override async getBlockNumber() {
-    return 1;
-  }
-}
 
 /** A Mock Event. Note the disabled no-empty-function rule at the top, it is needed to allow no-op functions in the mock. */
 class MockEvent implements Log {

--- a/apps/hubble/src/eth/ethEventsProvider.ts
+++ b/apps/hubble/src/eth/ethEventsProvider.ts
@@ -235,11 +235,11 @@ export class EthEventsProvider {
    * @param blockNumber
    */
   public async retryEventsFromBlock(blockNumber: number) {
-    await this.syncHistoricalIdEvents(IdRegistryEventType.REGISTER, blockNumber, blockNumber, this._chunkSize);
-    await this.syncHistoricalIdEvents(IdRegistryEventType.TRANSFER, blockNumber, blockNumber, this._chunkSize);
+    await this.syncHistoricalIdEvents(IdRegistryEventType.REGISTER, blockNumber, blockNumber + 1, 1);
+    await this.syncHistoricalIdEvents(IdRegistryEventType.TRANSFER, blockNumber, blockNumber + 1, 1);
 
     // Sync old Name Transfer events
-    await this.syncHistoricalNameEvents(NameRegistryEventType.TRANSFER, blockNumber, blockNumber, this._chunkSize);
+    await this.syncHistoricalNameEvents(NameRegistryEventType.TRANSFER, blockNumber, blockNumber + 1, 1);
   }
 
   /**

--- a/apps/hubble/src/eth/ethEventsProvider.ts
+++ b/apps/hubble/src/eth/ethEventsProvider.ts
@@ -146,9 +146,9 @@ export class EthEventsProvider {
     return this._lastBlockNumber;
   }
 
-  public async start() {
+  public async start(resyncEvents?: boolean) {
     // Connect to Ethereum RPC
-    await this.connectAndSyncHistoricalEvents();
+    await this.connectAndSyncHistoricalEvents(resyncEvents);
   }
 
   public async stop() {
@@ -186,7 +186,7 @@ export class EthEventsProvider {
   /* -------------------------------------------------------------------------- */
 
   /** Connect to Ethereum RPC */
-  private async connectAndSyncHistoricalEvents() {
+  private async connectAndSyncHistoricalEvents(resyncEvents?: boolean) {
     const latestBlockResult = await ResultAsync.fromPromise(this._jsonRpcProvider.getBlock('latest'), (err) => err);
     if (latestBlockResult.isErr()) {
       log.error(
@@ -211,6 +211,11 @@ export class EthEventsProvider {
     const hubState = await this._hub.getHubState();
     if (hubState.isOk()) {
       lastSyncedBlock = hubState.value.lastEthBlock;
+    }
+
+    if (resyncEvents) {
+      log.info(`Resyncing events from ${this._firstBlock} instead of ${lastSyncedBlock}`);
+      lastSyncedBlock = this._firstBlock;
     }
 
     log.info({ lastSyncedBlock }, 'last synced block');

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -127,6 +127,9 @@ export interface HubOptions {
   /** Number of blocks to batch when syncing historical events  */
   chunkSize?: number;
 
+  /** Resync events */
+  resyncEvents?: boolean;
+
   /** Name of the RocksDB instance */
   rocksDBName?: string;
 
@@ -351,7 +354,7 @@ export class Hub implements HubInterface {
 
     // Start the ETH registry provider first
     if (this.ethRegistryProvider) {
-      await this.ethRegistryProvider.start();
+      await this.ethRegistryProvider.start(this.options.resyncEvents);
     }
 
     // Start the sync engine

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -443,7 +443,11 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
             // if we don't get all the events from the Ethereum RPC provider.
             // We'll do it in the background, since this will not block the sync.
             setTimeout(async () => {
-              this.retryIdRegistryEvent(msg, rpcClient);
+              log.warn(
+                { fid: msg.data?.fid, err: result.error.message },
+                `Unknown fid ${msg.data?.fid}, reprocessing ID registry event`
+              );
+              await this.retryIdRegistryEvent(msg, rpcClient);
             }, 0);
 
             // We'll push this message as a failure, and we'll retry it on the next sync.
@@ -644,6 +648,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     // Get the ethereum block number from the custody event
     const custodyEventBlockNumber = custodyEventResult.value.blockNumber;
 
+    logger.info({ fid }, `Retrying events from block ${custodyEventBlockNumber}`);
     // We'll retry all events from this block number
     await this._ethEventsProvider?.retryEventsFromBlock(custodyEventBlockNumber);
   }

--- a/apps/hubble/src/test/mocks.ts
+++ b/apps/hubble/src/test/mocks.ts
@@ -12,6 +12,7 @@ import { HubInterface, HubSubmitSource } from '~/hubble';
 import { GossipNode } from '~/network/p2p/gossipNode';
 import RocksDB from '~/storage/db/rocksdb';
 import Engine from '~/storage/engine';
+import { AbstractProvider } from 'ethers';
 
 export class MockHub implements HubInterface {
   public db: RocksDB;
@@ -58,5 +59,24 @@ export class MockHub implements HubInterface {
   async gossipContactInfo(): HubAsyncResult<void> {
     this.gossipCount += 1;
     return ok(undefined);
+  }
+}
+
+/** A Mock RPC provider */
+export class MockRPCProvider extends AbstractProvider {
+  public getLogsCount = 0;
+
+  constructor() {
+    // The Goerli networkID is 5
+    super(5);
+  }
+
+  override async getLogs() {
+    this.getLogsCount += 1;
+    return [];
+  }
+
+  override async getBlockNumber() {
+    return 1;
   }
 }


### PR DESCRIPTION
## Motivation

Fixes https://github.com/farcasterxyz/hub-monorepo/issues/892

And helps with https://github.com/farcasterxyz/hub-monorepo/issues/898


## Change Summary

There's an off by one error when we retry fetching a id registry event which meant we weren't actually querying the events. This fixes the issue, and adds a flag to trigger a manual resync if desired

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](../CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
