### PR TITLE
fix: Remove stackblitz example

### DIFF
--- a/packages/hub-nodejs/examples/chron-feed/README.md
+++ b/packages/hub-nodejs/examples/chron-feed/README.md
@@ -1,9 +1,5 @@
 ## Generate a chronological feed
 
-### Run on StackBlitz
-
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/farcasterxyz/hubble/tree/main/packages/hub-nodejs/examples/chron-feed)
-
 ### Run locally
 
 1. Clone the repo locally


### PR DESCRIPTION
## Motivation

Running this example in stackblitz is broken https://github.com/stackblitz/webcontainer-core/issues/1045

## Change Summary

Removed the stackblitz example from the docs (requested by @varunsrin)

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `README.md` file for the `chron-feed` example in the `hub-nodejs` package. It adds instructions for running the example locally.

### Detailed summary
- Added instructions for running the example locally
- Updated numbering of steps to match the added instruction
- No other notable changes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->