### PR TITLE
feat: Sync status improvements

### DIFF
--- a/.changeset/cuddly-bottles-refuse.md
+++ b/.changeset/cuddly-bottles-refuse.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Add --watch to hub status command and more readable output

--- a/apps/hubble/README.md
+++ b/apps/hubble/README.md
@@ -33,6 +33,11 @@ Hubble will sync with the on-chain contracts, and issue thousands of messages li
 0 | hubble | { level: 30, time: 1679702496763, pid: 3259, hostname: 'ip-10-0-0-85', component: 'SyncEngine', total: 1, success: 1, msg: 'Merged messages', };
 ```
 
+You can monitor the status of the sync with:
+```
+yarn status --watch # Might need to pass in --insecure if you don't have TLS configured
+```
+
 ### 4. Switch to Mainnet
 
 Mainnet is Farcaster's production environment apps use and writing a message here will make it show up in all applications. Minimum requirements are 8GB RAM and 20GB of disk space.
@@ -88,6 +93,11 @@ Hubble will sync with the on-chain contracts, and issue thousands of messages li
 0 | hubble | { level: 30, time: 1679703063660, pid: 3259, hostname: 'ip-10-0-0-85', component: 'EthEventsProvider', blockNumber: 8712752, msg: 'new block: 8712752 };
 
 0 | hubble | { level: 30, time: 1679702496763, pid: 3259, hostname: 'ip-10-0-0-85', component: 'SyncEngine', total: 1, success: 1, msg: 'Merged messages', };
+```
+
+You can monitor the status of the sync with:
+```
+yarn status --watch # Might need to pass in --insecure if you don't have TLS configured
 ```
 
 ### 5. Switch to Mainnet

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -20,6 +20,7 @@ import { addressInfoFromParts, ipMultiAddrStrFromAddressInfo, parseAddress } fro
 import { DEFAULT_RPC_CONSOLE, startConsole } from './console/console';
 import RocksDB, { DB_DIRECTORY } from './storage/db/rocksdb';
 import { parseNetwork } from './utils/command';
+import { sleep } from '~/utils/crypto';
 
 /** A CLI to accept options from the user and start the Hub */
 
@@ -452,6 +453,7 @@ app
     DEFAULT_RPC_CONSOLE
   )
   .option('--insecure', 'Allow insecure connections to the RPC server', false)
