### PR TITLE
feat: Remember bad peers during sync and ignore them for a while.

### DIFF
--- a/.changeset/tall-squids-speak.md
+++ b/.changeset/tall-squids-speak.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Remember bad peers during sync and ignore them for a while to reduced excessive sync attempts

--- a/apps/hubble/src/network/sync/syncEnginePerf.test.ts
+++ b/apps/hubble/src/network/sync/syncEnginePerf.test.ts
@@ -80,7 +80,7 @@ describe('SyncEngine', () => {
         snapshot2.prefix = Buffer.from('00306622', 'hex');
 
         let rpcClient = new MockRpcClient(hub2.engine, syncEngine2);
-        await syncEngine1.performSync(snapshot2, rpcClient as unknown as HubRpcClient);
+        await syncEngine1.performSync('engine2', snapshot2, rpcClient as unknown as HubRpcClient);
         expect(rpcClient.getAllSyncIdsByPrefixCalls.length).toEqual(0);
         expect(rpcClient.getAllMessagesBySyncIdsCalls.length).toEqual(0);
 
@@ -90,6 +90,7 @@ describe('SyncEngine', () => {
         // Even with a bad snapshot, we should still not call the sync APIs because the hashes match
         rpcClient = new MockRpcClient(hub2.engine, syncEngine2);
         await syncEngine1.performSync(
+          'engine2',
           {
             numMessages: 1000,
             prefix: Buffer.from('999999'),

--- a/apps/hubble/src/test/bench/syncEngine.ts
+++ b/apps/hubble/src/test/bench/syncEngine.ts
@@ -214,9 +214,9 @@ export const benchSyncEngine = async ({
           } while (theirSyncEngine === ourSyncEngine);
 
           const otherSnapshot = (await theirSyncEngine.getSnapshot())._unsafeUnwrap();
-          if ((await ourSyncEngine.syncStatus(otherSnapshot))._unsafeUnwrap().shouldSync) {
+          if ((await ourSyncEngine.syncStatus(i.toString(), otherSnapshot))._unsafeUnwrap().shouldSync) {
             const rpcClient = new MockRpcClient((theirSyncEngine as any).engine, theirSyncEngine);
-            await ourSyncEngine.performSync(otherSnapshot, rpcClient as unknown as HubRpcClient);
+            await ourSyncEngine.performSync(i.toString(), otherSnapshot, rpcClient as unknown as HubRpcClient);
 
             const nodeMetadata = await ourSyncEngine.getTrieNodeMetadata(new Uint8Array());
             stats[i] = {


### PR DESCRIPTION

## Motivation

Helps with https://github.com/farcasterxyz/hub-monorepo/issues/898

This helps reduce excessive sync attempts (attempting to sync with a peer that's catching up for the first time, sync divergence prefix bugs, etc)

## Change Summary

If we sync with a peer and did not merge any messages successfully, then don't attempt to sync with it again for a few hours. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](../CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds functionality to remember bad peers during sync and ignore them for a while to reduce excessive sync attempts. 

### Detailed summary
- Added functionality to remember bad peers during sync and ignore them for a while to reduce excessive sync attempts.
- Changes made to `syncEngine.ts`, `syncEnginePerf.test.ts`, `syncEngine.test.ts`, and `multiPeerSyncEngine.test.ts`.
- `performSync()` and `syncStatus()` now take an additional parameter, `peerId`, to differentiate between peers.

> The following files were skipped due to too many changes: `apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts`, `apps/hubble/src/network/sync/syncEngine.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->