### PR TITLE
feat: Add a status hubble command for friendly reporting of current hub status

### DIFF
--- a/.changeset/shiny-tables-join.md
+++ b/.changeset/shiny-tables-join.md
@@ -1,0 +1,8 @@
+---
+'@farcaster/hub-nodejs': patch
+'@farcaster/hub-web': patch
+'@farcaster/core': patch
+'@farcaster/hubble': patch
+---
+
+Add a GetSyncStatus rpc call that exposes the hubs sync status with different peers

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -25,7 +25,7 @@
     "identity": "tsx src/cli.ts identity",
     "dbreset": "tsx src/cli.ts dbreset",
     "console": "tsx src/cli.ts console",
-    "syncstatus": "tsx src/cli.ts syncstatus",
+    "status": "tsx src/cli.ts status",
     "test": "yarn build && NODE_OPTIONS=--experimental-vm-modules jest",
     "test:ci": "ENVIRONMENT=test NODE_OPTIONS=--experimental-vm-modules jest --ci --forceExit --coverage"
   },

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -25,6 +25,7 @@
     "identity": "tsx src/cli.ts identity",
     "dbreset": "tsx src/cli.ts dbreset",
     "console": "tsx src/cli.ts console",
+    "syncstatus": "tsx src/cli.ts syncstatus",
     "test": "yarn build && NODE_OPTIONS=--experimental-vm-modules jest",
     "test:ci": "ENVIRONMENT=test NODE_OPTIONS=--experimental-vm-modules jest --ci --forceExit --coverage"
   },

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -462,9 +462,14 @@ app
     }
     const infoResult = await rpcClient.getInfo(HubInfoRequest.create({ dbStats: true }));
     const syncStatusResult = await rpcClient.getSyncStatus(SyncStatusRequest.create({ peerId: cliOptions.peerId }));
