### PR TITLE
chore: Run tests on larger VM instances

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,12 +120,11 @@ jobs:
 
   test:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: 'buildjet-4vcpu-ubuntu-2204'
 
     strategy:
       matrix:
         node_version: [18, 20]
-        os: ['ubuntu-latest']
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Motivation

We're starting to see occasional OOM errors.

## Change Summary

Allocate more memory (and vCPU so tests run faster as well).

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR changes the runner environment for the CI workflow.

### Detailed summary:
- Changes the runner environment from `ubuntu-latest` to `buildjet-4vcpu-ubuntu-2204`.
- Updates the `node_version` matrix to include versions 18 and 20.
- Removes the `os` matrix since it is no longer needed.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->