### PR TITLE
chore: Optimize replication example

### DIFF
--- a/packages/hub-nodejs/examples/replicate-data-postgres/README.md
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/README.md
@@ -14,12 +14,11 @@ This example shows you how you can quickly start ingesting data from a Farcaster
 
 There are some important points to consider when using this example:
 
-* **This is not intended to be used in production!**
-  It makes some simplifying assumptions (e.g. inserting messages one at a time instead of batching together, etc.) in order to be easily understandable.
+* **This is not intended to be used in production systems!** It's meant to serve as an example.
 
-* If you are running the Node.js application and Postgres DB on different servers, the time it takes to sync will be heavily dependent on the latency between those servers, making a process that normally takes a few hours take days instead. It is strongly recommended that you connect them using a private network, rather than connecting them via public internet. Many platforms like Supabase, Vercel, etc. (at time of writing) don't give you a low-latency connection due to their architecture.
+* The time it takes to sync is heavily dependent on the latency between the Node.js application and the Postgres database.
 
-* While the created tables have some indexes for query performance, they are not built to consider all possible query patterns.
+* While the created tables have some indexes to improve query performance, they are not built to consider all possible query patterns.
 
 ## Running the example
 
@@ -47,16 +46,17 @@ These two options are recommended because they are relatively quick and also all
 Once the Docker images have finished downloading, you should start to see messages like:
 
 ```
-replicate-data-postgres-app-1   | [01:06:37.823] INFO (86): [Backfill] Starting FID 1/12830
-replicate-data-postgres-app-1   | [01:06:38.478] INFO (86): [Backfill] Completed FID 1/12830
-replicate-data-postgres-app-1   | [01:06:38.478] INFO (86): [Backfill] Starting FID 2/12830
+replicate-data-postgres-app-1   | [04:46:13.051] INFO (61): [Backfill] Completed FID 1/12837. Estimated time remaining: 2h 6m 22.5s
+replicate-data-postgres-app-1   | [04:46:13.053] INFO (61): [Backfill] Completed FID 5/12837. Estimated time remaining: 2h 33m 36.9s
+replicate-data-postgres-app-1   | [04:46:13.767] INFO (61): [Backfill] Completed FID 6/12837. Estimated time remaining: 2h 33m 19.8s
+replicate-data-postgres-app-1   | [04:46:14.636] INFO (61): [Backfill] Completed FID 7/12837. Estimated time remaining: 2h 41m 25.5s
 ...
-replicate-data-postgres-app-1   | [01:06:50.142] INFO (86): [Sync] Processing merge event 304011714592768 from stream
-replicate-data-postgres-app-1   | [01:06:50.142] INFO (86): [Sync] Processing merge event 304011726786560 from stream
+replicate-data-postgres-app-1   | [04:56:50.142] INFO (86): [Sync] Processing merge event 304011714592768 from stream
+replicate-data-postgres-app-1   | [04:56:50.142] INFO (86): [Sync] Processing merge event 304011726786560 from stream
 ...
 ```
 
-If messages like these are appearing, replication is working as expected. Any other messages can usually be ignored.
+You may see messages out of order—this is fine. If messages like above are appearing, replication is working as expected. The message `FATAL:  role "root" does not exist` can safely be ignored.
 
 #### Connecting to Postgres
 

--- a/packages/hub-nodejs/examples/replicate-data-postgres/docker-compose.yml
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     command: ["sh", "-c", "yarn install && exec yarn start"]
     init: true
     environment:
+      - NODE_OPTIONS=--max-old-space-size=512 # Limit memory usage
       - POSTGRES_URL=postgres://app:password@postgres:5432/hub
     volumes:
       - .:/home/node/app

--- a/packages/hub-nodejs/examples/replicate-data-postgres/package.json
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/package.json
@@ -5,15 +5,17 @@
   "version": "0.0.0",
   "main": "index.ts",
   "scripts": {
-    "start": "NODE_OPTIONS=--max-old-space-size=512 tsx index.ts"
+    "start": "tsx index.ts"
   },
   "dependencies": {
     "@farcaster/hub-nodejs": "^0.7.1",
+    "fastq": "^1.15.0",
     "kysely": "^0.24.2",
     "kysely-postgres-js": "^1.1.1",
     "pino": "^8.12.1",
     "pino-pretty": "^10.0.0",
     "postgres": "^3.3.4",
+    "pretty-ms": "^8.0.0",
     "tiny-typed-emitter": "^2.1.0"
   },
   "devDependencies": {

--- a/packages/hub-nodejs/examples/replicate-data-postgres/yarn.lock
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/yarn.lock
@@ -665,6 +665,13 @@ fast-safe-stringify@^2.1.1:
   resolved "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
+fastq@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz#d04d07c6a2a68fe4599fea8d2e103a937fae6b3a"
+  integrity sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==
+  dependencies:
+    reusify "^1.0.4"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -823,6 +830,11 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
+parse-ms@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/parse-ms/-/parse-ms-3.0.0.tgz#3ea24a934913345fcc3656deda72df921da3a70e"
+  integrity sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==
+
 pino-abstract-transport@^1.0.0, pino-abstract-transport@v1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz#cc0d6955fffcadb91b7b49ef220a6cc111d48bb3"
@@ -877,6 +889,13 @@ postgres@^3.3.4:
   version "3.3.4"
   resolved "https://registry.npmjs.org/postgres/-/postgres-3.3.4.tgz#09635eb9fae26dd449db9b1bd3956ef56c5b78fa"
   integrity sha512-XVu0+d/Y56pl2lSaf0c7V19AhAEfpVrhID1IENWN8nf0xch6hFq6dAov5dtUX6ZD46wfr1TxvLhxLtV8WnNsOg==
+
+pretty-ms@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.npmjs.org/pretty-ms/-/pretty-ms-8.0.0.tgz#a35563b2a02df01e595538f86d7de54ca23194a3"
+  integrity sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==
+  dependencies:
+    parse-ms "^3.0.0"
 
 process-warning@^2.0.0:
   version "2.2.0"
@@ -947,6 +966,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
+reusify@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
 safe-buffer@~5.2.0:
   version "5.2.1"


### PR DESCRIPTION
## Motivation

It would be nice to have a faster working example. Implement one by using batching and running jobs concurrently.

## Change Summary

Fetch data in batches and execute jobs concurrently. This reduces the time estimate from ~4 hours to under 1 hour on my machine. Also include the time estimate in the output.

We could probably make this even faster by implementing a `getAllMessages` endpoint on the hubs. But this will do for now.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds new dependencies and updates some configurations in the `replicate-data-postgres` example. It also improves the performance of the backfill process by fetching messages in parallel and making some optimizations.

### Detailed summary
- Adds `fastq`, `pretty-ms` and other new dependencies
- Updates `MAX_PAGE_SIZE` to 3000
- Adds `MAX_JOB_CONCURRENCY` to optimize backfill process
- Fetches messages in parallel to improve performance

> The following files were skipped due to too many changes: `packages/hub-nodejs/examples/replicate-data-postgres/hubReplicator.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->