### PR TITLE
docs(hubble): add pm2 logrotate, exponential backoff to address failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ A monorepo codebase that implements the [Farcaster Hub specification](https://gi
 
 | Package Name                                  | Description                                                                    |
 | --------------------------------------------- | ------------------------------------------------------------------------------ |
-| [@farcaster/hubble](/apps/hubble)             | A Hub, which can be run as a stand-alone application.                          |
-| [@farcaster/core](/packages/core)             | Protobuf definitions and shared utility functions.                             |
-| [@farcaster/hub-nodejs](/packages/hub-nodejs) | Node.js package exporting `@farcaster/core` and gRPC client implementation     |
-| [@farcaster/hub-web](/packages//hub-web)      | Browser package exporting `@farcaster/core` and gRPC-Web client implementation |
+| [@farcaster/hubble](./apps/hubble)             | A Hub, which can be run as a stand-alone application.                          |
+| [@farcaster/core](./packages/core)             | Protobuf definitions and shared utility functions.                             |
+| [@farcaster/hub-nodejs](./packages/hub-nodejs) | Node.js package exporting `@farcaster/core` and gRPC client implementation     |
+| [@farcaster/hub-web](./packages/hub-web)      | Browser package exporting `@farcaster/core` and gRPC-Web client implementation |
 
 ## Contributing
 

--- a/apps/hubble/README.md
+++ b/apps/hubble/README.md
@@ -76,7 +76,8 @@ Next follow these instructions which should work on most Linux environments:
 Testnet is a sandboxed environment where you can read and write messages without affecting your production account. Dummy messages are broadcast every 10 seconds for testing. Minimum requirements are 4GB RAM and 5 GB of free space.
 
 1. Install pm2 to mange the process with `npm install -g pm2`
-2. Start Hubble with `pm2 start "yarn start -e <node url> -b /dns/testnet1.farcaster.xyz/tcp/2282 -n 2" --name hubble`
+2. Install pm2 logrotate to ensure the log files get trimmed `pm2 install pm2-logrotate` 
+2. Start Hubble with `pm2 start "yarn start -e <node url> -b /dns/testnet1.farcaster.xyz/tcp/2282 -n 2" --name hubble --exp-backoff-restart-delay=100`
 3. Check the logs with `pm2 logs`
 
 ### 4. Verify Your Setup
@@ -99,7 +100,7 @@ Mainnet is Farcaster's production environment apps use and writing a message her
 4. Get your PeerId from the file `.hub/<PEER_ID>_id.protobuf`
 5. Make a PR to add it to the [allowed peers list](https://github.com/farcasterxyz/hub-monorepo/blob/main/apps/hubble/src/allowedPeers.mainnet.ts).
 6. Wait for the core team to deploy changes, usually within 24-48 hours.
-7. Run `pm2 start "yarn start -e <node url> -b /dns/nemes.farcaster.xyz/tcp/2282 -n 1" --name hubble`
+7. Run `pm2 start "yarn start -e <node url> -b /dns/nemes.farcaster.xyz/tcp/2282 -n 1" --name hubble --exp-backoff-restart-delay=100`
 
 ## :hammer: Interacting with Hubble
 


### PR DESCRIPTION
## Motivation

Address instances running out of space and having databases corrupted.

## Change Summary

- Add pm2 logrotate to recommended setup which prunes log files
- Add exponential backoff to restart attempts to prevent db corruption when shutdown is messy

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](../CONTRIBUTING.md#22-signing-commits)

