### PR TITLE
fix: block number parsing in cli

### DIFF
--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -48,7 +48,7 @@ app
   .option('-c, --config <filepath>', 'Path to a config file with options', DEFAULT_CONFIG_FILE)
   .option('--fir-address <address>', 'The address of the Farcaster ID Registry contract')
   .option('--fnr-address <address>', 'The address of the Farcaster Name Registry contract')
-  .option('--first-block <number>', 'The block number to begin syncing events from Farcaster contracts')
+  .option('--first-block <number>', 'The block number to begin syncing events from Farcaster contracts', parseNumber)
   .option(
     '--chunk-size <number>',
     'The number of blocks to batch when syncing historical events from Farcaster contracts. (default: 10000)',


### PR DESCRIPTION
## Motivation

Block number is not parsed into a number, so, when provided via cli, the range is calculated using string concatenation rather than addition and so breaks.

## Change Summary

parse the cli input into a number

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new optional argument to the `--first-block` option in the `cli.ts` file, allowing users to parse a number. 

### Detailed summary
- Added `parseNumber` function to `--first-block` option in `cli.ts`
- Users can now input a number to begin syncing events from Farcaster contracts
- No other notable changes in this PR

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->