### PR TITLE
fix: Fix working directory so db directory will be under hubble app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run Hubble
         shell: bash
-        run: docker run --name hub --detach -p2282:2282 -p2283:2283 farcasterxyz/hubble:test sh -c 'node apps/hubble/build/cli.js identity create && node apps/hubble/build/cli.js start --rpc-port 2283 --ip 0.0.0.0 --gossip-port 2282 --eth-rpc-url "https://eth-goerli.g.alchemy.com/v2/IvjMoCKt1hT66f9OJoL_dMXypnvQYUdd" --network 3 --allowed-peers none'
+        run: docker run --name hub --detach -p2282:2282 -p2283:2283 farcasterxyz/hubble:test sh -c 'node build/cli.js identity create && node build/cli.js start --rpc-port 2283 --ip 0.0.0.0 --gossip-port 2282 --eth-rpc-url "https://eth-goerli.g.alchemy.com/v2/IvjMoCKt1hT66f9OJoL_dMXypnvQYUdd" --network 3 --allowed-peers none'
 
       - name: Download grpcurl
         shell: bash

--- a/Dockerfile.hubble
+++ b/Dockerfile.hubble
@@ -83,6 +83,6 @@ COPY --from=app / /
 USER node
 EXPOSE 2282
 EXPOSE 2283
-WORKDIR /home/node/app
+WORKDIR /home/node/app/apps/hubble
 
-CMD ["node", "apps/hubble/build/cli.js", "start", "--network", "1"]
+CMD ["node", "build/cli.js", "start", "--network", "1"]


### PR DESCRIPTION
## Motivation

Working directory was changed to be the root of the repo in https://github.com/farcasterxyz/hub-monorepo/pull/994/files#diff-77236ded6ccbbe696450a3696533e55fec45253994ab52fa4d59d7cb7704fc31L45-R86. 

Unfortunately this means the db will be created at the root instead of under `apps/hubble` which breaks the deployer.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Dockerfile and CI workflow for the Hubble app, changing the working directory and updating the CLI commands. 

### Detailed summary:
- Changes working directory to `/home/node/app/apps/hubble` in Dockerfile
- Updates `CMD` in Dockerfile to `["node", "build/cli.js", "start", "--network", "1"]`
- Updates `run` command in CI workflow to use updated CLI commands
- Removes mention of `grpcurl` download in CI workflow

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->