### PR TITLE
chore: upgrade to @noble/curves

### DIFF
--- a/.changeset/eleven-lies-wait.md
+++ b/.changeset/eleven-lies-wait.md
@@ -1,0 +1,8 @@
+---
+'@farcaster/core': minor
+'@farcaster/hubble': patch
+---
+
+replace @noble/ed25519 with faster and more secure @noble/curves
+
+- crypto/ed25119 functions are now synchronous

--- a/.changeset/eleven-lies-wait.md
+++ b/.changeset/eleven-lies-wait.md
@@ -1,8 +1,8 @@
 ---
 '@farcaster/core': minor
 '@farcaster/hubble': patch
+'@farcaster/hub-nodejs': patch
+'@farcaster/hub-web': patch
 ---
 
 replace @noble/ed25519 with faster and more secure @noble/curves
-
-- crypto/ed25119 functions are now synchronous

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -58,6 +58,7 @@
     "@libp2p/tcp": "^6.0.0",
     "@libp2p/utils": "^3.0.2",
     "@multiformats/multiaddr": "^11.0.0",
+    "@noble/curves": "^1.0.0",
     "async-lock": "^1.4.0",
     "commander": "~10.0.0",
     "ethers": "~6.2.1",

--- a/apps/hubble/src/utils/periodicTestDataJob.ts
+++ b/apps/hubble/src/utils/periodicTestDataJob.ts
@@ -15,7 +15,7 @@ import {
   CastAddBody,
 } from '@farcaster/hub-nodejs';
 import { logger } from '~/utils/logger';
-import * as ed from '@noble/ed25519';
+import { ed25519 as ed } from '@noble/curves/ed25519';
 import { faker } from '@faker-js/faker';
 import Server from '~/rpc/server';
 import { Result } from 'neverthrow';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@ethersproject/abstract-signer": "^5.7.0",
     "@faker-js/faker": "^7.6.0",
-    "@noble/ed25519": "^1.7.3",
+    "@noble/curves": "^1.0.0",
     "@noble/hashes": "^1.3.0",
     "ethers": "~6.2.1",
     "neverthrow": "^6.0.0",

--- a/packages/core/src/bytes.ts
+++ b/packages/core/src/bytes.ts
@@ -1,6 +1,6 @@
 /* eslint-disable security/detect-object-injection */
-import { utils } from '@noble/ed25519';
 import { err, ok, Result } from 'neverthrow';
+import { bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
 import { HubError, HubResult } from './errors';
 
 export const bytesCompare = (a: Uint8Array, b: Uint8Array): number => {
@@ -66,14 +66,14 @@ export const bytesDecrement = (inputBytes: Uint8Array): HubResult<Uint8Array> =>
 
 export const bytesToHexString = (bytes: Uint8Array): HubResult<string> => {
   return Result.fromThrowable(
-    (bytes: Uint8Array) => '0x' + utils.bytesToHex(bytes),
+    (bytes: Uint8Array) => '0x' + bytesToHex(bytes),
     (e) => new HubError('unknown', e as Error)
   )(bytes);
 };
 
 export const hexStringToBytes = (hex: string): HubResult<Uint8Array> => {
   return Result.fromThrowable(
-    (hex: string) => utils.hexToBytes(hex.substring(0, 2) === '0x' ? hex.substring(2) : hex),
+    (hex: string) => hexToBytes(hex.substring(0, 2) === '0x' ? hex.substring(2) : hex),
     (e) => new HubError('unknown', e as Error)
   )(hex);
 };

--- a/packages/core/src/crypto/ed25519.test.ts
+++ b/packages/core/src/crypto/ed25519.test.ts
@@ -1,22 +1,23 @@
 import * as protobufs from '../protobufs';
-import { ed25519 as ed } from '@noble/curves/ed25519';
+import * as ed from '@noble/ed25519';
 import { blake3 } from '@noble/hashes/blake3';
 import { randomBytes } from 'ethers';
+import { HubError } from '../errors';
 import { Factories } from '../factories';
 import * as ed25519 from './ed25519';
 
 let publicKey: Uint8Array;
 let privateKey: Uint8Array;
 
-beforeAll(() => {
+beforeAll(async () => {
   privateKey = ed.utils.randomPrivateKey();
-  publicKey = ed.getPublicKey(privateKey);
+  publicKey = await ed.getPublicKey(privateKey);
 });
 
 describe('getPublicKey', () => {
   test('succeeds with valid signature', async () => {
-    const result = ed25519.getPublicKey(privateKey);
-    expect(result).toEqual(publicKey);
+    const result = await ed25519.getPublicKey(privateKey);
+    expect(result._unsafeUnwrap()).toEqual(publicKey);
   });
 });
 
@@ -25,8 +26,8 @@ describe('signMessageHash', () => {
     const messageData = Factories.SignerAddData.build();
     const bytes = protobufs.MessageData.encode(messageData).finish();
     const hash = blake3(bytes, { dkLen: 20 });
-    const signature = ed25519.signMessageHash(hash, privateKey);
-    const isValid = ed.verify(signature, hash, publicKey);
+    const signature = await ed25519.signMessageHash(hash, privateKey);
+    const isValid = await ed.verify(signature._unsafeUnwrap(), hash, publicKey);
     expect(isValid).toBe(true);
   });
 });
@@ -36,15 +37,16 @@ describe('verifyMessageHashSignature', () => {
     const messageData = Factories.SignerAddData.build();
     const bytes = protobufs.MessageData.encode(messageData).finish();
     const hash = blake3(bytes, { dkLen: 20 });
-    const signature = ed25519.signMessageHash(hash, privateKey);
-    const isValid = ed25519.verifyMessageHashSignature(signature, hash, publicKey);
-    expect(isValid).toBe(true);
+    const signature = await ed25519.signMessageHash(hash, privateKey);
+    const isValid = await ed25519.verifyMessageHashSignature(signature._unsafeUnwrap(), hash, publicKey);
+    expect(isValid._unsafeUnwrap()).toBe(true);
   });
 
   test('fails with invalid signature', async () => {
     const messageData = Factories.SignerAddData.build();
     const bytes = protobufs.MessageData.encode(messageData).finish();
     const hash = blake3(bytes, { dkLen: 20 });
-    expect(() => ed25519.verifyMessageHashSignature(randomBytes(32), hash, privateKey)).toThrow();
+    const isValid = await ed25519.verifyMessageHashSignature(randomBytes(32), hash, privateKey);
+    expect(isValid._unsafeUnwrapErr()).toBeInstanceOf(HubError);
   });
 });

