### PR TITLE
docs(hubble): use hubble/latest instead of a specific version

### DIFF
--- a/apps/hubble/README.md
+++ b/apps/hubble/README.md
@@ -66,7 +66,7 @@ Next follow these instructions which should work on most Linux environments:
 3. Install node with `nvm install 18.7.0`
 4. Install yarn and pm2 with `npm install -g yarn`
 5. Clone the code with `git clone https://github.com/farcasterxyz/hubble.git`
-6. Checkout the stable release `cd hubble && git checkout @farcaster/hubble@1.0.22`
+6. Checkout the stable release `cd hubble && git checkout @farcaster/hubble@latest`
 7. Build Hubble with `yarn install && yarn build`
 8. Create an identity with `cd apps/hubble/ && yarn identity create`
 9. Get an Ethereum Goerli node RPC URL from [Alchemy](https://www.alchemy.com/) or [Infura](https://www.infura.io/)
@@ -113,7 +113,7 @@ Fetching data from Hubble requires communicating with its [gRPC](https://grpc.io
 ### Upgrading your Hubs
 
 1. Stop running hubs with `pm2 stop hubble` (or relevant command)
-2. Navigate to the repository root and run `git fetch && git checkout @farcaster/hubble@1.2.0` (or your preferred version)
+2. Navigate to the repository root and run `git fetch && git checkout @farcaster/hubble@latest` (or your preferred version)
 3. Run `yarn install && yarn build`
 4. Navigate to `apps/hubble`
 5. Start your hub with `pm2 start hubble` (or relevant command)


### PR DESCRIPTION
## Motivation

Docs should not need to be updated manually with every release

## Change Summary

- Added a `@farcaster/hubble@latest` tag to v1.2.0 
- Updated docs to pull from this `latest` tag instead of a specific version

Going forward, releases will need to be tagged with `latest` whenever they are released. 

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](../CONTRIBUTING.md#22-signing-commits)
