### PR TITLE
chore: Release 1.2.3

### DIFF
--- a/.changeset/cuddly-bottles-refuse.md
+++ b/.changeset/cuddly-bottles-refuse.md
@@ -1,5 +1,0 @@
----
-'@farcaster/hubble': patch
----
-
-Add --watch to hub status command and more readable output

--- a/.changeset/eight-mangos-change.md
+++ b/.changeset/eight-mangos-change.md
@@ -1,5 +1,0 @@
----
-'@farcaster/core': patch
----
-
-Remove unnecessary @faker-js/faker dependency from core

--- a/.changeset/eleven-lies-wait.md
+++ b/.changeset/eleven-lies-wait.md
@@ -1,8 +1,0 @@
----
-'@farcaster/core': minor
-'@farcaster/hubble': patch
-'@farcaster/hub-nodejs': patch
-'@farcaster/hub-web': patch
----
-
-replace @noble/ed25519 with faster and more secure @noble/curves

--- a/.changeset/four-bats-work.md
+++ b/.changeset/four-bats-work.md
@@ -1,5 +1,0 @@
----
-'@farcaster/hubble': patch
----
-
-fix(eth): add stronger retry logic to eth events provider

--- a/.changeset/slimy-ways-argue.md
+++ b/.changeset/slimy-ways-argue.md
@@ -1,5 +1,0 @@
----
-'@farcaster/hubble': patch
----
-
-Include semver as explicit dependency

--- a/.changeset/strange-otters-join.md
+++ b/.changeset/strange-otters-join.md
@@ -1,5 +1,0 @@
----
-'@farcaster/hubble': patch
----
-
-Switch from `rocksdb` to `@farcaster/rocksdb` NPM package

--- a/.changeset/strong-trainers-hide.md
+++ b/.changeset/strong-trainers-hide.md
@@ -1,5 +1,0 @@
----
-'@farcaster/hubble': patch
----
-
-Add @faker-js/faker as prod dependency

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @farcaster/hubble
 
+## 1.2.3
+
+### Patch Changes
+
+- c4891754: Add --watch to hub status command and more readable output
+- 2ca66b17: replace @noble/ed25519 with faster and more secure @noble/curves
+- 43444471: fix(eth): add stronger retry logic to eth events provider
+- ea55abcb: Include semver as explicit dependency
+- fe755fbd: Switch from `rocksdb` to `@farcaster/rocksdb` NPM package
+- 651df412: Add @faker-js/faker as prod dependency
+- Updated dependencies [2ca66b17]
+  - @farcaster/hub-nodejs@0.7.3
+
 ## 1.2.2
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -49,7 +49,7 @@
     "@chainsafe/libp2p-gossipsub": "6.1.0",
     "@chainsafe/libp2p-noise": "^11.0.0 ",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.7.2",
+    "@farcaster/hub-nodejs": "^0.7.3",
     "@farcaster/rocksdb": "^5.5.0",
     "@grpc/grpc-js": "~1.8.7",
     "@libp2p/interface-connection": "^3.0.2",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @farcaster/core
 
+## 0.8.0
+
+### Minor Changes
+
+- 2ca66b17: replace @noble/ed25519 with faster and more secure @noble/curves
+
+### Patch Changes
+
+- 651df412: Remove unnecessary @faker-js/faker dependency from core
+
 ## 0.7.2
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @farcaster/hub-nodejs
 
+## 0.7.3
+
+### Patch Changes
+
+- 2ca66b17: replace @noble/ed25519 with faster and more secure @noble/curves
+- Updated dependencies [651df412]
+- Updated dependencies [2ca66b17]
+  - @farcaster/core@0.8.0
+
 ## 0.7.2
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@farcaster/core": "0.7.2",
+    "@farcaster/core": "0.8.0",
     "@grpc/grpc-js": "^1.8.13",
     "@noble/hashes": "^1.3.0",
     "ethers": "~6.2.1",

--- a/packages/hub-web/CHANGELOG.md
+++ b/packages/hub-web/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @farcaster/hub-web
 
+## 0.3.3
+
+### Patch Changes
+
+- 2ca66b17: replace @noble/ed25519 with faster and more secure @noble/curves
+- Updated dependencies [651df412]
+- Updated dependencies [2ca66b17]
+  - @farcaster/core@0.8.0
+
 ## 0.3.2
 
 ### Patch Changes

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-web",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -29,7 +29,7 @@
     "ts-proto": "^1.146.0"
   },
   "dependencies": {
-    "@farcaster/core": "^0.7.2",
+    "@farcaster/core": "^0.8.0",
     "@improbable-eng/grpc-web": "^0.15.0",
     "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
     "rxjs": "^7.8.0"


### PR DESCRIPTION
## Motivation

Patch release.

## Change Summary

See individual changelogs for each package and app.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates various dependencies and makes some minor changes to improve performance and security. 

### Detailed summary
- Updated `@noble/ed25519` dependency to `@noble/curves` for faster and more secure encryption
- Removed unnecessary `@faker-js/faker` dependency from `@farcaster/core`
- Updated dependencies in `packages/hub-web` and `packages/hub-nodejs` to use `@farcaster/core@0.8.0`
- Added `@faker-js/faker` as a production dependency in `@farcaster/hubble`
- Switched from `rocksdb` to `@farcaster/rocksdb` NPM package in `@farcaster/hubble`
- Added stronger retry logic to eth events provider in `@farcaster/hubble`
- Included `semver` as an explicit dependency in `@farcaster/hubble`
- Added `--watch` option to hub status command and improved output readability in `@farcaster/hubble`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->