### PR TITLE
docs(hub-nodejs): update example

### DIFF
--- a/packages/hub-nodejs/README.md
+++ b/packages/hub-nodejs/README.md
@@ -26,12 +26,12 @@ pnpm install @farcaster/hub-nodejs
 ### Fetching Data from Hubs
 
 ```typescript
-import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
+import { getSSLHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = getInsecureHubRpcClient('testnet1.farcaster.xyz:2283');
+  const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
 
-  const castsResult = await client.getCastsByFid({ fid: 2 });
+  const castsResult = await client.getCastsByFid({ fid: 8928 });
 
   castsResult.map((casts) => casts.messages.map((cast) => console.log(cast.data?.castAddBody?.text)));
 

--- a/packages/hub-nodejs/README.md
+++ b/packages/hub-nodejs/README.md
@@ -29,7 +29,7 @@ pnpm install @farcaster/hub-nodejs
 import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = getSSLHubRpcClient('testnet1.farcaster.xyz:2283');
+  const client = getInsecureHubRpcClient('testnet1.farcaster.xyz:2283');
 
   const castsResult = await client.getCastsByFid({ fid: 2 });
 


### PR DESCRIPTION
## Motivation

In the flagship example for hub-nodejs we are importing `getInsecureHubRpcClient` but using `getSSLHubRpcClient` to instantiate a client.

Edit: I changed it to use `getSSLHubRpcClient` to work with the given URL format. I also changed the fid to be more realistic, as `fid: 2` will not yield any casts on testnet

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](../CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