--- a/packages/core/src/crypto/ed25519.ts
+++ b/packages/core/src/crypto/ed25519.ts
@@ -1,30 +1,13 @@
-import * as ed from '@noble/ed25519';
-import { sha512 } from '@noble/hashes/sha512';
-import { ResultAsync } from 'neverthrow';
-import { HubAsyncResult, HubError } from '../errors';
+import { ed25519 as ed } from '@noble/curves/ed25519';
 
-/** Setup ed to hash synchronously */
-ed.utils.sha512Sync = (...m) => sha512(ed.utils.concatBytes(...m));
-
-export const getPublicKeySync = (privateKey: Uint8Array): Uint8Array => {
-  return ed.sync.getPublicKey(privateKey);
+export const getPublicKey = (privateKey: Uint8Array): Uint8Array => {
+  return ed.getPublicKey(privateKey);
 };
 
-export const getPublicKey = async (privateKey: Uint8Array): HubAsyncResult<Uint8Array> => {
-  return ResultAsync.fromPromise(ed.getPublicKey(privateKey), (err) => new HubError('bad_request', err as Error));
+export const signMessageHash = (hash: Uint8Array, privateKey: Uint8Array): Uint8Array => {
+  return ed.sign(hash, privateKey);
 };
 
-export const signMessageHash = async (hash: Uint8Array, privateKey: Uint8Array): HubAsyncResult<Uint8Array> => {
-  return ResultAsync.fromPromise(ed.sign(hash, privateKey), (err) => new HubError('bad_request', err as Error));
-};
-
-export const verifyMessageHashSignature = async (
-  signature: Uint8Array,
-  hash: Uint8Array,
-  publicKey: Uint8Array
-): HubAsyncResult<boolean> => {
-  return ResultAsync.fromPromise(
-    ed.verify(signature, hash, publicKey),
-    (err) => new HubError('bad_request', err as Error)
-  );
+export const verifyMessageHashSignature = (signature: Uint8Array, hash: Uint8Array, publicKey: Uint8Array): boolean => {
+  return ed.verify(signature, hash, publicKey);
 };

--- a/packages/core/src/crypto/ed25519.ts
+++ b/packages/core/src/crypto/ed25519.ts
@@ -1,13 +1,23 @@
-import { ed25519 as ed } from '@noble/curves/ed25519';
+import { ed25519 } from '@noble/curves/ed25519';
+import { Result } from 'neverthrow';
+import { HubAsyncResult, HubError } from '../errors';
 
-export const getPublicKey = (privateKey: Uint8Array): Uint8Array => {
-  return ed.getPublicKey(privateKey);
+const safeGetPublicKey = Result.fromThrowable(ed25519.getPublicKey, (err) => new HubError('bad_request', err as Error));
+const safeSign = Result.fromThrowable(ed25519.sign, (err) => new HubError('bad_request', err as Error));
+const safeVerify = Result.fromThrowable(ed25519.verify, (err) => new HubError('bad_request', err as Error));
+
+export const getPublicKey = async (privateKey: Uint8Array): HubAsyncResult<Uint8Array> => {
+  return safeGetPublicKey(privateKey);
 };
 
-export const signMessageHash = (hash: Uint8Array, privateKey: Uint8Array): Uint8Array => {
-  return ed.sign(hash, privateKey);
+export const signMessageHash = async (hash: Uint8Array, privateKey: Uint8Array): HubAsyncResult<Uint8Array> => {
+  return safeSign(hash, privateKey);
 };
 
-export const verifyMessageHashSignature = (signature: Uint8Array, hash: Uint8Array, publicKey: Uint8Array): boolean => {
-  return ed.verify(signature, hash, publicKey);
+export const verifyMessageHashSignature = async (
+  signature: Uint8Array,
+  hash: Uint8Array,
+  publicKey: Uint8Array
+): HubAsyncResult<boolean> => {
+  return safeVerify(signature, hash, publicKey);
 };

--- a/packages/core/src/factories.ts
+++ b/packages/core/src/factories.ts
@@ -1,14 +1,14 @@
 import { faker } from '@faker-js/faker';
 import { Factory } from '@farcaster/fishery';
-import * as protobufs from './protobufs';
-import { utils } from '@noble/ed25519';
+import { ed25519 } from '@noble/curves/ed25519';
 import { blake3 } from '@noble/hashes/blake3';
 import { Wallet } from 'ethers';
+import * as protobufs from './protobufs';
 import { bytesToHexString } from './bytes';
-import * as ed25519 from './crypto/ed25519';
 import { Ed25519Signer, Eip712Signer, EthersEip712Signer, NobleEd25519Signer, Signer } from './signers';
 import { getFarcasterTime } from './time';
 import { VerificationEthAddressClaim } from './verifications';
+import { randomBytes } from '@noble/hashes/utils';
 
 /** Scalars */
 
@@ -18,7 +18,7 @@ const FidFactory = Factory.define<number>(() => {
 
 const BytesFactory = Factory.define<Uint8Array, { length?: number }>(({ transientParams }) => {
   const length = transientParams.length ?? faker.datatype.number({ max: 64, min: 1 });
-  return utils.randomBytes(length);
+  return randomBytes(length);
 });
 
 const MessageHashFactory = Factory.define<Uint8Array>(() => {
@@ -74,12 +74,12 @@ const TransactionHashFactory = Factory.define<Uint8Array>(() => {
 /** Signers */
 
 const Ed25519PrivateKeyFactory = Factory.define<Uint8Array>(() => {
-  return utils.randomPrivateKey();
+  return ed25519.utils.randomPrivateKey();
 });
 
 const Ed25519PPublicKeyFactory = Factory.define<Uint8Array>(() => {
   const privateKey = Ed25519PrivateKeyFactory.build();
-  return ed25519.getPublicKeySync(privateKey);
+  return ed25519.getPublicKey(privateKey);
 });
 
 const Ed25519SignerFactory = Factory.define<Ed25519Signer>(() => {

--- a/packages/core/src/signers/nobleEd25519Signer.test.ts
+++ b/packages/core/src/signers/nobleEd25519Signer.test.ts
@@ -1,9 +1,8 @@
 import { blake3 } from '@noble/hashes/blake3';
 import { randomBytes } from 'ethers';
-import { ok } from 'neverthrow';
-import { ed25519 } from '../crypto';
 import { Factories } from '../factories';
 import { NobleEd25519Signer } from './nobleEd25519Signer';
+import { ed25519 } from '@noble/curves/ed25519';
 
 describe('NobleEd25519Signer', () => {
   const privateKey = Factories.Ed25519PrivateKey.build();
@@ -20,8 +19,8 @@ describe('NobleEd25519Signer', () => {
       const hash = blake3(bytes, { dkLen: 20 });
       const signature = await signer.signMessageHash(hash);
       expect(signature.isOk()).toBeTruthy();
-      const isValid = await ed25519.verifyMessageHashSignature(signature._unsafeUnwrap(), hash, signerKey);
-      expect(isValid).toEqual(ok(true));
+      const isValid = ed25519.verify(signature._unsafeUnwrap(), hash, signerKey);
+      expect(isValid).toEqual(true);
     });
   });
 });

--- a/packages/core/src/signers/nobleEd25519Signer.ts
+++ b/packages/core/src/signers/nobleEd25519Signer.ts
@@ -1,4 +1,5 @@
-import { ed25519 } from '../crypto';
+import { ok } from 'neverthrow';
+import { ed25519 } from '@noble/curves/ed25519';
 import { HubAsyncResult } from '../errors';
 import { Ed25519Signer } from './ed25519Signer';
 
@@ -11,10 +12,10 @@ export class NobleEd25519Signer extends Ed25519Signer {
   }
 
   public async getSignerKey(): HubAsyncResult<Uint8Array> {
-    return ed25519.getPublicKey(this._privateKey);
+    return ok(ed25519.getPublicKey(this._privateKey));
   }
 
   public async signMessageHash(hash: Uint8Array): HubAsyncResult<Uint8Array> {
-    return ed25519.signMessageHash(hash, this._privateKey);
+    return ok(ed25519.sign(hash, this._privateKey));
   }
 }

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -1,8 +1,9 @@
 import * as protobufs from './protobufs';
 import { blake3 } from '@noble/hashes/blake3';
+import { ed25519 } from '@noble/curves/ed25519';
 import { err, ok, Result } from 'neverthrow';
 import { bytesCompare, bytesToUtf8String, utf8StringToBytes } from './bytes';
-import { ed25519, eip712 } from './crypto';
+import { eip712 } from './crypto';
 import { HubAsyncResult, HubError, HubResult } from './errors';
 import { getFarcasterTime } from './time';
 import { makeVerificationEthAddressClaim } from './verifications';
@@ -142,8 +143,8 @@ export const validateMessage = async (message: protobufs.Message): HubAsyncResul
       return err(new HubError('bad_request.validation_failure', 'signature does not match signer'));
     }
   } else if (message.signatureScheme === protobufs.SignatureScheme.ED25519 && !eip712SignerRequired) {
-    const signatureIsValid = await ed25519.verifyMessageHashSignature(signature, hash, signer);
-    if (signatureIsValid.isErr() || (signatureIsValid.isOk() && !signatureIsValid.value)) {
+    const signatureIsValid = ed25519.verify(signature, hash, signer);
+    if (!signatureIsValid) {
       return err(new HubError('bad_request.validation_failure', 'invalid signature'));
     }
   } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2002,6 +2002,13 @@
   dependencies:
     "@noble/hashes" "1.3.0"
 
+"@noble/curves@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/@noble/curves/-/curves-1.0.0.tgz#e40be8c7daf088aaf291887cbc73f43464a92932"
+  integrity sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==
+  dependencies:
+    "@noble/hashes" "1.3.0"
+
 "@noble/curves@~0.8.3":
   version "0.8.3"
   resolved "https://registry.npmjs.org/@noble/curves/-/curves-0.8.3.tgz#ad6d48baf2599cf1d58dcb734c14d5225c8996e0"
@@ -2013,11 +2020,6 @@
   version "1.7.2"
   resolved "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.2.tgz#7f8f395096a6417a65b8953d2a77fa48183c4c0a"
   integrity sha512-G0MeBXnCWDoFHrpytNcp32XQWlTzeplrTXKtZt24BjVehIh/D87Hs/ddj2+0vvvmxi/uvq+wz7oLgz9NnoW/1Q==
-
-"@noble/ed25519@^1.7.3":
-  version "1.7.3"
-  resolved "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz#57e1677bf6885354b466c38e2b620c62f45a7123"
-  integrity sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==
 
 "@noble/hashes@1.1.2":
   version "1.1.2"


### PR DESCRIPTION
## Motivation

Closes #776.

## Change Summary

Replaces @noble/ed25519 with @noble/curves.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR replaces the `@noble/ed25519` package with the more secure and faster `@noble/curves` package for signing and verifying messages. It also includes updates to related packages and files.

### Detailed summary
- Replaced `@noble/ed25519` with `@noble/curves` in various files and packages
- Updated dependencies for `@farcaster/core`, `@farcaster/hubble`, `@farcaster/hub-nodejs`, and `@farcaster/hub-web`
- Removed unused imports and code in `packages/core/src/crypto/ed25519.ts`
- Updated tests in `packages/core/src/signers/nobleEd25519Signer.test.ts` to use `@noble/curves/ed25519`
- Updated `packages/core/src/bytes.ts` to use `@noble/curves/abstract/utils` for hex conversion
- Updated `packages/core/src/validations.ts` to use `@noble/curves/ed25519` for signature verification
- Updated `packages/core/src/factories.ts` to use `@noble/hashes/utils` for random bytes generation

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->