### PR TITLE
chore: add peerid for [fc.bus.events]

### DIFF
--- a/apps/hubble/src/allowedPeers.mainnet.ts
+++ b/apps/hubble/src/allowedPeers.mainnet.ts
@@ -28,4 +28,5 @@ export const MAINNET_ALLOWED_PEERS = [
   '12D3KooWEZbpDyiupf2p9dWREfAigKou5wT4jcvxGVTcdXKXBuMu', // Jam.so
   '12D3KooWEr4WoKduAQg8VJSgwcNsqptbdkSQLw1ceEr8oSBQurJX', // @yanisme
   '12D3KooWMZK4VeMX3ZARugTuGexXFHNiGHgNFq6XE2vzi88fMgwC', // @event
+  '12D3KooWBhm9XdafZiBWPncDVcvMhcmV3kLFLnBiS83CjY833sWN', // @pjc
 ];

--- a/apps/hubble/src/allowedPeers.mainnet.ts
+++ b/apps/hubble/src/allowedPeers.mainnet.ts
@@ -28,5 +28,5 @@ export const MAINNET_ALLOWED_PEERS = [
   '12D3KooWEZbpDyiupf2p9dWREfAigKou5wT4jcvxGVTcdXKXBuMu', // Jam.so
   '12D3KooWEr4WoKduAQg8VJSgwcNsqptbdkSQLw1ceEr8oSBQurJX', // @yanisme
   '12D3KooWMZK4VeMX3ZARugTuGexXFHNiGHgNFq6XE2vzi88fMgwC', // @event
-  '12D3KooWBhm9XdafZiBWPncDVcvMhcmV3kLFLnBiS83CjY833sWN', // @pjc
+  '12D3KooWBhm9XdafZiBWPncDVcvMhcmV3kLFLnBiS83CjY833sWN', // @pjc (fc.bus.events)
 ];


### PR DESCRIPTION
## Motivation

Prep for mainnet.  
As per instructions on ([ref](https://github.com/philcockfield/hub-monorepo/tree/main/apps/hubble#4-switch-to-mainnet)):

<img width="1040" alt="image" src="https://user-images.githubusercontent.com/185555/236957286-23189db6-db37-4273-970b-26371afe48e4.png">


## Change Summary

Add peerid for @pjc (mainnet → fc.bus.events)

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)  
  (← N/A?? *Please let me know if you need this generated. My reading of "CONTRIBUTING.md" guide indicated this was for meaningful changes only....this is a one liner*)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

Who is this?: 
- **Phil Cockfield**
- https://warpcast.com/pjc  
- Peer Id: `12D3KooWBhm9XdafZiBWPncDVcvMhcmV3kLFLnBiS83CjY833sWN`

Identity created on dev machine (`yarn identity create`), prior to standing up full cloud-process to run the hub (which is targeted for subdomain [fc.bus.events](https://fc.bus.events) on [bus.events](https://bus.events))

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new allowed peer to the `allowedPeers.mainnet.ts` file.

### Detailed summary
- Added a new allowed peer (`12D3KooWBhm9XdafZiBWPncDVcvMhcmV3kLFLnBiS83CjY833sWN`) to `allowedPeers.mainnet.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->