### PR TITLE
fix: Dedup eth events retries by block number to save api calls

### DIFF
--- a/.changeset/kind-bugs-wave.md
+++ b/.changeset/kind-bugs-wave.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Dedupe eth events when retrying to be more efficient with api calls

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -327,7 +327,7 @@ describe('Multi peer sync engine', () => {
 
     // Because do it without awaiting, we need to wait for the promise to resolve
     await sleep(100);
-    expect(mockRPCProvider.getLogsCount).toBeGreaterThan(0);
+    expect(mockRPCProvider.getLogsCount).toEqual(3);
   });
 
   test('Merge with multiple signers', async () => {


### PR DESCRIPTION
## Motivation
Helps address https://github.com/farcasterxyz/hub-monorepo/issues/892

We'd make one multiple requests for the same block for every message we process. This fixes it so we only do it once per block.

## Change Summary

Dedupe eth events retry by block number.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](../CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a retry deduplication mechanism to the `EthEventsProvider` class in the Hubble app. It also includes a test case update.

### Detailed summary
- Adds `_retryDedupMap` to `EthEventsProvider` class
- Implements retry deduplication logic in `retryEventsFromBlock` method
- Deletes entry from `_retryDedupMap` after successful event submission in `submitHistoricalIdEvents` method
- Updates test case in `multiPeerSyncEngine.test.ts` to use `toEqual` instead of `toBeGreaterThan`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->