### PR TITLE
feat: Quickstart guide for running hubs with TLS

### DIFF
--- a/apps/hubble/quickstart/Caddyfile
+++ b/apps/hubble/quickstart/Caddyfile
@@ -1,0 +1,9 @@
+{$HUB_HOST}:2283 {
+        reverse_proxy h2c://hubble:2283 {
+        }
+}
+
+{$HUB_HOST}:2285 {
+        reverse_proxy http://envoy:2285 {
+        }
+}

--- a/apps/hubble/quickstart/README.md
+++ b/apps/hubble/quickstart/README.md
@@ -1,0 +1,60 @@
+# Start running a hub
+
+The following guide walks you through running a mainnet hub on your own server. It requires the following:
+
+- A server with:
+   - 8GB of RAM
+   - 20GB of disk space
+   - Docker installed
+   - Publicly reachable IP address
+- A domain name you control (i.e. you can set an `A` record to point at the server)
+
+## Getting started
+
+1. SSH into your server to open a console.
+
+2. Clone this repository:
+   ```sh
+   git clone https://github.com/farcasterxyz/hub-monorepo.git
+   ```
+
+3. Enter the directory for this walkthrough:
+   ```sh
+   cd apps/hubble/quickstart
+   ```
+
+4. Using the DNS zone you control, create an `A` record pointing at your server, e.g. `my-hub.example.com` →> `123.0.10.20`
+
+5. Create a `.env` file with the following content, using the domain name you chose.
+   ```
+   HUB_HOST=my-hub.example.com
+   ```
+
+6. Create an identity for your hub by running
+   ```sh
+   docker compose run hubble yarn identity create
+   ```
+
+7. Finally, start up the hub:
+   ```sh
+   docker compose up --detach
+   ```
+   This will start your hub in the background.
+
+8. View the logs to confirm your hub is running:
+   ```sh
+   docker compose logs -f hubble
+   ```
+
+9. Confirm that you can connect to your hub:
+   ```sh
+   source .env # Load HUB_HOST environment variable
+
+   docker run --rm -v $(git rev-parse --show-toplevel):/app \
+     fullstorydev/grpcurl -connect-timeout 5 \
+     -proto /app/protobufs/schemas/rpc.proto \
+     -import-path /app/protobufs/schemas \
+     $HUB_HOST:2283 \
+     HubService.GetInfo
+   ```
+   If you see output saying your hub is syncing, you're all set!

--- a/apps/hubble/quickstart/docker-compose.yml
+++ b/apps/hubble/quickstart/docker-compose.yml
@@ -1,0 +1,52 @@
+version: '3.9'
+
+services:
+  hubble:
+    image: farcasterxyz/hubble:latest
+    restart: unless-stopped
+    command: ["yarn", "start", "--ip", "0.0.0.0", "--gossip-port", "2282", "--rpc-port", "2283", "--eth-rpc-url", "https://eth-goerli.g.alchemy.com/v2/IvjMoCKt1hT66f9OJoL_dMXypnvQYUdd", "--network", "1"]
+    ports:
+      - '2282:2282'  # Gossip port
+      - '12283:2283' # RPC port 2283 served over TLS via Caddy. Use Port 12283 for plaintext.
+    volumes:
+      - hub_identity_data:/home/node/app/apps/hubble/.hub
+      - rocksdb_data:/home/node/app/apps/hubble/.rocks
+    networks:
+      - my-network
+
+  caddy:
+    image: caddy:2.6.4-alpine
+    restart: unless-stopped
+    environment:
+      - HUB_HOST
+    ports:
+      - '80:80'       # Needed for ACME TLS certificate
+      - '443:443'     # Needed for ACME TLS certificate
+      - '443:443/udp' # Needed for ACME TLS certificate
+      - '2283:2283'
+      - '2285:2285'
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - caddy-data:/data
+      - caddy-config:/config
+    networks:
+      - my-network
+
+  envoy:
+    image: envoyproxy/envoy:v1.26.1
+    restart: unless-stopped
+    ports:
+      - '12285:2285' # grpc-web port 2285 served over TLS via Caddy. Use Port 12285 for plaintext.
+    volumes:
+      - ./envoy.yaml:/etc/envoy/envoy.yaml
+    networks:
+      - my-network
+
+volumes:
+  caddy-data:
+  caddy-config:
+  hub_identity_data:
+  rocksdb_data:
+
+networks:
+  my-network:

--- a/apps/hubble/quickstart/envoy.yaml
+++ b/apps/hubble/quickstart/envoy.yaml
@@ -1,0 +1,64 @@
+admin:
+  access_log_path: /tmp/admin_access.log
+  address:
+    socket_address: { address: 0.0.0.0, port_value: 9901 }
+
+static_resources:
+  listeners:
+    - name: listener_0
+      address:
+        # update the port_value to the port of envoy
+        socket_address: { address: 0.0.0.0, port_value: 2285 }
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                codec_type: auto
+                stat_prefix: ingress_http
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains: ['*']
+                      routes:
+                        - match: { prefix: '/' }
+                          route:
+                            cluster: rpc_service
+                            timeout: 0s
+                            max_stream_duration:
+                              grpc_timeout_header_max: 0s
+                      cors:
+                        allow_origin_string_match:
+                          - prefix: '*'
+                        allow_methods: GET, PUT, DELETE, POST, OPTIONS
+                        allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
+                        max_age: '1728000'
+                        expose_headers: custom-header-1,grpc-status,grpc-message
+                http_filters:
+                  - name: envoy.filters.http.grpc_web
+                    typed_config:
+                      '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.cors
+                    typed_config:
+                      '@type': type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+    - name: rpc_service
+      connect_timeout: 0.25s
+      type: logical_dns
+      http2_protocol_options: {}
+      lb_policy: round_robin
+      load_assignment:
+        cluster_name: cluster_0
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      # win/mac hosts: Use address: host.docker.internal instead of address: localhost in the line below
+                      address: hubble
+                      # update the value to the port of rpc server
+                      port_value: 2283


### PR DESCRIPTION
## Motivation

We want to make it incredibly easy to set up a hub with TLS.

## Change Summary

Add a directory with a simple guide to follow.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for running a mainnet hub on a self-hosted server using Docker and Caddy. It includes changes to the Caddyfile, docker-compose.yml, README.md, and envoy.yaml files.

### Detailed summary
- Added reverse proxy support for hubble and envoy servers in Caddyfile
- Updated docker-compose.yml to include hubble, caddy, and envoy services
- Added instructions for running a mainnet hub using Docker and Caddy in README.md
- Added envoy.yaml file with configuration for the envoy server

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->