### PR TITLE
update: network migration instructions

### DIFF
--- a/apps/hubble/README.md
+++ b/apps/hubble/README.md
@@ -42,7 +42,7 @@ Mainnet is Farcaster's production environment apps use and writing a message her
 3. Make a PR to add it to the [allowed peers list](https://github.com/farcasterxyz/hub-monorepo/blob/main/apps/hubble/src/allowedPeers.mainnet.ts).
 4. Wait for the core team to deploy changes, usually within 24-48 hours.
 5. If you were on a different network, run `yarn dbreset` to clear the database.
-6. Run `yarn start -e <node url> -b /dns/nemes.farcaster.xyz/tcp/2282 -n 1`
+6. Run `pm2 start "yarn start -e <node url> -b /dns/nemes.farcaster.xyz/tcp/2282 -n 1" --name hubble`
 
 ## :cloud: Getting Started in the Cloud
 

--- a/apps/hubble/README.md
+++ b/apps/hubble/README.md
@@ -37,7 +37,7 @@ Hubble will sync with the on-chain contracts, and issue thousands of messages li
 
 Mainnet is Farcaster's production environment apps use and writing a message here will make it show up in all applications. Minimum requirements are 8GB RAM and 20GB of disk space.
 
-1. If you were on a different network, run `yarn dbreset` to clear the database.
+1. If you were on a different network, run `pm2 stop hubble` to stop the hub.
 2. Get your PeerId from the file `/apps/hubble/.hub/<PEER_ID>_id.protobuf`
 3. Make a PR to add it to the [allowed peers list](https://github.com/farcasterxyz/hub-monorepo/blob/main/apps/hubble/src/allowedPeers.mainnet.ts).
 4. Wait for the core team to deploy changes, usually within 24-48 hours.


### PR DESCRIPTION
## Motivation

Just cleaning up a duplicate command I found and updating with the one necessary to migrate.

## Change Summary

The yarn dbreset command was listed twice, and I added `pm2 stop hubble` since the dbreset command failed without stopping.

I've also updated step 6 to use pm2 when starting the hub again after dbreset.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [ ] All [commits have been signed](../CONTRIBUTING.md#22-signing-commits)

