### PR TITLE
fix: improve handling of duplicate messages on gossip

### DIFF
--- a/.changeset/fresh-impalas-switch.md
+++ b/.changeset/fresh-impalas-switch.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': major
+---
+
+improve handling of duplicate messages on gossip

--- a/.changeset/lucky-mails-develop.md
+++ b/.changeset/lucky-mails-develop.md
@@ -1,5 +1,5 @@
 ---
-'@farcaster/hubble': major
+'@farcaster/hubble': minor
 ---
 
 improve handling of duplicate messages on gossip

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -1,4 +1,5 @@
 import { gossipsub, GossipSub } from '@chainsafe/libp2p-gossipsub';
+import { Message as GossipSubMessage, PublishResult } from '@libp2p/interface-pubsub';
 import { noise } from '@chainsafe/libp2p-noise';
 import {
   ContactInfoContent,
@@ -11,6 +12,7 @@ import {
 } from '@farcaster/hub-nodejs';
 import { Connection } from '@libp2p/interface-connection';
 import { PeerId } from '@libp2p/interface-peer-id';
+import { peerIdFromBytes } from '@libp2p/peer-id';
 import { mplex } from '@libp2p/mplex';
 import { pubsubPeerDiscovery } from '@libp2p/pubsub-peer-discovery';
 import { tcp } from '@libp2p/tcp';
@@ -22,6 +24,7 @@ import { ConnectionFilter } from '~/network/p2p/connectionFilter';
 import { logger } from '~/utils/logger';
 import { addressInfoFromParts, checkNodeAddrs, ipMultiAddrStrFromAddressInfo } from '~/utils/p2p';
 import { PeriodicPeerCheckScheduler } from './periodicPeerCheck';
+import { GOSSIP_PROTOCOL_VERSION, msgIdFnStrictSign } from './protocol';
 
 const MultiaddrLocalHost = '/ip4/127.0.0.1';
 
@@ -184,40 +187,55 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
   }
 
   /** Serializes and publishes a Farcaster Message to the network */
