### PR TITLE
chore: Build and test on Node.js 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Restore cached dependencies for Node modules.
         id: module-cache
@@ -122,19 +122,24 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node_version: [18, 20]
+        os: ['ubuntu-latest']
+
     steps:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: ${{ matrix.node_version }}
 
       - name: Restore cached dependencies for Node modules.
         id: module-cache
         uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/node_modules
-          key: ${{ runner.os }}--node--${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}--node--${{ matrix.node_version}}--${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies
         run: yarn install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Before you get down to coding, take a minute to consider this:
 
 First, ensure that the following are installed globally on your machine:
 
-- [Node.js 18+](https://github.com/nvm-sh/nvm)
+- [Node.js 20+](https://nodejs.org/en/download/releases)
 - [Yarn](https://classic.yarnpkg.com/lang/en/docs/install)
 
 Then, from the root folder run:

--- a/Dockerfile.hubble
+++ b/Dockerfile.hubble
@@ -3,7 +3,7 @@
 # This assumes the Docker build context is the root of the monorepo
 # (i.e. not the same as
 
-FROM node:18.16.0-alpine3.17 as build
+FROM node:20.1.0-alpine3.17 as build
 
 # Needed for compilation step
 RUN apk add --no-cache libc6-compat python3 make g++ linux-headers
@@ -26,7 +26,7 @@ COPY ./apps/hubble/tsconfig.json ./apps/hubble/tsconfig.json
 COPY ./apps/hubble/.config ./apps/hubble/.config
 COPY ./apps/hubble/src ./apps/hubble/src
 
-FROM node:18.16.0-alpine3.17 as app
+FROM node:20.1.0-alpine3.17 as app
 
 # Requirement for runtime metrics integrations
 RUN apk add --no-cache libc6-compat

--- a/Dockerfile.hubble.test
+++ b/Dockerfile.hubble.test
@@ -5,7 +5,7 @@
 ############## Stage 1: Create pruned version of monorepo #####################
 ###############################################################################
 
-FROM node:18-alpine AS prune
+FROM node:20-alpine AS prune
 
 RUN apk add --no-cache libc6-compat
 
@@ -23,7 +23,7 @@ RUN /home/node/.yarn/bin/turbo prune --scope=@farcaster/hubble --docker
 ############## Stage 2: Build the code using a full node image ################
 ###############################################################################
 
-FROM node:18-alpine AS build
+FROM node:20-alpine AS build
 
 # Needed for compilation step
 RUN apk add --no-cache libc6-compat python3 make g++ linux-headers
@@ -54,7 +54,7 @@ RUN yarn install --production --ignore-scripts --prefer-offline --force --frozen
 ########## Stage 3: Copy over the built code to a leaner alpine image #########
 ###############################################################################
 
-FROM node:18-alpine as app
+FROM node:20-alpine as app
 
 # Requirement for runtime metrics integrations
 RUN apk add libc6-compat

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "engines": {
     "npm": ">=8.0.0",
-    "node": "^18.7.0"
+    "node": ">=18.7"
   },
   "devDependencies": {
     "@changesets/changelog-git": "^0.1.14",


### PR DESCRIPTION
## Motivation

This version includes updates to the V8 runtime and performance improvements.

## Change Summary

Update to testing against both Node 18 and 20, and build Docker images using Node 20.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Node.js version from 18 to 20 in various files.

### Detailed summary:

- `package.json`: updated the `node` engine requirement to `>=18.7`
- `CONTRIBUTING.md`: updated the required Node.js version to `20+`
- `Dockerfile.hubble`: updated the `FROM` image to `node:20.1.0-alpine3.17` for both `build` and `app` stages
- `.github/workflows/ci.yml`: added a `matrix` strategy to test with both Node.js 18 and 20 on `ubuntu-latest`
- `Dockerfile.hubble.test`: updated the `FROM` image to `node:20-alpine` for both `prune` and `build` stages

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->