### PR TITLE
chore(hub-nodejs): add example for replying to a URL (FIP-2)

### DIFF
--- a/packages/hub-nodejs/examples/make-cast/index.ts
+++ b/packages/hub-nodejs/examples/make-cast/index.ts
@@ -197,7 +197,38 @@ const NETWORK = FarcasterNetwork.TESTNET; // Network of the Hub
   );
   castResults.push(castWithEmojiLinkAttachmnent);
 
+  /**
+   * Example 7: A cast that replies to a URL
+   *
+   * "I think this is a great protocol 🚀"
+   */
+
+  const castReplyingToAUrl = await makeCastAdd(
+    {
+      text: 'I think this is a great protocol 🚀',
+      embeds: [],
+      embedsDeprecated: [],
+      mentions: [],
+      mentionsPositions: [],
+      parentUrl: 'https://www.farcaster.xyz/',
+    },
+    dataOptions,
+    ed25519Signer
+  );
+  castResults.push(castReplyingToAUrl);
+
+  /**
+   * Step 3: Broadcast CastAdd messages to Hub
+   *
+   * Send the new casts to a Hub so that they become part of the Farcaster network
+   */
+
+  // 1. If your client does not use authentication.
   castResults.map((castAddResult) => castAddResult.map((castAdd) => client.submitMessage(castAdd)));
+
+  // 2. If your client uses authentication.
+  // castResults.map((castAddResult) => castAddResult.map((castAdd) => client.submitMessage(castAdd, authMetadata)));
+
   console.log(`Broadcast ${castResults.length} casts`);
 
   client.close();


### PR DESCRIPTION
## Motivation

Describe the changes being made in 1-2 concise sentences.
With the introduction of FIP-2, Farcaster now supports replies to URLs. Want to add an example of how to craft such a message.

## Change Summary

* Add an example that constructs a message to reply to a URL
* Improve comments
* Add new line for submitting messages (commented out) to be used when the Hub requires authentication

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

N/A


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds an example of a cast that replies to a URL and includes instructions for broadcasting CastAdd messages to Hub.

### Detailed summary
- Added `castReplyingToAUrl` example to `make-cast` file
- Included instructions for broadcasting CastAdd messages to Hub

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->