### PR TITLE
chore: Fix readme and update peerId for blanker

### DIFF
--- a/apps/hubble/README.md
+++ b/apps/hubble/README.md
@@ -52,7 +52,7 @@ Mainnet is Farcaster's production environment apps use and writing a message her
 1. Update the `.env` file in your `apps/hubble` directory, substituting the relevant value for your `ETH_RPC_URL`:
    ```
    ETH_RPC_URL=your-ETH-RPC-URL
-   FC_NETWORK_ID=2
+   FC_NETWORK_ID=1
    BOOTSTRAP_NODE=/dns/nemes.farcaster.xyz/tcp/2282
    ```
 2. Get your PeerId from the file `/apps/hubble/.hub/<PEER_ID>_id.protobuf`
@@ -120,7 +120,7 @@ Mainnet is Farcaster's production environment apps use and writing a message her
 1. Update the `.env` file in your `apps/hubble` directory, substituting the relevant value for your `ETH_RPC_URL`:
    ```
    ETH_RPC_URL=your-ETH-RPC-URL
-   FC_NETWORK_ID=2
+   FC_NETWORK_ID=1
    BOOTSTRAP_NODE=/dns/nemes.farcaster.xyz/tcp/2282
    ```
 2. Get your PeerId from the file `apps/hubble/.hub/<PEER_ID>_id.protobuf`

--- a/apps/hubble/src/allowedPeers.mainnet.ts
+++ b/apps/hubble/src/allowedPeers.mainnet.ts
@@ -31,5 +31,5 @@ export const MAINNET_ALLOWED_PEERS = [
   '12D3KooWEs1QcvJcoVv3ihHqqa3yxh4gijegrjyyVkvso2qayUdj', // @colin / @paragraph
   '12D3KooWBhm9XdafZiBWPncDVcvMhcmV3kLFLnBiS83CjY833sWN', // @pjc (fc.bus.events)
   '12D3KooWFHsw17MsY9eSbYLhkemUYcAwAjPPA7D6g3wTuhnLgAbT', // @sds
-  '12D3KooWNR1PJaUH3Ssgfp7gcpF2F9Hm5HsXYyeBhujQdg1TU9Pm', // @blanker
+  '12D3KooWKEuT74vxNfhGJh5XGUURaenDj1qokjA811Wv78tFo5WV', // @blanker
 ];


### PR DESCRIPTION
## Change Summary

- Fix typo in the README file of hubble. 
- Update my peer id because I removed my identity file by mistakes when debugging with @sanjayprabhu.  

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `allowedPeers` list and the `.env` file in the `hubble` app, preparing it for production use on the Farcaster mainnet.

### Detailed summary
- Updated `allowedPeers` list in `allowedPeers.mainnet.ts`
- Changed `FC_NETWORK_ID` in `.env` from 2 to 1
- Updated `README.md` to reflect changes in `.env` file and provide instructions for obtaining PeerId

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->