### PR TITLE
chore: Release 1.2.2

### DIFF
--- a/.changeset/lucky-mails-develop.md
+++ b/.changeset/lucky-mails-develop.md
@@ -1,5 +1,0 @@
----
-'@farcaster/hubble': minor
----
-
-improve handling of duplicate messages on gossip

--- a/.changeset/shiny-tables-join.md
+++ b/.changeset/shiny-tables-join.md
@@ -1,8 +1,0 @@
----
-'@farcaster/hub-nodejs': patch
-'@farcaster/hub-web': patch
-'@farcaster/core': patch
-'@farcaster/hubble': patch
----
-
-Add a GetSyncStatus rpc call that exposes the hubs sync status with different peers

--- a/.changeset/smart-glasses-confess.md
+++ b/.changeset/smart-glasses-confess.md
@@ -1,6 +1,0 @@
----
-'@farcaster/core': patch
-'@farcaster/hubble': patch
----
-
-Reject prunable messages on merge

--- a/.changeset/thin-pets-admire.md
+++ b/.changeset/thin-pets-admire.md
@@ -1,5 +1,0 @@
----
-'@farcaster/core': patch
----
-
-fix: validate parentUrl and targetUrl comprehensively

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @farcaster/hubble
 
+## 1.2.2
+
+### Patch Changes
+
+- 5308788: improve handling of duplicate messages on gossip
+- 1236b4e: Add a GetSyncStatus rpc call that exposes the hubs sync status with different peers
+- 2e633db: Reject prunable messages on merge
+- Updated dependencies [1236b4e]
+  - @farcaster/hub-nodejs@0.7.2
+
 ## 1.2.1
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -49,7 +49,7 @@
   "dependencies": {
     "@chainsafe/libp2p-gossipsub": "6.1.0",
     "@chainsafe/libp2p-noise": "^11.0.0 ",
-    "@farcaster/hub-nodejs": "^0.7.1",
+    "@farcaster/hub-nodejs": "^0.7.2",
     "@grpc/grpc-js": "~1.8.7",
     "@libp2p/interface-connection": "^3.0.2",
     "@libp2p/interface-peer-id": "^2.0.0",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/core
 
+## 0.7.2
+
+### Patch Changes
+
+- 1236b4e: Add a GetSyncStatus rpc call that exposes the hubs sync status with different peers
+- 2e633db: Reject prunable messages on merge
+- d2cb5e4: fix: validate parentUrl and targetUrl comprehensively
+
 ## 0.7.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @farcaster/hub-nodejs
 
+## 0.7.2
+
+### Patch Changes
+
+- 1236b4e: Add a GetSyncStatus rpc call that exposes the hubs sync status with different peers
+- Updated dependencies [1236b4e]
+- Updated dependencies [2e633db]
+- Updated dependencies [d2cb5e4]
+  - @farcaster/core@0.7.2
+
 ## 0.7.1
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@farcaster/core": "0.7.1",
+    "@farcaster/core": "0.7.2",
     "@grpc/grpc-js": "^1.8.13",
     "@noble/hashes": "^1.3.0",
     "ethers": "~6.2.1",

--- a/packages/hub-web/CHANGELOG.md
+++ b/packages/hub-web/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @farcaster/hub-web
 
+## 0.3.2
+
+### Patch Changes
+
+- 1236b4e: Add a GetSyncStatus rpc call that exposes the hubs sync status with different peers
+- Updated dependencies [1236b4e]
+- Updated dependencies [2e633db]
+- Updated dependencies [d2cb5e4]
+  - @farcaster/core@0.7.2
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-web",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -29,7 +29,7 @@
     "ts-proto": "^1.146.0"
   },
   "dependencies": {
-    "@farcaster/core": "^0.7.1",
+    "@farcaster/core": "^0.7.2",
     "@improbable-eng/grpc-web": "^0.15.0",
     "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
     "rxjs": "^7.8.0"


### PR DESCRIPTION
## Motivation

Release 1.2.2

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `@farcaster/core` to `0.7.2` and includes various patch changes across packages and apps.

### Detailed summary
- Updated version of `@farcaster/core` to `0.7.2`
- Added `GetSyncStatus` rpc call to expose hub sync status with different peers
- Rejected prunable messages on merge
- Improved handling of duplicate messages on gossip
- Validated parentUrl and targetUrl comprehensively
- Updated dependencies for `@farcaster/core`, `@farcaster/hub-nodejs`, and `@farcaster/hub-web`
- Updated version of `@farcaster/hub-nodejs` to `0.7.2`
- Updated version of `@farcaster/hub-web` to `0.3.2`
- Updated version of `@farcaster/hubble` to `1.2.2`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->