### PR TITLE
fix: Reduce memory consumption of replication example

### DIFF
--- a/packages/hub-nodejs/examples/replicate-data-postgres/package.json
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.0",
   "main": "index.ts",
   "scripts": {
-    "start": "tsx index.ts"
+    "start": "NODE_OPTIONS=--max-old-space-size=1024 tsx index.ts"
   },
   "dependencies": {
     "@farcaster/hub-nodejs": "^0.7.1",


### PR DESCRIPTION
## Motivation

We had a report of one user on modern MacBook with 16GB of memory who was running into heap allocation issues. This was likely due to the excessive number of promises we were creating (as well as buffering all data for each call).


## Change Summary

Change the logic to fetch in batches of 1K records at most. This slows down the initial sync but should reduce the likelihood that someone will hit a memory limit.

We also specify a custom limit in the `yarn start` command so that when we test locally we are using the same limit as everyone else.


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a backfilling feature to the `HubReplicator` class and includes changes to fetch messages in batches to reduce memory consumption.

### Detailed summary
- Added `MAX_PAGE_SIZE` constant to control the batch size for fetching messages.
- Added backfilling feature to fetch historical data.
- Refactored message fetching methods to fetch messages serially in batches.
- Updated log messages to give more information about the events being processed.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->