+  .option('--watch', 'Keep running and periodically report status', false)
   .option('-p, --peerId <peerId>', 'Peer id of the hub to compare with (defaults to bootstrap peers)')
   .action(async (cliOptions) => {
     let rpcClient;
@@ -461,30 +463,55 @@ app
       rpcClient = getSSLHubRpcClient(cliOptions.server);
     }
     const infoResult = await rpcClient.getInfo(HubInfoRequest.create({ dbStats: true }));
-    const syncStatusResult = await rpcClient.getSyncStatus(SyncStatusRequest.create({ peerId: cliOptions.peerId }));
-    if (syncStatusResult.isErr()) {
+    if (infoResult.isErr()) {
       logger.error(
-        { errCode: syncStatusResult.error.errCode, errMsg: syncStatusResult.error.message },
-        'Failed to get hub status'
+        { errCode: infoResult.error.errCode, errMsg: infoResult.error.message },
+        'Failed to get hub status. Do you need to pass in --insecure?'
       );
-      exit(1);
-    } else if (infoResult.isErr()) {
-      logger.error({ errCode: infoResult.error.errCode, errMsg: infoResult.error.message }, 'Failed to get hub status');
       exit(1);
     }
     const dbStats = infoResult.value.dbStats;
     logger.info(
       `Hub Version: ${infoResult.value.version} Messages: ${dbStats?.numMessages} FIDs: ${dbStats?.numFidEvents} FNames: ${dbStats?.numFnameEvents}}`
     );
-    for (const peerStatus of syncStatusResult.value.syncStatus) {
-      const messageDelta = peerStatus.theirMessages - peerStatus.ourMessages;
-      if (syncStatusResult.value.isSyncing) {
-        logger.info(`Peer ${peerStatus.peerId}: Sync in progress. (msg delta: ${messageDelta})`);
-      } else {
-        logger.info(
-          `Peer ${peerStatus.peerId}: In Sync: ${peerStatus.inSync} (msg delta: ${messageDelta}, diverged ${peerStatus.divergenceSecondsAgo} seconds ago)`
+    for (;;) {
+      const syncResult = await rpcClient.getSyncStatus(SyncStatusRequest.create({ peerId: cliOptions.peerId }));
+      if (syncResult.isErr()) {
+        logger.error(
+          { errCode: syncResult.error.errCode, errMsg: syncResult.error.message },
+          'Failed to get sync status'
         );
+        exit(1);
       }
+
+      let isSyncing = false;
+      const msgPercents: number[] = [];
+      for (const peerStatus of syncResult.value.syncStatus) {
+        const messagePercent = (peerStatus.ourMessages / peerStatus.theirMessages) * 100;
+        msgPercents.push(messagePercent);
+        if (syncResult.value.isSyncing) {
+          isSyncing = true;
+        }
+      }
+      const numPeers = msgPercents.length;
+      if (numPeers === 0) {
+        logger.info('Sync Status: No peers');
+      } else {
+        const avgMsgPercent = msgPercents.reduce((a, b) => a + b, 0) / numPeers;
+        if (isSyncing) {
+          logger.info(
+            `Sync Status: Sync in progress. Hub has ${avgMsgPercent.toFixed(2)}% of messages of ${numPeers} peers`
+          );
+        } else {
+          logger.info(`Sync Status: Hub has ${avgMsgPercent.toFixed(2)}% of messages of ${numPeers} peers`);
+        }
+      }
+
+      if (!cliOptions.watch) {
+        break;
+      }
+
+      await sleep(10_000);
     }
     exit(0);
   });

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -69,12 +69,10 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
   private _node?: Libp2p;
   private _periodicPeerCheckJob?: PeriodicPeerCheckScheduler;
   private _network: FarcasterNetwork;
-  private _bootstrapPeerIds: Set<string>;
 
   constructor(network?: FarcasterNetwork) {
     super();
     this._network = network ?? FarcasterNetwork.NONE;
-    this._bootstrapPeerIds = new Set<string>();
   }
 
   /** Returns the PeerId (public key) of this node */
@@ -261,16 +259,13 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
   }
 
   /** Connect to a peer Gossip Node using a specific address */
-  async connectAddress(address: Multiaddr, isBootstrapNode = false): Promise<HubResult<void>> {
+  async connectAddress(address: Multiaddr): Promise<HubResult<void>> {
     log.debug({ identity: this.identity, address }, `Attempting to connect to address ${address}`);
     try {
       const conn = await this._node?.dial(address);
 
       if (conn) {
         log.info({ identity: this.identity, address }, `Connected to peer at address: ${address}`);
-        if (isBootstrapNode) {
-          this._bootstrapPeerIds.add(conn.remotePeer.toString());
-        }
         return ok(undefined);
       }
     } catch (error: any) {
@@ -341,8 +336,8 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
     return [this.primaryTopic(), this.contactInfoTopic()];
   }
 
-  get bootstrapPeerIds(): Set<string> {
-    return this._bootstrapPeerIds;
+  allPeerIds(): string[] {
+    return this._node?.getPeers()?.map((peer) => peer.toString()) ?? [];
   }
 
   //TODO: Needs better typesafety
@@ -372,7 +367,7 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
   /* Attempts to dial all the addresses in the bootstrap list */
   public async bootstrap(bootstrapAddrs: Multiaddr[]): Promise<HubResult<void>> {
     if (bootstrapAddrs.length == 0) return ok(undefined);
-    const results = await Promise.all(bootstrapAddrs.map((addr) => this.connectAddress(addr, true)));
+    const results = await Promise.all(bootstrapAddrs.map((addr) => this.connectAddress(addr)));
 
     const finalResults = Result.combineWithAllErrors(results) as Result<void[], HubError[]>;
     if (finalResults.isErr() && finalResults.error.length == bootstrapAddrs.length) {

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -299,7 +299,7 @@ export default class Server {
           if (call.request.peerId && call.request.peerId.length > 0) {
             peersToCheck = [call.request.peerId];
           } else {
-            peersToCheck = Array.from(this.gossipNode.bootstrapPeerIds.values());
+            peersToCheck = this.gossipNode.allPeerIds();
           }
 
           const response = SyncStatusResponse.create({

--- a/apps/hubble/src/rpc/test/syncService.test.ts
+++ b/apps/hubble/src/rpc/test/syncService.test.ts
@@ -19,7 +19,7 @@ import { GossipNode } from '~/network/p2p/gossipNode';
 const db = jestRocksDB('protobufs.rpc.syncService.test');
 const network = FarcasterNetwork.TESTNET;
 const mockGossipNode = {
-  bootstrapPeerIds: ['test'],
+  allPeerIds: () => ['test'],
 } as unknown as GossipNode;
 const engine = new Engine(db, network);
 const hub = new MockHub(db, engine, mockGossipNode);


### PR DESCRIPTION
## Motivation

https://github.com/farcasterxyz/hub-monorepo/issues/874

Improve status command to report data from all peers, add a --watch flag and output more friendly messages.

```
{"level":30,"time":1683691363393,"pid":65695,"hostname":"Sanjays-MacBook-Pro.local","msg":"Sync Status: Sync in progress. Hub has 53.60% of messages of 3 peers"}
```


## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds the `--watch` option to the `yarn status` command in the Hubble app, allowing users to monitor the sync status of the hub. It also provides more readable output for the `status` command and removes unused code.

### Detailed summary
- Adds `--watch` option to `yarn status` command
- Provides more readable output for `status` command
- Removes unused code

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->