### PR TITLE
docs: minor fix on hubs interaction link

### DIFF
--- a/apps/hubble/README.md
+++ b/apps/hubble/README.md
@@ -4,7 +4,7 @@ Hubble is a Typescript implementation of a [Farcaster Hub](https://github.com/fa
 
 A Hub will download an entire copy of the network to your machine and keep it in sync. Messages can be created and uploaded to a Hub and they will propagate to all other Hubs. Running a Hub gives you a private instance that you can query as much as you like and helps decentralized the network.
 
-If you already have the URL of a publicly hosted Hub, just follow instructions on [interacting with Hubs](#🔨-interacting-with-hubble).
+If you already have the URL of a publicly hosted Hub, just follow instructions on [interacting with Hubs](#hammer-interacting-with-hubble).
 
 ## :computer: Getting Started Locally
 


### PR DESCRIPTION
## Motivation

Very minor fix on the hubs interaction internal link.

## Change Summary

Change emoji to name on hubs interaction link.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates a link in the Hubble README file. 

### Detailed summary
- Updated a link in the Hubble README file from `#🔨-interacting-with-hubble` to `#hammer-interacting-with-hubble`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->