### PR TITLE
fix: Don't require Depot to build images for PRs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,18 +59,19 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: depot/setup-action@v1
+      - name: Install Docker buildx
+        uses: docker/setup-buildx-action@v2
 
-      - uses: depot/build-push-action@v1
+      - name: Build Docker image
+        id: docker-image
+        uses: docker/build-push-action@v4
         with:
-          buildx-fallback: true # If Depot fails, try building locally
-          project: ${{ secrets.DEPOT_PROJECT_ID }}
-          token: ${{ secrets.DEPOT_TOKEN }}
+          cache-from: type=gha
+          cache-to: type=gha,type=inline
           context: .
           file: Dockerfile.hubble
-          platforms: 'linux/amd64,linux/arm64'
+          load: true
           tags: farcasterxyz/hubble:test
-          load: true # Load into Docker daemon
 
       - name: Run Hubble
         shell: bash


### PR DESCRIPTION
## Motivation

GitHub's permission scheme doesn't share the secret with forks.

## Change Summary

Switch to using a vanilla Docker build (it'll be fast enough anyway).

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Docker build and push actions in the CI workflow to use the latest versions and improve caching. 

### Detailed summary
- Replaces `depot/setup-action` with `docker/setup-buildx-action@v2`
- Upgrades `docker/build-push-action` to `v4`
- Adds caching for faster builds
- Removes unused `buildx-fallback` option
- Adds `load: true` to load built image into Docker daemon

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->