### PR TITLE
chore: Remove unnecessary @faker-js/faker dependency from core

### DIFF
--- a/.changeset/eight-mangos-change.md
+++ b/.changeset/eight-mangos-change.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/core': patch
+---
+
+Remove unnecessary @faker-js/faker dependency from core

--- a/.changeset/strong-trainers-hide.md
+++ b/.changeset/strong-trainers-hide.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Add @faker-js/faker as prod dependency

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -30,7 +30,6 @@
     "test:ci": "ENVIRONMENT=test NODE_OPTIONS=--experimental-vm-modules jest --ci --forceExit --coverage"
   },
   "devDependencies": {
-    "@faker-js/faker": "~7.6.0",
     "@libp2p/interface-mocks": "^9.0.0",
     "@types/async-lock": "^1.4.0",
     "@types/chance": "^1.1.3",
@@ -49,6 +48,7 @@
   "dependencies": {
     "@chainsafe/libp2p-gossipsub": "6.1.0",
     "@chainsafe/libp2p-noise": "^11.0.0 ",
+    "@faker-js/faker": "~7.6.0",
     "@farcaster/hub-nodejs": "^0.7.2",
     "@farcaster/rocksdb": "^5.5.0",
     "@grpc/grpc-js": "~1.8.7",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,6 @@
   "license": "MIT",
   "dependencies": {
     "@ethersproject/abstract-signer": "^5.7.0",
-    "@faker-js/faker": "^7.6.0",
     "@noble/curves": "^1.0.0",
     "@noble/hashes": "^1.3.0",
     "ethers": "~6.2.1",
@@ -34,6 +33,7 @@
     "prepublishOnly": "yarn run build"
   },
   "devDependencies": {
+    "@faker-js/faker": "^7.6.0",
     "@farcaster/fishery": "2.2.3",
     "eslint-config-custom": "*",
     "ethers5": "npm:ethers@^5.7.0",


### PR DESCRIPTION
## Motivation

This dependency is only required for dev, not production. It is however used by Hubble in testnet/devnet nodes in order to produce fake data, so add it as a production dependency there.

## Change Summary

Change the dependency to a dev dependency, since it's only used in tests.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes an unnecessary dependency from the `@farcaster/core` package and adds `@faker-js/faker` as a production dependency to `@farcaster/hubble`.

### Detailed summary
- Removes `@faker-js/faker` dependency from `@farcaster/core` package
- Adds `@faker-js/faker` as a production dependency to `@farcaster/hubble` package

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->