### PR TITLE
chore: ensure we clear the event handler cache in tests

### DIFF
--- a/apps/hubble/src/storage/stores/castStore.test.ts
+++ b/apps/hubble/src/storage/stores/castStore.test.ts
@@ -39,6 +39,10 @@ beforeAll(async () => {
   });
 });
 
+beforeEach(async () => {
+  await eventHandler.syncCache();
+});
+
 describe('getCastAdd', () => {
   const getCastAdd = () => store.getCastAdd(fid, castAdd.hash);
 
@@ -700,10 +704,6 @@ describe('pruneMessages', () => {
     remove3 = await generateRemoveWithTimestamp(fid, time + 3, add3);
     remove4 = await generateRemoveWithTimestamp(fid, time + 4, add4);
     remove5 = await generateRemoveWithTimestamp(fid, time + 5, add5);
-  });
-
-  beforeEach(async () => {
-    await eventHandler.syncCache();
   });
 
   describe('with size limit', () => {

--- a/apps/hubble/src/storage/stores/reactionStore.test.ts
+++ b/apps/hubble/src/storage/stores/reactionStore.test.ts
@@ -63,6 +63,10 @@ beforeAll(async () => {
   });
 });
 
+beforeEach(async () => {
+  await eventHandler.syncCache();
+});
+
 describe('getReactionAdd', () => {
   test('fails if no ReactionAdd is present', async () => {
     await expect(set.getReactionAdd(fid, reactionAdd.data.reactionBody.type, castId)).rejects.toThrow(HubError);
@@ -859,10 +863,6 @@ describe('pruneMessages', () => {
     remove3 = await generateRemoveWithTimestamp(fid, time + 3, add3.data.reactionBody);
     remove4 = await generateRemoveWithTimestamp(fid, time + 4, add4.data.reactionBody);
     remove5 = await generateRemoveWithTimestamp(fid, time + 5, add5.data.reactionBody);
-  });
-
-  beforeEach(async () => {
-    await eventHandler.syncCache();
   });
 
   describe('with size limit', () => {

--- a/apps/hubble/src/storage/stores/signerStore.test.ts
+++ b/apps/hubble/src/storage/stores/signerStore.test.ts
@@ -65,6 +65,10 @@ beforeAll(async () => {
   );
 });
 
+beforeEach(async () => {
+  await eventHandler.syncCache();
+});
+
 describe('getIdRegistryEvent', () => {
   test('returns contract event if it exists', async () => {
     await set.mergeIdRegistryEvent(custody1Event);
@@ -997,7 +1001,6 @@ describe('pruneMessages', () => {
   });
 
   beforeEach(() => {
-    eventHandler.syncCache();
     prunedMessages = [];
   });
 
@@ -1048,10 +1051,6 @@ describe('pruneMessages', () => {
     remove3 = await generateRemoveWithTimestamp(fid, time + 3, add3.data.signerAddBody.signer);
     remove4 = await generateRemoveWithTimestamp(fid, time + 4, add4.data.signerAddBody.signer);
     remove5 = await generateRemoveWithTimestamp(fid, time + 5, add5.data.signerAddBody.signer);
-  });
-
-  beforeEach(async () => {
-    await eventHandler.syncCache();
   });
 
   describe('with size limit', () => {

--- a/apps/hubble/src/storage/stores/storeEventHandler.test.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.test.ts
@@ -21,9 +21,10 @@ beforeAll(() => {
   eventHandler.on('mergeMessage', eventListener);
 });
 
-beforeEach(() => {
+beforeEach(async () => {
   events = [];
   currentTime = getFarcasterTime()._unsafeUnwrap();
+  await eventHandler.syncCache();
 });
 
 afterAll(() => {

--- a/apps/hubble/src/storage/stores/userDataStore.test.ts
+++ b/apps/hubble/src/storage/stores/userDataStore.test.ts
@@ -34,6 +34,10 @@ beforeAll(async () => {
   });
 });
 
+beforeEach(async () => {
+  await eventHandler.syncCache();
+});
+
 describe('getUserDataAdd', () => {
   test('fails if missing', async () => {
     await expect(set.getUserDataAdd(fid, UserDataType.PFP)).rejects.toThrow(HubError);
@@ -292,10 +296,6 @@ describe('pruneMessages', () => {
     add3 = await generateAddWithTimestamp(fid, time + 3, UserDataType.BIO);
     add4 = await generateAddWithTimestamp(fid, time + 5, UserDataType.URL);
     addOld1 = await generateAddWithTimestamp(fid, time - 60 * 60, UserDataType.URL);
-  });
-
-  beforeEach(async () => {
-    await eventHandler.syncCache();
   });
 
   describe('with size limit', () => {

--- a/apps/hubble/src/storage/stores/verificationStore.test.ts
+++ b/apps/hubble/src/storage/stores/verificationStore.test.ts
@@ -48,6 +48,10 @@ beforeAll(async () => {
   });
 });
 
+beforeEach(async () => {
+  await eventHandler.syncCache();
+});
+
 describe('getVerificationAdd', () => {
   test('fails if missing', async () => {
     await expect(set.getVerificationAdd(fid, ethSignerKey)).rejects.toThrow(HubError);
@@ -532,10 +536,6 @@ describe('pruneMessages', () => {
     remove3 = await generateRemoveWithTimestamp(fid, time + 3, add3.data.verificationAddEthAddressBody.address);
     remove4 = await generateRemoveWithTimestamp(fid, time + 4, add4.data.verificationAddEthAddressBody.address);
     remove5 = await generateRemoveWithTimestamp(fid, time + 5, add5.data.verificationAddEthAddressBody.address);
-  });
-
-  beforeEach(async () => {
-    await eventHandler.syncCache();
   });
 
   describe('with size limit', () => {


### PR DESCRIPTION
## Motivation

Tests are flaky sometimes because the cache was not being cleared between tests.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds `await eventHandler.syncCache()` to the `beforeEach` hook in several test files. 

### Detailed summary
- Adds `await eventHandler.syncCache()` to `beforeEach` hook in `storeEventHandler.test.ts`, `castStore.test.ts`, `userDataStore.test.ts`, `verificationStore.test.ts`, `reactionStore.test.ts`, and `signerStore.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->