### PR TITLE
feat: add fallback to dbreset

### DIFF
--- a/.changeset/rude-items-teach.md
+++ b/.changeset/rude-items-teach.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+added fallback to dbreset

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -418,16 +418,25 @@ app
     if (!rocksDBName) throw new Error('No RocksDB name provided.');
 
     const rocksDB = new RocksDB(rocksDBName);
+    const fallback = () => {
+      fs.rmSync(rocksDB.location, { recursive: true, force: true });
+    };
+
     const dbResult = await ResultAsync.fromPromise(rocksDB.open(), (e) => e as Error);
     if (dbResult.isErr()) {
-      logger.error({ rocksDBName }, 'Failed to open RocksDB');
-      exit(1);
+      logger.warn({ rocksDBName }, 'Failed to open RocksDB, falling back to rm');
+      fallback();
+    } else {
+      const clearResult = await ResultAsync.fromPromise(rocksDB.clear(), (e) => e as Error);
+      if (clearResult.isErr()) {
+        logger.warn({ rocksDBName }, 'Failed to open RocksDB, falling back to rm');
+        fallback();
+      }
+
+      await rocksDB.close();
     }
-    await rocksDB.clear();
 
-    await rocksDB.close();
     logger.info({ rocksDBName }, 'Database cleared.');
-
     exit(0);
   });
 


### PR DESCRIPTION
## Motivation

`yarn dbreset` fails when the disk is full and the RocksDB can't be opened

## Change Summary

Updates the `dbreset` cli command to fallback to `rm -rf` if the RocksDB is unable to be cleared.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a fallback to `dbreset` in case `RocksDB` fails to open. 

### Detailed summary
- Added a `fallback` function that removes the `RocksDB` location directory.
- If `RocksDB` fails to open, the `fallback` function is called and the logs are updated to reflect the fallback.
- If `RocksDB` clears fail, the `fallback` function is called.
- The `await rocksDB.clear()` and `await rocksDB.close()` lines were removed, as they were redundant.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->