### PR TITLE
fix: validate the network in ethEventsProvider

### DIFF
--- a/.changeset/thin-rivers-tie.md
+++ b/.changeset/thin-rivers-tie.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Validate the eth network in ethEventsProvider

--- a/apps/hubble/README.md
+++ b/apps/hubble/README.md
@@ -51,6 +51,7 @@ Mainnet is Farcaster's production environment apps use and writing a message her
 
 1. Update the `.env` file in your `apps/hubble` directory, substituting the relevant value for your `ETH_RPC_URL`:
    ```
+   # Note: this should still point to goerli and not eth mainnet
    ETH_RPC_URL=your-ETH-RPC-URL
    FC_NETWORK_ID=1
    BOOTSTRAP_NODE=/dns/nemes.farcaster.xyz/tcp/2282
@@ -119,6 +120,7 @@ Mainnet is Farcaster's production environment apps use and writing a message her
 
 1. Update the `.env` file in your `apps/hubble` directory, substituting the relevant value for your `ETH_RPC_URL`:
    ```
+   # Note: this should still point to goerli and not eth mainnet
    ETH_RPC_URL=your-ETH-RPC-URL
    FC_NETWORK_ID=1
    BOOTSTRAP_NODE=/dns/nemes.farcaster.xyz/tcp/2282


### PR DESCRIPTION
## Motivation

Fixes https://github.com/farcasterxyz/hub-monorepo/issues/981

## Change Summary

Validate that we're connected to the correct network

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds validation for the Ethereum network in `ethEventsProvider.ts` and updates the `README.md` file to include a note about the `ETH_RPC_URL` pointing to Goerli and not Eth mainnet.

### Detailed summary
- Added validation for Ethereum network in `ethEventsProvider.ts`
- Updated `README.md` to include a note about `ETH_RPC_URL` pointing to Goerli and not Eth mainnet

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->