### PR TITLE
docs(hub-nodejs): cleanup replicate example readme

### DIFF
--- a/packages/hub-nodejs/examples/README.md
+++ b/packages/hub-nodejs/examples/README.md
@@ -1,16 +1,10 @@
 # Examples
 
-A collection of Typescript examples showcasing the things you can do with `hub-nodejs`. Each example is a self-
-contained repository that includes a StackBlitz link to run it in a cloud REPL.
+A collection of Typescript examples showcasing the things you can do with `hub-nodejs`. 
 
 - [Generate a chronological feed](./chron-feed/)
 - [Writing data for a user](./write-data/)
 - [Building casts correctly](./make-cast/)
 - [Replicating data into Postgres](./replicate-data-postgres/)
 
-Other examples that should be added:
-
-- Subscribe to updates about a user
-- Rotating signers without losing messages
-
-Contributions for these examples and more are welcome!
+Contributions for other examples are welcome!


### PR DESCRIPTION
## Motivation

Simplify some of the language around the replicate example to make it easier to read

## Change Summary

See motivation

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

No changeset for docs

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes some examples and updates the README for the `replicate-data-postgres` example in the `hub-nodejs` package. It also adds a new section to the README with SQL queries examples.

### Detailed summary
- Removed two examples from the `hub-nodejs` package README
- Updated the `replicate-data-postgres` example README with clearer instructions and formatting
- Added a new section to the `replicate-data-postgres` example README with SQL query examples

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->