### PR TITLE
feat: added jam hub 4 key in allowed peers and removed old hub id

### DIFF
--- a/apps/hubble/src/allowedPeers.mainnet.ts
+++ b/apps/hubble/src/allowedPeers.mainnet.ts
@@ -25,7 +25,6 @@ export const MAINNET_ALLOWED_PEERS = [
   '12D3KooWCZBZAirRXA2cecgud2zC7T5iN4hwr9nf7VAn9d8u9px2', // @rss3
   '12D3KooWJwBPFDdCkxWqVE6tCWPs4sDx2t4Pgy2cCewqKzLTRHgr', // @cryptobenkei
   '12D3KooWPaHFmDULq5ahsFM7TQ9tC3UmpiC5XUjtYe9xaoaw7iAs', // @les
-  '12D3KooWEZbpDyiupf2p9dWREfAigKou5wT4jcvxGVTcdXKXBuMu', // Jam.so
   '12D3KooWEr4WoKduAQg8VJSgwcNsqptbdkSQLw1ceEr8oSBQurJX', // @yanisme
   '12D3KooWMZK4VeMX3ZARugTuGexXFHNiGHgNFq6XE2vzi88fMgwC', // @event
   '12D3KooWEs1QcvJcoVv3ihHqqa3yxh4gijegrjyyVkvso2qayUdj', // @colin / @paragraph
@@ -39,4 +38,5 @@ export const MAINNET_ALLOWED_PEERS = [
   '12D3KooWSJj9pDSX5sEFoZum1fsdHuCJnoxwgHKhCg5rrLU7Gepe', // @pfista
   '12D3KooWDXSemEhSAidFCZT1HyRhTHayunCokg68VSuwStf8UEU5', // @98967eth
   '12D3KooWHcViME8KUZXo1wStoRF2jmg4edWidexGy5utVyoxNNnn', // @parthkohli
+  '12D3KooWJtEEh7Bcx9T2oKUpcMb9K8xuMFFk5BQNNdJ63Rsx853C', // Jam.so Hub 4
 ];


### PR DESCRIPTION
## Change Summary

Added key of Hub 4 of Jam.so 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes one peer and adds one new peer to the `MAINNET_ALLOWED_PEERS` array in `allowedPeers.mainnet.ts` file.

### Detailed summary
- Removed one peer from the `MAINNET_ALLOWED_PEERS` array
- Added one new peer to the `MAINNET_ALLOWED_PEERS` array

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->