### PR TITLE
chore: Release 1.3

### DIFF
--- a/.changeset/dirty-badgers-sparkle.md
+++ b/.changeset/dirty-badgers-sparkle.md
@@ -1,7 +1,0 @@
----
-'@farcaster/hub-web': patch
-'@farcaster/core': patch
-'@farcaster/hubble': patch
----
-
-Add app version to contactInfo message

--- a/.changeset/neat-trains-camp.md
+++ b/.changeset/neat-trains-camp.md
@@ -1,5 +1,0 @@
----
-'@farcaster/hubble': patch
----
-
-Correctly error when sequence ID exceeds max allowed value

--- a/.changeset/rude-items-teach.md
+++ b/.changeset/rude-items-teach.md
@@ -1,5 +1,0 @@
----
-'@farcaster/hubble': patch
----
-
-added fallback to dbreset

--- a/.changeset/thin-hotels-greet.md
+++ b/.changeset/thin-hotels-greet.md
@@ -1,7 +1,0 @@
----
-'@farcaster/hub-nodejs': minor
-'@farcaster/core': minor
-'@farcaster/hubble': minor
----
-
-Added support for Links

--- a/.changeset/thin-rivers-tie.md
+++ b/.changeset/thin-rivers-tie.md
@@ -1,5 +1,0 @@
----
-'@farcaster/hubble': patch
----
-
-Validate the eth network in ethEventsProvider

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @farcaster/hubble
 
+## 1.3.0
+
+### Minor Changes
+
+- 2bc598a: Added support for Links
+
+### Patch Changes
+
+- 37f515f: Add app version to contactInfo message
+- 7f050d2: Correctly error when sequence ID exceeds max allowed value
+- 27181c6: added fallback to dbreset
+- 16ea9b4: Validate the eth network in ethEventsProvider
+- Updated dependencies [2bc598a]
+  - @farcaster/hub-nodejs@0.8.0
+
 ## 1.2.4
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -51,7 +51,7 @@
     "@chainsafe/libp2p-gossipsub": "6.1.0",
     "@chainsafe/libp2p-noise": "^11.0.0 ",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.7.4",
+    "@farcaster/hub-nodejs": "^0.8.0",
     "@farcaster/rocksdb": "^5.5.0",
     "@grpc/grpc-js": "~1.8.7",
     "@libp2p/interface-connection": "^3.0.2",

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -67,10 +67,11 @@ export type HubSubmitSource = 'gossip' | 'rpc' | 'eth-provider' | 'sync';
 export const APP_VERSION = process.env['npm_package_version'] ?? '1.0.0';
 export const APP_NICKNAME = process.env['HUBBLE_NAME'] ?? 'Farcaster Hub';
 
-export const FARCASTER_VERSION = '2023.4.19';
+export const FARCASTER_VERSION = '2023.5.31';
 export const FARCASTER_VERSIONS_SCHEDULE: VersionSchedule[] = [
   { version: '2023.3.1', expiresAt: 1682553600000 }, // expires at 4/27/23 00:00 UTC
   { version: '2023.4.19', expiresAt: 1686700800000 }, // expires at 6/14/23 00:00 UTC
+  { version: '2023.5.31', expiresAt: 1690329600000 }, // expires at 7/26/23 00:00 UTC
 ];
 
 export interface HubInterface {
@@ -355,7 +356,9 @@ export class Hub implements HubInterface {
 
     // Set the network in the DB
     await this.setDbNetwork(this.options.network);
-    log.info(`starting hub with Farcaster version ${FARCASTER_VERSION} and network ${this.options.network}`);
+    log.info(
+      `starting hub with Farcaster version ${FARCASTER_VERSION}, app version ${APP_VERSION} and network ${this.options.network}`
+    );
 
     await this.engine.start();
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @farcaster/core
 
+## 0.9.0
+
+### Minor Changes
+
+- 2bc598a: Added support for Links
+
+### Patch Changes
+
+- 37f515f: Add app version to contactInfo message
+
 ## 0.8.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @farcaster/hub-nodejs
 
+## 0.8.0
+
+### Minor Changes
+
+- 2bc598a: Added support for Links
+
+### Patch Changes
+
+- Updated dependencies [37f515f]
+- Updated dependencies [2bc598a]
+  - @farcaster/core@0.9.0
+
 ## 0.7.4
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@farcaster/core": "0.8.1",
+    "@farcaster/core": "0.9.0",
     "@grpc/grpc-js": "^1.8.13",
     "@noble/hashes": "^1.3.0",
     "ethers": "~6.2.1",

--- a/packages/hub-web/CHANGELOG.md
+++ b/packages/hub-web/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @farcaster/hub-web
 
+## 0.3.5
+
+### Patch Changes
+
+- 37f515f: Add app version to contactInfo message
+- Updated dependencies [37f515f]
+- Updated dependencies [2bc598a]
+  - @farcaster/core@0.9.0
+
 ## 0.3.4
 
 ### Patch Changes

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-web",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -29,7 +29,7 @@
     "ts-proto": "^1.146.0"
   },
   "dependencies": {
-    "@farcaster/core": "^0.8.1",
+    "@farcaster/core": "^0.9.0",
     "@improbable-eng/grpc-web": "^0.15.0",
     "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
     "rxjs": "^7.8.0"


### PR DESCRIPTION
## Motivation

Release hub version `1.3` and bump protocol version to `2023.5.31`

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of several packages and introduces support for links in the core package. It also adds the app version to contact info messages and updates dependencies.

### Detailed summary
- Updated @farcaster/core package version to 0.9.0
- Added support for links in @farcaster/core package
- Added app version to contact info messages
- Updated dependencies in several packages
- Updated app version to 1.3.0 in @farcaster/hubble package
- Updated FARCASTER_VERSION in @farcaster/hubble/src/hubble.ts to '2023.5.31'

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->