### PR TITLE
fix: Correctly error when sequence ID exceeds max allowed value

### DIFF
--- a/.changeset/neat-trains-camp.md
+++ b/.changeset/neat-trains-camp.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Correctly error when sequence ID exceeds max allowed value

--- a/apps/hubble/src/storage/stores/storeEventHandler.test.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.test.ts
@@ -49,6 +49,13 @@ describe('HubEventIdGenerator', () => {
       lastId = id;
     }
   });
+
+  test('fails if sequence ID exceeds max allowed', () => {
+    const currentTimestamp = Date.now();
+    const generator = new HubEventIdGenerator({ lastTimestamp: currentTimestamp, lastIndex: 4094 });
+    expect(generator.generateId({ currentTimestamp }).isOk()).toEqual(true);
+    expect(generator.generateId({ currentTimestamp }).isErr()).toEqual(true);
+  });
 });
 
 describe('commitTransaction', () => {

--- a/apps/hubble/src/storage/stores/storeEventHandler.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.ts
@@ -110,14 +110,14 @@ export class HubEventIdGenerator {
   private _lastSeq: number;
   private _epoch: number;
 
-  constructor(options: { epoch?: number; lastTimestamp?: 0; lastIndex?: 0 } = {}) {
+  constructor(options: { epoch?: number; lastTimestamp?: number; lastIndex?: number } = {}) {
     this._epoch = options.epoch ?? 0;
     this._lastTimestamp = options.lastTimestamp ?? 0;
     this._lastSeq = options.lastIndex ?? 0;
   }
 
-  generateId(): HubResult<number> {
-    const timestamp = Date.now() - this._epoch;
+  generateId(options: { currentTimestamp?: number } = {}): HubResult<number> {
+    const timestamp = (options.currentTimestamp || Date.now()) - this._epoch;
 
     if (timestamp === this._lastTimestamp) {
       this._lastSeq = this._lastSeq + 1;
@@ -126,11 +126,11 @@ export class HubEventIdGenerator {
       this._lastSeq = 0;
     }
 
-    if (this._lastTimestamp > 2 ** TIMESTAMP_BITS) {
+    if (this._lastTimestamp >= 2 ** TIMESTAMP_BITS) {
       return err(new HubError('bad_request.invalid_param', `timestamp > ${TIMESTAMP_BITS} bits`));
     }
 
-    if (this._lastSeq > 2 ** SEQUENCE_BITS) {
+    if (this._lastSeq >= 2 ** SEQUENCE_BITS) {
       return err(new HubError('bad_request.invalid_param', `sequence > ${SEQUENCE_BITS} bits`));
     }
 


### PR DESCRIPTION
## Motivation

We had this implemented incorrectly. We need to error once it meets or exceeds the limit, since you can only store (2^N - 1) for a binary value with N bits.

## Change Summary

Update the inequality check.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR corrects errors in the `HubEventIdGenerator` class in the `storeEventHandler` file of the Hubble app. 

### Detailed summary
- Adds a test to ensure the sequence ID doesn't exceed the maximum allowed value
- Modifies the constructor to accept `lastTimestamp` and `lastIndex` as numbers instead of defaulting to 0
- Modifies the `generateId` method to accept a `currentTimestamp` option and correctly handle timestamp and sequence number overflow errors

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->