-    if (syncStatusResult.isErr() || infoResult.isErr()) {
-      const res = infoResult.isErr() ? infoResult : syncStatusResult;
-      logger.error({ errCode: res.error.errCode, errMsg: res.error.message }, 'Failed to get hub status');
+    if (syncStatusResult.isErr()) {
+      logger.error(
+        { errCode: syncStatusResult.error.errCode, errMsg: syncStatusResult.error.message },
+        'Failed to get hub status'
+      );
+      exit(1);
+    } else if (infoResult.isErr()) {
+      logger.error({ errCode: infoResult.error.errCode, errMsg: infoResult.error.message }, 'Failed to get hub status');
       exit(1);
     }
     const dbStats = infoResult.value.dbStats;

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -470,8 +470,8 @@ app
     }
     for (const peerStatus of syncStatusResult.value.syncStatus) {
       const messageDelta = peerStatus.theirMessages - peerStatus.ourMessages;
-      if (!syncStatusResult.value.isSyncing) {
-        logger.info(`Peer ${peerStatus.peerId}: Sync in progress with a peer. (msg delta: ${messageDelta})`);
+      if (syncStatusResult.value.isSyncing) {
+        logger.info(`Peer ${peerStatus.peerId}: Sync in progress. (msg delta: ${messageDelta})`);
       } else {
         logger.info(
           `Peer ${peerStatus.peerId}: In Sync: ${peerStatus.inSync} (msg delta: ${messageDelta}, diverged ${peerStatus.divergenceSecondsAgo} seconds ago)`

--- a/apps/hubble/src/console/console.ts
+++ b/apps/hubble/src/console/console.ts
@@ -88,7 +88,7 @@ export const startConsole = async (addressString: string, useInsecure: boolean) 
 
   // Run the info command to start
 
-  const info = await rpcClient.getInfo(HubInfoRequest.create({ syncStats: true }), new Metadata(), {
+  const info = await rpcClient.getInfo(HubInfoRequest.create({ dbStats: true }), new Metadata(), {
     deadline: Date.now() + 2000,
   });
 

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -73,6 +73,7 @@ export interface HubInterface {
   getHubState(): HubAsyncResult<HubState>;
   putHubState(hubState: HubState): HubAsyncResult<void>;
   gossipContactInfo(): HubAsyncResult<void>;
+  getRPCClientForPeer(peerId: PeerId, peer: ContactInfoContent): Promise<HubRpcClient | undefined>;
 }
 
 export interface HubOptions {

--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -246,7 +246,6 @@ describe('SyncEngine', () => {
       expect(shouldSync.isOk()).toBeTruthy();
       expect(shouldSync._unsafeUnwrap().isSyncing).toBeTruthy();
       expect(shouldSync._unsafeUnwrap().shouldSync).toBeFalsy();
-      expect(shouldSync._unsafeUnwrap().ourSnapshot).toBeUndefined();
       called = true;
 
       // Return an empty child map so sync will finish with a noop

--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -332,7 +332,7 @@ describe('SyncEngine', () => {
     await engine.mergeMessage(signerAdd);
     await addMessagesWithTimestamps([167, 169]);
 
-    const stats = await syncEngine.getSyncStats();
+    const stats = await syncEngine.getDbStats();
     expect(stats.numFids).toEqual(1);
     expect(stats.numFnames).toEqual(2);
     expect(stats.numMessages).toEqual(3);

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -22,13 +22,14 @@ import { TypedEmitter } from 'tiny-typed-emitter';
 import { EthEventsProvider } from '~/eth/ethEventsProvider';
 import { Hub, HubInterface } from '~/hubble';
 import { MerkleTrie, NodeMetadata } from '~/network/sync/merkleTrie';
-import { SyncId, timestampToPaddedTimestampPrefix } from '~/network/sync/syncId';
+import { prefixToTimestamp, SyncId, timestampToPaddedTimestampPrefix } from '~/network/sync/syncId';
 import { TrieSnapshot } from '~/network/sync/trieNode';
 import { getManyMessages } from '~/storage/db/message';
 import RocksDB from '~/storage/db/rocksdb';
 import { sleepWhile } from '~/utils/crypto';
 import { logger } from '~/utils/logger';
 import { RootPrefix } from '~/storage/db/types';
+import { fromFarcasterTime } from '@farcaster/core';
 
 // Number of seconds to wait for the network to "settle" before syncing. We will only
 // attempt to sync messages that are older than this time.
@@ -65,13 +66,16 @@ type MergeResult = {
 
 type SyncStatus = {
   isSyncing: boolean;
-  inSync: 'true' | 'false' | 'unknown';
+  inSync: 'true' | 'false' | 'unknown' | 'blocked';
   shouldSync: boolean;
   theirSnapshot: TrieSnapshot;
   ourSnapshot?: TrieSnapshot;
+  divergencePrefix: string;
+  divergenceSecondsAgo: number;
+  lastBadSync: number;
 };
 
-type SyncStats = {
+type DbStats = {
   numMessages: number;
   numFids: number;
   numFnames: number;
@@ -297,7 +301,9 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
           ourMessages: syncStatus.ourSnapshot?.numMessages,
           peerNetwork: peerContact.network,
           peerVersion: peerContact.hubVersion,
-          lastBadSync: this._unproductivePeers.get(peerIdString)?.getTime(),
+          divergencePrefix: syncStatus.divergencePrefix,
+          divergenceSeconds: syncStatus.divergenceSecondsAgo,
+          lastBadSync: syncStatus.lastBadSync,
         },
         'SyncStatus' // Search for this string in the logs to get summary of sync status
       );
@@ -326,15 +332,29 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
   }
 
   public async syncStatus(peerId: string, theirSnapshot: TrieSnapshot): HubAsyncResult<SyncStatus> {
+    const lastBadSync = this._unproductivePeers.get(peerId);
     if (this._isSyncing) {
-      log.info('shouldSync: already syncing');
-      return ok({ isSyncing: true, inSync: 'unknown', shouldSync: false, theirSnapshot });
+      return ok({
+        isSyncing: true,
+        inSync: 'unknown',
+        shouldSync: false,
+        theirSnapshot,
+        divergencePrefix: '',
+        divergenceSecondsAgo: -1,
+        lastBadSync: -1,
+      });
     }
 
-    const lastBadSync = this._unproductivePeers.get(peerId);
     if (lastBadSync && Date.now() < lastBadSync.getTime() + BAD_PEER_BLOCK_TIMEOUT) {
-      log.info(`shouldSync: bad peer (blocked until ${lastBadSync.getTime() + BAD_PEER_BLOCK_TIMEOUT})`);
-      return ok({ isSyncing: false, inSync: 'false', shouldSync: false, theirSnapshot });
+      return ok({
+        isSyncing: false,
+        inSync: 'blocked',
+        shouldSync: false,
+        theirSnapshot,
+        divergencePrefix: '',
+        divergenceSecondsAgo: -1,
+        lastBadSync: lastBadSync.getTime(),
+      });
     }
 
     const ourSnapshotResult = await this.getSnapshot(theirSnapshot.prefix);
@@ -348,7 +368,14 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
         // eslint-disable-next-line security/detect-object-injection
         ourSnapshot.excludedHashes.every((value, index) => value === theirSnapshot.excludedHashes[index]);
 
-      log.info({ excludedHashesMatch }, `shouldSync: excluded hashes`);
+      const divergencePrefix = Buffer.from(
+        this.getDivergencePrefix(ourSnapshot, theirSnapshot.excludedHashes)
+      ).toString('ascii');
+      const divergedAt = fromFarcasterTime(prefixToTimestamp(divergencePrefix));
+      let divergenceSecondsAgo = -1;
+      if (divergedAt.isOk()) {
+        divergenceSecondsAgo = Math.floor((Date.now() - divergedAt.value) / 1000);
+      }
 
       return ok({
         isSyncing: false,
@@ -356,6 +383,9 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
         shouldSync: !excludedHashesMatch,
         ourSnapshot,
         theirSnapshot,
+        divergencePrefix,
+        divergenceSecondsAgo,
+        lastBadSync: lastBadSync?.getTime() ?? -1,
       });
     }
   }
@@ -371,7 +401,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
         log.warn({ errCode: snapshot.error.errCode }, `Error performing sync: ${snapshot.error.message}}`);
       } else {
         const ourSnapshot = snapshot.value;
-        const divergencePrefix = await this.getDivergencePrefix(ourSnapshot, otherSnapshot.excludedHashes);
+        const divergencePrefix = this.getDivergencePrefix(ourSnapshot, otherSnapshot.excludedHashes);
         log.info(
           {
             divergencePrefix: Buffer.from(divergencePrefix).toString('ascii'),
@@ -423,7 +453,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
    * @param prefix - the prefix of the external trie.
    * @param otherExcludedHashes - the excluded hashes of the external trie.
    */
-  async getDivergencePrefix(ourSnapshot: TrieSnapshot, otherExcludedHashes: string[]): Promise<Uint8Array> {
+  getDivergencePrefix(ourSnapshot: TrieSnapshot, otherExcludedHashes: string[]): Uint8Array {
     const { prefix, excludedHashes } = ourSnapshot;
 
     for (let i = 0; i < prefix.length; i++) {
@@ -661,7 +691,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     return false;
   }
 
-  public async getSyncStats(): Promise<SyncStats> {
+  public async getDbStats(): Promise<DbStats> {
     let numFids = 0,
       numFnames = 0;
 
@@ -684,6 +714,28 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
       numFids: numFids,
       numFnames: numFnames,
     };
+  }
+
+  public async getSyncStatusForPeer(peerId: string, hub: HubInterface): HubAsyncResult<SyncStatus> {
+    const c = this.currentHubPeerContacts.get(peerId);
+    if (!c?.peerId || !c?.contactInfo) {
+      return err(new HubError('unavailable.network_failure', `No contact info for peer ${peerId}`));
+    }
+    const rpcClient = await hub.getRPCClientForPeer(c?.peerId, c?.contactInfo);
+    if (!rpcClient) {
+      return err(new HubError('unavailable.network_failure', `Could not create a RPC client for peer ${peerId}`));
+    }
+    const peerStateResult = await rpcClient.getSyncSnapshotByPrefix(
+      TrieNodePrefix.create({ prefix: new Uint8Array() }),
+      new Metadata(),
+      rpcDeadline()
+    );
+    if (peerStateResult.isErr()) {
+      return err(peerStateResult.error);
+    }
+
+    const theirSnapshot = peerStateResult.value;
+    return this.syncStatus(peerId, theirSnapshot);
   }
 
   public get shouldCompactDb(): boolean {

--- a/apps/hubble/src/network/sync/syncId.ts
+++ b/apps/hubble/src/network/sync/syncId.ts
@@ -64,4 +64,8 @@ const timestampToPaddedTimestampPrefix = (timestamp: number): string => {
   return Math.floor(timestamp).toString().padStart(TIMESTAMP_LENGTH, '0');
 };
 
-export { SyncId, timestampToPaddedTimestampPrefix, TIMESTAMP_LENGTH, HASH_LENGTH };
+const prefixToTimestamp = (prefix: string): number => {
+  return parseInt(prefix.padEnd(TIMESTAMP_LENGTH, '0'), 10);
+};
+
+export { SyncId, timestampToPaddedTimestampPrefix, prefixToTimestamp, TIMESTAMP_LENGTH, HASH_LENGTH };

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -275,9 +275,9 @@ export default class Server {
             rootHash: (await this.syncEngine?.trie.rootHash()) ?? '',
           });
 
-          if (call.request.syncStats && this.syncEngine) {
-            const stats = await this.syncEngine.getSyncStats();
-            info.syncStats = SyncStats.create({
+          if (call.request.dbStats && this.syncEngine) {
+            const stats = await this.syncEngine.getDbStats();
+            info.dbStats = DbStats.create({
               numMessages: stats?.numMessages,
               numFidEvents: stats?.numFids,
               numFnameEvents: stats?.numFnames,
@@ -285,6 +285,20 @@ export default class Server {
           }
 
           callback(null, info);
+        })();
+      },
+      getSyncStatus: (call, callback) => {
+        (async () => {
+          if (!this.gossipNode || !this.syncEngine || !this.hub) {
+            callback(null);
+            return;
+          }
+          const peersToCheck = this.gossipNode.bootstrapPeerIds ?? [];
+          for (const peerId of peersToCheck) {
+            await this.syncEngine.getSyncStatusForPeer(peerId, this.hub);
+          }
+
+          callback(null);
         })();
       },
       getAllSyncIdsByPrefix: (call, callback) => {

--- a/apps/hubble/src/rpc/test/syncService.test.ts
+++ b/apps/hubble/src/rpc/test/syncService.test.ts
@@ -1,0 +1,88 @@
+import { jestRocksDB } from '~/storage/db/jestUtils';
+import {
+  CastAddMessage,
+  Factories,
+  FarcasterNetwork,
+  getInsecureHubRpcClient,
+  HubInfoRequest,
+  HubRpcClient,
+  IdRegistryEvent,
+  SignerAddMessage,
+  SyncStatusRequest,
+} from '@farcaster/hub-nodejs';
+import Engine from '~/storage/engine';
+import { MockHub } from '~/test/mocks';
+import Server from '~/rpc/server';
+import SyncEngine from '~/network/sync/syncEngine';
+import { GossipNode } from '~/network/p2p/gossipNode';
+
+const db = jestRocksDB('protobufs.rpc.syncService.test');
+const network = FarcasterNetwork.TESTNET;
+const mockGossipNode = {
+  bootstrapPeerIds: ['test'],
+} as unknown as GossipNode;
+const engine = new Engine(db, network);
+const hub = new MockHub(db, engine, mockGossipNode);
+
+let server: Server;
+let client: HubRpcClient;
+
+beforeAll(async () => {
+  server = new Server(hub, engine, new SyncEngine(hub, db), mockGossipNode);
+  const port = await server.start();
+  client = getInsecureHubRpcClient(`127.0.0.1:${port}`);
+});
+
+afterAll(async () => {
+  client.close();
+  await server.stop();
+  await engine.stop();
+});
+
+const fid = Factories.Fid.build();
+const signer = Factories.Ed25519Signer.build();
+const custodySigner = Factories.Eip712Signer.build();
+
+let custodyEvent: IdRegistryEvent;
+let signerAdd: SignerAddMessage;
+let castAdd: CastAddMessage;
+
+beforeAll(async () => {
+  const signerKey = (await signer.getSignerKey())._unsafeUnwrap();
+  const custodySignerKey = (await custodySigner.getSignerKey())._unsafeUnwrap();
+  custodyEvent = Factories.IdRegistryEvent.build({ fid, to: custodySignerKey });
+
+  signerAdd = await Factories.SignerAddMessage.create(
+    { data: { fid, network, signerAddBody: { signer: signerKey } } },
+    { transient: { signer: custodySigner } }
+  );
+
+  castAdd = await Factories.CastAddMessage.create({ data: { fid, network } }, { transient: { signer } });
+});
+
+describe('getInfo', () => {
+  test('succeeds', async () => {
+    await engine.mergeIdRegistryEvent(custodyEvent);
+    await engine.mergeMessage(signerAdd);
+    await engine.mergeMessage(castAdd);
+
+    const result = await client.getInfo(HubInfoRequest.create({ dbStats: true }));
+    expect(result.isOk()).toBeTruthy();
+    expect(result._unsafeUnwrap().dbStats?.numMessages).toEqual(2);
+    expect(result._unsafeUnwrap().dbStats?.numFidEvents).toEqual(1);
+    expect(result._unsafeUnwrap().dbStats?.numFnameEvents).toEqual(0);
+  });
+});
+
+describe('getSyncStatus', () => {
+  test('succeeds', async () => {
+    await engine.mergeIdRegistryEvent(custodyEvent);
+    await engine.mergeMessage(signerAdd);
+    await engine.mergeMessage(castAdd);
+
+    const result = await client.getSyncStatus(SyncStatusRequest.create());
+    expect(result.isOk()).toBeTruthy();
+    expect(result._unsafeUnwrap().isSyncing).toEqual(false);
+    expect(result._unsafeUnwrap().syncStatus).toHaveLength(0);
+  });
+});

--- a/apps/hubble/src/test/mocks.ts
+++ b/apps/hubble/src/test/mocks.ts
@@ -2,6 +2,7 @@ import {
   FarcasterNetwork,
   HubAsyncResult,
   HubError,
+  HubRpcClient,
   HubState,
   IdRegistryEvent,
   Message,
@@ -13,6 +14,8 @@ import { GossipNode } from '~/network/p2p/gossipNode';
 import RocksDB from '~/storage/db/rocksdb';
 import Engine from '~/storage/engine';
 import { AbstractProvider } from 'ethers';
+import { PeerId } from '@libp2p/interface-peer-id';
+import { ContactInfoContent } from '@farcaster/core';
 
 export class MockHub implements HubInterface {
   public db: RocksDB;
@@ -59,6 +62,10 @@ export class MockHub implements HubInterface {
   async gossipContactInfo(): HubAsyncResult<void> {
     this.gossipCount += 1;
     return ok(undefined);
+  }
+
+  async getRPCClientForPeer(peerId: PeerId, peer: ContactInfoContent): Promise<HubRpcClient | undefined> {
+    return undefined;
   }
 }
 

--- a/apps/hubble/src/test/mocks.ts
+++ b/apps/hubble/src/test/mocks.ts
@@ -64,7 +64,7 @@ export class MockHub implements HubInterface {
     return ok(undefined);
   }
 
-  async getRPCClientForPeer(peerId: PeerId, peer: ContactInfoContent): Promise<HubRpcClient | undefined> {
+  async getRPCClientForPeer(_peerId: PeerId, _peer: ContactInfoContent): Promise<HubRpcClient | undefined> {
     return undefined;
   }
 }

--- a/packages/core/src/protobufs/generated/request_response.ts
+++ b/packages/core/src/protobufs/generated/request_response.ts
@@ -25,7 +25,7 @@ export interface EventRequest {
 }
 
 export interface HubInfoRequest {
-  syncStats: boolean;
+  dbStats: boolean;
 }
 
 /** Response Types for the Sync RPC Methods */
@@ -34,13 +34,33 @@ export interface HubInfoResponse {
   isSyncing: boolean;
   nickname: string;
   rootHash: string;
-  syncStats: SyncStats | undefined;
+  dbStats: DbStats | undefined;
 }
 
-export interface SyncStats {
+export interface DbStats {
   numMessages: number;
   numFidEvents: number;
   numFnameEvents: number;
+}
+
+export interface SyncStatusRequest {
+  peerId?: string | undefined;
+}
+
+export interface SyncStatusResponse {
+  isSyncing: boolean;
+  syncStatus: SyncStatus[];
+}
+
+export interface SyncStatus {
+  peerId: string;
+  inSync: string;
+  shouldSync: boolean;
+  divergencePrefix: string;
+  divergenceSecondsAgo: number;
+  theirMessages: number;
+  ourMessages: number;
+  lastBadSync: number;
 }
 
 export interface TrieNodeMetadataResponse {
@@ -334,13 +354,13 @@ export const EventRequest = {
 };
 
 function createBaseHubInfoRequest(): HubInfoRequest {
-  return { syncStats: false };
+  return { dbStats: false };
 }
 
 export const HubInfoRequest = {
   encode(message: HubInfoRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.syncStats === true) {
-      writer.uint32(8).bool(message.syncStats);
+    if (message.dbStats === true) {
+      writer.uint32(8).bool(message.dbStats);
     }
     return writer;
   },
@@ -357,7 +377,7 @@ export const HubInfoRequest = {
             break;
           }
 
-          message.syncStats = reader.bool();
+          message.dbStats = reader.bool();
           continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
@@ -369,12 +389,12 @@ export const HubInfoRequest = {
   },
 
   fromJSON(object: any): HubInfoRequest {
-    return { syncStats: isSet(object.syncStats) ? Boolean(object.syncStats) : false };
+    return { dbStats: isSet(object.dbStats) ? Boolean(object.dbStats) : false };
   },
 
   toJSON(message: HubInfoRequest): unknown {
     const obj: any = {};
-    message.syncStats !== undefined && (obj.syncStats = message.syncStats);
+    message.dbStats !== undefined && (obj.dbStats = message.dbStats);
     return obj;
   },
 
@@ -384,13 +404,13 @@ export const HubInfoRequest = {
 
   fromPartial<I extends Exact<DeepPartial<HubInfoRequest>, I>>(object: I): HubInfoRequest {
     const message = createBaseHubInfoRequest();
-    message.syncStats = object.syncStats ?? false;
+    message.dbStats = object.dbStats ?? false;
     return message;
   },
 };
 
 function createBaseHubInfoResponse(): HubInfoResponse {
-  return { version: '', isSyncing: false, nickname: '', rootHash: '', syncStats: undefined };
+  return { version: '', isSyncing: false, nickname: '', rootHash: '', dbStats: undefined };
 }
 
 export const HubInfoResponse = {
@@ -407,8 +427,8 @@ export const HubInfoResponse = {
     if (message.rootHash !== '') {
       writer.uint32(34).string(message.rootHash);
     }
-    if (message.syncStats !== undefined) {
-      SyncStats.encode(message.syncStats, writer.uint32(42).fork()).ldelim();
+    if (message.dbStats !== undefined) {
+      DbStats.encode(message.dbStats, writer.uint32(42).fork()).ldelim();
     }
     return writer;
   },
@@ -453,7 +473,7 @@ export const HubInfoResponse = {
             break;
           }
 
-          message.syncStats = SyncStats.decode(reader, reader.uint32());
+          message.dbStats = DbStats.decode(reader, reader.uint32());
           continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
@@ -470,7 +490,7 @@ export const HubInfoResponse = {
       isSyncing: isSet(object.isSyncing) ? Boolean(object.isSyncing) : false,
       nickname: isSet(object.nickname) ? String(object.nickname) : '',
       rootHash: isSet(object.rootHash) ? String(object.rootHash) : '',
-      syncStats: isSet(object.syncStats) ? SyncStats.fromJSON(object.syncStats) : undefined,
+      dbStats: isSet(object.dbStats) ? DbStats.fromJSON(object.dbStats) : undefined,
     };
   },
 
@@ -480,8 +500,7 @@ export const HubInfoResponse = {
     message.isSyncing !== undefined && (obj.isSyncing = message.isSyncing);
     message.nickname !== undefined && (obj.nickname = message.nickname);
     message.rootHash !== undefined && (obj.rootHash = message.rootHash);
-    message.syncStats !== undefined &&
-      (obj.syncStats = message.syncStats ? SyncStats.toJSON(message.syncStats) : undefined);
+    message.dbStats !== undefined && (obj.dbStats = message.dbStats ? DbStats.toJSON(message.dbStats) : undefined);
     return obj;
   },
 
@@ -495,18 +514,18 @@ export const HubInfoResponse = {
     message.isSyncing = object.isSyncing ?? false;
     message.nickname = object.nickname ?? '';
     message.rootHash = object.rootHash ?? '';
-    message.syncStats =
-      object.syncStats !== undefined && object.syncStats !== null ? SyncStats.fromPartial(object.syncStats) : undefined;
+    message.dbStats =
+      object.dbStats !== undefined && object.dbStats !== null ? DbStats.fromPartial(object.dbStats) : undefined;
     return message;
   },
 };
 
-function createBaseSyncStats(): SyncStats {
+function createBaseDbStats(): DbStats {
   return { numMessages: 0, numFidEvents: 0, numFnameEvents: 0 };
 }
 
-export const SyncStats = {
-  encode(message: SyncStats, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+export const DbStats = {
+  encode(message: DbStats, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.numMessages !== 0) {
       writer.uint32(8).uint64(message.numMessages);
     }
@@ -519,10 +538,10 @@ export const SyncStats = {
     return writer;
   },
 
-  decode(input: _m0.Reader | Uint8Array, length?: number): SyncStats {
+  decode(input: _m0.Reader | Uint8Array, length?: number): DbStats {
     const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseSyncStats();
+    const message = createBaseDbStats();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -556,7 +575,7 @@ export const SyncStats = {
     return message;
   },
 
-  fromJSON(object: any): SyncStats {
+  fromJSON(object: any): DbStats {
     return {
       numMessages: isSet(object.numMessages) ? Number(object.numMessages) : 0,
       numFidEvents: isSet(object.numFidEvents) ? Number(object.numFidEvents) : 0,
@@ -564,7 +583,7 @@ export const SyncStats = {
     };
   },
 
-  toJSON(message: SyncStats): unknown {
+  toJSON(message: DbStats): unknown {
     const obj: any = {};
     message.numMessages !== undefined && (obj.numMessages = Math.round(message.numMessages));
     message.numFidEvents !== undefined && (obj.numFidEvents = Math.round(message.numFidEvents));
@@ -572,15 +591,304 @@ export const SyncStats = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<SyncStats>, I>>(base?: I): SyncStats {
-    return SyncStats.fromPartial(base ?? {});
+  create<I extends Exact<DeepPartial<DbStats>, I>>(base?: I): DbStats {
+    return DbStats.fromPartial(base ?? {});
   },
 
-  fromPartial<I extends Exact<DeepPartial<SyncStats>, I>>(object: I): SyncStats {
-    const message = createBaseSyncStats();
+  fromPartial<I extends Exact<DeepPartial<DbStats>, I>>(object: I): DbStats {
+    const message = createBaseDbStats();
     message.numMessages = object.numMessages ?? 0;
     message.numFidEvents = object.numFidEvents ?? 0;
     message.numFnameEvents = object.numFnameEvents ?? 0;
+    return message;
+  },
+};
+
+function createBaseSyncStatusRequest(): SyncStatusRequest {
+  return { peerId: undefined };
+}
+
+export const SyncStatusRequest = {
+  encode(message: SyncStatusRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.peerId !== undefined) {
+      writer.uint32(10).string(message.peerId);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): SyncStatusRequest {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSyncStatusRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.peerId = reader.string();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SyncStatusRequest {
+    return { peerId: isSet(object.peerId) ? String(object.peerId) : undefined };
+  },
+
+  toJSON(message: SyncStatusRequest): unknown {
+    const obj: any = {};
+    message.peerId !== undefined && (obj.peerId = message.peerId);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SyncStatusRequest>, I>>(base?: I): SyncStatusRequest {
+    return SyncStatusRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SyncStatusRequest>, I>>(object: I): SyncStatusRequest {
+    const message = createBaseSyncStatusRequest();
+    message.peerId = object.peerId ?? undefined;
+    return message;
+  },
+};
+
+function createBaseSyncStatusResponse(): SyncStatusResponse {
+  return { isSyncing: false, syncStatus: [] };
+}
+
+export const SyncStatusResponse = {
+  encode(message: SyncStatusResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.isSyncing === true) {
+      writer.uint32(8).bool(message.isSyncing);
+    }
+    for (const v of message.syncStatus) {
+      SyncStatus.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): SyncStatusResponse {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSyncStatusResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.isSyncing = reader.bool();
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.syncStatus.push(SyncStatus.decode(reader, reader.uint32()));
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SyncStatusResponse {
+    return {
+      isSyncing: isSet(object.isSyncing) ? Boolean(object.isSyncing) : false,
+      syncStatus: Array.isArray(object?.syncStatus) ? object.syncStatus.map((e: any) => SyncStatus.fromJSON(e)) : [],
+    };
+  },
+
+  toJSON(message: SyncStatusResponse): unknown {
+    const obj: any = {};
+    message.isSyncing !== undefined && (obj.isSyncing = message.isSyncing);
+    if (message.syncStatus) {
+      obj.syncStatus = message.syncStatus.map((e) => (e ? SyncStatus.toJSON(e) : undefined));
+    } else {
+      obj.syncStatus = [];
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SyncStatusResponse>, I>>(base?: I): SyncStatusResponse {
+    return SyncStatusResponse.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SyncStatusResponse>, I>>(object: I): SyncStatusResponse {
+    const message = createBaseSyncStatusResponse();
+    message.isSyncing = object.isSyncing ?? false;
+    message.syncStatus = object.syncStatus?.map((e) => SyncStatus.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBaseSyncStatus(): SyncStatus {
+  return {
+    peerId: '',
+    inSync: '',
+    shouldSync: false,
+    divergencePrefix: '',
+    divergenceSecondsAgo: 0,
+    theirMessages: 0,
+    ourMessages: 0,
+    lastBadSync: 0,
+  };
+}
+
+export const SyncStatus = {
+  encode(message: SyncStatus, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.peerId !== '') {
+      writer.uint32(10).string(message.peerId);
+    }
+    if (message.inSync !== '') {
+      writer.uint32(18).string(message.inSync);
+    }
+    if (message.shouldSync === true) {
+      writer.uint32(24).bool(message.shouldSync);
+    }
+    if (message.divergencePrefix !== '') {
+      writer.uint32(34).string(message.divergencePrefix);
+    }
+    if (message.divergenceSecondsAgo !== 0) {
+      writer.uint32(40).int32(message.divergenceSecondsAgo);
+    }
+    if (message.theirMessages !== 0) {
+      writer.uint32(48).uint64(message.theirMessages);
+    }
+    if (message.ourMessages !== 0) {
+      writer.uint32(56).uint64(message.ourMessages);
+    }
+    if (message.lastBadSync !== 0) {
+      writer.uint32(64).int64(message.lastBadSync);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): SyncStatus {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSyncStatus();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.peerId = reader.string();
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.inSync = reader.string();
+          continue;
+        case 3:
+          if (tag != 24) {
+            break;
+          }
+
+          message.shouldSync = reader.bool();
+          continue;
+        case 4:
+          if (tag != 34) {
+            break;
+          }
+
+          message.divergencePrefix = reader.string();
+          continue;
+        case 5:
+          if (tag != 40) {
+            break;
+          }
+
+          message.divergenceSecondsAgo = reader.int32();
+          continue;
+        case 6:
+          if (tag != 48) {
+            break;
+          }
+
+          message.theirMessages = longToNumber(reader.uint64() as Long);
+          continue;
+        case 7:
+          if (tag != 56) {
+            break;
+          }
+
+          message.ourMessages = longToNumber(reader.uint64() as Long);
+          continue;
+        case 8:
+          if (tag != 64) {
+            break;
+          }
+
+          message.lastBadSync = longToNumber(reader.int64() as Long);
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SyncStatus {
+    return {
+      peerId: isSet(object.peerId) ? String(object.peerId) : '',
+      inSync: isSet(object.inSync) ? String(object.inSync) : '',
+      shouldSync: isSet(object.shouldSync) ? Boolean(object.shouldSync) : false,
+      divergencePrefix: isSet(object.divergencePrefix) ? String(object.divergencePrefix) : '',
+      divergenceSecondsAgo: isSet(object.divergenceSecondsAgo) ? Number(object.divergenceSecondsAgo) : 0,
+      theirMessages: isSet(object.theirMessages) ? Number(object.theirMessages) : 0,
+      ourMessages: isSet(object.ourMessages) ? Number(object.ourMessages) : 0,
+      lastBadSync: isSet(object.lastBadSync) ? Number(object.lastBadSync) : 0,
+    };
+  },
+
+  toJSON(message: SyncStatus): unknown {
+    const obj: any = {};
+    message.peerId !== undefined && (obj.peerId = message.peerId);
+    message.inSync !== undefined && (obj.inSync = message.inSync);
+    message.shouldSync !== undefined && (obj.shouldSync = message.shouldSync);
+    message.divergencePrefix !== undefined && (obj.divergencePrefix = message.divergencePrefix);
+    message.divergenceSecondsAgo !== undefined && (obj.divergenceSecondsAgo = Math.round(message.divergenceSecondsAgo));
+    message.theirMessages !== undefined && (obj.theirMessages = Math.round(message.theirMessages));
+    message.ourMessages !== undefined && (obj.ourMessages = Math.round(message.ourMessages));
+    message.lastBadSync !== undefined && (obj.lastBadSync = Math.round(message.lastBadSync));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SyncStatus>, I>>(base?: I): SyncStatus {
+    return SyncStatus.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SyncStatus>, I>>(object: I): SyncStatus {
+    const message = createBaseSyncStatus();
+    message.peerId = object.peerId ?? '';
+    message.inSync = object.inSync ?? '';
+    message.shouldSync = object.shouldSync ?? false;
+    message.divergencePrefix = object.divergencePrefix ?? '';
+    message.divergenceSecondsAgo = object.divergenceSecondsAgo ?? 0;
+    message.theirMessages = object.theirMessages ?? 0;
+    message.ourMessages = object.ourMessages ?? 0;
+    message.lastBadSync = object.lastBadSync ?? 0;
     return message;
   },
 };

--- a/packages/hub-nodejs/src/generated/request_response.ts
+++ b/packages/hub-nodejs/src/generated/request_response.ts
@@ -25,7 +25,7 @@ export interface EventRequest {
 }
 
 export interface HubInfoRequest {
-  syncStats: boolean;
+  dbStats: boolean;
 }
 
 /** Response Types for the Sync RPC Methods */
@@ -34,13 +34,33 @@ export interface HubInfoResponse {
   isSyncing: boolean;
   nickname: string;
   rootHash: string;
-  syncStats: SyncStats | undefined;
+  dbStats: DbStats | undefined;
 }
 
-export interface SyncStats {
+export interface DbStats {
   numMessages: number;
   numFidEvents: number;
   numFnameEvents: number;
+}
+
+export interface SyncStatusRequest {
+  peerId?: string | undefined;
+}
+
+export interface SyncStatusResponse {
+  isSyncing: boolean;
+  syncStatus: SyncStatus[];
+}
+
+export interface SyncStatus {
+  peerId: string;
+  inSync: string;
+  shouldSync: boolean;
+  divergencePrefix: string;
+  divergenceSecondsAgo: number;
+  theirMessages: number;
+  ourMessages: number;
+  lastBadSync: number;
 }
 
 export interface TrieNodeMetadataResponse {
@@ -334,13 +354,13 @@ export const EventRequest = {
 };
 
 function createBaseHubInfoRequest(): HubInfoRequest {
-  return { syncStats: false };
+  return { dbStats: false };
 }
 
 export const HubInfoRequest = {
   encode(message: HubInfoRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.syncStats === true) {
-      writer.uint32(8).bool(message.syncStats);
+    if (message.dbStats === true) {
+      writer.uint32(8).bool(message.dbStats);
     }
     return writer;
   },
@@ -357,7 +377,7 @@ export const HubInfoRequest = {
             break;
           }
 
-          message.syncStats = reader.bool();
+          message.dbStats = reader.bool();
           continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
@@ -369,12 +389,12 @@ export const HubInfoRequest = {
   },
 
   fromJSON(object: any): HubInfoRequest {
-    return { syncStats: isSet(object.syncStats) ? Boolean(object.syncStats) : false };
+    return { dbStats: isSet(object.dbStats) ? Boolean(object.dbStats) : false };
   },
 
   toJSON(message: HubInfoRequest): unknown {
     const obj: any = {};
-    message.syncStats !== undefined && (obj.syncStats = message.syncStats);
+    message.dbStats !== undefined && (obj.dbStats = message.dbStats);
     return obj;
   },
 
@@ -384,13 +404,13 @@ export const HubInfoRequest = {
 
   fromPartial<I extends Exact<DeepPartial<HubInfoRequest>, I>>(object: I): HubInfoRequest {
     const message = createBaseHubInfoRequest();
-    message.syncStats = object.syncStats ?? false;
+    message.dbStats = object.dbStats ?? false;
     return message;
   },
 };
 
 function createBaseHubInfoResponse(): HubInfoResponse {
-  return { version: '', isSyncing: false, nickname: '', rootHash: '', syncStats: undefined };
+  return { version: '', isSyncing: false, nickname: '', rootHash: '', dbStats: undefined };
 }
 
 export const HubInfoResponse = {
@@ -407,8 +427,8 @@ export const HubInfoResponse = {
     if (message.rootHash !== '') {
       writer.uint32(34).string(message.rootHash);
     }
-    if (message.syncStats !== undefined) {
-      SyncStats.encode(message.syncStats, writer.uint32(42).fork()).ldelim();
+    if (message.dbStats !== undefined) {
+      DbStats.encode(message.dbStats, writer.uint32(42).fork()).ldelim();
     }
     return writer;
   },
@@ -453,7 +473,7 @@ export const HubInfoResponse = {
             break;
           }
 
-          message.syncStats = SyncStats.decode(reader, reader.uint32());
+          message.dbStats = DbStats.decode(reader, reader.uint32());
           continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
@@ -470,7 +490,7 @@ export const HubInfoResponse = {
       isSyncing: isSet(object.isSyncing) ? Boolean(object.isSyncing) : false,
       nickname: isSet(object.nickname) ? String(object.nickname) : '',
       rootHash: isSet(object.rootHash) ? String(object.rootHash) : '',
-      syncStats: isSet(object.syncStats) ? SyncStats.fromJSON(object.syncStats) : undefined,
+      dbStats: isSet(object.dbStats) ? DbStats.fromJSON(object.dbStats) : undefined,
     };
   },
 
@@ -480,8 +500,7 @@ export const HubInfoResponse = {
     message.isSyncing !== undefined && (obj.isSyncing = message.isSyncing);
     message.nickname !== undefined && (obj.nickname = message.nickname);
     message.rootHash !== undefined && (obj.rootHash = message.rootHash);
-    message.syncStats !== undefined &&
-      (obj.syncStats = message.syncStats ? SyncStats.toJSON(message.syncStats) : undefined);
+    message.dbStats !== undefined && (obj.dbStats = message.dbStats ? DbStats.toJSON(message.dbStats) : undefined);
     return obj;
   },
 
@@ -495,18 +514,18 @@ export const HubInfoResponse = {
     message.isSyncing = object.isSyncing ?? false;
     message.nickname = object.nickname ?? '';
     message.rootHash = object.rootHash ?? '';
-    message.syncStats =
-      object.syncStats !== undefined && object.syncStats !== null ? SyncStats.fromPartial(object.syncStats) : undefined;
+    message.dbStats =
+      object.dbStats !== undefined && object.dbStats !== null ? DbStats.fromPartial(object.dbStats) : undefined;
     return message;
   },
 };
 
-function createBaseSyncStats(): SyncStats {
+function createBaseDbStats(): DbStats {
   return { numMessages: 0, numFidEvents: 0, numFnameEvents: 0 };
 }
 
-export const SyncStats = {
-  encode(message: SyncStats, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+export const DbStats = {
+  encode(message: DbStats, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.numMessages !== 0) {
       writer.uint32(8).uint64(message.numMessages);
     }
@@ -519,10 +538,10 @@ export const SyncStats = {
     return writer;
   },
 
-  decode(input: _m0.Reader | Uint8Array, length?: number): SyncStats {
+  decode(input: _m0.Reader | Uint8Array, length?: number): DbStats {
     const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseSyncStats();
+    const message = createBaseDbStats();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -556,7 +575,7 @@ export const SyncStats = {
     return message;
   },
 
-  fromJSON(object: any): SyncStats {
+  fromJSON(object: any): DbStats {
     return {
       numMessages: isSet(object.numMessages) ? Number(object.numMessages) : 0,
       numFidEvents: isSet(object.numFidEvents) ? Number(object.numFidEvents) : 0,
@@ -564,7 +583,7 @@ export const SyncStats = {
     };
   },
 
-  toJSON(message: SyncStats): unknown {
+  toJSON(message: DbStats): unknown {
     const obj: any = {};
     message.numMessages !== undefined && (obj.numMessages = Math.round(message.numMessages));
     message.numFidEvents !== undefined && (obj.numFidEvents = Math.round(message.numFidEvents));
@@ -572,15 +591,304 @@ export const SyncStats = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<SyncStats>, I>>(base?: I): SyncStats {
-    return SyncStats.fromPartial(base ?? {});
+  create<I extends Exact<DeepPartial<DbStats>, I>>(base?: I): DbStats {
+    return DbStats.fromPartial(base ?? {});
   },
 
-  fromPartial<I extends Exact<DeepPartial<SyncStats>, I>>(object: I): SyncStats {
-    const message = createBaseSyncStats();
+  fromPartial<I extends Exact<DeepPartial<DbStats>, I>>(object: I): DbStats {
+    const message = createBaseDbStats();
     message.numMessages = object.numMessages ?? 0;
     message.numFidEvents = object.numFidEvents ?? 0;
     message.numFnameEvents = object.numFnameEvents ?? 0;
+    return message;
+  },
+};
+
+function createBaseSyncStatusRequest(): SyncStatusRequest {
+  return { peerId: undefined };
+}
+
+export const SyncStatusRequest = {
+  encode(message: SyncStatusRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.peerId !== undefined) {
+      writer.uint32(10).string(message.peerId);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): SyncStatusRequest {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSyncStatusRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.peerId = reader.string();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SyncStatusRequest {
+    return { peerId: isSet(object.peerId) ? String(object.peerId) : undefined };
+  },
+
+  toJSON(message: SyncStatusRequest): unknown {
+    const obj: any = {};
+    message.peerId !== undefined && (obj.peerId = message.peerId);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SyncStatusRequest>, I>>(base?: I): SyncStatusRequest {
+    return SyncStatusRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SyncStatusRequest>, I>>(object: I): SyncStatusRequest {
+    const message = createBaseSyncStatusRequest();
+    message.peerId = object.peerId ?? undefined;
+    return message;
+  },
+};
+
+function createBaseSyncStatusResponse(): SyncStatusResponse {
+  return { isSyncing: false, syncStatus: [] };
+}
+
+export const SyncStatusResponse = {
+  encode(message: SyncStatusResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.isSyncing === true) {
+      writer.uint32(8).bool(message.isSyncing);
+    }
+    for (const v of message.syncStatus) {
+      SyncStatus.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): SyncStatusResponse {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSyncStatusResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.isSyncing = reader.bool();
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.syncStatus.push(SyncStatus.decode(reader, reader.uint32()));
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SyncStatusResponse {
+    return {
+      isSyncing: isSet(object.isSyncing) ? Boolean(object.isSyncing) : false,
+      syncStatus: Array.isArray(object?.syncStatus) ? object.syncStatus.map((e: any) => SyncStatus.fromJSON(e)) : [],
+    };
+  },
+
+  toJSON(message: SyncStatusResponse): unknown {
+    const obj: any = {};
+    message.isSyncing !== undefined && (obj.isSyncing = message.isSyncing);
+    if (message.syncStatus) {
+      obj.syncStatus = message.syncStatus.map((e) => (e ? SyncStatus.toJSON(e) : undefined));
+    } else {
+      obj.syncStatus = [];
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SyncStatusResponse>, I>>(base?: I): SyncStatusResponse {
+    return SyncStatusResponse.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SyncStatusResponse>, I>>(object: I): SyncStatusResponse {
+    const message = createBaseSyncStatusResponse();
+    message.isSyncing = object.isSyncing ?? false;
+    message.syncStatus = object.syncStatus?.map((e) => SyncStatus.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBaseSyncStatus(): SyncStatus {
+  return {
+    peerId: '',
+    inSync: '',
+    shouldSync: false,
+    divergencePrefix: '',
+    divergenceSecondsAgo: 0,
+    theirMessages: 0,
+    ourMessages: 0,
+    lastBadSync: 0,
+  };
+}
+
+export const SyncStatus = {
+  encode(message: SyncStatus, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.peerId !== '') {
+      writer.uint32(10).string(message.peerId);
+    }
+    if (message.inSync !== '') {
+      writer.uint32(18).string(message.inSync);
+    }
+    if (message.shouldSync === true) {
+      writer.uint32(24).bool(message.shouldSync);
+    }
+    if (message.divergencePrefix !== '') {
+      writer.uint32(34).string(message.divergencePrefix);
+    }
+    if (message.divergenceSecondsAgo !== 0) {
+      writer.uint32(40).int32(message.divergenceSecondsAgo);
+    }
+    if (message.theirMessages !== 0) {
+      writer.uint32(48).uint64(message.theirMessages);
+    }
+    if (message.ourMessages !== 0) {
+      writer.uint32(56).uint64(message.ourMessages);
+    }
+    if (message.lastBadSync !== 0) {
+      writer.uint32(64).int64(message.lastBadSync);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): SyncStatus {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSyncStatus();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.peerId = reader.string();
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.inSync = reader.string();
+          continue;
+        case 3:
+          if (tag != 24) {
+            break;
+          }
+
+          message.shouldSync = reader.bool();
+          continue;
+        case 4:
+          if (tag != 34) {
+            break;
+          }
+
+          message.divergencePrefix = reader.string();
+          continue;
+        case 5:
+          if (tag != 40) {
+            break;
+          }
+
+          message.divergenceSecondsAgo = reader.int32();
+          continue;
+        case 6:
+          if (tag != 48) {
+            break;
+          }
+
+          message.theirMessages = longToNumber(reader.uint64() as Long);
+          continue;
+        case 7:
+          if (tag != 56) {
+            break;
+          }
+
+          message.ourMessages = longToNumber(reader.uint64() as Long);
+          continue;
+        case 8:
+          if (tag != 64) {
+            break;
+          }
+
+          message.lastBadSync = longToNumber(reader.int64() as Long);
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SyncStatus {
+    return {
+      peerId: isSet(object.peerId) ? String(object.peerId) : '',
+      inSync: isSet(object.inSync) ? String(object.inSync) : '',
+      shouldSync: isSet(object.shouldSync) ? Boolean(object.shouldSync) : false,
+      divergencePrefix: isSet(object.divergencePrefix) ? String(object.divergencePrefix) : '',
+      divergenceSecondsAgo: isSet(object.divergenceSecondsAgo) ? Number(object.divergenceSecondsAgo) : 0,
+      theirMessages: isSet(object.theirMessages) ? Number(object.theirMessages) : 0,
+      ourMessages: isSet(object.ourMessages) ? Number(object.ourMessages) : 0,
+      lastBadSync: isSet(object.lastBadSync) ? Number(object.lastBadSync) : 0,
+    };
+  },
+
+  toJSON(message: SyncStatus): unknown {
+    const obj: any = {};
+    message.peerId !== undefined && (obj.peerId = message.peerId);
+    message.inSync !== undefined && (obj.inSync = message.inSync);
+    message.shouldSync !== undefined && (obj.shouldSync = message.shouldSync);
+    message.divergencePrefix !== undefined && (obj.divergencePrefix = message.divergencePrefix);
+    message.divergenceSecondsAgo !== undefined && (obj.divergenceSecondsAgo = Math.round(message.divergenceSecondsAgo));
+    message.theirMessages !== undefined && (obj.theirMessages = Math.round(message.theirMessages));
+    message.ourMessages !== undefined && (obj.ourMessages = Math.round(message.ourMessages));
+    message.lastBadSync !== undefined && (obj.lastBadSync = Math.round(message.lastBadSync));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SyncStatus>, I>>(base?: I): SyncStatus {
+    return SyncStatus.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SyncStatus>, I>>(object: I): SyncStatus {
+    const message = createBaseSyncStatus();
+    message.peerId = object.peerId ?? '';
+    message.inSync = object.inSync ?? '';
+    message.shouldSync = object.shouldSync ?? false;
+    message.divergencePrefix = object.divergencePrefix ?? '';
+    message.divergenceSecondsAgo = object.divergenceSecondsAgo ?? 0;
+    message.theirMessages = object.theirMessages ?? 0;
+    message.ourMessages = object.ourMessages ?? 0;
+    message.lastBadSync = object.lastBadSync ?? 0;
     return message;
   },
 };

--- a/packages/hub-nodejs/src/generated/rpc.ts
+++ b/packages/hub-nodejs/src/generated/rpc.ts
@@ -36,6 +36,8 @@ import {
   SignerRequest,
   SubscribeRequest,
   SyncIds,
+  SyncStatusRequest,
+  SyncStatusResponse,
   TrieNodeMetadataResponse,
   TrieNodePrefix,
   TrieNodeSnapshotResponse,
@@ -299,6 +301,15 @@ export const HubServiceService = {
     responseSerialize: (value: HubInfoResponse) => Buffer.from(HubInfoResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => HubInfoResponse.decode(value),
   },
+  getSyncStatus: {
+    path: '/HubService/GetSyncStatus',
+    requestStream: false,
+    responseStream: false,
+    requestSerialize: (value: SyncStatusRequest) => Buffer.from(SyncStatusRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => SyncStatusRequest.decode(value),
+    responseSerialize: (value: SyncStatusResponse) => Buffer.from(SyncStatusResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer) => SyncStatusResponse.decode(value),
+  },
   getAllSyncIdsByPrefix: {
     path: '/HubService/GetAllSyncIdsByPrefix',
     requestStream: false,
@@ -377,6 +388,7 @@ export interface HubServiceServer extends UntypedServiceImplementation {
   getAllUserDataMessagesByFid: handleUnaryCall<FidRequest, MessagesResponse>;
   /** Sync Methods */
   getInfo: handleUnaryCall<HubInfoRequest, HubInfoResponse>;
+  getSyncStatus: handleUnaryCall<SyncStatusRequest, SyncStatusResponse>;
   getAllSyncIdsByPrefix: handleUnaryCall<TrieNodePrefix, SyncIds>;
   getAllMessagesBySyncIds: handleUnaryCall<SyncIds, MessagesResponse>;
   getSyncMetadataByPrefix: handleUnaryCall<TrieNodePrefix, TrieNodeMetadataResponse>;
@@ -777,6 +789,21 @@ export interface HubServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: HubInfoResponse) => void
+  ): ClientUnaryCall;
+  getSyncStatus(
+    request: SyncStatusRequest,
+    callback: (error: ServiceError | null, response: SyncStatusResponse) => void
+  ): ClientUnaryCall;
+  getSyncStatus(
+    request: SyncStatusRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: SyncStatusResponse) => void
+  ): ClientUnaryCall;
+  getSyncStatus(
+    request: SyncStatusRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: SyncStatusResponse) => void
   ): ClientUnaryCall;
   getAllSyncIdsByPrefix(
     request: TrieNodePrefix,

--- a/packages/hub-web/src/generated/request_response.ts
+++ b/packages/hub-web/src/generated/request_response.ts
@@ -25,7 +25,7 @@ export interface EventRequest {
 }
 
 export interface HubInfoRequest {
-  syncStats: boolean;
+  dbStats: boolean;
 }
 
 /** Response Types for the Sync RPC Methods */
@@ -34,13 +34,33 @@ export interface HubInfoResponse {
   isSyncing: boolean;
   nickname: string;
   rootHash: string;
-  syncStats: SyncStats | undefined;
+  dbStats: DbStats | undefined;
 }
 
-export interface SyncStats {
+export interface DbStats {
   numMessages: number;
   numFidEvents: number;
   numFnameEvents: number;
+}
+
+export interface SyncStatusRequest {
+  peerId?: string | undefined;
+}
+
+export interface SyncStatusResponse {
+  isSyncing: boolean;
+  syncStatus: SyncStatus[];
+}
+
+export interface SyncStatus {
+  peerId: string;
+  inSync: string;
+  shouldSync: boolean;
+  divergencePrefix: string;
+  divergenceSecondsAgo: number;
+  theirMessages: number;
+  ourMessages: number;
+  lastBadSync: number;
 }
 
 export interface TrieNodeMetadataResponse {
@@ -334,13 +354,13 @@ export const EventRequest = {
 };
 
 function createBaseHubInfoRequest(): HubInfoRequest {
-  return { syncStats: false };
+  return { dbStats: false };
 }
 
 export const HubInfoRequest = {
   encode(message: HubInfoRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.syncStats === true) {
-      writer.uint32(8).bool(message.syncStats);
+    if (message.dbStats === true) {
+      writer.uint32(8).bool(message.dbStats);
     }
     return writer;
   },
@@ -357,7 +377,7 @@ export const HubInfoRequest = {
             break;
           }
 
-          message.syncStats = reader.bool();
+          message.dbStats = reader.bool();
           continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
@@ -369,12 +389,12 @@ export const HubInfoRequest = {
   },
 
   fromJSON(object: any): HubInfoRequest {
-    return { syncStats: isSet(object.syncStats) ? Boolean(object.syncStats) : false };
+    return { dbStats: isSet(object.dbStats) ? Boolean(object.dbStats) : false };
   },
 
   toJSON(message: HubInfoRequest): unknown {
     const obj: any = {};
-    message.syncStats !== undefined && (obj.syncStats = message.syncStats);
+    message.dbStats !== undefined && (obj.dbStats = message.dbStats);
     return obj;
   },
 
@@ -384,13 +404,13 @@ export const HubInfoRequest = {
 
   fromPartial<I extends Exact<DeepPartial<HubInfoRequest>, I>>(object: I): HubInfoRequest {
     const message = createBaseHubInfoRequest();
-    message.syncStats = object.syncStats ?? false;
+    message.dbStats = object.dbStats ?? false;
     return message;
   },
 };
 
 function createBaseHubInfoResponse(): HubInfoResponse {
-  return { version: '', isSyncing: false, nickname: '', rootHash: '', syncStats: undefined };
+  return { version: '', isSyncing: false, nickname: '', rootHash: '', dbStats: undefined };
 }
 
 export const HubInfoResponse = {
@@ -407,8 +427,8 @@ export const HubInfoResponse = {
     if (message.rootHash !== '') {
       writer.uint32(34).string(message.rootHash);
     }
-    if (message.syncStats !== undefined) {
-      SyncStats.encode(message.syncStats, writer.uint32(42).fork()).ldelim();
+    if (message.dbStats !== undefined) {
+      DbStats.encode(message.dbStats, writer.uint32(42).fork()).ldelim();
     }
     return writer;
   },
@@ -453,7 +473,7 @@ export const HubInfoResponse = {
             break;
           }
 
-          message.syncStats = SyncStats.decode(reader, reader.uint32());
+          message.dbStats = DbStats.decode(reader, reader.uint32());
           continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
@@ -470,7 +490,7 @@ export const HubInfoResponse = {
       isSyncing: isSet(object.isSyncing) ? Boolean(object.isSyncing) : false,
       nickname: isSet(object.nickname) ? String(object.nickname) : '',
       rootHash: isSet(object.rootHash) ? String(object.rootHash) : '',
-      syncStats: isSet(object.syncStats) ? SyncStats.fromJSON(object.syncStats) : undefined,
+      dbStats: isSet(object.dbStats) ? DbStats.fromJSON(object.dbStats) : undefined,
     };
   },
 
@@ -480,8 +500,7 @@ export const HubInfoResponse = {
     message.isSyncing !== undefined && (obj.isSyncing = message.isSyncing);
     message.nickname !== undefined && (obj.nickname = message.nickname);
     message.rootHash !== undefined && (obj.rootHash = message.rootHash);
-    message.syncStats !== undefined &&
-      (obj.syncStats = message.syncStats ? SyncStats.toJSON(message.syncStats) : undefined);
+    message.dbStats !== undefined && (obj.dbStats = message.dbStats ? DbStats.toJSON(message.dbStats) : undefined);
     return obj;
   },
 
@@ -495,18 +514,18 @@ export const HubInfoResponse = {
     message.isSyncing = object.isSyncing ?? false;
     message.nickname = object.nickname ?? '';
     message.rootHash = object.rootHash ?? '';
-    message.syncStats =
-      object.syncStats !== undefined && object.syncStats !== null ? SyncStats.fromPartial(object.syncStats) : undefined;
+    message.dbStats =
+      object.dbStats !== undefined && object.dbStats !== null ? DbStats.fromPartial(object.dbStats) : undefined;
     return message;
   },
 };
 
-function createBaseSyncStats(): SyncStats {
+function createBaseDbStats(): DbStats {
   return { numMessages: 0, numFidEvents: 0, numFnameEvents: 0 };
 }
 
-export const SyncStats = {
-  encode(message: SyncStats, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+export const DbStats = {
+  encode(message: DbStats, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.numMessages !== 0) {
       writer.uint32(8).uint64(message.numMessages);
     }
@@ -519,10 +538,10 @@ export const SyncStats = {
     return writer;
   },
 
-  decode(input: _m0.Reader | Uint8Array, length?: number): SyncStats {
+  decode(input: _m0.Reader | Uint8Array, length?: number): DbStats {
     const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseSyncStats();
+    const message = createBaseDbStats();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -556,7 +575,7 @@ export const SyncStats = {
     return message;
   },
 
-  fromJSON(object: any): SyncStats {
+  fromJSON(object: any): DbStats {
     return {
       numMessages: isSet(object.numMessages) ? Number(object.numMessages) : 0,
       numFidEvents: isSet(object.numFidEvents) ? Number(object.numFidEvents) : 0,
@@ -564,7 +583,7 @@ export const SyncStats = {
     };
   },
 
-  toJSON(message: SyncStats): unknown {
+  toJSON(message: DbStats): unknown {
     const obj: any = {};
     message.numMessages !== undefined && (obj.numMessages = Math.round(message.numMessages));
     message.numFidEvents !== undefined && (obj.numFidEvents = Math.round(message.numFidEvents));
@@ -572,15 +591,304 @@ export const SyncStats = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<SyncStats>, I>>(base?: I): SyncStats {
-    return SyncStats.fromPartial(base ?? {});
+  create<I extends Exact<DeepPartial<DbStats>, I>>(base?: I): DbStats {
+    return DbStats.fromPartial(base ?? {});
   },
 
-  fromPartial<I extends Exact<DeepPartial<SyncStats>, I>>(object: I): SyncStats {
-    const message = createBaseSyncStats();
+  fromPartial<I extends Exact<DeepPartial<DbStats>, I>>(object: I): DbStats {
+    const message = createBaseDbStats();
     message.numMessages = object.numMessages ?? 0;
     message.numFidEvents = object.numFidEvents ?? 0;
     message.numFnameEvents = object.numFnameEvents ?? 0;
+    return message;
+  },
+};
+
+function createBaseSyncStatusRequest(): SyncStatusRequest {
+  return { peerId: undefined };
+}
+
+export const SyncStatusRequest = {
+  encode(message: SyncStatusRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.peerId !== undefined) {
+      writer.uint32(10).string(message.peerId);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): SyncStatusRequest {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSyncStatusRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.peerId = reader.string();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SyncStatusRequest {
+    return { peerId: isSet(object.peerId) ? String(object.peerId) : undefined };
+  },
+
+  toJSON(message: SyncStatusRequest): unknown {
+    const obj: any = {};
+    message.peerId !== undefined && (obj.peerId = message.peerId);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SyncStatusRequest>, I>>(base?: I): SyncStatusRequest {
+    return SyncStatusRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SyncStatusRequest>, I>>(object: I): SyncStatusRequest {
+    const message = createBaseSyncStatusRequest();
+    message.peerId = object.peerId ?? undefined;
+    return message;
+  },
+};
+
+function createBaseSyncStatusResponse(): SyncStatusResponse {
+  return { isSyncing: false, syncStatus: [] };
+}
+
+export const SyncStatusResponse = {
+  encode(message: SyncStatusResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.isSyncing === true) {
+      writer.uint32(8).bool(message.isSyncing);
+    }
+    for (const v of message.syncStatus) {
+      SyncStatus.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): SyncStatusResponse {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSyncStatusResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.isSyncing = reader.bool();
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.syncStatus.push(SyncStatus.decode(reader, reader.uint32()));
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SyncStatusResponse {
+    return {
+      isSyncing: isSet(object.isSyncing) ? Boolean(object.isSyncing) : false,
+      syncStatus: Array.isArray(object?.syncStatus) ? object.syncStatus.map((e: any) => SyncStatus.fromJSON(e)) : [],
+    };
+  },
+
+  toJSON(message: SyncStatusResponse): unknown {
+    const obj: any = {};
+    message.isSyncing !== undefined && (obj.isSyncing = message.isSyncing);
+    if (message.syncStatus) {
+      obj.syncStatus = message.syncStatus.map((e) => (e ? SyncStatus.toJSON(e) : undefined));
+    } else {
+      obj.syncStatus = [];
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SyncStatusResponse>, I>>(base?: I): SyncStatusResponse {
+    return SyncStatusResponse.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SyncStatusResponse>, I>>(object: I): SyncStatusResponse {
+    const message = createBaseSyncStatusResponse();
+    message.isSyncing = object.isSyncing ?? false;
+    message.syncStatus = object.syncStatus?.map((e) => SyncStatus.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBaseSyncStatus(): SyncStatus {
+  return {
+    peerId: '',
+    inSync: '',
+    shouldSync: false,
+    divergencePrefix: '',
+    divergenceSecondsAgo: 0,
+    theirMessages: 0,
+    ourMessages: 0,
+    lastBadSync: 0,
+  };
+}
+
+export const SyncStatus = {
+  encode(message: SyncStatus, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.peerId !== '') {
+      writer.uint32(10).string(message.peerId);
+    }
+    if (message.inSync !== '') {
+      writer.uint32(18).string(message.inSync);
+    }
+    if (message.shouldSync === true) {
+      writer.uint32(24).bool(message.shouldSync);
+    }
+    if (message.divergencePrefix !== '') {
+      writer.uint32(34).string(message.divergencePrefix);
+    }
+    if (message.divergenceSecondsAgo !== 0) {
+      writer.uint32(40).uint64(message.divergenceSecondsAgo);
+    }
+    if (message.theirMessages !== 0) {
+      writer.uint32(48).uint64(message.theirMessages);
+    }
+    if (message.ourMessages !== 0) {
+      writer.uint32(56).uint64(message.ourMessages);
+    }
+    if (message.lastBadSync !== 0) {
+      writer.uint32(64).uint64(message.lastBadSync);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): SyncStatus {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSyncStatus();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.peerId = reader.string();
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.inSync = reader.string();
+          continue;
+        case 3:
+          if (tag != 24) {
+            break;
+          }
+
+          message.shouldSync = reader.bool();
+          continue;
+        case 4:
+          if (tag != 34) {
+            break;
+          }
+
+          message.divergencePrefix = reader.string();
+          continue;
+        case 5:
+          if (tag != 40) {
+            break;
+          }
+
+          message.divergenceSecondsAgo = longToNumber(reader.uint64() as Long);
+          continue;
+        case 6:
+          if (tag != 48) {
+            break;
+          }
+
+          message.theirMessages = longToNumber(reader.uint64() as Long);
+          continue;
+        case 7:
+          if (tag != 56) {
+            break;
+          }
+
+          message.ourMessages = longToNumber(reader.uint64() as Long);
+          continue;
+        case 8:
+          if (tag != 64) {
+            break;
+          }
+
+          message.lastBadSync = longToNumber(reader.uint64() as Long);
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SyncStatus {
+    return {
+      peerId: isSet(object.peerId) ? String(object.peerId) : '',
+      inSync: isSet(object.inSync) ? String(object.inSync) : '',
+      shouldSync: isSet(object.shouldSync) ? Boolean(object.shouldSync) : false,
+      divergencePrefix: isSet(object.divergencePrefix) ? String(object.divergencePrefix) : '',
+      divergenceSecondsAgo: isSet(object.divergenceSecondsAgo) ? Number(object.divergenceSecondsAgo) : 0,
+      theirMessages: isSet(object.theirMessages) ? Number(object.theirMessages) : 0,
+      ourMessages: isSet(object.ourMessages) ? Number(object.ourMessages) : 0,
+      lastBadSync: isSet(object.lastBadSync) ? Number(object.lastBadSync) : 0,
+    };
+  },
+
+  toJSON(message: SyncStatus): unknown {
+    const obj: any = {};
+    message.peerId !== undefined && (obj.peerId = message.peerId);
+    message.inSync !== undefined && (obj.inSync = message.inSync);
+    message.shouldSync !== undefined && (obj.shouldSync = message.shouldSync);
+    message.divergencePrefix !== undefined && (obj.divergencePrefix = message.divergencePrefix);
+    message.divergenceSecondsAgo !== undefined && (obj.divergenceSecondsAgo = Math.round(message.divergenceSecondsAgo));
+    message.theirMessages !== undefined && (obj.theirMessages = Math.round(message.theirMessages));
+    message.ourMessages !== undefined && (obj.ourMessages = Math.round(message.ourMessages));
+    message.lastBadSync !== undefined && (obj.lastBadSync = Math.round(message.lastBadSync));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SyncStatus>, I>>(base?: I): SyncStatus {
+    return SyncStatus.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SyncStatus>, I>>(object: I): SyncStatus {
+    const message = createBaseSyncStatus();
+    message.peerId = object.peerId ?? '';
+    message.inSync = object.inSync ?? '';
+    message.shouldSync = object.shouldSync ?? false;
+    message.divergencePrefix = object.divergencePrefix ?? '';
+    message.divergenceSecondsAgo = object.divergenceSecondsAgo ?? 0;
+    message.theirMessages = object.theirMessages ?? 0;
+    message.ourMessages = object.ourMessages ?? 0;
+    message.lastBadSync = object.lastBadSync ?? 0;
     return message;
   },
 };

--- a/packages/hub-web/src/generated/rpc.ts
+++ b/packages/hub-web/src/generated/rpc.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import grpcWeb from '@improbable-eng/grpc-web';
+import { grpc } from '@improbable-eng/grpc-web';
 import { BrowserHeaders } from 'browser-headers';
 import { Observable } from 'rxjs';
 import { share } from 'rxjs/operators';
@@ -26,6 +26,8 @@ import {
   SignerRequest,
   SubscribeRequest,
   SyncIds,
+  SyncStatusRequest,
+  SyncStatusResponse,
   TrieNodeMetadataResponse,
   TrieNodePrefix,
   TrieNodeSnapshotResponse,
@@ -35,87 +37,67 @@ import {
 
 export interface HubService {
   /** Submit Methods */
-  submitMessage(request: DeepPartial<Message>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
+  submitMessage(request: DeepPartial<Message>, metadata?: grpc.Metadata): Promise<Message>;
   /** Event Methods */
-  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpcWeb.grpc.Metadata): Observable<HubEvent>;
-  getEvent(request: DeepPartial<EventRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubEvent>;
+  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpc.Metadata): Observable<HubEvent>;
+  getEvent(request: DeepPartial<EventRequest>, metadata?: grpc.Metadata): Promise<HubEvent>;
   /** Casts */
-  getCast(request: DeepPartial<CastId>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
-  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
-  getCastsByParent(
-    request: DeepPartial<CastsByParentRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse>;
-  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getCast(request: DeepPartial<CastId>, metadata?: grpc.Metadata): Promise<Message>;
+  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getCastsByParent(request: DeepPartial<CastsByParentRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /** Reactions */
-  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
-  getReactionsByFid(
-    request: DeepPartial<ReactionsByFidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse>;
+  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpc.Metadata): Promise<Message>;
+  getReactionsByFid(request: DeepPartial<ReactionsByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /** To be deprecated */
   getReactionsByCast(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<MessagesResponse>;
   getReactionsByTarget(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<MessagesResponse>;
   /** User Data */
-  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
-  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpc.Metadata): Promise<Message>;
+  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   getNameRegistryEvent(
     request: DeepPartial<NameRegistryEventRequest>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<NameRegistryEvent>;
   /** Verifications */
-  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
-  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpc.Metadata): Promise<Message>;
+  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /** Signer */
-  getSigner(request: DeepPartial<SignerRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
-  getSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
-  getIdRegistryEvent(
-    request: DeepPartial<IdRegistryEventRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<IdRegistryEvent>;
+  getSigner(request: DeepPartial<SignerRequest>, metadata?: grpc.Metadata): Promise<Message>;
+  getSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getIdRegistryEvent(request: DeepPartial<IdRegistryEventRequest>, metadata?: grpc.Metadata): Promise<IdRegistryEvent>;
   getIdRegistryEventByAddress(
     request: DeepPartial<IdRegistryEventByAddressRequest>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<IdRegistryEvent>;
-  getFids(request: DeepPartial<FidsRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<FidsResponse>;
+  getFids(request: DeepPartial<FidsRequest>, metadata?: grpc.Metadata): Promise<FidsResponse>;
   /** Bulk Methods */
-  getAllCastMessagesByFid(
-    request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse>;
-  getAllReactionMessagesByFid(
-    request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse>;
+  getAllCastMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getAllReactionMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   getAllVerificationMessagesByFid(
     request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<MessagesResponse>;
-  getAllSignerMessagesByFid(
-    request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse>;
-  getAllUserDataMessagesByFid(
-    request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse>;
+  getAllSignerMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /** Sync Methods */
-  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubInfoResponse>;
-  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncIds>;
-  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpc.Metadata): Promise<HubInfoResponse>;
+  getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpc.Metadata): Promise<SyncStatusResponse>;
+  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpc.Metadata): Promise<SyncIds>;
+  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   getSyncMetadataByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<TrieNodeMetadataResponse>;
   getSyncSnapshotByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<TrieNodeSnapshotResponse>;
 }
 
@@ -151,109 +133,101 @@ export class HubServiceClientImpl implements HubService {
     this.getAllSignerMessagesByFid = this.getAllSignerMessagesByFid.bind(this);
     this.getAllUserDataMessagesByFid = this.getAllUserDataMessagesByFid.bind(this);
     this.getInfo = this.getInfo.bind(this);
+    this.getSyncStatus = this.getSyncStatus.bind(this);
     this.getAllSyncIdsByPrefix = this.getAllSyncIdsByPrefix.bind(this);
     this.getAllMessagesBySyncIds = this.getAllMessagesBySyncIds.bind(this);
     this.getSyncMetadataByPrefix = this.getSyncMetadataByPrefix.bind(this);
     this.getSyncSnapshotByPrefix = this.getSyncSnapshotByPrefix.bind(this);
   }
 
-  submitMessage(request: DeepPartial<Message>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  submitMessage(request: DeepPartial<Message>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceSubmitMessageDesc, Message.fromPartial(request), metadata);
   }
 
-  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpcWeb.grpc.Metadata): Observable<HubEvent> {
+  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpc.Metadata): Observable<HubEvent> {
     return this.rpc.invoke(HubServiceSubscribeDesc, SubscribeRequest.fromPartial(request), metadata);
   }
 
-  getEvent(request: DeepPartial<EventRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubEvent> {
+  getEvent(request: DeepPartial<EventRequest>, metadata?: grpc.Metadata): Promise<HubEvent> {
     return this.rpc.unary(HubServiceGetEventDesc, EventRequest.fromPartial(request), metadata);
   }
 
-  getCast(request: DeepPartial<CastId>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  getCast(request: DeepPartial<CastId>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetCastDesc, CastId.fromPartial(request), metadata);
   }
 
-  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetCastsByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getCastsByParent(
-    request: DeepPartial<CastsByParentRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse> {
+  getCastsByParent(request: DeepPartial<CastsByParentRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetCastsByParentDesc, CastsByParentRequest.fromPartial(request), metadata);
   }
 
-  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetCastsByMentionDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetReactionDesc, ReactionRequest.fromPartial(request), metadata);
   }
 
-  getReactionsByFid(
-    request: DeepPartial<ReactionsByFidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse> {
+  getReactionsByFid(request: DeepPartial<ReactionsByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetReactionsByFidDesc, ReactionsByFidRequest.fromPartial(request), metadata);
   }
 
   getReactionsByCast(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetReactionsByCastDesc, ReactionsByTargetRequest.fromPartial(request), metadata);
   }
 
   getReactionsByTarget(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetReactionsByTargetDesc, ReactionsByTargetRequest.fromPartial(request), metadata);
   }
 
-  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetUserDataDesc, UserDataRequest.fromPartial(request), metadata);
   }
 
-  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetUserDataByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
   getNameRegistryEvent(
     request: DeepPartial<NameRegistryEventRequest>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<NameRegistryEvent> {
     return this.rpc.unary(HubServiceGetNameRegistryEventDesc, NameRegistryEventRequest.fromPartial(request), metadata);
   }
 
-  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetVerificationDesc, VerificationRequest.fromPartial(request), metadata);
   }
 
-  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetVerificationsByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getSigner(request: DeepPartial<SignerRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  getSigner(request: DeepPartial<SignerRequest>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetSignerDesc, SignerRequest.fromPartial(request), metadata);
   }
 
-  getSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetSignersByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getIdRegistryEvent(
-    request: DeepPartial<IdRegistryEventRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<IdRegistryEvent> {
+  getIdRegistryEvent(request: DeepPartial<IdRegistryEventRequest>, metadata?: grpc.Metadata): Promise<IdRegistryEvent> {
     return this.rpc.unary(HubServiceGetIdRegistryEventDesc, IdRegistryEventRequest.fromPartial(request), metadata);
   }
 
   getIdRegistryEventByAddress(
     request: DeepPartial<IdRegistryEventByAddressRequest>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<IdRegistryEvent> {
     return this.rpc.unary(
       HubServiceGetIdRegistryEventByAddressDesc,
@@ -262,67 +236,59 @@ export class HubServiceClientImpl implements HubService {
     );
   }
 
-  getFids(request: DeepPartial<FidsRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<FidsResponse> {
+  getFids(request: DeepPartial<FidsRequest>, metadata?: grpc.Metadata): Promise<FidsResponse> {
     return this.rpc.unary(HubServiceGetFidsDesc, FidsRequest.fromPartial(request), metadata);
   }
 
-  getAllCastMessagesByFid(
-    request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse> {
+  getAllCastMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllCastMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getAllReactionMessagesByFid(
-    request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse> {
+  getAllReactionMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllReactionMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
   getAllVerificationMessagesByFid(
     request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllVerificationMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getAllSignerMessagesByFid(
-    request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse> {
+  getAllSignerMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllSignerMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getAllUserDataMessagesByFid(
-    request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse> {
+  getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllUserDataMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubInfoResponse> {
+  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpc.Metadata): Promise<HubInfoResponse> {
     return this.rpc.unary(HubServiceGetInfoDesc, HubInfoRequest.fromPartial(request), metadata);
   }
 
-  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncIds> {
+  getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpc.Metadata): Promise<SyncStatusResponse> {
+    return this.rpc.unary(HubServiceGetSyncStatusDesc, SyncStatusRequest.fromPartial(request), metadata);
+  }
+
+  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpc.Metadata): Promise<SyncIds> {
     return this.rpc.unary(HubServiceGetAllSyncIdsByPrefixDesc, TrieNodePrefix.fromPartial(request), metadata);
   }
 
-  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllMessagesBySyncIdsDesc, SyncIds.fromPartial(request), metadata);
   }
 
   getSyncMetadataByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<TrieNodeMetadataResponse> {
     return this.rpc.unary(HubServiceGetSyncMetadataByPrefixDesc, TrieNodePrefix.fromPartial(request), metadata);
   }
 
   getSyncSnapshotByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<TrieNodeSnapshotResponse> {
     return this.rpc.unary(HubServiceGetSyncSnapshotByPrefixDesc, TrieNodePrefix.fromPartial(request), metadata);
   }
@@ -951,6 +917,29 @@ export const HubServiceGetInfoDesc: UnaryMethodDefinitionish = {
   } as any,
 };
 
+export const HubServiceGetSyncStatusDesc: UnaryMethodDefinitionish = {
+  methodName: 'GetSyncStatus',
+  service: HubServiceDesc,
+  requestStream: false,
+  responseStream: false,
+  requestType: {
+    serializeBinary() {
+      return SyncStatusRequest.encode(this).finish();
+    },
+  } as any,
+  responseType: {
+    deserializeBinary(data: Uint8Array) {
+      const value = SyncStatusResponse.decode(data);
+      return {
+        ...value,
+        toObject() {
+          return value;
+        },
+      };
+    },
+  } as any,
+};
+
 export const HubServiceGetAllSyncIdsByPrefixDesc: UnaryMethodDefinitionish = {
   methodName: 'GetAllSyncIdsByPrefix',
   service: HubServiceDesc,
@@ -1044,15 +1033,12 @@ export const HubServiceGetSyncSnapshotByPrefixDesc: UnaryMethodDefinitionish = {
 };
 
 export interface AdminService {
-  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty>;
-  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty>;
-  submitIdRegistryEvent(
-    request: DeepPartial<IdRegistryEvent>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<IdRegistryEvent>;
+  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty>;
+  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty>;
+  submitIdRegistryEvent(request: DeepPartial<IdRegistryEvent>, metadata?: grpc.Metadata): Promise<IdRegistryEvent>;
   submitNameRegistryEvent(
     request: DeepPartial<NameRegistryEvent>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<NameRegistryEvent>;
 }
 
@@ -1067,24 +1053,21 @@ export class AdminServiceClientImpl implements AdminService {
     this.submitNameRegistryEvent = this.submitNameRegistryEvent.bind(this);
   }
 
-  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty> {
+  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty> {
     return this.rpc.unary(AdminServiceRebuildSyncTrieDesc, Empty.fromPartial(request), metadata);
   }
 
-  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty> {
+  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty> {
     return this.rpc.unary(AdminServiceDeleteAllMessagesFromDbDesc, Empty.fromPartial(request), metadata);
   }
 
-  submitIdRegistryEvent(
-    request: DeepPartial<IdRegistryEvent>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<IdRegistryEvent> {
+  submitIdRegistryEvent(request: DeepPartial<IdRegistryEvent>, metadata?: grpc.Metadata): Promise<IdRegistryEvent> {
     return this.rpc.unary(AdminServiceSubmitIdRegistryEventDesc, IdRegistryEvent.fromPartial(request), metadata);
   }
 
   submitNameRegistryEvent(
     request: DeepPartial<NameRegistryEvent>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<NameRegistryEvent> {
     return this.rpc.unary(AdminServiceSubmitNameRegistryEventDesc, NameRegistryEvent.fromPartial(request), metadata);
   }
@@ -1184,7 +1167,7 @@ export const AdminServiceSubmitNameRegistryEventDesc: UnaryMethodDefinitionish =
   } as any,
 };
 
-interface UnaryMethodDefinitionishR extends grpcWeb.grpc.UnaryMethodDefinition<any, any> {
+interface UnaryMethodDefinitionishR extends grpc.UnaryMethodDefinition<any, any> {
   requestStream: any;
   responseStream: any;
 }
@@ -1195,32 +1178,32 @@ interface Rpc {
   unary<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     request: any,
-    metadata: grpcWeb.grpc.Metadata | undefined
+    metadata: grpc.Metadata | undefined
   ): Promise<any>;
   invoke<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     request: any,
-    metadata: grpcWeb.grpc.Metadata | undefined
+    metadata: grpc.Metadata | undefined
   ): Observable<any>;
 }
 
 export class GrpcWebImpl {
   private host: string;
   private options: {
-    transport?: grpcWeb.grpc.TransportFactory;
-    streamingTransport?: grpcWeb.grpc.TransportFactory;
+    transport?: grpc.TransportFactory;
+    streamingTransport?: grpc.TransportFactory;
     debug?: boolean;
-    metadata?: grpcWeb.grpc.Metadata;
+    metadata?: grpc.Metadata;
     upStreamRetryCodes?: number[];
   };
 
   constructor(
     host: string,
     options: {
-      transport?: grpcWeb.grpc.TransportFactory;
-      streamingTransport?: grpcWeb.grpc.TransportFactory;
+      transport?: grpc.TransportFactory;
+      streamingTransport?: grpc.TransportFactory;
       debug?: boolean;
-      metadata?: grpcWeb.grpc.Metadata;
+      metadata?: grpc.Metadata;
       upStreamRetryCodes?: number[];
     }
   ) {
@@ -1231,7 +1214,7 @@ export class GrpcWebImpl {
   unary<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     _request: any,
-    metadata: grpcWeb.grpc.Metadata | undefined
+    metadata: grpc.Metadata | undefined
   ): Promise<any> {
     const request = { ..._request, ...methodDesc.requestType };
     const maybeCombinedMetadata =
@@ -1239,14 +1222,14 @@ export class GrpcWebImpl {
         ? new BrowserHeaders({ ...this.options?.metadata.headersMap, ...metadata?.headersMap })
         : metadata || this.options.metadata;
     return new Promise((resolve, reject) => {
-      grpcWeb.grpc.unary(methodDesc, {
+      grpc.unary(methodDesc, {
         request,
         host: this.host,
         metadata: maybeCombinedMetadata,
         transport: this.options.transport,
         debug: this.options.debug,
         onEnd: function (response) {
-          if (response.status === grpcWeb.grpc.Code.OK) {
+          if (response.status === grpc.Code.OK) {
             resolve(response.message!.toObject());
           } else {
             const err = new GrpcWebError(response.statusMessage, response.status, response.trailers);
@@ -1260,7 +1243,7 @@ export class GrpcWebImpl {
   invoke<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     _request: any,
-    metadata: grpcWeb.grpc.Metadata | undefined
+    metadata: grpc.Metadata | undefined
   ): Observable<any> {
     const upStreamCodes = this.options.upStreamRetryCodes || [];
     const DEFAULT_TIMEOUT_TIME: number = 3_000;
@@ -1271,14 +1254,14 @@ export class GrpcWebImpl {
         : metadata || this.options.metadata;
     return new Observable((observer) => {
       const upStream = () => {
-        const client = grpcWeb.grpc.invoke(methodDesc, {
+        const client = grpc.invoke(methodDesc, {
           host: this.host,
           request,
           transport: this.options.streamingTransport || this.options.transport,
           metadata: maybeCombinedMetadata,
           debug: this.options.debug,
           onMessage: (next) => observer.next(next),
-          onEnd: (code: grpcWeb.grpc.Code, message: string, trailers: grpcWeb.grpc.Metadata) => {
+          onEnd: (code: grpc.Code, message: string, trailers: grpc.Metadata) => {
             if (code === 0) {
               observer.complete();
             } else if (upStreamCodes.includes(code)) {
@@ -1334,7 +1317,7 @@ type DeepPartial<T> = T extends Builtin
   : Partial<T>;
 
 export class GrpcWebError extends tsProtoGlobalThis.Error {
-  constructor(message: string, public code: grpcWeb.grpc.Code, public metadata: grpcWeb.grpc.Metadata) {
+  constructor(message: string, public code: grpc.Code, public metadata: grpc.Metadata) {
     super(message);
   }
 }

--- a/packages/hub-web/src/generated/rpc.ts
+++ b/packages/hub-web/src/generated/rpc.ts
@@ -1,5 +1,6 @@
 /* eslint-disable */
-import { grpc } from '@improbable-eng/grpc-web';
+// This must be manually change to a default import right now
+import grpcWeb from '@improbable-eng/grpc-web';
 import { BrowserHeaders } from 'browser-headers';
 import { Observable } from 'rxjs';
 import { share } from 'rxjs/operators';
@@ -37,67 +38,88 @@ import {
 
 export interface HubService {
   /** Submit Methods */
-  submitMessage(request: DeepPartial<Message>, metadata?: grpc.Metadata): Promise<Message>;
+  submitMessage(request: DeepPartial<Message>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
   /** Event Methods */
-  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpc.Metadata): Observable<HubEvent>;
-  getEvent(request: DeepPartial<EventRequest>, metadata?: grpc.Metadata): Promise<HubEvent>;
+  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpcWeb.grpc.Metadata): Observable<HubEvent>;
+  getEvent(request: DeepPartial<EventRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubEvent>;
   /** Casts */
-  getCast(request: DeepPartial<CastId>, metadata?: grpc.Metadata): Promise<Message>;
-  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
-  getCastsByParent(request: DeepPartial<CastsByParentRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
-  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getCast(request: DeepPartial<CastId>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
+  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getCastsByParent(
+    request: DeepPartial<CastsByParentRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse>;
+  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
   /** Reactions */
-  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpc.Metadata): Promise<Message>;
-  getReactionsByFid(request: DeepPartial<ReactionsByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
+  getReactionsByFid(
+    request: DeepPartial<ReactionsByFidRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse>;
   /** To be deprecated */
   getReactionsByCast(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<MessagesResponse>;
   getReactionsByTarget(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<MessagesResponse>;
   /** User Data */
-  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpc.Metadata): Promise<Message>;
-  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
+  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
   getNameRegistryEvent(
     request: DeepPartial<NameRegistryEventRequest>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<NameRegistryEvent>;
   /** Verifications */
-  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpc.Metadata): Promise<Message>;
-  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
+  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
   /** Signer */
-  getSigner(request: DeepPartial<SignerRequest>, metadata?: grpc.Metadata): Promise<Message>;
-  getSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
-  getIdRegistryEvent(request: DeepPartial<IdRegistryEventRequest>, metadata?: grpc.Metadata): Promise<IdRegistryEvent>;
+  getSigner(request: DeepPartial<SignerRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
+  getSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getIdRegistryEvent(
+    request: DeepPartial<IdRegistryEventRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<IdRegistryEvent>;
   getIdRegistryEventByAddress(
     request: DeepPartial<IdRegistryEventByAddressRequest>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<IdRegistryEvent>;
-  getFids(request: DeepPartial<FidsRequest>, metadata?: grpc.Metadata): Promise<FidsResponse>;
+  getFids(request: DeepPartial<FidsRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<FidsResponse>;
   /** Bulk Methods */
-  getAllCastMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
-  getAllReactionMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getAllCastMessagesByFid(
+    request: DeepPartial<FidRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse>;
+  getAllReactionMessagesByFid(
+    request: DeepPartial<FidRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse>;
   getAllVerificationMessagesByFid(
     request: DeepPartial<FidRequest>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<MessagesResponse>;
-  getAllSignerMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
-  getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getAllSignerMessagesByFid(
+    request: DeepPartial<FidRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse>;
+  getAllUserDataMessagesByFid(
+    request: DeepPartial<FidRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse>;
   /** Sync Methods */
-  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpc.Metadata): Promise<HubInfoResponse>;
-  getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpc.Metadata): Promise<SyncStatusResponse>;
-  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpc.Metadata): Promise<SyncIds>;
-  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubInfoResponse>;
+  getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncStatusResponse>;
+  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncIds>;
+  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
   getSyncMetadataByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<TrieNodeMetadataResponse>;
   getSyncSnapshotByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<TrieNodeSnapshotResponse>;
 }
 
@@ -140,94 +162,103 @@ export class HubServiceClientImpl implements HubService {
     this.getSyncSnapshotByPrefix = this.getSyncSnapshotByPrefix.bind(this);
   }
 
-  submitMessage(request: DeepPartial<Message>, metadata?: grpc.Metadata): Promise<Message> {
+  submitMessage(request: DeepPartial<Message>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceSubmitMessageDesc, Message.fromPartial(request), metadata);
   }
 
-  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpc.Metadata): Observable<HubEvent> {
+  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpcWeb.grpc.Metadata): Observable<HubEvent> {
     return this.rpc.invoke(HubServiceSubscribeDesc, SubscribeRequest.fromPartial(request), metadata);
   }
 
-  getEvent(request: DeepPartial<EventRequest>, metadata?: grpc.Metadata): Promise<HubEvent> {
+  getEvent(request: DeepPartial<EventRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubEvent> {
     return this.rpc.unary(HubServiceGetEventDesc, EventRequest.fromPartial(request), metadata);
   }
 
-  getCast(request: DeepPartial<CastId>, metadata?: grpc.Metadata): Promise<Message> {
+  getCast(request: DeepPartial<CastId>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetCastDesc, CastId.fromPartial(request), metadata);
   }
 
-  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetCastsByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getCastsByParent(request: DeepPartial<CastsByParentRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getCastsByParent(
+    request: DeepPartial<CastsByParentRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetCastsByParentDesc, CastsByParentRequest.fromPartial(request), metadata);
   }
 
-  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetCastsByMentionDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpc.Metadata): Promise<Message> {
+  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetReactionDesc, ReactionRequest.fromPartial(request), metadata);
   }
 
-  getReactionsByFid(request: DeepPartial<ReactionsByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getReactionsByFid(
+    request: DeepPartial<ReactionsByFidRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetReactionsByFidDesc, ReactionsByFidRequest.fromPartial(request), metadata);
   }
 
   getReactionsByCast(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetReactionsByCastDesc, ReactionsByTargetRequest.fromPartial(request), metadata);
   }
 
   getReactionsByTarget(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetReactionsByTargetDesc, ReactionsByTargetRequest.fromPartial(request), metadata);
   }
 
-  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpc.Metadata): Promise<Message> {
+  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetUserDataDesc, UserDataRequest.fromPartial(request), metadata);
   }
 
-  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetUserDataByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
   getNameRegistryEvent(
     request: DeepPartial<NameRegistryEventRequest>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<NameRegistryEvent> {
     return this.rpc.unary(HubServiceGetNameRegistryEventDesc, NameRegistryEventRequest.fromPartial(request), metadata);
   }
 
-  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpc.Metadata): Promise<Message> {
+  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetVerificationDesc, VerificationRequest.fromPartial(request), metadata);
   }
 
-  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetVerificationsByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getSigner(request: DeepPartial<SignerRequest>, metadata?: grpc.Metadata): Promise<Message> {
+  getSigner(request: DeepPartial<SignerRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetSignerDesc, SignerRequest.fromPartial(request), metadata);
   }
 
-  getSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetSignersByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getIdRegistryEvent(request: DeepPartial<IdRegistryEventRequest>, metadata?: grpc.Metadata): Promise<IdRegistryEvent> {
+  getIdRegistryEvent(
+    request: DeepPartial<IdRegistryEventRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<IdRegistryEvent> {
     return this.rpc.unary(HubServiceGetIdRegistryEventDesc, IdRegistryEventRequest.fromPartial(request), metadata);
   }
 
   getIdRegistryEventByAddress(
     request: DeepPartial<IdRegistryEventByAddressRequest>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<IdRegistryEvent> {
     return this.rpc.unary(
       HubServiceGetIdRegistryEventByAddressDesc,
@@ -236,59 +267,74 @@ export class HubServiceClientImpl implements HubService {
     );
   }
 
-  getFids(request: DeepPartial<FidsRequest>, metadata?: grpc.Metadata): Promise<FidsResponse> {
+  getFids(request: DeepPartial<FidsRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<FidsResponse> {
     return this.rpc.unary(HubServiceGetFidsDesc, FidsRequest.fromPartial(request), metadata);
   }
 
-  getAllCastMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getAllCastMessagesByFid(
+    request: DeepPartial<FidRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllCastMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getAllReactionMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getAllReactionMessagesByFid(
+    request: DeepPartial<FidRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllReactionMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
   getAllVerificationMessagesByFid(
     request: DeepPartial<FidRequest>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllVerificationMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getAllSignerMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getAllSignerMessagesByFid(
+    request: DeepPartial<FidRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllSignerMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getAllUserDataMessagesByFid(
+    request: DeepPartial<FidRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllUserDataMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpc.Metadata): Promise<HubInfoResponse> {
+  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubInfoResponse> {
     return this.rpc.unary(HubServiceGetInfoDesc, HubInfoRequest.fromPartial(request), metadata);
   }
 
-  getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpc.Metadata): Promise<SyncStatusResponse> {
+  getSyncStatus(
+    request: DeepPartial<SyncStatusRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<SyncStatusResponse> {
     return this.rpc.unary(HubServiceGetSyncStatusDesc, SyncStatusRequest.fromPartial(request), metadata);
   }
 
-  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpc.Metadata): Promise<SyncIds> {
+  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncIds> {
     return this.rpc.unary(HubServiceGetAllSyncIdsByPrefixDesc, TrieNodePrefix.fromPartial(request), metadata);
   }
 
-  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllMessagesBySyncIdsDesc, SyncIds.fromPartial(request), metadata);
   }
 
   getSyncMetadataByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<TrieNodeMetadataResponse> {
     return this.rpc.unary(HubServiceGetSyncMetadataByPrefixDesc, TrieNodePrefix.fromPartial(request), metadata);
   }
 
   getSyncSnapshotByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<TrieNodeSnapshotResponse> {
     return this.rpc.unary(HubServiceGetSyncSnapshotByPrefixDesc, TrieNodePrefix.fromPartial(request), metadata);
   }
@@ -1033,12 +1079,15 @@ export const HubServiceGetSyncSnapshotByPrefixDesc: UnaryMethodDefinitionish = {
 };
 
 export interface AdminService {
-  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty>;
-  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty>;
-  submitIdRegistryEvent(request: DeepPartial<IdRegistryEvent>, metadata?: grpc.Metadata): Promise<IdRegistryEvent>;
+  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty>;
+  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty>;
+  submitIdRegistryEvent(
+    request: DeepPartial<IdRegistryEvent>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<IdRegistryEvent>;
   submitNameRegistryEvent(
     request: DeepPartial<NameRegistryEvent>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<NameRegistryEvent>;
 }
 
@@ -1053,21 +1102,24 @@ export class AdminServiceClientImpl implements AdminService {
     this.submitNameRegistryEvent = this.submitNameRegistryEvent.bind(this);
   }
 
-  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty> {
+  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty> {
     return this.rpc.unary(AdminServiceRebuildSyncTrieDesc, Empty.fromPartial(request), metadata);
   }
 
-  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty> {
+  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty> {
     return this.rpc.unary(AdminServiceDeleteAllMessagesFromDbDesc, Empty.fromPartial(request), metadata);
   }
 
-  submitIdRegistryEvent(request: DeepPartial<IdRegistryEvent>, metadata?: grpc.Metadata): Promise<IdRegistryEvent> {
+  submitIdRegistryEvent(
+    request: DeepPartial<IdRegistryEvent>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<IdRegistryEvent> {
     return this.rpc.unary(AdminServiceSubmitIdRegistryEventDesc, IdRegistryEvent.fromPartial(request), metadata);
   }
 
   submitNameRegistryEvent(
     request: DeepPartial<NameRegistryEvent>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<NameRegistryEvent> {
     return this.rpc.unary(AdminServiceSubmitNameRegistryEventDesc, NameRegistryEvent.fromPartial(request), metadata);
   }
@@ -1167,7 +1219,7 @@ export const AdminServiceSubmitNameRegistryEventDesc: UnaryMethodDefinitionish =
   } as any,
 };
 
-interface UnaryMethodDefinitionishR extends grpc.UnaryMethodDefinition<any, any> {
+interface UnaryMethodDefinitionishR extends grpcWeb.grpc.UnaryMethodDefinition<any, any> {
   requestStream: any;
   responseStream: any;
 }
@@ -1178,32 +1230,32 @@ interface Rpc {
   unary<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     request: any,
-    metadata: grpc.Metadata | undefined
+    metadata: grpcWeb.grpc.Metadata | undefined
   ): Promise<any>;
   invoke<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     request: any,
-    metadata: grpc.Metadata | undefined
+    metadata: grpcWeb.grpc.Metadata | undefined
   ): Observable<any>;
 }
 
 export class GrpcWebImpl {
   private host: string;
   private options: {
-    transport?: grpc.TransportFactory;
-    streamingTransport?: grpc.TransportFactory;
+    transport?: grpcWeb.grpc.TransportFactory;
+    streamingTransport?: grpcWeb.grpc.TransportFactory;
     debug?: boolean;
-    metadata?: grpc.Metadata;
+    metadata?: grpcWeb.grpc.Metadata;
     upStreamRetryCodes?: number[];
   };
 
   constructor(
     host: string,
     options: {
-      transport?: grpc.TransportFactory;
-      streamingTransport?: grpc.TransportFactory;
+      transport?: grpcWeb.grpc.TransportFactory;
+      streamingTransport?: grpcWeb.grpc.TransportFactory;
       debug?: boolean;
-      metadata?: grpc.Metadata;
+      metadata?: grpcWeb.grpc.Metadata;
       upStreamRetryCodes?: number[];
     }
   ) {
@@ -1214,7 +1266,7 @@ export class GrpcWebImpl {
   unary<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     _request: any,
-    metadata: grpc.Metadata | undefined
+    metadata: grpcWeb.grpc.Metadata | undefined
   ): Promise<any> {
     const request = { ..._request, ...methodDesc.requestType };
     const maybeCombinedMetadata =
@@ -1222,14 +1274,14 @@ export class GrpcWebImpl {
         ? new BrowserHeaders({ ...this.options?.metadata.headersMap, ...metadata?.headersMap })
         : metadata || this.options.metadata;
     return new Promise((resolve, reject) => {
-      grpc.unary(methodDesc, {
+      grpcWeb.grpc.unary(methodDesc, {
         request,
         host: this.host,
         metadata: maybeCombinedMetadata,
         transport: this.options.transport,
         debug: this.options.debug,
         onEnd: function (response) {
-          if (response.status === grpc.Code.OK) {
+          if (response.status === grpcWeb.grpc.Code.OK) {
             resolve(response.message!.toObject());
           } else {
             const err = new GrpcWebError(response.statusMessage, response.status, response.trailers);
@@ -1243,7 +1295,7 @@ export class GrpcWebImpl {
   invoke<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     _request: any,
-    metadata: grpc.Metadata | undefined
+    metadata: grpcWeb.grpc.Metadata | undefined
   ): Observable<any> {
     const upStreamCodes = this.options.upStreamRetryCodes || [];
     const DEFAULT_TIMEOUT_TIME: number = 3_000;
@@ -1254,14 +1306,14 @@ export class GrpcWebImpl {
         : metadata || this.options.metadata;
     return new Observable((observer) => {
       const upStream = () => {
-        const client = grpc.invoke(methodDesc, {
+        const client = grpcWeb.grpc.invoke(methodDesc, {
           host: this.host,
           request,
           transport: this.options.streamingTransport || this.options.transport,
           metadata: maybeCombinedMetadata,
           debug: this.options.debug,
           onMessage: (next) => observer.next(next),
-          onEnd: (code: grpc.Code, message: string, trailers: grpc.Metadata) => {
+          onEnd: (code: grpcWeb.grpc.Code, message: string, trailers: grpcWeb.grpc.Metadata) => {
             if (code === 0) {
               observer.complete();
             } else if (upStreamCodes.includes(code)) {
@@ -1317,7 +1369,7 @@ type DeepPartial<T> = T extends Builtin
   : Partial<T>;
 
 export class GrpcWebError extends tsProtoGlobalThis.Error {
-  constructor(message: string, public code: grpc.Code, public metadata: grpc.Metadata) {
+  constructor(message: string, public code: grpcWeb.grpc.Code, public metadata: grpcWeb.grpc.Metadata) {
     super(message);
   }
 }

--- a/protobufs/schemas/request_response.proto
+++ b/protobufs/schemas/request_response.proto
@@ -15,7 +15,7 @@ message EventRequest {
 }
 
 message HubInfoRequest {
-  bool sync_stats = 1;
+  bool db_stats = 1;
 }
 
 // Response Types for the Sync RPC Methods
@@ -24,13 +24,32 @@ message HubInfoResponse {
   bool is_syncing = 2;
   string nickname = 3;
   string root_hash = 4;
-  SyncStats sync_stats = 5;
+  DbStats sync_stats = 5;
 }
 
-message SyncStats {
+message DbStats {
   uint64 num_messages = 1;
   uint64 num_fid_events = 2;
   uint64 num_fname_events = 3;
+}
+
+message SyncStatusRequest {
+  string peerId = 1;
+}
+
+message SyncStatusResponse {
+  bool is_syncing = 1;
+  repeated SyncStatus sync_status = 2;
+}
+
+message SyncStatus {
+  string peerId = 1;
+  bool shouldSync = 2;
+  string divergencePrefix = 3;
+  uint64 divergenceSecondsAgo = 4;
+  uint64 theirMessages = 5;
+  uint64 ourMessages = 6;
+  uint64 lastBadSync = 7;
 }
 
 message TrieNodeMetadataResponse {

--- a/protobufs/schemas/request_response.proto
+++ b/protobufs/schemas/request_response.proto
@@ -24,7 +24,7 @@ message HubInfoResponse {
   bool is_syncing = 2;
   string nickname = 3;
   string root_hash = 4;
-  DbStats sync_stats = 5;
+  DbStats db_stats = 5;
 }
 
 message DbStats {
@@ -34,7 +34,7 @@ message DbStats {
 }
 
 message SyncStatusRequest {
-  string peerId = 1;
+  optional string peerId = 1;
 }
 
 message SyncStatusResponse {
@@ -44,12 +44,13 @@ message SyncStatusResponse {
 
 message SyncStatus {
   string peerId = 1;
-  bool shouldSync = 2;
-  string divergencePrefix = 3;
-  uint64 divergenceSecondsAgo = 4;
-  uint64 theirMessages = 5;
-  uint64 ourMessages = 6;
-  uint64 lastBadSync = 7;
+  string inSync = 2;
+  bool shouldSync = 3;
+  string divergencePrefix = 4;
+  int32 divergenceSecondsAgo = 5;
+  uint64 theirMessages = 6;
+  uint64 ourMessages = 7;
+  int64 lastBadSync = 8;
 }
 
 message TrieNodeMetadataResponse {

--- a/protobufs/schemas/rpc.proto
+++ b/protobufs/schemas/rpc.proto
@@ -51,6 +51,7 @@ service HubService {
 
   // Sync Methods
   rpc GetInfo(HubInfoRequest) returns (HubInfoResponse);
+  rpc GetSyncStatus(SyncStatusRequest) returns (SyncStatusResponse);
   rpc GetAllSyncIdsByPrefix(TrieNodePrefix) returns (SyncIds);
   rpc GetAllMessagesBySyncIds(SyncIds) returns (MessagesResponse);
   rpc GetSyncMetadataByPrefix(TrieNodePrefix) returns (TrieNodeMetadataResponse);


### PR DESCRIPTION
## Motivation

Adds a new command that provides a human readable report of the hub's status.

e.g.:

```
yarn status --insecure
yarn run v1.22.19
$ tsx src/cli.ts status --insecure
{"level":30,"time":1683338099555,"pid":45242,"hostname":"Sanjays-MacBook-Pro.local","msg":"Hub Version: 1.2.1 Messages: 49785 FIDs: 12716 FNames: 12716}"}
{"level":30,"time":1683338099556,"pid":45242,"hostname":"Sanjays-MacBook-Pro.local","msg":"Peer 12D3KooWQaNFSaNLfsa69QtDiwX9SNHV3VPqnRUeHXCuM3G8yknG: Sync in progress. (msg delta: -3061)"}
✨  Done in 1.51s.
```

## Change Summary

Adds a GetSyncStatus RPC call that returns the hub's sync status with another peer.
Adds a `yarn status` command that shows the status in a friendly way.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new `GetSyncStatus` RPC call that exposes the hub's sync status with different peers. It also renames `syncStats` to `dbStats` in the `HubInfoResponse`. 

### Detailed summary
- Adds a new `GetSyncStatus` RPC call that exposes the hub's sync status with different peers.
- Renames `syncStats` to `dbStats` in the `HubInfoResponse`. 
- Adds a `prefixToTimestamp` function to `syncId.ts`.
- Adds a `getRPCClientForPeer` function to `console.ts`.
- Adds a `bootstrapPeerIds` property to `gossipNode.ts`.
- Updates the `connectAddress` function in `gossipNode.ts` to accept a new `isBootstrapNode` parameter.
- Updates the `bootstrap` function in `gossipNode.ts` to pass `true` as the `isBootstrapNode` parameter to `connectAddress`.
- Updates the `Server` class in `server.ts` to expose the `getSyncStatus` method.
- Adds a `SyncStatusRequest` and a `SyncStatusResponse` message to `rpc.proto`.
- Adds a `SyncStatus` message to `rpc.proto`.
- Adds a `getSyncStatusForPeer` method to `syncEngine.ts`.
- Adds a `getRPCClientForPeer` method to `mocks.ts`.
- Adds `HubRpcClient` to `mocks.ts`.
- Updates the `console` command in `cli.ts` to include a new `status` command.

> The following files were skipped due to too many changes: `apps/hubble/src/cli.ts`, `apps/hubble/src/rpc/test/syncService.test.ts`, `packages/hub-web/src/generated/rpc.ts`, `apps/hubble/src/network/sync/syncEngine.ts`, `packages/hub-nodejs/src/generated/request_response.ts`, `packages/core/src/protobufs/generated/request_response.ts`, `packages/hub-web/src/generated/request_response.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->