### PR TITLE
feat: Add app version to contact info and log it when syncing

### DIFF
--- a/.changeset/dirty-badgers-sparkle.md
+++ b/.changeset/dirty-badgers-sparkle.md
@@ -1,0 +1,7 @@
+---
+'@farcaster/hub-web': patch
+'@farcaster/core': patch
+'@farcaster/hubble': patch
+---
+
+Add app version to contactInfo message

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -428,6 +428,7 @@ export class Hub implements HubInterface {
         count: snapshot.numMessages,
         hubVersion: FARCASTER_VERSION,
         network: this.options.network,
+        appVersion: APP_VERSION,
       });
     });
   }

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -301,6 +301,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
           ourMessages: syncStatus.ourSnapshot?.numMessages,
           peerNetwork: peerContact.network,
           peerVersion: peerContact.hubVersion,
+          peerAppVersion: peerContact.appVersion,
           divergencePrefix: syncStatus.divergencePrefix,
           divergenceSeconds: syncStatus.divergenceSecondsAgo,
           lastBadSync: syncStatus.lastBadSync,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "./node_modules/.bin/turbo run build",
     "clean": "./node_modules/.bin/turbo run clean",
     "dev": "./node_modules/.bin/turbo run dev --parallel",
-    "protoc": "./node_modules/.bin/turbo run protoc --parallel",
+    "protoc": "cd packages/core && yarn protoc && cd ../hub-nodejs && yarn protoc && cd ../hub-web && yarn protoc",
     "test": "./node_modules/.bin/turbo run test",
     "test:ci": "./node_modules/.bin/turbo run test:ci -- --passWithNoTests",
     "lint": "./node_modules/.bin/turbo run lint --parallel",

--- a/packages/core/src/protobufs/generated/gossip.ts
+++ b/packages/core/src/protobufs/generated/gossip.ts
@@ -46,6 +46,7 @@ export interface ContactInfoContent {
   count: number;
   hubVersion: string;
   network: FarcasterNetwork;
+  appVersion: string;
 }
 
 export interface GossipMessage {
@@ -155,7 +156,15 @@ export const GossipAddressInfo = {
 };
 
 function createBaseContactInfoContent(): ContactInfoContent {
-  return { gossipAddress: undefined, rpcAddress: undefined, excludedHashes: [], count: 0, hubVersion: '', network: 0 };
+  return {
+    gossipAddress: undefined,
+    rpcAddress: undefined,
+    excludedHashes: [],
+    count: 0,
+    hubVersion: '',
+    network: 0,
+    appVersion: '',
+  };
 }
 
 export const ContactInfoContent = {
@@ -177,6 +186,9 @@ export const ContactInfoContent = {
     }
     if (message.network !== 0) {
       writer.uint32(48).int32(message.network);
+    }
+    if (message.appVersion !== '') {
+      writer.uint32(58).string(message.appVersion);
     }
     return writer;
   },
@@ -230,6 +242,13 @@ export const ContactInfoContent = {
 
           message.network = reader.int32() as any;
           continue;
+        case 7:
+          if (tag != 58) {
+            break;
+          }
+
+          message.appVersion = reader.string();
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -247,6 +266,7 @@ export const ContactInfoContent = {
       count: isSet(object.count) ? Number(object.count) : 0,
       hubVersion: isSet(object.hubVersion) ? String(object.hubVersion) : '',
       network: isSet(object.network) ? farcasterNetworkFromJSON(object.network) : 0,
+      appVersion: isSet(object.appVersion) ? String(object.appVersion) : '',
     };
   },
 
@@ -264,6 +284,7 @@ export const ContactInfoContent = {
     message.count !== undefined && (obj.count = Math.round(message.count));
     message.hubVersion !== undefined && (obj.hubVersion = message.hubVersion);
     message.network !== undefined && (obj.network = farcasterNetworkToJSON(message.network));
+    message.appVersion !== undefined && (obj.appVersion = message.appVersion);
     return obj;
   },
 
@@ -285,6 +306,7 @@ export const ContactInfoContent = {
     message.count = object.count ?? 0;
     message.hubVersion = object.hubVersion ?? '';
     message.network = object.network ?? 0;
+    message.appVersion = object.appVersion ?? '';
     return message;
   },
 };

--- a/packages/hub-web/src/generated/request_response.ts
+++ b/packages/hub-web/src/generated/request_response.ts
@@ -763,7 +763,7 @@ export const SyncStatus = {
       writer.uint32(34).string(message.divergencePrefix);
     }
     if (message.divergenceSecondsAgo !== 0) {
-      writer.uint32(40).uint64(message.divergenceSecondsAgo);
+      writer.uint32(40).int32(message.divergenceSecondsAgo);
     }
     if (message.theirMessages !== 0) {
       writer.uint32(48).uint64(message.theirMessages);
@@ -772,7 +772,7 @@ export const SyncStatus = {
       writer.uint32(56).uint64(message.ourMessages);
     }
     if (message.lastBadSync !== 0) {
-      writer.uint32(64).uint64(message.lastBadSync);
+      writer.uint32(64).int64(message.lastBadSync);
     }
     return writer;
   },
@@ -817,7 +817,7 @@ export const SyncStatus = {
             break;
           }
 
-          message.divergenceSecondsAgo = longToNumber(reader.uint64() as Long);
+          message.divergenceSecondsAgo = reader.int32();
           continue;
         case 6:
           if (tag != 48) {
@@ -838,7 +838,7 @@ export const SyncStatus = {
             break;
           }
 
-          message.lastBadSync = longToNumber(reader.uint64() as Long);
+          message.lastBadSync = longToNumber(reader.int64() as Long);
           continue;
       }
       if ((tag & 7) == 4 || tag == 0) {

--- a/protobufs/schemas/gossip.proto
+++ b/protobufs/schemas/gossip.proto
@@ -22,6 +22,7 @@ message ContactInfoContent {
   uint32 count = 4;
   string hub_version = 5;
   FarcasterNetwork network = 6;
+  string app_version = 7;
 }
 
 message GossipMessage {


### PR DESCRIPTION
## Motivation

Fixes https://github.com/farcasterxyz/hub-monorepo/issues/958

## Change Summary

Adds app version to the contact info so we peers can report their app versions in addition to the protocol version.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds the `appVersion` field to the contactInfo message in the Farcaster Hub. 

### Detailed summary
- Added `appVersion` field to `ContactInfoContent` protobuf message.
- Updated `createBaseContactInfoContent()` function to include `appVersion` field.
- Updated `protobufs/schemas/gossip.proto` to include `app_version` field.
- Updated `packages/core/src/protobufs/generated/gossip.ts` to include `appVersion` field in `GossipAddressInfo` interface.
- Updated `apps/hubble/src/hubble.ts` to include `appVersion` field in `ContactInfo` object.
- Updated `apps/hubble/src/network/sync/syncEngine.ts` to include `peerAppVersion` field in `SyncPeer` interface.
- Updated `packages/hub-web/src/generated/request_response.ts` to use `int32` instead of `uint64` for `divergenceSecondsAgo` and `lastBadSync` fields.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->