-  async gossipMessage(message: Message) {
+  async gossipMessage(message: Message): Promise<HubResult<PublishResult>[]> {
     const gossipMessage = GossipMessage.create({
       message,
       topics: [this.primaryTopic()],
       peerId: this.peerId?.toBytes() ?? new Uint8Array(),
     });
-    await this.publish(gossipMessage);
+    return this.publish(gossipMessage);
   }
 
   /** Serializes and publishes this node's ContactInfo to the network */
-  async gossipContactInfo(contactInfo: ContactInfoContent) {
+  async gossipContactInfo(contactInfo: ContactInfoContent): Promise<HubResult<PublishResult>[]> {
     const gossipMessage = GossipMessage.create({
       contactInfoContent: contactInfo,
       topics: [this.contactInfoTopic()],
       peerId: this.peerId?.toBytes() ?? new Uint8Array(),
     });
-    await this.publish(gossipMessage);
+    return this.publish(gossipMessage);
   }
 
   /** Publishes a Gossip Message to the network */
-  async publish(message: GossipMessage) {
+  async publish(message: GossipMessage): Promise<HubResult<PublishResult>[]> {
     const topics = message.topics;
     const encodedMessage = GossipNode.encodeMessage(message);
 
     log.debug({ identity: this.identity }, `Publishing message to topics: ${topics}`);
-    encodedMessage.match(
-      async (msg) => {
-        const results = await Promise.all(topics.map((topic) => this.gossip?.publish(topic, msg)));
-        log.debug({ identity: this.identity, results }, 'Published to gossip peers');
-      },
-      async (err) => {
-        log.error(err, 'Failed to publish message.');
-      }
-    );
+    if (this.gossip == undefined) {
+      return [err(new HubError('unavailable', new Error('GossipSub not initialized')))];
+    }
+    const gossip = this.gossip;
+
+    if (encodedMessage.isErr()) {
+      log.error(encodedMessage.error, 'Failed to publish message.');
+      return [err(encodedMessage.error)];
+    } else {
+      const results = await Promise.all(
+        topics.map(async (topic) => {
+          try {
+            const publishResult = await gossip.publish(topic, encodedMessage.value);
+            return ok(publishResult);
+          } catch (error: any) {
+            log.error(error, 'Failed to publish message');
+            return err(new HubError('bad_request.duplicate', error));
+          }
+        })
+      );
+
+      log.debug({ identity: this.identity, results }, 'Published to gossip peers');
+      return results;
+    }
   }
 
   /** Connects to a peer GossipNode */
@@ -263,10 +281,17 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
       log.info({ peer: event.detail.remotePeer }, `P2P Connection disconnected`);
       this.emit('peerDisconnect', event.detail);
     });
-    this.gossip?.addEventListener('message', (event) => {
+    this.gossip?.addEventListener('gossipsub:message', (event) => {
+      log.debug({
+        identity: this.identity,
+        gossipMessageId: event.detail.msgId,
+        from: event.detail.propagationSource,
+        topic: event.detail.msg.topic,
+      });
+
       // ignore messages not in our topic lists (e.g. GossipSub peer discovery messages)
-      if (this.gossipTopics().includes(event.detail.topic)) {
-        this.emit('message', event.detail.topic, GossipNode.decodeMessage(event.detail.data));
+      if (this.gossipTopics().includes(event.detail.msg.topic)) {
+        this.emit('message', event.detail.msg.topic, GossipNode.decodeMessage(event.detail.msg.data));
       }
     });
   }
@@ -313,10 +338,18 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
     return ok(GossipMessage.encode(message).finish());
   }
 
-  //TODO: Needs better typesafety
   static decodeMessage(message: Uint8Array): HubResult<GossipMessage> {
     // Convert GossipMessage to Uint8Array or decode will return nested Uint8Arrays as Buffers
-    return ok(GossipMessage.decode(Uint8Array.from(message)));
+    try {
+      const gossipMessage = GossipMessage.decode(Uint8Array.from(message));
+      if (gossipMessage.topics.length == 0 || gossipMessage.version != GOSSIP_PROTOCOL_VERSION) {
+        return err(new HubError('bad_request.parse_failure', 'invalid message'));
+      }
+      peerIdFromBytes(gossipMessage.peerId);
+      return ok(GossipMessage.decode(Uint8Array.from(message)));
+    } catch (error: any) {
+      return err(new HubError('bad_request.parse_failure', error));
+    }
   }
 
   /* -------------------------------------------------------------------------- */
@@ -335,6 +368,27 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
     }
 
     return ok(undefined);
+  }
+
+  /* Generates a message ID for gossip messages
+   *
+   * Specifically overrides the default behavior for Farcaster Protocol Messages that are created by user interactions
+   *
+   * @param message - The message to generate an ID for
+   * @returns The message ID as an Uint8Array
+   */
+  public getMessageId(message: GossipSubMessage): Uint8Array {
+    if (message.topic.includes(this.primaryTopic())) {
+      // check if message is a Farcaster Protocol Message
+      const protocolMessage = GossipNode.decodeMessage(message.data);
+      if (protocolMessage.isOk()) {
+        if (protocolMessage.value.message != undefined)
+          return protocolMessage._unsafeUnwrap().message?.hash as Uint8Array;
+        if (protocolMessage.value.idRegistryEvent != undefined)
+          return protocolMessage.value.idRegistryEvent?.transactionHash as Uint8Array;
+      }
+    }
+    return msgIdFnStrictSign(message);
   }
 
   /** Creates a Libp2p node with GossipSub */
@@ -363,6 +417,7 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
       emitSelf: false,
       allowPublishToZeroPeers: true,
       globalSignaturePolicy: 'StrictSign',
+      msgIdFn: this.getMessageId.bind(this),
     });
 
     if (options.allowedPeerIdStrs) {

--- a/apps/hubble/src/network/p2p/protocol.ts
+++ b/apps/hubble/src/network/p2p/protocol.ts
@@ -1,4 +1,17 @@
 import { GossipVersion } from '@farcaster/hub-nodejs';
+import { Message as GossipSubMessage } from '@libp2p/interface-pubsub';
+import { msgId } from '@libp2p/pubsub/utils';
 
 // Current gossip protocol version
 export const GOSSIP_PROTOCOL_VERSION = GossipVersion.V1;
+
+/* This has been imported from the libp2p-gossipsub implementation as it's not public there */
+export const msgIdFnStrictSign = (message: GossipSubMessage): Uint8Array => {
+  if (message.type !== 'signed') {
+    throw new Error('expected signed message type');
+  }
+  // Should never happen
+  if (message.sequenceNumber == null) throw Error('missing seqno field');
+
+  return msgId(message.from.toBytes(), message.sequenceNumber);
+};

--- a/apps/hubble/src/network/p2p/protocol.ts
+++ b/apps/hubble/src/network/p2p/protocol.ts
@@ -3,7 +3,7 @@ import { Message as GossipSubMessage } from '@libp2p/interface-pubsub';
 import { msgId } from '@libp2p/pubsub/utils';
 
 // Current gossip protocol version
-export const GOSSIP_PROTOCOL_VERSION = GossipVersion.V1;
+export const GOSSIP_PROTOCOL_VERSION = GossipVersion.V1_1;
 
 /* This has been imported from the libp2p-gossipsub implementation as it's not public there */
 export const msgIdFnStrictSign = (message: GossipSubMessage): Uint8Array => {

--- a/apps/hubble/src/network/utils/factories.ts
+++ b/apps/hubble/src/network/utils/factories.ts
@@ -42,7 +42,7 @@ const GossipMessageFactory = Factory.define<GossipMessage, { peerId?: PeerId }, 
       peerId: transientParams.peerId ? transientParams.peerId.toBytes() : new Uint8Array(),
       message: Factories.Message.build(),
       topics: ['f_network_0_primary'],
-      version: GossipVersion.V1,
+      version: GossipVersion.V1_1,
     });
   }
 );

