### PR TITLE
fix: Correct time remaining estimate

### DIFF
--- a/packages/hub-nodejs/examples/replicate-data-postgres/README.md
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/README.md
@@ -56,7 +56,7 @@ replicate-data-postgres-app-1   | [04:56:50.142] INFO (86): [Sync] Processing me
 ...
 ```
 
-You may see messages out of order—this is fine. If messages like above are appearing, replication is working as expected. The message `FATAL:  role "root" does not exist` can safely be ignored.
+You may see messages out of order—this is fine. If messages like above are appearing, replication is working as expected.
 
 #### Connecting to Postgres
 

--- a/packages/hub-nodejs/examples/replicate-data-postgres/docker-compose.yml
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/docker-compose.yml
@@ -30,7 +30,8 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready']
+      # Need to specify name/user to avoid `FATAL: role "root" does not exist` errors in logs
+      test: ['CMD-SHELL', 'env', 'pg_isready', '--dbname', '$$POSTGRES_DB', '-U', '$$POSTGRES_USER']
       interval: 10s
       timeout: 10s
       retries: 3

--- a/packages/hub-nodejs/examples/replicate-data-postgres/hubReplicator.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/hubReplicator.ts
@@ -136,7 +136,7 @@ export class HubReplicator {
 
       totalProcessed += 1;
       const elapsedMs = Date.now() - startTime;
-      const millisRemaining = Math.ceil((elapsedMs / totalProcessed) * maxFid);
+      const millisRemaining = Math.ceil((elapsedMs / totalProcessed) * (maxFid - totalProcessed));
       this.log.info(
         `[Backfill] Completed FID ${fid}/${maxFid}. Estimated time remaining: ${prettyMilliseconds(millisRemaining)}`
       );
@@ -147,6 +147,7 @@ export class HubReplicator {
     }
 
     await queue.drained();
+    this.log.info(`[Backfill] Completed in ${prettyMilliseconds(Date.now() - startTime)}`);
   }
 
   private async processAllMessagesForFid(fid: number) {


### PR DESCRIPTION
## Motivation

We were not calculating this correctly.

While here, also fix the health check to not result in `FATAL` error messages in the logs.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves the replication process for a Node.js package by updating the Postgres connection and providing better logging information. 

### Detailed summary:
- Updated Postgres connection to avoid "role 'root' does not exist" errors
- Improved logging information for backfill completion time and completed FIDs

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->