### PR TITLE
chore: add peerid @blanker

### DIFF
--- a/apps/hubble/src/allowedPeers.mainnet.ts
+++ b/apps/hubble/src/allowedPeers.mainnet.ts
@@ -31,4 +31,5 @@ export const MAINNET_ALLOWED_PEERS = [
   '12D3KooWEs1QcvJcoVv3ihHqqa3yxh4gijegrjyyVkvso2qayUdj', // @colin / @paragraph
   '12D3KooWBhm9XdafZiBWPncDVcvMhcmV3kLFLnBiS83CjY833sWN', // @pjc (fc.bus.events)
   '12D3KooWFHsw17MsY9eSbYLhkemUYcAwAjPPA7D6g3wTuhnLgAbT', // @sds
+  '12D3KooWNR1PJaUH3Ssgfp7gcpF2F9Hm5HsXYyeBhujQdg1TU9Pm', // @blanker
 ];


### PR DESCRIPTION
## Motivation

I would love to contribute to Farcaster Hub on the mainnet, and already prepared a powerful server with 8TB storage for my Hub, with localhost Ethereum geth on mainnet. 

## Change Summary

Add a new PeerId in the allow list. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new peer to the `allowedPeers.mainnet.ts` file in the `hubble` app.

### Detailed summary
- Added a new peer with the address `12D3KooWNR1PJaUH3Ssgfp7gcpF2F9Hm5HsXYyeBhujQdg1TU9Pm` to the `allowedPeers.mainnet.ts` file in the `hubble` app. The peer is identified as `@blanker`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->