--- a/apps/hubble/src/test/e2e/gossipNetwork.test.ts
+++ b/apps/hubble/src/test/e2e/gossipNetwork.test.ts
@@ -68,9 +68,11 @@ describe('gossip network tests', () => {
       });
 
       // Create a message and send it to a random node
-      const message = NetworkFactories.GossipMessage.build();
+      const message = await NetworkFactories.GossipMessage.create();
       const randomNode = nodes[Math.floor(Math.random() * nodes.length)] as GossipNode;
-      expect(randomNode.publish(message)).resolves.toBeUndefined();
+      const publishResult = await randomNode.publish(message);
+      expect(publishResult.length).toBe(1);
+      expect(publishResult[0]?.isOk()).toBeTruthy();
 
       // Sleep 5 heartbeat ticks
       await sleep(PROPAGATION_DELAY);

--- a/packages/core/src/protobufs/generated/gossip.ts
+++ b/packages/core/src/protobufs/generated/gossip.ts
@@ -5,6 +5,7 @@ import { FarcasterNetwork, farcasterNetworkFromJSON, farcasterNetworkToJSON, Mes
 
 export enum GossipVersion {
   V1 = 0,
+  V1_1 = 1,
 }
 
 export function gossipVersionFromJSON(object: any): GossipVersion {
@@ -12,6 +13,9 @@ export function gossipVersionFromJSON(object: any): GossipVersion {
     case 0:
     case 'GOSSIP_VERSION_V1':
       return GossipVersion.V1;
+    case 1:
+    case 'GOSSIP_VERSION_V1_1':
+      return GossipVersion.V1_1;
     default:
       throw new tsProtoGlobalThis.Error('Unrecognized enum value ' + object + ' for enum GossipVersion');
   }
@@ -21,6 +25,8 @@ export function gossipVersionToJSON(object: GossipVersion): string {
   switch (object) {
     case GossipVersion.V1:
       return 'GOSSIP_VERSION_V1';
+    case GossipVersion.V1_1:
+      return 'GOSSIP_VERSION_V1_1';
     default:
       throw new tsProtoGlobalThis.Error('Unrecognized enum value ' + object + ' for enum GossipVersion');
   }

--- a/protobufs/schemas/gossip.proto
+++ b/protobufs/schemas/gossip.proto
@@ -5,6 +5,7 @@ import "id_registry_event.proto";
 
 enum GossipVersion {
   GOSSIP_VERSION_V1 = 0;
+  GOSSIP_VERSION_V1_1 = 1;
 }
 
 message GossipAddressInfo {


### PR DESCRIPTION
fixes https://github.com/farcasterxyz/hub-monorepo/issues/904

## Motivation

Gossip should be able to de-duplicate Farcaster Protocol messages.

## Change Summary


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](../CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves the handling of duplicate messages on gossip and updates the GossipSub protocol version to V1.1.

### Detailed summary
- Adds `GossipVersion.V1_1` to `protobufs/schemas/gossip.proto`.
- Updates `apps/hubble/src/network/utils/factories.ts` to use `GossipVersion.V1_1`.
- Adds `msgIdFnStrictSign` to `apps/hubble/src/network/p2p/protocol.ts`.
- Updates `apps/hubble/src/network/p2p/protocol.ts` to use `GossipVersion.V1_1`.
- Adds `GossipVersion.V1_1` to `packages/core/src/protobufs/generated/gossip.ts`.
- Updates `apps/hubble/src/test/e2e/gossipNetwork.test.ts` to use `await` and add new tests.
- Updates `apps/hubble/src/network/p2p/gossipNode.ts` to handle duplicate messages and publish results.

> The following files were skipped due to too many changes: `apps/hubble/src/network/p2p/gossipNode.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->