### PR TITLE
chore(hub-nodejs): add hub urls, steps to chron-feed examples

### DIFF
--- a/packages/hub-nodejs/examples/chron-feed/README.md
+++ b/packages/hub-nodejs/examples/chron-feed/README.md
@@ -1,3 +1,12 @@
 ## Generate a chronological feed
 
+### Run on StackBlitz
+
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/farcasterxyz/hubble/tree/main/packages/hub-nodejs/examples/chron-feed)
+
+### Run locally
+
+1. Clone the repo locally
+2. Navigate to this folder with `cd packages/hub-nodejs/examples/chron-feed directory`
+3. Run `yarn install` to install dependencies
+4. Run `yarn start`

--- a/packages/hub-nodejs/examples/chron-feed/index.ts
+++ b/packages/hub-nodejs/examples/chron-feed/index.ts
@@ -21,7 +21,7 @@ const timeAgo = new TimeAgo('en-US');
  * Populate the following constants with your own values
  */
 
-const HUB_URL = process.env['HUB_ADDR'] || ''; // URL of the Hub
+const HUB_URL = 'nemes.farcaster.xyz:2283'; // URL of the Hub
 const FIDS = [2, 3]; // User IDs to fetch casts for
 
 /**
@@ -98,7 +98,6 @@ const castToString = async (cast: CastAddMessage, nameMapping: Map<number, strin
 };
 
 (async () => {
-  // Set address as an environment variable or pass in directly here
   // const client = getInsecureHubRpcClient(HUB_URL); // Use this if you're not using SSL
   const client = getSSLHubRpcClient(HUB_URL);
 
@@ -109,6 +108,7 @@ const castToString = async (cast: CastAddMessage, nameMapping: Map<number, strin
   const fnameResults = Result.combine(await Promise.all(fnameResultPromises));
 
   if (fnameResults.isErr()) {
+    console.error('Fetching fnames failed');
     console.error(fnameResults.error);
     return;
   }
@@ -128,7 +128,8 @@ const castToString = async (cast: CastAddMessage, nameMapping: Map<number, strin
   const castsResult = Result.combine(await Promise.all(castResultPromises));
 
   if (castsResult.isErr()) {
-    console.error('Fetching fnames failed:' + castsResult.error);
+    console.error('Fetching casts failed');
+    console.error(castsResult.error);
     return;
   }
 

--- a/packages/hub-nodejs/examples/chron-feed/package.json
+++ b/packages/hub-nodejs/examples/chron-feed/package.json
@@ -8,7 +8,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@farcaster/hub-nodejs": "^0.6.3",
+    "@farcaster/hub-nodejs": "^0.7.0",
     "javascript-time-ago": "^2.5.9"
   },
   "devDependencies": {

--- a/packages/hub-nodejs/examples/chron-feed/yarn.lock
+++ b/packages/hub-nodejs/examples/chron-feed/yarn.lock
@@ -293,10 +293,10 @@
   resolved "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz#9ea331766084288634a9247fcd8b84f16ff4ba07"
   integrity sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==
 
-"@farcaster/core@0.6.1":
-  version "0.6.1"
-  resolved "https://registry.npmjs.org/@farcaster/core/-/core-0.6.1.tgz#08debfcf1938b76b2aad804e5e7e371f8741f6fc"
-  integrity sha512-gukmCefLKc+tTZbRaM1CdbT0+gvZbzpxi5/7CcvgZ2M2yicTE36j6qrJ0XkYLTZBy+/UCY3UaE3FpAi17CBNjg==
+"@farcaster/core@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.npmjs.org/@farcaster/core/-/core-0.7.0.tgz#5397af42edd768e7bc0dabcdc4e554c38c007cc5"
+  integrity sha512-eP0vVnfIdnEZAyM3Iaa25y89AQyj88v8T7YbUe08qVGWCEIq82/7Y/pBYB+vRrMgXW4PUVuPfUi1hu9eE7KeDQ==
   dependencies:
     "@ethersproject/abstract-signer" "^5.7.0"
     "@faker-js/faker" "^7.6.0"
@@ -305,12 +305,12 @@
     ethers "~6.2.1"
     neverthrow "^6.0.0"
 
-"@farcaster/hub-nodejs@^0.6.3":
-  version "0.6.3"
-  resolved "https://registry.npmjs.org/@farcaster/hub-nodejs/-/hub-nodejs-0.6.3.tgz#49462e9e5b0a78708a91a00a243f6507a12be8f9"
-  integrity sha512-GjQd4OrK2LJg5mSjU9poVe4ZnmWjLO8WxPHGah0uNzx1Tc2awDU2zUpcwyJwe5t/emS/FslrX7FDPD/XA5DfPQ==
+"@farcaster/hub-nodejs@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.npmjs.org/@farcaster/hub-nodejs/-/hub-nodejs-0.7.0.tgz#ce148d73e447556a6927d1aa1532e32acd6f7fd2"
+  integrity sha512-dH/C929VKDPEdGxkwL2xBPINzXgcQTF4R7XIfCFyFMBe5uUW47ux1VOeBQS6oe8lBbsM9FWQeshtKlbfuwpNaA==
   dependencies:
-    "@farcaster/core" "0.6.1"
+    "@farcaster/core" "0.7.0"
     "@grpc/grpc-js" "^1.8.13"
     "@noble/hashes" "^1.3.0"
     ethers "~6.2.1"

--- a/packages/hub-web/examples/chron-feed/index.ts
+++ b/packages/hub-web/examples/chron-feed/index.ts
@@ -21,7 +21,7 @@ const timeAgo = new TimeAgo('en-US');
  * Populate the following constants with your own values
  */
 
-const HUB_URL = process.env['HUB_ADDR'] || ''; // URL of the Hub
+const HUB_URL = 'nemes.farcaster.xyz:2283'; // URL of the Hub
 const FIDS = [2, 3]; // User IDs to fetch casts for
 
 /**


### PR DESCRIPTION
## Motivation

Fixes issues with the chron feed examples

## Change Summary

- Added URLs for mainnet hubs directly into examples
- Added URls for repos 

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](../CONTRIBUTING.md#22-signing-commits)

No changeset for example PRs