### PR TITLE
feat: Implement FIP-3, serialization agnostic hash verification

### DIFF
--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -2,7 +2,6 @@ import {
   ContactInfoContent,
   FarcasterNetwork,
   GossipAddressInfo,
-  GossipMessage,
   HubState,
   IdRegistryEvent,
   Message,
@@ -15,6 +14,8 @@ import {
   HubRpcClient,
   getSSLHubRpcClient,
   getInsecureHubRpcClient,
+  GossipMessageWithDataBytes,
+  MessageWithDataBytes,
 } from '@farcaster/hub-nodejs';
 import { PeerId } from '@libp2p/interface-peer-id';
 import { peerIdFromBytes } from '@libp2p/peer-id';
@@ -500,7 +501,7 @@ export class Hub implements HubInterface {
   /*                                  Private Methods                           */
   /* -------------------------------------------------------------------------- */
 
-  private async handleGossipMessage(gossipMessage: GossipMessage): HubAsyncResult<void> {
+  private async handleGossipMessage(gossipMessage: GossipMessageWithDataBytes): HubAsyncResult<void> {
     const peerIdResult = Result.fromThrowable(
       () => peerIdFromBytes(gossipMessage.peerId ?? new Uint8Array([])),
       (error) => new HubError('bad_request.parse_failure', error as Error)
@@ -687,7 +688,7 @@ export class Hub implements HubInterface {
 
     this.gossipNode.on('message', async (_topic, message) => {
       await message.match(
-        async (gossipMessage: GossipMessage) => {
+        async (gossipMessage: GossipMessageWithDataBytes) => {
           await this.handleGossipMessage(gossipMessage);
         },
         async (error: HubError) => {
@@ -714,7 +715,7 @@ export class Hub implements HubInterface {
   /*                               RPC Handler API                              */
   /* -------------------------------------------------------------------------- */
 
-  async submitMessage(message: Message, source?: HubSubmitSource): HubAsyncResult<number> {
+  async submitMessage(message: MessageWithDataBytes, source?: HubSubmitSource): HubAsyncResult<number> {
     // message is a reserved key in some logging systems, so we use submittedMessage instead
     const logMessage = log.child({ submittedMessage: messageToLog(message), source });
 

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -18,6 +18,7 @@ import {
   MergeMessageHubEvent,
   MergeNameRegistryEventHubEvent,
   Message,
+  MessageWithDataBytes,
   NameRegistryEvent,
   NameRegistryEventType,
   PruneMessageHubEvent,
@@ -167,7 +168,7 @@ class Engine {
     return Promise.all(messages.map((message) => this.mergeMessage(message)));
   }
 
-  async mergeMessage(message: Message): HubAsyncResult<number> {
+  async mergeMessage(message: MessageWithDataBytes): HubAsyncResult<number> {
     const validatedMessage = await this.validateMessage(message);
     if (validatedMessage.isErr()) {
       return err(validatedMessage.error);
@@ -605,7 +606,7 @@ class Engine {
   /*                               Private Methods                              */
   /* -------------------------------------------------------------------------- */
 
-  private async validateMessage(message: Message): HubAsyncResult<Message> {
+  private async validateMessage(message: MessageWithDataBytes): HubAsyncResult<Message> {
     // 1. Ensure message data is present
     if (!message || !message.data) {
       return err(new HubError('bad_request.validation_failure', 'message data is missing'));

--- a/packages/core/src/protobufs/generated/gossip.ts
+++ b/packages/core/src/protobufs/generated/gossip.ts
@@ -1,7 +1,13 @@
 /* eslint-disable */
 import _m0 from 'protobufjs/minimal';
 import { IdRegistryEvent } from './id_registry_event';
-import { FarcasterNetwork, farcasterNetworkFromJSON, farcasterNetworkToJSON, Message } from './message';
+import {
+  FarcasterNetwork,
+  farcasterNetworkFromJSON,
+  farcasterNetworkToJSON,
+  Message,
+  MessageForSignatureVerification,
+} from './message';
 
 export enum GossipVersion {
   V1 = 0,
@@ -55,6 +61,10 @@ export interface GossipMessage {
   topics: string[];
   peerId: Uint8Array;
   version: GossipVersion;
+}
+
+export interface GossipMessageForSignatureVerification {
+  message?: MessageForSignatureVerification | undefined;
 }
 
 function createBaseGossipAddressInfo(): GossipAddressInfo {
@@ -433,6 +443,70 @@ export const GossipMessage = {
     message.topics = object.topics?.map((e) => e) || [];
     message.peerId = object.peerId ?? new Uint8Array();
     message.version = object.version ?? 0;
+    return message;
+  },
+};
+
+function createBaseGossipMessageForSignatureVerification(): GossipMessageForSignatureVerification {
+  return { message: undefined };
+}
+
+export const GossipMessageForSignatureVerification = {
+  encode(message: GossipMessageForSignatureVerification, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.message !== undefined) {
+      MessageForSignatureVerification.encode(message.message, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): GossipMessageForSignatureVerification {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGossipMessageForSignatureVerification();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.message = MessageForSignatureVerification.decode(reader, reader.uint32());
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GossipMessageForSignatureVerification {
+    return { message: isSet(object.message) ? MessageForSignatureVerification.fromJSON(object.message) : undefined };
+  },
+
+  toJSON(message: GossipMessageForSignatureVerification): unknown {
+    const obj: any = {};
+    message.message !== undefined &&
+      (obj.message = message.message ? MessageForSignatureVerification.toJSON(message.message) : undefined);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GossipMessageForSignatureVerification>, I>>(
+    base?: I
+  ): GossipMessageForSignatureVerification {
+    return GossipMessageForSignatureVerification.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<GossipMessageForSignatureVerification>, I>>(
+    object: I
+  ): GossipMessageForSignatureVerification {
+    const message = createBaseGossipMessageForSignatureVerification();
+    message.message =
+      object.message !== undefined && object.message !== null
+        ? MessageForSignatureVerification.fromPartial(object.message)
+        : undefined;
     return message;
   },
 };

--- a/packages/core/src/protobufs/generated/message.ts
+++ b/packages/core/src/protobufs/generated/message.ts
@@ -319,6 +319,11 @@ export interface Message {
   signer: Uint8Array;
 }
 
+export interface MessageForSignatureVerification {
+  /** Contents of the message as bytes, ignore the rest of the data */
+  data: Uint8Array;
+}
+
 /**
  * A MessageData object contains properties common to all messages and wraps a body object which
  * contains properties specific to the MessageType.
@@ -556,6 +561,65 @@ export const Message = {
     message.signature = object.signature ?? new Uint8Array();
     message.signatureScheme = object.signatureScheme ?? 0;
     message.signer = object.signer ?? new Uint8Array();
+    return message;
+  },
+};
+
+function createBaseMessageForSignatureVerification(): MessageForSignatureVerification {
+  return { data: new Uint8Array() };
+}
+
+export const MessageForSignatureVerification = {
+  encode(message: MessageForSignatureVerification, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.data.length !== 0) {
+      writer.uint32(10).bytes(message.data);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MessageForSignatureVerification {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMessageForSignatureVerification();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.data = reader.bytes();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MessageForSignatureVerification {
+    return { data: isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array() };
+  },
+
+  toJSON(message: MessageForSignatureVerification): unknown {
+    const obj: any = {};
+    message.data !== undefined &&
+      (obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array()));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<MessageForSignatureVerification>, I>>(base?: I): MessageForSignatureVerification {
+    return MessageForSignatureVerification.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MessageForSignatureVerification>, I>>(
+    object: I
+  ): MessageForSignatureVerification {
+    const message = createBaseMessageForSignatureVerification();
+    message.data = object.data ?? new Uint8Array();
     return message;
   },
 };

--- a/packages/core/src/protobufs/types.ts
+++ b/packages/core/src/protobufs/types.ts
@@ -2,6 +2,15 @@ import { IdRegistryEvent } from './generated/id_registry_event';
 import { NameRegistryEvent } from './generated/name_registry_event';
 import * as hubEventProtobufs from './generated/hub_event';
 import * as protobufs from './generated/message';
+import * as gossipProtobufs from './generated/gossip';
+
+export type MessageWithDataBytes = protobufs.Message & {
+  dataAsBytes?: Uint8Array | undefined;
+};
+
+export type GossipMessageWithDataBytes = gossipProtobufs.GossipMessage & {
+  message?: MessageWithDataBytes | undefined;
+};
 
 /** Message types */
 

--- a/packages/hub-nodejs/src/generated/message.ts
+++ b/packages/hub-nodejs/src/generated/message.ts
@@ -319,6 +319,11 @@ export interface Message {
   signer: Uint8Array;
 }
 
+export interface MessageForSignatureVerification {
+  /** Contents of the message as bytes, ignore the rest of the data */
+  data: Uint8Array;
+}
+
 /**
  * A MessageData object contains properties common to all messages and wraps a body object which
  * contains properties specific to the MessageType.
@@ -556,6 +561,65 @@ export const Message = {
     message.signature = object.signature ?? new Uint8Array();
     message.signatureScheme = object.signatureScheme ?? 0;
     message.signer = object.signer ?? new Uint8Array();
+    return message;
+  },
+};
+
+function createBaseMessageForSignatureVerification(): MessageForSignatureVerification {
+  return { data: new Uint8Array() };
+}
+
+export const MessageForSignatureVerification = {
+  encode(message: MessageForSignatureVerification, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.data.length !== 0) {
+      writer.uint32(10).bytes(message.data);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MessageForSignatureVerification {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMessageForSignatureVerification();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.data = reader.bytes();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MessageForSignatureVerification {
+    return { data: isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array() };
+  },
+
+  toJSON(message: MessageForSignatureVerification): unknown {
+    const obj: any = {};
+    message.data !== undefined &&
+      (obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array()));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<MessageForSignatureVerification>, I>>(base?: I): MessageForSignatureVerification {
+    return MessageForSignatureVerification.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MessageForSignatureVerification>, I>>(
+    object: I
+  ): MessageForSignatureVerification {
+    const message = createBaseMessageForSignatureVerification();
+    message.data = object.data ?? new Uint8Array();
     return message;
   },
 };

--- a/packages/hub-web/src/generated/message.ts
+++ b/packages/hub-web/src/generated/message.ts
@@ -319,6 +319,11 @@ export interface Message {
   signer: Uint8Array;
 }
 
+export interface MessageForSignatureVerification {
+  /** Contents of the message as bytes, ignore the rest of the data */
+  data: Uint8Array;
+}
+
 /**
  * A MessageData object contains properties common to all messages and wraps a body object which
  * contains properties specific to the MessageType.
@@ -556,6 +561,65 @@ export const Message = {
     message.signature = object.signature ?? new Uint8Array();
     message.signatureScheme = object.signatureScheme ?? 0;
     message.signer = object.signer ?? new Uint8Array();
+    return message;
+  },
+};
+
+function createBaseMessageForSignatureVerification(): MessageForSignatureVerification {
+  return { data: new Uint8Array() };
+}
+
+export const MessageForSignatureVerification = {
+  encode(message: MessageForSignatureVerification, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.data.length !== 0) {
+      writer.uint32(10).bytes(message.data);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MessageForSignatureVerification {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMessageForSignatureVerification();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.data = reader.bytes();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MessageForSignatureVerification {
+    return { data: isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array() };
+  },
+
+  toJSON(message: MessageForSignatureVerification): unknown {
+    const obj: any = {};
+    message.data !== undefined &&
+      (obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array()));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<MessageForSignatureVerification>, I>>(base?: I): MessageForSignatureVerification {
+    return MessageForSignatureVerification.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MessageForSignatureVerification>, I>>(
+    object: I
+  ): MessageForSignatureVerification {
+    const message = createBaseMessageForSignatureVerification();
+    message.data = object.data ?? new Uint8Array();
     return message;
   },
 };

--- a/packages/hub-web/src/generated/request_response.ts
+++ b/packages/hub-web/src/generated/request_response.ts
@@ -763,7 +763,7 @@ export const SyncStatus = {
       writer.uint32(34).string(message.divergencePrefix);
     }
     if (message.divergenceSecondsAgo !== 0) {
-      writer.uint32(40).uint64(message.divergenceSecondsAgo);
+      writer.uint32(40).int32(message.divergenceSecondsAgo);
     }
     if (message.theirMessages !== 0) {
       writer.uint32(48).uint64(message.theirMessages);
@@ -772,7 +772,7 @@ export const SyncStatus = {
       writer.uint32(56).uint64(message.ourMessages);
     }
     if (message.lastBadSync !== 0) {
-      writer.uint32(64).uint64(message.lastBadSync);
+      writer.uint32(64).int64(message.lastBadSync);
     }
     return writer;
   },
@@ -817,7 +817,7 @@ export const SyncStatus = {
             break;
           }
 
-          message.divergenceSecondsAgo = longToNumber(reader.uint64() as Long);
+          message.divergenceSecondsAgo = reader.int32();
           continue;
         case 6:
           if (tag != 48) {
@@ -838,7 +838,7 @@ export const SyncStatus = {
             break;
           }
 
-          message.lastBadSync = longToNumber(reader.uint64() as Long);
+          message.lastBadSync = longToNumber(reader.int64() as Long);
           continue;
       }
       if ((tag & 7) == 4 || tag == 0) {

--- a/packages/hub-web/src/generated/rpc.ts
+++ b/packages/hub-web/src/generated/rpc.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-// This must be manually change to a default import right now
+// This must be manually changed to a default import right now
 import grpcWeb from '@improbable-eng/grpc-web';
 import { BrowserHeaders } from 'browser-headers';
 import { Observable } from 'rxjs';

--- a/protobufs/schemas/gossip.proto
+++ b/protobufs/schemas/gossip.proto
@@ -34,3 +34,9 @@ message GossipMessage {
   bytes peer_id = 5;
   GossipVersion version = 6;
 }
+
+message GossipMessageForSignatureVerification {
+  oneof content {
+    MessageForSignatureVerification message = 1;
+  }
+}

--- a/protobufs/schemas/message.proto
+++ b/protobufs/schemas/message.proto
@@ -13,7 +13,11 @@ message Message {
   bytes signer = 6; // Public key or address of the key pair that produced the signature
 }
 
-  /** 
+message MessageForSignatureVerification {
+  bytes data = 1; // Contents of the message as bytes, ignore the rest of the data
+}
+
+  /**
  * A MessageData object contains properties common to all messages and wraps a body object which 
  * contains properties specific to the MessageType.
  */


### PR DESCRIPTION
## Motivation

TODO:
 - Update FIP draft
 - Tests
 - Length validations

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for a new `MessageForSignatureVerification` in the protobuf schema, updates the `validateMessage` function to use it, and adds a new `MessageForSignatureVerification` interface to TypeScript. It also includes other minor changes such as fixing typos and updating RPC handlers.

### Detailed summary
- Adds `GossipMessageForSignatureVerification` to `gossip.proto`
- Adds `MessageForSignatureVerification` to `message.proto` and updates `validateMessage` function to use it
- Adds `MessageForSignatureVerification` interface to TypeScript in `types.ts`, `rpc.ts`, and `hubble.ts`
- Updates `rpc.ts` to fix typos
- Updates `SyncStatus` in `request_response.ts` to use `int32` and `int64` instead of `uint64`
- Adds `MessageForSignatureVerification` to `generated/message.ts`, `generated/message.ts`, and `generated/rpc.ts`
- Minor changes to `engine/index.ts` and `validations.ts`
- Updates `handleGossipMessage` function in `hubble.ts` to use `GossipMessageWithDataBytes` instead of `GossipMessage`

> The following files were skipped due to too many changes: `packages/core/src/protobufs/generated/message.ts`, `apps/hubble/src/network/p2p/gossipNode.ts`, `packages/core/src/protobufs/generated/gossip.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->