### PR TITLE
Fix handling of conflicts on UserData insertion

### DIFF
--- a/packages/hub-nodejs/examples/replicate-data-postgres/hubReplicator.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/hubReplicator.ts
@@ -442,8 +442,9 @@ export class HubReplicator {
       })
       .onConflict((oc) =>
         oc
-          .columns(['hash'])
+          .columns(['fid', 'type'])
           .doUpdateSet({
+            hash: message.hash,
             timestamp: farcasterTimeToDate(message.data.timestamp),
             value: message.data.userDataBody.value,
             updatedAt: new Date(),
@@ -451,6 +452,7 @@ export class HubReplicator {
           .where(({ or, cmpr, ref }) =>
             // Only update if a value has actually changed
             or([
+              cmpr('excluded.hash', '!=', ref('userData.hash')),
               cmpr('excluded.timestamp', '!=', ref('userData.timestamp')),
               cmpr('excluded.value', '!=', ref('userData.value')),
               cmpr('excluded.updatedAt', '!=', ref('userData.updatedAt')),


### PR DESCRIPTION
## Motivation

We were using hash as the conflict ID instead of FID + type for the sync/replication example.

## Change Summary

Switch to using FID + type in the conflict ID.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)
