### PR TITLE
fix: Only consider a peer bad if we failed to merge a large number of messages

### DIFF
--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -37,6 +37,7 @@ const HASHES_PER_FETCH = 256;
 const SYNC_INTERRUPT_TIMEOUT = 30 * 1000; // 30 seconds
 const COMPACTION_THRESHOLD = 100_000; // Sync
 const BAD_PEER_BLOCK_TIMEOUT = 5 * 60 * 60 * 1000; // 5 hours, arbitrary, may need to be adjusted as network grows
+const BAD_PEER_MESSAGE_THRESHOLD = 1000; // Number of messages we can't merge before we consider a peer "bad"
 
 const log = logger.child({
   component: 'SyncEngine',
@@ -390,7 +391,11 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
         log.info({ syncResult: fullSyncResult }, 'Fetched missing hashes');
 
         // If we did not merge any messages and didn't defer any. Then this peer only had old messages.
-        if (fullSyncResult.successCount === 0 && fullSyncResult.deferredCount === 0) {
+        if (
+          fullSyncResult.total > BAD_PEER_MESSAGE_THRESHOLD &&
+          fullSyncResult.successCount === 0 &&
+          fullSyncResult.deferredCount === 0
+        ) {
           log.warn(`No messages were successfully fetched`);
           this._unproductivePeers.set(peerId, new Date());
         }


### PR DESCRIPTION
## Motivation

Discovered that hubs were blocking each other as bad peers when they were only off by a handful of messages. Set a high threshold of failures before we mark a peer as bad.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new constant to define the number of messages that can't be merged before a peer is considered "bad". It also updates the conditional statement that checks for unproductive peers.

### Detailed summary
- Added `BAD_PEER_MESSAGE_THRESHOLD` constant
- Updated conditional statement to check for unproductive peers based on `BAD_PEER_MESSAGE_THRESHOLD` constant

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->