### PR TITLE
docs: fix 404 links in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,10 +11,10 @@ Describe the changes being made in 1-2 concise sentences.
 _Choose all relevant options below by adding an `x` now or at any time before submitting for review_
 
 - [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
-- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
+- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
 - [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
 - [ ] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
-- [ ] All [commits have been signed](../CONTRIBUTING.md#22-signing-commits)
+- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)
 
 ## Additional Context
 


### PR DESCRIPTION
## Motivation

The "changeset" and "signing commits" link when making PR is 404.

## Change Summary

This PR fixes it by using absolute links.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](../CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates links in the pull request template to point to the correct location in the repository. 

### Detailed summary
- Updated link to changeset in pull request template
- Updated link to signing commits in pull request template

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->