### PR TITLE
chore: add peerid @bhgomes

### DIFF
--- a/.changeset/cool-emus-decide.md
+++ b/.changeset/cool-emus-decide.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Refactored stores to use a generic implementation for easier addition of types

--- a/.changeset/curvy-hotels-joke.md
+++ b/.changeset/curvy-hotels-joke.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Handle peers with no messages in status command

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@
 
 Thanks for your interest in improving the Farcaster Hub!
 
-No contribution is too small and we welcome to your help. There's always something to work on, no matter how experienced you are. If you're looking for ideas, start with the [good first issue](https://github.com/farcasterxyz/hub/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) or [help wanted](https://github.com/farcasterxyz/hub/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) sections in the issues. You can help make Farcaster better by:
+No contribution is too small and we welcome your help. There's always something to work on, no matter how experienced you are. If you're looking for ideas, start with the [good first issue](https://github.com/farcasterxyz/hub/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) or [help wanted](https://github.com/farcasterxyz/hub/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) sections in the issues. You can help make Farcaster better by:
 
 - Opening issues or adding details to existing issues
 - Fixing bugs in the code
@@ -80,7 +80,7 @@ You can run commands like `yarn test` and `yarn build` which TurboRepo will auto
 - [Installing Packages](https://turbo.build/repo/docs/handbook/package-installation)
 - [Creating New Packages](https://turbo.build/repo/docs/handbook/sharing-code/internal-packages)
 
-TurboRepo uses a local cache which can be disabled by adding the `--force` option to yarn commmands. Remote caching is not enabled since the performance gains at our scale are not worth the cost of introducing subtle caching bugs.
+TurboRepo uses a local cache which can be disabled by adding the `--force` option to yarn commands. Remote caching is not enabled since the performance gains at our scale are not worth the cost of introducing subtle caching bugs.
 
 ## 3. Proposing Changes
 
@@ -112,7 +112,7 @@ All changes should have supporting documentation that makes reviewing and unders
 
 Errors are not handled using `throw` and `try / catch` as is common with Javascript programs. This pattern makes it hard for people to reason about whether methods are safe which leads to incomplete test coverage, unexpected errors and less safety. Instead we use a more functional approach to dealing with errors. See [this issue](https://github.com/farcasterxyz/hub/issues/213) for the rationale behind this approach.
 
-All errors must be constructed using the `HubError` class which extends extends Error. It is stricter than error and requires a Hub Error Code (e.g. `unavailable.database_error`) and some additional context. Codes are used a replacement for error subclassing since they can be easily serialized over network calls. Codes also have multiple levels (e.g. `database_error` is a type of `unavailable`) which help with making decisions about error handling.
+All errors must be constructed using the `HubError` class which extends Error. It is stricter than error and requires a Hub Error Code (e.g. `unavailable.database_error`) and some additional context. Codes are used a replacement for error subclassing since they can be easily serialized over network calls. Codes also have multiple levels (e.g. `database_error` is a type of `unavailable`) which help with making decisions about error handling.
 
 Functions that can fail should always return `HubResult` which is a type that can either be the desired value or an error. Callers of the function should inspect the value and handle the success and failure case explicitly. The HubResult is an alias over [neverthrow's Result](https://github.com/supermacro/neverthrow). If you have never used a language where this is common (like Rust) you may want to start with the [API docs](https://github.com/supermacro/neverthrow#api-documentation). This pattern ensures that:
 
@@ -191,7 +191,7 @@ public something(): HubResult<number> {
   const result = computationThatMightFail();
   if (result.isErr()) return err(new HubError('unavailable', 'down'));
 
-   // do a lot of things that would be unweidly to put in a match
+   // do a lot of things that would be unwieldy to put in a match
    // ...
    // ...
    return ok(200);
@@ -278,7 +278,7 @@ are at all unsure about how to proceed, please reach out to Varun ([Github](http
 6. Hubble is private and must be manually tagged with `git tag -a @farcaster/hubble@<version>` if bumped.
 7. Run `git push origin <tag>` on each tag to push up the tags.
 
-## 4. TroubleShooting
+## 4. Troubleshooting
 
 ### Upgrading Libp2p
 

--- a/apps/hubble/README.md
+++ b/apps/hubble/README.md
@@ -150,6 +150,7 @@ Fetching data from Hubble requires communicating with its [gRPC](https://grpc.io
 1. Go to `apps/hubble` in this repo
 2. Pull the latest image: `docker pull farcasterxyz/hubble:latest`
 3. Run `docker compose stop && docker compose up -d --force-recreate`
+4. If you are upgrading from a non-docker deployment to docker, make sure the `.hub` and `.rocks` directories are writable for all users. 
 
 Check the logs to ensure your hub is running successfully:
 ```sh

--- a/apps/hubble/src/allowedPeers.mainnet.ts
+++ b/apps/hubble/src/allowedPeers.mainnet.ts
@@ -39,4 +39,7 @@ export const MAINNET_ALLOWED_PEERS = [
   '12D3KooWSJj9pDSX5sEFoZum1fsdHuCJnoxwgHKhCg5rrLU7Gepe', // @pfista
   '12D3KooWDXSemEhSAidFCZT1HyRhTHayunCokg68VSuwStf8UEU5', // @98967eth
   '12D3KooWHcViME8KUZXo1wStoRF2jmg4edWidexGy5utVyoxNNnn', // @parthkohli
+  '12D3KooWJtEEh7Bcx9T2oKUpcMb9K8xuMFFk5BQNNdJ63Rsx853C', // Jam.so Hub 4
+  '12D3KooWH3FAGri9Ki4j7xBBjghav9nRTyu8jVVBsRh55odGxraM', // @kencodes
+  '12D3KooWNLshuXk4x2gacFTMEJjMGGFxPjpHg5KcV88KoqJP7dDR', // @bhgomes
 ];

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -498,6 +498,9 @@ app
       let isSyncing = false;
       const msgPercents: number[] = [];
       for (const peerStatus of syncResult.value.syncStatus) {
+        if (peerStatus.theirMessages === 0) {
+          continue;
+        }
         const messagePercent = (peerStatus.ourMessages / peerStatus.theirMessages) * 100;
         msgPercents.push(messagePercent);
         if (syncResult.value.isSyncing) {

--- a/apps/hubble/src/storage/stores/castStore.test.ts
+++ b/apps/hubble/src/storage/stores/castStore.test.ts
@@ -437,7 +437,7 @@ describe('merge', () => {
       test('fails with an earlier timestamp', async () => {
         await store.merge(castRemoveLater);
         await expect(store.merge(castRemove)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent CastRemove')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent remove')
         );
 
         await assertMessageDoesNotExist(castRemove);
@@ -472,7 +472,7 @@ describe('merge', () => {
       test('fails with an earlier hash', async () => {
         await store.merge(castRemoveLater);
         await expect(store.merge(castRemove)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent CastRemove')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent remove')
         );
 
         await assertMessageDoesNotExist(castRemove);

--- a/apps/hubble/src/storage/stores/linkStore.test.ts
+++ b/apps/hubble/src/storage/stores/linkStore.test.ts
@@ -406,7 +406,7 @@ describe('merge', () => {
       test('fails with an earlier timestamp', async () => {
         await set.merge(linkAddLater);
         await expect(set.merge(linkAdd)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent LinkAdd')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent add')
         );
 
         await assertLinkDoesNotExist(linkAdd);
@@ -440,7 +440,7 @@ describe('merge', () => {
       test('fails with a lower hash', async () => {
         await set.merge(linkAddLater);
         await expect(set.merge(linkAdd)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent LinkAdd')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent add')
         );
 
         await assertLinkDoesNotExist(linkAdd);
@@ -469,7 +469,7 @@ describe('merge', () => {
       test('fails with an earlier timestamp', async () => {
         await set.merge(linkRemove);
         await expect(set.merge(linkAdd)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent LinkRemove')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent remove')
         );
 
         await assertLinkRemoveWins(linkRemove);
@@ -489,7 +489,7 @@ describe('merge', () => {
 
         await set.merge(linkRemoveLater);
         await expect(set.merge(linkAdd)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent LinkRemove')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent remove')
         );
 
         await assertLinkRemoveWins(linkRemoveLater);
@@ -507,7 +507,7 @@ describe('merge', () => {
 
         await set.merge(linkRemoveEarlier);
         await expect(set.merge(linkAdd)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent LinkRemove')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent remove')
         );
 
         await assertLinkRemoveWins(linkRemoveEarlier);
@@ -559,7 +559,7 @@ describe('merge', () => {
       test('fails with an earlier timestamp', async () => {
         await set.merge(linkRemoveLater);
         await expect(set.merge(linkRemove)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent LinkRemove')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent remove')
         );
 
         await assertLinkDoesNotExist(linkRemove);
@@ -593,7 +593,7 @@ describe('merge', () => {
       test('fails with a lower hash', async () => {
         await set.merge(linkRemoveLater);
         await expect(set.merge(linkRemove)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent LinkRemove')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent remove')
         );
 
         await assertLinkDoesNotExist(linkRemove);
@@ -625,7 +625,7 @@ describe('merge', () => {
 
         await set.merge(linkAddLater);
         await expect(set.merge(linkRemove)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent LinkAdd')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent add')
         );
         await assertLinkAddWins(linkAddLater);
         await assertLinkDoesNotExist(linkRemove);

--- a/apps/hubble/src/storage/stores/linkStore.ts
+++ b/apps/hubble/src/storage/stores/linkStore.ts
@@ -1,38 +1,25 @@
 import {
-  bytesCompare,
-  getFarcasterTime,
   HubAsyncResult,
   HubError,
-  HubEventType,
-  isHubError,
-  isLinkAddMessage,
-  isLinkRemoveMessage,
   LinkAddMessage,
   LinkRemoveMessage,
-  Message,
   MessageType,
+  isLinkAddMessage,
+  isLinkRemoveMessage,
 } from '@farcaster/hub-nodejs';
-import AsyncLock from 'async-lock';
-import { err, ok, ResultAsync } from 'neverthrow';
 import {
-  deleteMessageTransaction,
   getManyMessages,
-  getMessage,
-  getMessagesPageByPrefix,
-  getMessagesPruneIterator,
-  getNextMessageFromIterator,
   getPageIteratorByPrefix,
   makeFidKey,
   makeMessagePrimaryKey,
   makeTsHash,
   makeUserKey,
-  putMessageTransaction,
 } from '../../storage/db/message.js';
-import RocksDB, { Transaction } from '../db/rocksdb.js';
-import { RootPrefix, TSHASH_LENGTH, UserPostfix } from '../db/types.js';
-import StoreEventHandler, { HubEventArgs } from './storeEventHandler.js';
-import { MERGE_TIMEOUT_DEFAULT, MessagesPage, PAGE_SIZE_MAX, PageOptions, StorePruneOptions } from './types.js';
-import { logger } from '../../utils/logger.js';
+import { RootPrefix, TSHASH_LENGTH, UserMessagePostfix, UserPostfix } from '../db/types.js';
+import { MessagesPage, PAGE_SIZE_MAX, PageOptions } from './types.js';
+import { Store } from './store.js';
+import { ResultAsync, err, ok } from 'neverthrow';
+import { Transaction } from '../db/rocksdb.js';
 
 const PRUNE_SIZE_LIMIT_DEFAULT = 2_500;
 
@@ -140,17 +127,65 @@ const makeLinksByTargetKey = (target: number, fid?: number, tsHash?: Uint8Array)
  * 2. fid:set:targetCastTsHash:linkType -> fid:tsHash (Set Index)
  * 3. linkTarget:linkType:targetCastTsHash -> fid:tsHash (Target Index)
  */
-class LinkStore {
-  private _db: RocksDB;
-  private _eventHandler: StoreEventHandler;
-  private _pruneSizeLimit: number;
-  private _mergeLock: AsyncLock;
+class LinkStore extends Store<LinkAddMessage, LinkRemoveMessage> {
+  override _postfix: UserMessagePostfix = UserPostfix.LinkMessage;
 
-  constructor(db: RocksDB, eventHandler: StoreEventHandler, options: StorePruneOptions = {}) {
-    this._db = db;
-    this._eventHandler = eventHandler;
-    this._pruneSizeLimit = options.pruneSizeLimit ?? PRUNE_SIZE_LIMIT_DEFAULT;
-    this._mergeLock = new AsyncLock();
+  override makeAddKey(msg: LinkAddMessage) {
+    return makeLinkAddsKey(msg.data.fid, msg.data.linkBody.type, msg.data.linkBody.targetFid) as Buffer;
+  }
+
+  override makeRemoveKey(msg: LinkRemoveMessage) {
+    return makeLinkRemovesKey(msg.data.fid, msg.data.linkBody.type, msg.data.linkBody.targetFid);
+  }
+
+  override async findMergeAddConflicts(_message: LinkAddMessage): HubAsyncResult<void> {
+    return ok(undefined);
+  }
+
+  override async findMergeRemoveConflicts(_message: LinkRemoveMessage): HubAsyncResult<void> {
+    return ok(undefined);
+  }
+
+  override _isAddType = isLinkAddMessage;
+  override _isRemoveType = isLinkRemoveMessage;
+  override _addMessageType = MessageType.LINK_ADD;
+  override _removeMessageType = MessageType.LINK_REMOVE;
+  protected override PRUNE_SIZE_LIMIT_DEFAULT = PRUNE_SIZE_LIMIT_DEFAULT;
+
+  override async buildSecondaryIndices(txn: Transaction, message: LinkAddMessage): HubAsyncResult<void> {
+    const tsHash = makeTsHash(message.data.timestamp, message.hash);
+
+    if (tsHash.isErr()) {
+      return err(tsHash.error);
+    }
+
+    if (!message.data.linkBody.targetFid) {
+      return err(new HubError('bad_request.invalid_param', 'targetfid null'));
+    }
+
+    // Puts message key into the byTarget index
+    const byTargetKey = makeLinksByTargetKey(message.data.linkBody.targetFid, message.data.fid, tsHash.value);
+    txn = txn.put(byTargetKey, Buffer.from(message.data.linkBody.type));
+
+    return ok(undefined);
+  }
+
+  override async deleteSecondaryIndices(txn: Transaction, message: LinkAddMessage): HubAsyncResult<void> {
+    const tsHash = makeTsHash(message.data.timestamp, message.hash);
+
+    if (tsHash.isErr()) {
+      return err(tsHash.error);
+    }
+
+    if (!message.data.linkBody.targetFid) {
+      return err(new HubError('bad_request.invalid_param', 'targetfid null'));
+    }
+
+    // Delete the message key from byTarget index
+    const byTargetKey = makeLinksByTargetKey(message.data.linkBody.targetFid, message.data.fid, tsHash.value);
+    txn = txn.del(byTargetKey);
+
+    return ok(undefined);
   }
 
   /* -------------------------------------------------------------------------- */
@@ -167,10 +202,7 @@ class LinkStore {
    * @returns the LinkAdd Model if it exists, undefined otherwise
    */
   async getLinkAdd(fid: number, type: string, target: number): Promise<LinkAddMessage> {
-    const linkAddsSetKey = makeLinkAddsKey(fid, type, target);
-    const linkMessageKey = await this._db.get(linkAddsSetKey);
-
-    return getMessage(this._db, fid, UserPostfix.LinkMessage, linkMessageKey);
+    return await this.getAdd({ data: { fid, linkBody: { type, targetFid: target } } });
   }
 
   /**
@@ -182,10 +214,7 @@ class LinkStore {
    * @returns the LinkRemove message if it exists, undefined otherwise
    */
   async getLinkRemove(fid: number, type: string, target: number): Promise<LinkRemoveMessage> {
-    const linkRemovesKey = makeLinkRemovesKey(fid, type, target);
-    const linkMessageKey = await this._db.get(linkRemovesKey);
-
-    return getMessage(this._db, fid, UserPostfix.LinkMessage, linkMessageKey);
+    return await this.getRemove({ data: { fid, linkBody: { type, targetFid: target } } });
   }
 
   /** Finds all LinkAdd Messages by iterating through the prefixes */
@@ -194,11 +223,7 @@ class LinkStore {
     type?: string,
     pageOptions: PageOptions = {}
   ): Promise<MessagesPage<LinkAddMessage>> {
-    const prefix = makeMessagePrimaryKey(fid, UserPostfix.LinkMessage);
-    const filter = (message: Message): message is LinkAddMessage => {
-      return isLinkAddMessage(message) && (type ? message.data.linkBody.type === type : true);
-    };
-    return getMessagesPageByPrefix(this._db, prefix, filter, pageOptions);
+    return await this.getAddsByFid({ data: { fid, linkBody: { type: type as string } } }, pageOptions);
   }
 
   /** Finds all LinkRemove Messages by iterating through the prefixes */
@@ -207,22 +232,14 @@ class LinkStore {
     type?: string,
     pageOptions: PageOptions = {}
   ): Promise<MessagesPage<LinkRemoveMessage>> {
-    const prefix = makeMessagePrimaryKey(fid, UserPostfix.LinkMessage);
-    const filter = (message: Message): message is LinkRemoveMessage => {
-      return isLinkRemoveMessage(message) && (type ? message.data.linkBody.type === type : true);
-    };
-    return getMessagesPageByPrefix(this._db, prefix, filter, pageOptions);
+    return await this.getRemovesByFid({ data: { fid, linkBody: { type: type as string } } }, pageOptions);
   }
 
   async getAllLinkMessagesByFid(
     fid: number,
     pageOptions: PageOptions = {}
   ): Promise<MessagesPage<LinkAddMessage | LinkRemoveMessage>> {
-    const prefix = makeMessagePrimaryKey(fid, UserPostfix.LinkMessage);
-    const filter = (message: Message): message is LinkAddMessage | LinkRemoveMessage => {
-      return isLinkAddMessage(message) || isLinkRemoveMessage(message);
-    };
-    return getMessagesPageByPrefix(this._db, prefix, filter, pageOptions);
+    return await this.getAllMessagesByFid(fid, pageOptions);
   }
 
   /** Finds all LinkAdds that point to a specific target by iterating through the prefixes */
@@ -273,434 +290,6 @@ class LinkStore {
     } else {
       return { messages, nextPageToken: undefined };
     }
-  }
-
-  /** Merges a LinkAdd or LinkRemove message into the LinkStore */
-  async merge(message: Message): Promise<number> {
-    if (!isLinkAddMessage(message) && !isLinkRemoveMessage(message)) {
-      throw new HubError('bad_request.validation_failure', 'invalid message type');
-    }
-
-    return this._mergeLock
-      .acquire(
-        message.data.fid.toString(),
-        async () => {
-          const prunableResult = await this._eventHandler.isPrunable(
-            message,
-            UserPostfix.LinkMessage,
-            this._pruneSizeLimit
-          );
-          if (prunableResult.isErr()) {
-            throw prunableResult.error;
-          } else if (prunableResult.value) {
-            throw new HubError('bad_request.prunable', 'message would be pruned');
-          }
-
-          if (isLinkAddMessage(message)) {
-            return this.mergeAdd(message);
-          } else if (isLinkRemoveMessage(message)) {
-            return this.mergeRemove(message);
-          } else {
-            throw new HubError('bad_request.validation_failure', 'invalid message type');
-          }
-        },
-        { timeout: MERGE_TIMEOUT_DEFAULT }
-      )
-      .catch((e: any) => {
-        throw isHubError(e) ? e : new HubError('unavailable.storage_failure', 'merge timed out');
-      });
-  }
-
-  async revoke(message: Message): HubAsyncResult<number> {
-    let txn = this._db.transaction();
-    if (isLinkAddMessage(message)) {
-      txn = this.deleteLinkAddTransaction(txn, message);
-    } else if (isLinkRemoveMessage(message)) {
-      txn = this.deleteLinkRemoveTransaction(txn, message);
-    } else {
-      return err(new HubError('bad_request.invalid_param', 'invalid message type'));
-    }
-
-    return this._eventHandler.commitTransaction(txn, {
-      type: HubEventType.REVOKE_MESSAGE,
-      revokeMessageBody: { message },
-    });
-  }
-
-  async pruneMessages(fid: number): HubAsyncResult<number[]> {
-    const commits: number[] = [];
-
-    const cachedCount = await this._eventHandler.getCacheMessageCount(fid, UserPostfix.LinkMessage);
-
-    // Require storage cache to be synced to prune
-    if (cachedCount.isErr()) {
-      return err(cachedCount.error);
-    }
-
-    // Return immediately if there are no messages to prune
-    if (cachedCount.value === 0) {
-      return ok(commits);
-    }
-
-    const farcasterTime = getFarcasterTime();
-    if (farcasterTime.isErr()) {
-      return err(farcasterTime.error);
-    }
-
-    // Create a rocksdb iterator for all messages with the given prefix
-    const pruneIterator = getMessagesPruneIterator(this._db, fid, UserPostfix.LinkMessage);
-
-    const pruneNextMessage = async (): HubAsyncResult<number | undefined> => {
-      const nextMessage = await ResultAsync.fromPromise(getNextMessageFromIterator(pruneIterator), () => undefined);
-      if (nextMessage.isErr()) {
-        return ok(undefined); // Nothing left to prune
-      }
-
-      const count = await this._eventHandler.getCacheMessageCount(fid, UserPostfix.LinkMessage);
-      if (count.isErr()) {
-        return err(count.error);
-      }
-
-      if (count.value <= this._pruneSizeLimit) {
-        return ok(undefined);
-      }
-
-      let txn = this._db.transaction();
-
-      if (isLinkAddMessage(nextMessage.value)) {
-        txn = this.deleteLinkAddTransaction(txn, nextMessage.value);
-      } else if (isLinkRemoveMessage(nextMessage.value)) {
-        txn = this.deleteLinkRemoveTransaction(txn, nextMessage.value);
-      } else {
-        return err(new HubError('unknown', 'invalid message type'));
-      }
-
-      return this._eventHandler.commitTransaction(txn, {
-        type: HubEventType.PRUNE_MESSAGE,
-        pruneMessageBody: { message: nextMessage.value },
-      });
-    };
-
-    let pruneResult = await pruneNextMessage();
-    while (!(pruneResult.isOk() && pruneResult.value === undefined)) {
-      pruneResult.match(
-        (commit) => {
-          if (commit) {
-            commits.push(commit);
-          }
-        },
-        (e) => {
-          logger.error({ errCode: e.errCode }, `error pruning link message for fid ${fid}: ${e.message}`);
-        }
-      );
-
-      pruneResult = await pruneNextMessage();
-    }
-
-    await pruneIterator.end();
-
-    return ok(commits);
-  }
-
-  /* -------------------------------------------------------------------------- */
-  /*                               Private Methods                              */
-  /* -------------------------------------------------------------------------- */
-
-  private async mergeAdd(message: LinkAddMessage): Promise<number> {
-    const mergeConflicts = await this.getMergeConflicts(message);
-    if (mergeConflicts.isErr()) {
-      throw mergeConflicts.error;
-    }
-
-    // Create rocksdb transaction to delete the merge conflicts
-    let txn = this.deleteManyTransaction(this._db.transaction(), mergeConflicts.value);
-
-    // Add ops to store the message by messageKey and index the the messageKey by set and by target
-    txn = this.putLinkAddTransaction(txn, message);
-
-    const hubEvent: HubEventArgs = {
-      type: HubEventType.MERGE_MESSAGE,
-      mergeMessageBody: { message, deletedMessages: mergeConflicts.value },
-    };
-
-    // Commit the RocksDB transaction
-    const result = await this._eventHandler.commitTransaction(txn, hubEvent);
-    if (result.isErr()) {
-      throw result.error;
-    }
-    return result.value;
-  }
-
-  private async mergeRemove(message: LinkRemoveMessage): Promise<number> {
-    const mergeConflicts = await this.getMergeConflicts(message);
-
-    if (mergeConflicts.isErr()) {
-      throw mergeConflicts.error;
-    }
-
-    // Create rocksdb transaction to delete the merge conflicts
-    let txn = this.deleteManyTransaction(this._db.transaction(), mergeConflicts.value);
-
-    // Add ops to store the message by messageKey and index the the messageKey by set
-    txn = this.putLinkRemoveTransaction(txn, message);
-
-    const hubEvent: HubEventArgs = {
-      type: HubEventType.MERGE_MESSAGE,
-      mergeMessageBody: { message, deletedMessages: mergeConflicts.value },
-    };
-
-    // Commit the RocksDB transaction
-    const result = await this._eventHandler.commitTransaction(txn, hubEvent);
-    if (result.isErr()) {
-      throw result.error;
-    }
-    return result.value;
-  }
-
-  private linkMessageCompare(
-    aType: MessageType.LINK_ADD | MessageType.LINK_REMOVE,
-    aTsHash: Uint8Array,
-    bType: MessageType.LINK_ADD | MessageType.LINK_REMOVE,
-    bTsHash: Uint8Array
-  ): number {
-    // Compare timestamps (first 4 bytes of tsHash) to enforce Last-Write-Wins
-    const timestampOrder = bytesCompare(aTsHash.subarray(0, 4), bTsHash.subarray(0, 4));
-    if (timestampOrder !== 0) {
-      return timestampOrder;
-    }
-
-    // Compare message types to enforce that RemoveWins in case of LWW ties.
-    if (aType === MessageType.LINK_REMOVE && bType === MessageType.LINK_ADD) {
-      return 1;
-    } else if (aType === MessageType.LINK_ADD && bType === MessageType.LINK_REMOVE) {
-      return -1;
-    }
-
-    // Compare hashes (last 4 bytes of tsHash) to break ties between messages of the same type and timestamp
-    return bytesCompare(aTsHash.subarray(4), bTsHash.subarray(4));
-  }
-
-  /**
-   * Determines the RocksDB keys that must be modified to settle merge conflicts as a result of
-   * adding a Link to the Store.
-   *
-   * @returns a RocksDB transaction if keys must be added or removed, undefined otherwise
-   */
-  private async getMergeConflicts(
-    message: LinkAddMessage | LinkRemoveMessage
-  ): HubAsyncResult<(LinkAddMessage | LinkRemoveMessage)[]> {
-    const target = message.data.linkBody.targetFid;
-    if (!target) {
-      throw new HubError('bad_request.validation_failure', 'target is missing');
-    }
-
-    const tsHash = makeTsHash(message.data.timestamp, message.hash);
-    if (tsHash.isErr()) {
-      throw tsHash.error;
-    }
-
-    const conflicts: (LinkAddMessage | LinkRemoveMessage)[] = [];
-
-    // Checks if there is a remove timestamp hash for this link
-    const linkRemoveKey = makeLinkRemovesKey(message.data.fid, message.data.linkBody.type, target);
-    const linkRemoveTsHash = await ResultAsync.fromPromise(this._db.get(linkRemoveKey), () => undefined);
-
-    if (linkRemoveTsHash.isOk()) {
-      const removeCompare = this.linkMessageCompare(
-        MessageType.LINK_REMOVE,
-        new Uint8Array(linkRemoveTsHash.value),
-        message.data.type,
-        tsHash.value
-      );
-      if (removeCompare > 0) {
-        return err(new HubError('bad_request.conflict', 'message conflicts with a more recent LinkRemove'));
-      } else if (removeCompare === 0) {
-        return err(new HubError('bad_request.duplicate', 'message has already been merged'));
-      } else {
-        // If the existing remove has a lower order than the new message, retrieve the full
-        // LinkRemove message and delete it as part of the RocksDB transaction
-        const existingRemove = await getMessage<LinkRemoveMessage>(
-          this._db,
-          message.data.fid,
-          UserPostfix.LinkMessage,
-          linkRemoveTsHash.value
-        );
-        conflicts.push(existingRemove);
-      }
-    }
-
-    // Checks if there is an add timestamp hash for this link
-    const linkAddKey = makeLinkAddsKey(message.data.fid, message.data.linkBody.type, target);
-    const linkAddTsHash = await ResultAsync.fromPromise(this._db.get(linkAddKey), () => undefined);
-
-    if (linkAddTsHash.isOk()) {
-      const addCompare = this.linkMessageCompare(
-        MessageType.LINK_ADD,
-        new Uint8Array(linkAddTsHash.value),
-        message.data.type,
-        tsHash.value
-      );
-      if (addCompare > 0) {
-        return err(new HubError('bad_request.conflict', 'message conflicts with a more recent LinkAdd'));
-      } else if (addCompare === 0) {
-        return err(new HubError('bad_request.duplicate', 'message has already been merged'));
-      } else {
-        // If the existing add has a lower order than the new message, retrieve the full
-        // LinkAdd message and delete it as part of the RocksDB transaction
-        const existingAdd = await getMessage<LinkAddMessage>(
-          this._db,
-          message.data.fid,
-          UserPostfix.LinkMessage,
-          linkAddTsHash.value
-        );
-        conflicts.push(existingAdd);
-      }
-    }
-
-    return ok(conflicts);
-  }
-
-  private deleteManyTransaction(txn: Transaction, messages: (LinkAddMessage | LinkRemoveMessage)[]): Transaction {
-    for (const message of messages) {
-      if (isLinkAddMessage(message)) {
-        txn = this.deleteLinkAddTransaction(txn, message);
-      } else if (isLinkRemoveMessage(message)) {
-        txn = this.deleteLinkRemoveTransaction(txn, message);
-      }
-    }
-    return txn;
-  }
-
-  /* Builds a RocksDB transaction to insert a LinkAdd message and construct its indices */
-  private putLinkAddTransaction(txn: Transaction, message: LinkAddMessage): Transaction {
-    const tsHash = makeTsHash(message.data.timestamp, message.hash);
-    if (tsHash.isErr()) {
-      throw tsHash.error;
-    }
-
-    const target = message.data.linkBody.targetFid;
-    if (!target) {
-      throw new HubError('bad_request.validation_failure', 'target is missing');
-    }
-
-    const type = message.data.linkBody.type;
-    if (!type) {
-      throw new HubError('bad_request.validation_failure', 'type is missing');
-    } else {
-      const typeBuffer = Buffer.from(type);
-      if (type.length === 0 || typeBuffer.length > 8) {
-        throw new HubError('bad_request.validation_failure', 'type must be 1-8 bytes');
-      }
-    }
-
-    // Puts the message into the database
-    txn = putMessageTransaction(txn, message);
-
-    // Puts the message into the LinkAdds Set index
-    const addsKey = makeLinkAddsKey(message.data.fid, type, target);
-    txn = txn.put(addsKey, Buffer.from(tsHash.value));
-
-    // Puts message key into the byTarget index
-    const byTargetKey = makeLinksByTargetKey(target, message.data.fid, tsHash.value);
-    txn = txn.put(byTargetKey, Buffer.from(type));
-
-    return txn;
-  }
-
-  /* Builds a RocksDB transaction to remove a LinkAdd message and delete its indices */
-  private deleteLinkAddTransaction(txn: Transaction, message: LinkAddMessage): Transaction {
-    const tsHash = makeTsHash(message.data.timestamp, message.hash);
-    if (tsHash.isErr()) {
-      throw tsHash.error;
-    }
-
-    const target = message.data.linkBody.targetFid;
-    if (!target) {
-      throw new HubError('bad_request.validation_failure', 'target is missing');
-    }
-
-    const type = message.data.linkBody.type;
-    if (!type) {
-      throw new HubError('bad_request.validation_failure', 'type is missing');
-    } else {
-      const typeBuffer = Buffer.from(type);
-      if (type.length === 0 || typeBuffer.length > 8) {
-        throw new HubError('bad_request.validation_failure', 'type must be 1-8 bytes');
-      }
-    }
-
-    // Delete the message key from byTarget index
-    const byTargetKey = makeLinksByTargetKey(target, message.data.fid, tsHash.value);
-    txn = txn.del(byTargetKey);
-
-    // Delete the message key from LinkAdds Set index
-    const addsKey = makeLinkAddsKey(message.data.fid, type, target);
-    txn = txn.del(addsKey);
-
-    // Delete the message
-    return deleteMessageTransaction(txn, message);
-  }
-
-  /* Builds a RocksDB transaction to insert a LinkRemove message and construct its indices */
-  private putLinkRemoveTransaction(txn: Transaction, message: LinkRemoveMessage): Transaction {
-    const tsHash = makeTsHash(message.data.timestamp, message.hash);
-    if (tsHash.isErr()) {
-      throw tsHash.error;
-    }
-
-    const target = message.data.linkBody.targetFid;
-    if (!target) {
-      throw new HubError('bad_request.validation_failure', 'target is missing');
-    }
-
-    const type = message.data.linkBody.type;
-    if (!type) {
-      throw new HubError('bad_request.validation_failure', 'type is missing');
-    } else {
-      const typeBuffer = Buffer.from(type);
-      if (type.length === 0 || typeBuffer.length > 8) {
-        throw new HubError('bad_request.validation_failure', 'type must be 1-8 bytes');
-      }
-    }
-
-    // Puts the message
-    txn = putMessageTransaction(txn, message);
-
-    // Puts message key into the LinkRemoves Set index
-    const removesKey = makeLinkRemovesKey(message.data.fid, type, target);
-    txn = txn.put(removesKey, Buffer.from(tsHash.value));
-
-    return txn;
-  }
-
-  /* Builds a RocksDB transaction to remove a LinkRemove message and delete its indices */
-  private deleteLinkRemoveTransaction(txn: Transaction, message: LinkRemoveMessage): Transaction {
-    const tsHash = makeTsHash(message.data.timestamp, message.hash);
-    if (tsHash.isErr()) {
-      throw tsHash.error;
-    }
-
-    const target = message.data.linkBody.targetFid;
-    if (!target) {
-      throw new HubError('bad_request.validation_failure', 'target is missing');
-    }
-
-    const type = message.data.linkBody.type;
-    if (!type) {
-      throw new HubError('bad_request.validation_failure', 'type is missing');
-    } else {
-      const typeBuffer = Buffer.from(type);
-      if (type.length === 0 || typeBuffer.length > 8) {
-        throw new HubError('bad_request.validation_failure', 'type must be 1-8 bytes');
-      }
-    }
-
-    // Delete message key from LinkRemoves Set index
-    const removesKey = makeLinkRemovesKey(message.data.fid, type, target);
-    txn = txn.del(removesKey);
-
-    // Delete the message
-    return deleteMessageTransaction(txn, message);
   }
 }
 

--- a/apps/hubble/src/storage/stores/reactionStore.test.ts
+++ b/apps/hubble/src/storage/stores/reactionStore.test.ts
@@ -433,7 +433,7 @@ describe('merge', () => {
       test('fails with an earlier timestamp', async () => {
         await set.merge(reactionAddLater);
         await expect(set.merge(reactionAdd)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent ReactionAdd')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent add')
         );
 
         await assertReactionDoesNotExist(reactionAdd);
@@ -467,7 +467,7 @@ describe('merge', () => {
       test('fails with a lower hash', async () => {
         await set.merge(reactionAddLater);
         await expect(set.merge(reactionAdd)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent ReactionAdd')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent add')
         );
 
         await assertReactionDoesNotExist(reactionAdd);
@@ -496,7 +496,7 @@ describe('merge', () => {
       test('fails with an earlier timestamp', async () => {
         await set.merge(reactionRemove);
         await expect(set.merge(reactionAdd)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent ReactionRemove')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent remove')
         );
 
         await assertReactionRemoveWins(reactionRemove);
@@ -516,7 +516,7 @@ describe('merge', () => {
 
         await set.merge(reactionRemoveLater);
         await expect(set.merge(reactionAdd)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent ReactionRemove')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent remove')
         );
 
         await assertReactionRemoveWins(reactionRemoveLater);
@@ -534,7 +534,7 @@ describe('merge', () => {
 
         await set.merge(reactionRemoveEarlier);
         await expect(set.merge(reactionAdd)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent ReactionRemove')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent remove')
         );
 
         await assertReactionRemoveWins(reactionRemoveEarlier);
@@ -586,7 +586,7 @@ describe('merge', () => {
       test('fails with an earlier timestamp', async () => {
         await set.merge(reactionRemoveLater);
         await expect(set.merge(reactionRemove)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent ReactionRemove')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent remove')
         );
 
         await assertReactionDoesNotExist(reactionRemove);
@@ -620,7 +620,7 @@ describe('merge', () => {
       test('fails with a lower hash', async () => {
         await set.merge(reactionRemoveLater);
         await expect(set.merge(reactionRemove)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent ReactionRemove')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent remove')
         );
 
         await assertReactionDoesNotExist(reactionRemove);
@@ -652,7 +652,7 @@ describe('merge', () => {
 
         await set.merge(reactionAddLater);
         await expect(set.merge(reactionRemove)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent ReactionAdd')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent add')
         );
         await assertReactionAddWins(reactionAddLater);
         await assertReactionDoesNotExist(reactionRemove);

--- a/apps/hubble/src/storage/stores/reactionStore.ts
+++ b/apps/hubble/src/storage/stores/reactionStore.ts
@@ -1,41 +1,29 @@
 import {
-  bytesCompare,
   CastId,
-  getFarcasterTime,
   HubAsyncResult,
   HubError,
-  HubEventType,
-  isHubError,
   isReactionAddMessage,
   isReactionRemoveMessage,
-  Message,
   MessageType,
   ReactionAddMessage,
   ReactionRemoveMessage,
   ReactionType,
 } from '@farcaster/hub-nodejs';
-import AsyncLock from 'async-lock';
 import { err, ok, ResultAsync } from 'neverthrow';
 import {
-  deleteMessageTransaction,
   getManyMessages,
-  getMessage,
-  getMessagesPageByPrefix,
-  getMessagesPruneIterator,
-  getNextMessageFromIterator,
   getPageIteratorByPrefix,
   makeCastIdKey,
   makeFidKey,
   makeMessagePrimaryKey,
   makeTsHash,
   makeUserKey,
-  putMessageTransaction,
 } from '../db/message.js';
 import RocksDB, { Transaction } from '../db/rocksdb.js';
-import { RootPrefix, TSHASH_LENGTH, UserPostfix } from '../db/types.js';
-import StoreEventHandler, { HubEventArgs } from '../stores/storeEventHandler.js';
-import { MERGE_TIMEOUT_DEFAULT, MessagesPage, PAGE_SIZE_MAX, PageOptions, StorePruneOptions } from '../stores/types.js';
-import { logger } from '../../utils/logger.js';
+import { RootPrefix, TSHASH_LENGTH, UserMessagePostfix, UserPostfix } from '../db/types.js';
+import StoreEventHandler from '../stores/storeEventHandler.js';
+import { MessagesPage, PAGE_SIZE_MAX, PageOptions, StorePruneOptions } from '../stores/types.js';
+import { Store } from './store.js';
 
 const PRUNE_SIZE_LIMIT_DEFAULT = 5_000;
 const PRUNE_TIME_LIMIT_DEFAULT = 60 * 60 * 24 * 90; // 90 days
@@ -136,19 +124,82 @@ const makeReactionsByTargetKey = (target: CastId | string, fid?: number, tsHash?
  * 2. fid:set:targetCastTsHash:reactionType -> fid:tsHash (Set Index)
  * 3. reactionTarget:reactionType:targetCastTsHash -> fid:tsHash (Target Index)
  */
-class ReactionStore {
-  private _db: RocksDB;
-  private _eventHandler: StoreEventHandler;
-  private _pruneSizeLimit: number;
-  private _pruneTimeLimit: number;
-  private _mergeLock: AsyncLock;
+class ReactionStore extends Store<ReactionAddMessage, ReactionRemoveMessage> {
+  override _postfix: UserMessagePostfix = UserPostfix.ReactionMessage;
+  override makeAddKey(msg: ReactionAddMessage) {
+    return makeReactionAddsKey(
+      msg.data.fid,
+      msg.data.reactionBody.type,
+      msg.data.reactionBody.targetUrl || msg.data.reactionBody.targetCastId
+    ) as Buffer;
+  }
+
+  override makeRemoveKey(msg: ReactionRemoveMessage) {
+    return makeReactionRemovesKey(
+      msg.data.fid,
+      msg.data.reactionBody.type,
+      msg.data.reactionBody.targetUrl || msg.data.reactionBody.targetCastId
+    );
+  }
+
+  override _isAddType = isReactionAddMessage;
+  override _isRemoveType = isReactionRemoveMessage;
+  override _addMessageType = MessageType.REACTION_ADD;
+  override _removeMessageType = MessageType.REACTION_REMOVE;
+  protected override PRUNE_SIZE_LIMIT_DEFAULT = PRUNE_SIZE_LIMIT_DEFAULT;
+  protected override PRUNE_TIME_LIMIT_DEFAULT = PRUNE_TIME_LIMIT_DEFAULT;
 
   constructor(db: RocksDB, eventHandler: StoreEventHandler, options: StorePruneOptions = {}) {
-    this._db = db;
-    this._eventHandler = eventHandler;
-    this._pruneSizeLimit = options.pruneSizeLimit ?? PRUNE_SIZE_LIMIT_DEFAULT;
-    this._pruneTimeLimit = options.pruneTimeLimit ?? PRUNE_TIME_LIMIT_DEFAULT;
-    this._mergeLock = new AsyncLock();
+    super(db, eventHandler, options);
+    this._pruneTimeLimit = options.pruneTimeLimit ?? this.PRUNE_TIME_LIMIT_DEFAULT;
+  }
+
+  override async findMergeAddConflicts(_message: ReactionAddMessage): HubAsyncResult<void> {
+    return ok(undefined);
+  }
+
+  override async findMergeRemoveConflicts(_message: ReactionRemoveMessage): HubAsyncResult<void> {
+    return ok(undefined);
+  }
+
+  override async buildSecondaryIndices(txn: Transaction, message: ReactionAddMessage): HubAsyncResult<void> {
+    const tsHash = makeTsHash(message.data.timestamp, message.hash);
+
+    if (tsHash.isErr()) {
+      return err(tsHash.error);
+    }
+
+    const target = message.data.reactionBody.targetCastId || message.data.reactionBody.targetUrl;
+
+    if (!target) {
+      return err(new HubError('bad_request.invalid_param', 'targetfid null'));
+    }
+
+    // Puts message key into the byTarget index
+    const byTargetKey = makeReactionsByTargetKey(target, message.data.fid, tsHash.value);
+    txn = txn.put(byTargetKey, Buffer.from([message.data.reactionBody.type]));
+
+    return ok(undefined);
+  }
+
+  override async deleteSecondaryIndices(txn: Transaction, message: ReactionAddMessage): HubAsyncResult<void> {
+    const tsHash = makeTsHash(message.data.timestamp, message.hash);
+
+    if (tsHash.isErr()) {
+      return err(tsHash.error);
+    }
+
+    const target = message.data.reactionBody.targetCastId || message.data.reactionBody.targetUrl;
+
+    if (!target) {
+      return err(new HubError('bad_request.invalid_param', 'targetfid null'));
+    }
+
+    // Delete the message key from byTarget index
+    const byTargetKey = makeReactionsByTargetKey(target, message.data.fid, tsHash.value);
+    txn = txn.del(byTargetKey);
+
+    return ok(undefined);
   }
 
   /* -------------------------------------------------------------------------- */
@@ -165,10 +216,9 @@ class ReactionStore {
    * @returns the ReactionAdd Model if it exists, undefined otherwise
    */
   async getReactionAdd(fid: number, type: ReactionType, target: CastId | string): Promise<ReactionAddMessage> {
-    const reactionAddsSetKey = makeReactionAddsKey(fid, type, target);
-    const reactionMessageKey = await this._db.get(reactionAddsSetKey);
-
-    return getMessage(this._db, fid, UserPostfix.ReactionMessage, reactionMessageKey);
+    const targetUrl = typeof target === 'string' ? target : undefined;
+    const targetCastId = typeof target === 'string' ? undefined : target;
+    return await this.getAdd({ data: { fid, reactionBody: { type, targetCastId, targetUrl } } });
   }
 
   /**
@@ -180,10 +230,9 @@ class ReactionStore {
    * @returns the ReactionRemove message if it exists, undefined otherwise
    */
   async getReactionRemove(fid: number, type: ReactionType, target: CastId | string): Promise<ReactionRemoveMessage> {
-    const reactionRemovesKey = makeReactionRemovesKey(fid, type, target);
-    const reactionMessageKey = await this._db.get(reactionRemovesKey);
-
-    return getMessage(this._db, fid, UserPostfix.ReactionMessage, reactionMessageKey);
+    const targetUrl = typeof target === 'string' ? target : undefined;
+    const targetCastId = typeof target === 'string' ? undefined : target;
+    return await this.getRemove({ data: { fid, reactionBody: { type, targetCastId, targetUrl } } });
   }
 
   /** Finds all ReactionAdd Messages by iterating through the prefixes */
@@ -192,11 +241,7 @@ class ReactionStore {
     type?: ReactionType,
     pageOptions: PageOptions = {}
   ): Promise<MessagesPage<ReactionAddMessage>> {
-    const prefix = makeMessagePrimaryKey(fid, UserPostfix.ReactionMessage);
-    const filter = (message: Message): message is ReactionAddMessage => {
-      return isReactionAddMessage(message) && (type ? message.data.reactionBody.type === type : true);
-    };
-    return getMessagesPageByPrefix(this._db, prefix, filter, pageOptions);
+    return await this.getAddsByFid({ data: { fid, reactionBody: { type: type as ReactionType } } }, pageOptions);
   }
 
   /** Finds all ReactionRemove Messages by iterating through the prefixes */
@@ -205,22 +250,14 @@ class ReactionStore {
     type?: ReactionType,
     pageOptions: PageOptions = {}
   ): Promise<MessagesPage<ReactionRemoveMessage>> {
-    const prefix = makeMessagePrimaryKey(fid, UserPostfix.ReactionMessage);
-    const filter = (message: Message): message is ReactionRemoveMessage => {
-      return isReactionRemoveMessage(message) && (type ? message.data.reactionBody.type === type : true);
-    };
-    return getMessagesPageByPrefix(this._db, prefix, filter, pageOptions);
+    return await this.getRemovesByFid({ data: { fid, reactionBody: { type: type as ReactionType } } }, pageOptions);
   }
 
   async getAllReactionMessagesByFid(
     fid: number,
     pageOptions: PageOptions = {}
   ): Promise<MessagesPage<ReactionAddMessage | ReactionRemoveMessage>> {
-    const prefix = makeMessagePrimaryKey(fid, UserPostfix.ReactionMessage);
-    const filter = (message: Message): message is ReactionAddMessage | ReactionRemoveMessage => {
-      return isReactionAddMessage(message) || isReactionRemoveMessage(message);
-    };
-    return getMessagesPageByPrefix(this._db, prefix, filter, pageOptions);
+    return await this.getAllMessagesByFid(fid, pageOptions);
   }
 
   /** Finds all ReactionAdds that point to a specific target by iterating through the prefixes */
@@ -271,405 +308,6 @@ class ReactionStore {
     } else {
       return { messages, nextPageToken: undefined };
     }
-  }
-
-  /** Merges a ReactionAdd or ReactionRemove message into the ReactionStore */
-  async merge(message: Message): Promise<number> {
-    if (!isReactionAddMessage(message) && !isReactionRemoveMessage(message)) {
-      throw new HubError('bad_request.validation_failure', 'invalid message type');
-    }
-
-    return this._mergeLock
-      .acquire(
-        message.data.fid.toString(),
-        async () => {
-          const prunableResult = await this._eventHandler.isPrunable(
-            message,
-            UserPostfix.ReactionMessage,
-            this._pruneSizeLimit,
-            this._pruneTimeLimit
-          );
-          if (prunableResult.isErr()) {
-            throw prunableResult.error;
-          } else if (prunableResult.value) {
-            throw new HubError('bad_request.prunable', 'message would be pruned');
-          }
-
-          if (isReactionAddMessage(message)) {
-            return this.mergeAdd(message);
-          } else if (isReactionRemoveMessage(message)) {
-            return this.mergeRemove(message);
-          } else {
-            throw new HubError('bad_request.validation_failure', 'invalid message type');
-          }
-        },
-        { timeout: MERGE_TIMEOUT_DEFAULT }
-      )
-      .catch((e: any) => {
-        throw isHubError(e) ? e : new HubError('unavailable.storage_failure', 'merge timed out');
-      });
-  }
-
-  async revoke(message: Message): HubAsyncResult<number> {
-    let txn = this._db.transaction();
-    if (isReactionAddMessage(message)) {
-      txn = this.deleteReactionAddTransaction(txn, message);
-    } else if (isReactionRemoveMessage(message)) {
-      txn = this.deleteReactionRemoveTransaction(txn, message);
-    } else {
-      return err(new HubError('bad_request.invalid_param', 'invalid message type'));
-    }
-
-    return this._eventHandler.commitTransaction(txn, {
-      type: HubEventType.REVOKE_MESSAGE,
-      revokeMessageBody: { message },
-    });
-  }
-
-  async pruneMessages(fid: number): HubAsyncResult<number[]> {
-    const commits: number[] = [];
-
-    const cachedCount = await this._eventHandler.getCacheMessageCount(fid, UserPostfix.ReactionMessage);
-
-    // Require storage cache to be synced to prune
-    if (cachedCount.isErr()) {
-      return err(cachedCount.error);
-    }
-
-    // Return immediately if there are no messages to prune
-    if (cachedCount.value === 0) {
-      return ok(commits);
-    }
-
-    const farcasterTime = getFarcasterTime();
-    if (farcasterTime.isErr()) {
-      return err(farcasterTime.error);
-    }
-
-    // Calculate the timestamp cut-off to prune
-    const timestampToPrune = farcasterTime.value - this._pruneTimeLimit;
-
-    // Create a rocksdb iterator for all messages with the given prefix
-    const pruneIterator = getMessagesPruneIterator(this._db, fid, UserPostfix.ReactionMessage);
-
-    const pruneNextMessage = async (): HubAsyncResult<number | undefined> => {
-      const nextMessage = await ResultAsync.fromPromise(getNextMessageFromIterator(pruneIterator), () => undefined);
-      if (nextMessage.isErr()) {
-        return ok(undefined); // Nothing left to prune
-      }
-
-      const count = await this._eventHandler.getCacheMessageCount(fid, UserPostfix.ReactionMessage);
-      if (count.isErr()) {
-        return err(count.error);
-      }
-
-      if (
-        count.value <= this._pruneSizeLimit &&
-        nextMessage.value.data &&
-        nextMessage.value.data.timestamp >= timestampToPrune
-      ) {
-        return ok(undefined);
-      }
-
-      let txn = this._db.transaction();
-
-      if (isReactionAddMessage(nextMessage.value)) {
-        txn = this.deleteReactionAddTransaction(txn, nextMessage.value);
-      } else if (isReactionRemoveMessage(nextMessage.value)) {
-        txn = this.deleteReactionRemoveTransaction(txn, nextMessage.value);
-      } else {
-        return err(new HubError('unknown', 'invalid message type'));
-      }
-
-      return this._eventHandler.commitTransaction(txn, {
-        type: HubEventType.PRUNE_MESSAGE,
-        pruneMessageBody: { message: nextMessage.value },
-      });
-    };
-
-    let pruneResult = await pruneNextMessage();
-    while (!(pruneResult.isOk() && pruneResult.value === undefined)) {
-      pruneResult.match(
-        (commit) => {
-          if (commit) {
-            commits.push(commit);
-          }
-        },
-        (e) => {
-          logger.error({ errCode: e.errCode }, `error pruning reaction message for fid ${fid}: ${e.message}`);
-        }
-      );
-
-      pruneResult = await pruneNextMessage();
-    }
-
-    await pruneIterator.end();
-
-    return ok(commits);
-  }
-
-  /* -------------------------------------------------------------------------- */
-  /*                               Private Methods                              */
-  /* -------------------------------------------------------------------------- */
-
-  private async mergeAdd(message: ReactionAddMessage): Promise<number> {
-    const mergeConflicts = await this.getMergeConflicts(message);
-    if (mergeConflicts.isErr()) {
-      throw mergeConflicts.error;
-    }
-
-    // Create rocksdb transaction to delete the merge conflicts
-    let txn = this.deleteManyTransaction(this._db.transaction(), mergeConflicts.value);
-
-    // Add ops to store the message by messageKey and index the the messageKey by set and by target
-    txn = this.putReactionAddTransaction(txn, message);
-
-    const hubEvent: HubEventArgs = {
-      type: HubEventType.MERGE_MESSAGE,
-      mergeMessageBody: { message, deletedMessages: mergeConflicts.value },
-    };
-
-    // Commit the RocksDB transaction
-    const result = await this._eventHandler.commitTransaction(txn, hubEvent);
-    if (result.isErr()) {
-      throw result.error;
-    }
-    return result.value;
-  }
-
-  private async mergeRemove(message: ReactionRemoveMessage): Promise<number> {
-    const mergeConflicts = await this.getMergeConflicts(message);
-
-    if (mergeConflicts.isErr()) {
-      throw mergeConflicts.error;
-    }
-
-    // Create rocksdb transaction to delete the merge conflicts
-    let txn = this.deleteManyTransaction(this._db.transaction(), mergeConflicts.value);
-
-    // Add ops to store the message by messageKey and index the the messageKey by set
-    txn = this.putReactionRemoveTransaction(txn, message);
-
-    const hubEvent: HubEventArgs = {
-      type: HubEventType.MERGE_MESSAGE,
-      mergeMessageBody: { message, deletedMessages: mergeConflicts.value },
-    };
-
-    // Commit the RocksDB transaction
-    const result = await this._eventHandler.commitTransaction(txn, hubEvent);
-    if (result.isErr()) {
-      throw result.error;
-    }
-    return result.value;
-  }
-
-  private reactionMessageCompare(
-    aType: MessageType.REACTION_ADD | MessageType.REACTION_REMOVE,
-    aTsHash: Uint8Array,
-    bType: MessageType.REACTION_ADD | MessageType.REACTION_REMOVE,
-    bTsHash: Uint8Array
-  ): number {
-    // Compare timestamps (first 4 bytes of tsHash) to enforce Last-Write-Wins
-    const timestampOrder = bytesCompare(aTsHash.subarray(0, 4), bTsHash.subarray(0, 4));
-    if (timestampOrder !== 0) {
-      return timestampOrder;
-    }
-
-    // Compare message types to enforce that RemoveWins in case of LWW ties.
-    if (aType === MessageType.REACTION_REMOVE && bType === MessageType.REACTION_ADD) {
-      return 1;
-    } else if (aType === MessageType.REACTION_ADD && bType === MessageType.REACTION_REMOVE) {
-      return -1;
-    }
-
-    // Compare hashes (last 4 bytes of tsHash) to break ties between messages of the same type and timestamp
-    return bytesCompare(aTsHash.subarray(4), bTsHash.subarray(4));
-  }
-
-  /**
-   * Determines the RocksDB keys that must be modified to settle merge conflicts as a result of
-   * adding a Reaction to the Store.
-   *
-   * @returns a RocksDB transaction if keys must be added or removed, undefined otherwise
-   */
-  private async getMergeConflicts(
-    message: ReactionAddMessage | ReactionRemoveMessage
-  ): HubAsyncResult<(ReactionAddMessage | ReactionRemoveMessage)[]> {
-    const target = message.data.reactionBody.targetCastId ?? message.data.reactionBody.targetUrl;
-    if (!target) {
-      throw new HubError('bad_request.validation_failure', 'target is missing');
-    }
-
-    const tsHash = makeTsHash(message.data.timestamp, message.hash);
-    if (tsHash.isErr()) {
-      throw tsHash.error;
-    }
-
-    const conflicts: (ReactionAddMessage | ReactionRemoveMessage)[] = [];
-
-    // Checks if there is a remove timestamp hash for this reaction
-    const reactionRemoveKey = makeReactionRemovesKey(message.data.fid, message.data.reactionBody.type, target);
-    const reactionRemoveTsHash = await ResultAsync.fromPromise(this._db.get(reactionRemoveKey), () => undefined);
-
-    if (reactionRemoveTsHash.isOk()) {
-      const removeCompare = this.reactionMessageCompare(
-        MessageType.REACTION_REMOVE,
-        new Uint8Array(reactionRemoveTsHash.value),
-        message.data.type,
-        tsHash.value
-      );
-      if (removeCompare > 0) {
-        return err(new HubError('bad_request.conflict', 'message conflicts with a more recent ReactionRemove'));
-      } else if (removeCompare === 0) {
-        return err(new HubError('bad_request.duplicate', 'message has already been merged'));
-      } else {
-        // If the existing remove has a lower order than the new message, retrieve the full
-        // ReactionRemove message and delete it as part of the RocksDB transaction
-        const existingRemove = await getMessage<ReactionRemoveMessage>(
-          this._db,
-          message.data.fid,
-          UserPostfix.ReactionMessage,
-          reactionRemoveTsHash.value
-        );
-        conflicts.push(existingRemove);
-      }
-    }
-
-    // Checks if there is an add timestamp hash for this reaction
-    const reactionAddKey = makeReactionAddsKey(message.data.fid, message.data.reactionBody.type, target);
-    const reactionAddTsHash = await ResultAsync.fromPromise(this._db.get(reactionAddKey), () => undefined);
-
-    if (reactionAddTsHash.isOk()) {
-      const addCompare = this.reactionMessageCompare(
-        MessageType.REACTION_ADD,
-        new Uint8Array(reactionAddTsHash.value),
-        message.data.type,
-        tsHash.value
-      );
-      if (addCompare > 0) {
-        return err(new HubError('bad_request.conflict', 'message conflicts with a more recent ReactionAdd'));
-      } else if (addCompare === 0) {
-        return err(new HubError('bad_request.duplicate', 'message has already been merged'));
-      } else {
-        // If the existing add has a lower order than the new message, retrieve the full
-        // ReactionAdd message and delete it as part of the RocksDB transaction
-        const existingAdd = await getMessage<ReactionAddMessage>(
-          this._db,
-          message.data.fid,
-          UserPostfix.ReactionMessage,
-          reactionAddTsHash.value
-        );
-        conflicts.push(existingAdd);
-      }
-    }
-
-    return ok(conflicts);
-  }
-
-  private deleteManyTransaction(
-    txn: Transaction,
-    messages: (ReactionAddMessage | ReactionRemoveMessage)[]
-  ): Transaction {
-    for (const message of messages) {
-      if (isReactionAddMessage(message)) {
-        txn = this.deleteReactionAddTransaction(txn, message);
-      } else if (isReactionRemoveMessage(message)) {
-        txn = this.deleteReactionRemoveTransaction(txn, message);
-      }
-    }
-    return txn;
-  }
-
-  /* Builds a RocksDB transaction to insert a ReactionAdd message and construct its indices */
-  private putReactionAddTransaction(txn: Transaction, message: ReactionAddMessage): Transaction {
-    const tsHash = makeTsHash(message.data.timestamp, message.hash);
-    if (tsHash.isErr()) {
-      throw tsHash.error;
-    }
-
-    const target = message.data.reactionBody.targetCastId ?? message.data.reactionBody.targetUrl;
-    if (!target) {
-      throw new HubError('bad_request.validation_failure', 'target is missing');
-    }
-
-    // Puts the message into the database
-    txn = putMessageTransaction(txn, message);
-
-    // Puts the message into the ReactionAdds Set index
-    const addsKey = makeReactionAddsKey(message.data.fid, message.data.reactionBody.type, target);
-    txn = txn.put(addsKey, Buffer.from(tsHash.value));
-
-    // Puts message key into the byTarget index
-    const byTargetKey = makeReactionsByTargetKey(target, message.data.fid, tsHash.value);
-    txn = txn.put(byTargetKey, Buffer.from([message.data.reactionBody.type]));
-
-    return txn;
-  }
-
-  /* Builds a RocksDB transaction to remove a ReactionAdd message and delete its indices */
-  private deleteReactionAddTransaction(txn: Transaction, message: ReactionAddMessage): Transaction {
-    const tsHash = makeTsHash(message.data.timestamp, message.hash);
-    if (tsHash.isErr()) {
-      throw tsHash.error;
-    }
-
-    const target = message.data.reactionBody.targetCastId ?? message.data.reactionBody.targetUrl;
-    if (!target) {
-      throw new HubError('bad_request.validation_failure', 'target is missing');
-    }
-
-    // Delete the message key from byTarget index
-    const byTargetKey = makeReactionsByTargetKey(target, message.data.fid, tsHash.value);
-    txn = txn.del(byTargetKey);
-
-    // Delete the message key from ReactionAdds Set index
-    const addsKey = makeReactionAddsKey(message.data.fid, message.data.reactionBody.type, target);
-    txn = txn.del(addsKey);
-
-    // Delete the message
-    return deleteMessageTransaction(txn, message);
-  }
-
-  /* Builds a RocksDB transaction to insert a ReactionRemove message and construct its indices */
-  private putReactionRemoveTransaction(txn: Transaction, message: ReactionRemoveMessage): Transaction {
-    const tsHash = makeTsHash(message.data.timestamp, message.hash);
-    if (tsHash.isErr()) {
-      throw tsHash.error;
-    }
-
-    const target = message.data.reactionBody.targetCastId ?? message.data.reactionBody.targetUrl;
-    if (!target) {
-      throw new HubError('bad_request.validation_failure', 'target is missing');
-    }
-
-    // Puts the message
-    txn = putMessageTransaction(txn, message);
-
-    // Puts message key into the ReactionRemoves Set index
-    const removesKey = makeReactionRemovesKey(message.data.fid, message.data.reactionBody.type, target);
-    txn = txn.put(removesKey, Buffer.from(tsHash.value));
-
-    return txn;
-  }
-
-  /* Builds a RocksDB transaction to remove a ReactionRemove message and delete its indices */
-  private deleteReactionRemoveTransaction(txn: Transaction, message: ReactionRemoveMessage): Transaction {
-    const tsHash = makeTsHash(message.data.timestamp, message.hash);
-    if (tsHash.isErr()) {
-      throw tsHash.error;
-    }
-
-    const target = message.data.reactionBody.targetCastId ?? message.data.reactionBody.targetUrl;
-    if (!target) {
-      throw new HubError('bad_request.validation_failure', 'target is missing');
-    }
-
-    // Delete message key from ReactionRemoves Set index
-    const removesKey = makeReactionRemovesKey(message.data.fid, message.data.reactionBody.type, target);
-    txn = txn.del(removesKey);
-
-    // Delete the message
-    return deleteMessageTransaction(txn, message);
   }
 }
 

--- a/apps/hubble/src/storage/stores/signerStore.test.ts
+++ b/apps/hubble/src/storage/stores/signerStore.test.ts
@@ -581,7 +581,7 @@ describe('merge', () => {
       test('fails with an earlier timestamp', async () => {
         await set.merge(signerAddLater);
         await expect(set.merge(signerAdd)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent SignerAdd')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent add')
         );
 
         await assertSignerDoesNotExist(signerAdd);
@@ -619,7 +619,7 @@ describe('merge', () => {
       test('fails with a lower hash', async () => {
         await set.merge(signerAddLater);
         await expect(set.merge(signerAdd)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent SignerAdd')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent add')
         );
 
         await assertSignerDoesNotExist(signerAdd);
@@ -651,7 +651,7 @@ describe('merge', () => {
       test('fails with an earlier timestamp', async () => {
         await set.merge(signerRemove);
         await expect(set.merge(signerAdd)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent SignerRemove')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent remove')
         );
 
         await assertSignerRemoveWins(signerRemove);
@@ -671,7 +671,7 @@ describe('merge', () => {
 
         await set.merge(signerRemoveLater);
         await expect(set.merge(signerAdd)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent SignerRemove')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent remove')
         );
 
         await assertSignerRemoveWins(signerRemoveLater);
@@ -687,7 +687,7 @@ describe('merge', () => {
 
         await set.merge(signerRemoveEarlier);
         await expect(set.merge(signerAdd)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent SignerRemove')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent remove')
         );
 
         await assertSignerDoesNotExist(signerAdd);
@@ -742,7 +742,7 @@ describe('merge', () => {
       test('fails with an earlier timestamp', async () => {
         await set.merge(signerRemoveLater);
         await expect(set.merge(signerRemove)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent SignerRemove')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent remove')
         );
 
         await assertSignerDoesNotExist(signerRemove);
@@ -779,7 +779,7 @@ describe('merge', () => {
       test('fails with a lower hash', async () => {
         await set.merge(signerRemoveLater);
         await expect(set.merge(signerRemove)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent SignerRemove')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent remove')
         );
 
         await assertSignerDoesNotExist(signerRemove);
@@ -811,7 +811,7 @@ describe('merge', () => {
 
         await set.merge(signerAddLater);
         await expect(set.merge(signerRemove)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent SignerAdd')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent add')
         );
 
         await assertSignerAddWins(signerAddLater);

--- a/apps/hubble/src/storage/stores/signerStore.ts
+++ b/apps/hubble/src/storage/stores/signerStore.ts
@@ -1,42 +1,26 @@
 import {
-  bytesCompare,
   HubAsyncResult,
   HubError,
   HubEventType,
   IdRegistryEvent,
-  isHubError,
   isSignerAddMessage,
   isSignerRemoveMessage,
-  Message,
   MessageType,
   SignerAddMessage,
   SignerRemoveMessage,
 } from '@farcaster/hub-nodejs';
-import AsyncLock from 'async-lock';
-import { err, ok, ResultAsync } from 'neverthrow';
+import { ok, ResultAsync } from 'neverthrow';
 import {
   getIdRegistryEvent,
   getIdRegistryEventByCustodyAddress,
   putIdRegistryEventTransaction,
 } from '../db/idRegistryEvent.js';
-import {
-  deleteMessageTransaction,
-  getMessage,
-  getMessagesPageByPrefix,
-  getMessagesPruneIterator,
-  getNextMessageFromIterator,
-  getPageIteratorByPrefix,
-  makeMessagePrimaryKey,
-  makeTsHash,
-  makeUserKey,
-  putMessageTransaction,
-} from '../db/message.js';
-import RocksDB, { Iterator, Transaction } from '../db/rocksdb.js';
-import { RootPrefix, UserPostfix } from '../db/types.js';
-import StoreEventHandler, { HubEventArgs } from './storeEventHandler.js';
-import { MERGE_TIMEOUT_DEFAULT, MessagesPage, PAGE_SIZE_MAX, PageOptions, StorePruneOptions } from './types.js';
+import { getPageIteratorByPrefix, makeUserKey } from '../db/message.js';
+import { Iterator } from '../db/rocksdb.js';
+import { RootPrefix, UserMessagePostfix, UserPostfix } from '../db/types.js';
+import { MessagesPage, PAGE_SIZE_MAX, PageOptions } from './types.js';
 import { eventCompare } from './utils.js';
-import { logger } from '../../utils/logger.js';
+import { Store } from './store.js';
 
 const PRUNE_SIZE_LIMIT_DEFAULT = 100;
 
@@ -98,17 +82,27 @@ const makeSignerRemovesKey = (fid: number, signerPubKey?: Uint8Array): Buffer =>
  * 1. fid:tsHash -> signer message
  * 2. fid:set:signerAddress -> fid:tsHash (Set Index)
  */
-class SignerStore {
-  private _db: RocksDB;
-  private _eventHandler: StoreEventHandler;
-  private _pruneSizeLimit: number;
-  private _mergeLock: AsyncLock;
+class SignerStore extends Store<SignerAddMessage, SignerRemoveMessage> {
+  override _postfix: UserMessagePostfix = UserPostfix.SignerMessage;
+  override makeAddKey(msg: SignerAddMessage) {
+    return makeSignerAddsKey(msg.data.fid, (msg.data.signerAddBody || msg.data.signerRemoveBody).signer) as Buffer;
+  }
 
-  constructor(db: RocksDB, eventHandler: StoreEventHandler, options: StorePruneOptions = {}) {
-    this._db = db;
-    this._eventHandler = eventHandler;
-    this._pruneSizeLimit = options.pruneSizeLimit ?? PRUNE_SIZE_LIMIT_DEFAULT;
-    this._mergeLock = new AsyncLock();
+  override makeRemoveKey(msg: SignerRemoveMessage) {
+    return makeSignerRemovesKey(msg.data.fid, (msg.data.signerAddBody || msg.data.signerRemoveBody).signer);
+  }
+
+  override _isAddType = isSignerAddMessage;
+  override _isRemoveType = isSignerRemoveMessage;
+  override _addMessageType = MessageType.SIGNER_ADD;
+  override _removeMessageType = MessageType.SIGNER_REMOVE;
+  protected override PRUNE_SIZE_LIMIT_DEFAULT = PRUNE_SIZE_LIMIT_DEFAULT;
+
+  override async findMergeAddConflicts(_message: SignerAddMessage): HubAsyncResult<void> {
+    return ok(undefined);
+  }
+  override async findMergeRemoveConflicts(_message: SignerRemoveMessage): HubAsyncResult<void> {
+    return ok(undefined);
   }
 
   /** Returns the most recent event from the IdRegistry contract that affected the fid  */
@@ -128,9 +122,7 @@ class SignerStore {
    * @returns the SignerAdd Model if it exists, throws Error otherwise
    */
   async getSignerAdd(fid: number, signer: Uint8Array): Promise<SignerAddMessage> {
-    const addKey = makeSignerAddsKey(fid, signer);
-    const messageTsHash = await this._db.get(addKey);
-    return getMessage(this._db, fid, UserPostfix.SignerMessage, messageTsHash);
+    return await this.getAdd({ data: { fid, signerAddBody: { signer } } });
   }
 
   /**
@@ -141,9 +133,7 @@ class SignerStore {
    * @returns the SignerRemove message if it exists, throws HubError otherwise
    */
   async getSignerRemove(fid: number, signer: Uint8Array): Promise<SignerRemoveMessage> {
-    const removeKey = makeSignerRemovesKey(fid, signer);
-    const messageTsHash = await this._db.get(removeKey);
-    return getMessage(this._db, fid, UserPostfix.SignerMessage, messageTsHash);
+    return await this.getRemove({ data: { fid, signerRemoveBody: { signer } } });
   }
 
   /**
@@ -153,8 +143,7 @@ class SignerStore {
    * @returns the SignerAdd messages if it exists, throws HubError otherwise
    */
   async getSignerAddsByFid(fid: number, pageOptions: PageOptions = {}): Promise<MessagesPage<SignerAddMessage>> {
-    const signerMessagesPrefix = makeMessagePrimaryKey(fid, UserPostfix.SignerMessage);
-    return getMessagesPageByPrefix(this._db, signerMessagesPrefix, isSignerAddMessage, pageOptions);
+    return await this.getAddsByFid({ data: { fid } }, pageOptions);
   }
 
   /**
@@ -164,19 +153,14 @@ class SignerStore {
    * @returns the SignerRemove messages if it exists, throws HubError otherwise
    */
   async getSignerRemovesByFid(fid: number, pageOptions: PageOptions = {}): Promise<MessagesPage<SignerRemoveMessage>> {
-    const signerMessagesPrefix = makeMessagePrimaryKey(fid, UserPostfix.SignerMessage);
-    return getMessagesPageByPrefix(this._db, signerMessagesPrefix, isSignerRemoveMessage, pageOptions);
+    return await this.getRemovesByFid({ data: { fid } }, pageOptions);
   }
 
   async getAllSignerMessagesByFid(
     fid: number,
     pageOptions: PageOptions = {}
   ): Promise<MessagesPage<SignerAddMessage | SignerRemoveMessage>> {
-    const signerMessagesPrefix = makeMessagePrimaryKey(fid, UserPostfix.SignerMessage);
-    const filter = (message: Message): message is SignerAddMessage | SignerRemoveMessage => {
-      return isSignerAddMessage(message) || isSignerRemoveMessage(message);
-    };
-    return getMessagesPageByPrefix(this._db, signerMessagesPrefix, filter, pageOptions);
+    return await this.getAllMessagesByFid(fid, pageOptions);
   }
 
   async getFids(pageOptions: PageOptions = {}): Promise<{
@@ -239,353 +223,6 @@ class SignerStore {
       throw result.error;
     }
     return result.value;
-  }
-
-  /** Merges a SignerAdd or SignerRemove message into the SignerStore */
-  async merge(message: Message): Promise<number> {
-    if (!isSignerAddMessage(message) && !isSignerRemoveMessage(message)) {
-      throw new HubError('bad_request.validation_failure', 'invalid message type');
-    }
-
-    return this._mergeLock
-      .acquire(
-        message.data.fid.toString(),
-        async () => {
-          const prunableResult = await this._eventHandler.isPrunable(
-            message,
-            UserPostfix.SignerMessage,
-            this._pruneSizeLimit
-          );
-          if (prunableResult.isErr()) {
-            throw prunableResult.error;
-          } else if (prunableResult.value) {
-            throw new HubError('bad_request.prunable', 'message would be pruned');
-          }
-
-          if (isSignerAddMessage(message)) {
-            return this.mergeAdd(message);
-          } else if (isSignerRemoveMessage(message)) {
-            return this.mergeRemove(message);
-          } else {
-            throw new HubError('bad_request.validation_failure', 'invalid message type');
-          }
-        },
-        { timeout: MERGE_TIMEOUT_DEFAULT }
-      )
-      .catch((e: Error) => {
-        throw isHubError(e) ? e : new HubError('unavailable.storage_failure', e.message);
-      });
-  }
-
-  async revoke(message: Message): HubAsyncResult<number> {
-    let txn = this._db.transaction();
-    if (isSignerAddMessage(message)) {
-      txn = this.deleteSignerAddTransaction(txn, message);
-    } else if (isSignerRemoveMessage(message)) {
-      txn = this.deleteSignerRemoveTransaction(txn, message);
-    } else {
-      return err(new HubError('bad_request.invalid_param', 'invalid message type'));
-    }
-
-    return this._eventHandler.commitTransaction(txn, {
-      type: HubEventType.REVOKE_MESSAGE,
-      revokeMessageBody: { message },
-    });
-  }
-
-  async pruneMessages(fid: number): HubAsyncResult<number[]> {
-    const commits: number[] = [];
-
-    const cachedCount = await this._eventHandler.getCacheMessageCount(fid, UserPostfix.SignerMessage);
-
-    // Require storage cache to be synced to prune
-    if (cachedCount.isErr()) {
-      return err(cachedCount.error);
-    }
-
-    // Return immediately if there are no messages to prune
-    if (cachedCount.value === 0) {
-      return ok(commits);
-    }
-
-    // Create a rocksdb iterator for all messages with the given prefix
-    const pruneIterator = getMessagesPruneIterator(this._db, fid, UserPostfix.SignerMessage);
-
-    const pruneNextMessage = async (): HubAsyncResult<number | undefined> => {
-      const nextMessage = await ResultAsync.fromPromise(getNextMessageFromIterator(pruneIterator), () => undefined);
-      if (nextMessage.isErr()) {
-        return ok(undefined); // Nothing left to prune
-      }
-
-      const count = await this._eventHandler.getCacheMessageCount(fid, UserPostfix.SignerMessage);
-      if (count.isErr()) {
-        return err(count.error);
-      }
-
-      if (count.value <= this._pruneSizeLimit) {
-        return ok(undefined);
-      }
-
-      let txn = this._db.transaction();
-
-      if (isSignerAddMessage(nextMessage.value)) {
-        txn = this.deleteSignerAddTransaction(txn, nextMessage.value);
-      } else if (isSignerRemoveMessage(nextMessage.value)) {
-        txn = this.deleteSignerRemoveTransaction(txn, nextMessage.value);
-      } else {
-        return err(new HubError('unknown', 'invalid message type'));
-      }
-
-      return this._eventHandler.commitTransaction(txn, {
-        type: HubEventType.PRUNE_MESSAGE,
-        pruneMessageBody: { message: nextMessage.value },
-      });
-    };
-
-    let pruneResult = await pruneNextMessage();
-    while (!(pruneResult.isOk() && pruneResult.value === undefined)) {
-      pruneResult.match(
-        (commit) => {
-          if (commit) {
-            commits.push(commit);
-          }
-        },
-        (e) => {
-          logger.error({ errCode: e.errCode }, `error pruning signer message for fid ${fid}: ${e.message}`);
-        }
-      );
-
-      pruneResult = await pruneNextMessage();
-    }
-
-    await pruneIterator.end();
-
-    return ok(commits);
-  }
-
-  /* -------------------------------------------------------------------------- */
-  /*                               Private Methods                              */
-  /* -------------------------------------------------------------------------- */
-
-  private async mergeAdd(message: SignerAddMessage): Promise<number> {
-    const mergeConflicts = await this.getMergeConflicts(message);
-
-    if (mergeConflicts.isErr()) {
-      throw mergeConflicts.error;
-    }
-
-    // Create rocksdb transaction to delete the merge conflicts
-    let txn = this.deleteManyTransaction(this._db.transaction(), mergeConflicts.value);
-
-    // Add putSignerAdd operations to the RocksDB transaction
-    txn = this.putSignerAddTransaction(txn, message);
-
-    const hubEvent: HubEventArgs = {
-      type: HubEventType.MERGE_MESSAGE,
-      mergeMessageBody: { message, deletedMessages: mergeConflicts.value },
-    };
-
-    // Commit the RocksDB transaction
-    const result = await this._eventHandler.commitTransaction(txn, hubEvent);
-    if (result.isErr()) {
-      throw result.error;
-    }
-    return result.value;
-  }
-
-  private async mergeRemove(message: SignerRemoveMessage): Promise<number> {
-    const mergeConflicts = await this.getMergeConflicts(message);
-
-    if (mergeConflicts.isErr()) {
-      throw mergeConflicts.error;
-    }
-
-    // Create rocksdb transaction to delete the merge conflicts
-    let txn = this.deleteManyTransaction(this._db.transaction(), mergeConflicts.value);
-
-    // Add putSignerRemove operations to the RocksDB transaction
-    txn = this.putSignerRemoveTransaction(txn, message);
-
-    const hubEvent: HubEventArgs = {
-      type: HubEventType.MERGE_MESSAGE,
-      mergeMessageBody: { message, deletedMessages: mergeConflicts.value },
-    };
-
-    // Commit the RocksDB transaction
-    const result = await this._eventHandler.commitTransaction(txn, hubEvent);
-    if (result.isErr()) {
-      throw result.error;
-    }
-    return result.value;
-  }
-
-  private signerMessageCompare(
-    aType: MessageType.SIGNER_ADD | MessageType.SIGNER_REMOVE,
-    aTsHash: Uint8Array,
-    bType: MessageType.SIGNER_ADD | MessageType.SIGNER_REMOVE,
-    bTsHash: Uint8Array
-  ): number {
-    // Compare timestamps (first 4 bytes of tsHash) to enforce Last-Write-Wins
-    const timestampOrder = bytesCompare(aTsHash.subarray(0, 4), bTsHash.subarray(0, 4));
-    if (timestampOrder !== 0) {
-      return timestampOrder;
-    }
-
-    if (aType === MessageType.SIGNER_REMOVE && bType === MessageType.SIGNER_ADD) {
-      return 1;
-    } else if (aType === MessageType.SIGNER_ADD && bType === MessageType.SIGNER_REMOVE) {
-      return -1;
-    }
-
-    // Compare hashes (last 4 bytes of tsHash) to break ties between messages of the same type and timestamp
-    return bytesCompare(aTsHash.subarray(4), bTsHash.subarray(4));
-  }
-
-  /**
-   * Determines the RocksDB keys that must be modified to settle merge conflicts as a result of adding a Signer to the Store.
-   *
-   * @returns a RocksDB transaction if keys must be added or removed, undefined otherwise
-   */
-  private async getMergeConflicts(
-    message: SignerAddMessage | SignerRemoveMessage
-  ): HubAsyncResult<(SignerAddMessage | SignerRemoveMessage)[]> {
-    const conflicts: (SignerAddMessage | SignerRemoveMessage)[] = [];
-
-    const signer = (message.data.signerAddBody ?? message.data.signerRemoveBody)?.signer;
-    if (!signer) {
-      return err(new HubError('bad_request.validation_failure', 'signer is missing'));
-    }
-
-    const tsHash = makeTsHash(message.data.timestamp, message.hash);
-    if (tsHash.isErr()) {
-      throw tsHash.error;
-    }
-
-    // Look up the remove tsHash for this signer
-    const removeTsHash = await ResultAsync.fromPromise(
-      this._db.get(makeSignerRemovesKey(message.data.fid, signer)),
-      () => undefined
-    );
-
-    if (removeTsHash.isOk()) {
-      const removeCompare = this.signerMessageCompare(
-        MessageType.SIGNER_REMOVE,
-        removeTsHash.value,
-        message.data.type,
-        tsHash.value
-      );
-      if (removeCompare > 0) {
-        return err(new HubError('bad_request.conflict', 'message conflicts with a more recent SignerRemove'));
-      } else if (removeCompare === 0) {
-        return err(new HubError('bad_request.duplicate', 'message has already been merged'));
-      } else {
-        // If the existing remove has a lower order than the new message, retrieve the full
-        // SignerRemove message and delete it as part of the RocksDB transaction
-        const existingRemove = await getMessage<SignerRemoveMessage>(
-          this._db,
-          message.data.fid,
-          UserPostfix.SignerMessage,
-          removeTsHash.value
-        );
-        conflicts.push(existingRemove);
-      }
-    }
-
-    // Look up the add tsHash for this custody address and signer
-    const addTsHash = await ResultAsync.fromPromise(
-      this._db.get(makeSignerAddsKey(message.data.fid, signer)),
-      () => undefined
-    );
-
-    if (addTsHash.isOk()) {
-      const addCompare = this.signerMessageCompare(
-        MessageType.SIGNER_ADD,
-        addTsHash.value,
-        message.data.type,
-        tsHash.value
-      );
-      if (addCompare > 0) {
-        return err(new HubError('bad_request.conflict', 'message conflicts with a more recent SignerAdd'));
-      } else if (addCompare === 0) {
-        return err(new HubError('bad_request.duplicate', 'message has already been merged'));
-      } else {
-        // If the existing add has a lower order than the new message, retrieve the full
-        // SignerAdd message and delete it as part of the RocksDB transaction
-        const existingAdd = await getMessage<SignerAddMessage>(
-          this._db,
-          message.data.fid,
-          UserPostfix.SignerMessage,
-          addTsHash.value
-        );
-        conflicts.push(existingAdd);
-      }
-    }
-
-    return ok(conflicts);
-  }
-
-  private deleteManyTransaction(txn: Transaction, messages: (SignerAddMessage | SignerRemoveMessage)[]): Transaction {
-    for (const message of messages) {
-      if (isSignerAddMessage(message)) {
-        txn = this.deleteSignerAddTransaction(txn, message);
-      } else if (isSignerRemoveMessage(message)) {
-        txn = this.deleteSignerRemoveTransaction(txn, message);
-      }
-    }
-    return txn;
-  }
-
-  /* Builds a RocksDB transaction to insert a SignerAdd message and construct its indices */
-  private putSignerAddTransaction(txn: Transaction, message: SignerAddMessage): Transaction {
-    const tsHash = makeTsHash(message.data.timestamp, message.hash);
-    if (tsHash.isErr()) {
-      throw tsHash.error;
-    }
-
-    // Put message and index by signer
-    txn = putMessageTransaction(txn, message);
-
-    // Put signerAdds index
-    txn = txn.put(makeSignerAddsKey(message.data.fid, message.data.signerAddBody.signer), Buffer.from(tsHash.value));
-
-    return txn;
-  }
-
-  /* Builds a RocksDB transaction to remove a SignerAdd message and delete its indices */
-  private deleteSignerAddTransaction(txn: Transaction, message: SignerAddMessage): Transaction {
-    // Delete from signerAdds
-    txn = txn.del(makeSignerAddsKey(message.data.fid, message.data.signerAddBody.signer));
-
-    // Delete message
-    return deleteMessageTransaction(txn, message);
-  }
-
-  /* Builds a RocksDB transaction to insert a SignerRemove message and construct its indices */
-  private putSignerRemoveTransaction(txn: Transaction, message: SignerRemoveMessage): Transaction {
-    const tsHash = makeTsHash(message.data.timestamp, message.hash);
-    if (tsHash.isErr()) {
-      throw tsHash.error;
-    }
-
-    // Put message and index by signer
-    txn = putMessageTransaction(txn, message);
-
-    // Put signerRemoves index
-    txn = txn.put(
-      makeSignerRemovesKey(message.data.fid, message.data.signerRemoveBody.signer),
-      Buffer.from(tsHash.value)
-    );
-
-    return txn;
-  }
-
-  /* Builds a RocksDB transaction to remove a SignerRemove message and delete its indices */
-  private deleteSignerRemoveTransaction(txn: Transaction, message: SignerRemoveMessage): Transaction {
-    // Delete from signerRemoves
-    txn = txn.del(makeSignerRemovesKey(message.data.fid, message.data.signerRemoveBody.signer));
-
-    // Delete message
-    return deleteMessageTransaction(txn, message);
   }
 }
 

--- a/apps/hubble/src/storage/stores/store.test.ts
+++ b/apps/hubble/src/storage/stores/store.test.ts
@@ -1,0 +1,124 @@
+import { CastAddMessage, CastRemoveMessage, NobleEd25519Signer, makeCastAdd } from '@farcaster/hub-nodejs';
+import * as ed from '@noble/ed25519';
+import { DeepPartial, Store } from './store.js';
+import { MessageType, HubAsyncResult } from '@farcaster/hub-nodejs';
+import { UserMessagePostfix, UserPostfix } from '../db/types.js';
+import { Message } from '@farcaster/hub-nodejs';
+import { isCastAddMessage } from '@farcaster/hub-nodejs';
+import { isCastRemoveMessage } from '@farcaster/hub-nodejs';
+import StoreEventHandler from './storeEventHandler.js';
+import { jestRocksDB } from '../db/jestUtils.js';
+import { ResultAsync, ok } from 'neverthrow';
+import { HubError } from '@farcaster/hub-nodejs';
+import { Transaction } from '../db/rocksdb.js';
+
+const db = jestRocksDB('protobufs.generalStore.test');
+const eventHandler = new StoreEventHandler(db);
+
+class TestStore extends Store<CastAddMessage, CastRemoveMessage> {
+  override makeAddKey(data: DeepPartial<CastAddMessage>) {
+    return data.hash as Uint8Array as Buffer;
+  }
+  override makeRemoveKey(data: DeepPartial<CastRemoveMessage>) {
+    return data.hash as Uint8Array as Buffer;
+  }
+  override _isAddType: (message: Message) => message is CastAddMessage = isCastAddMessage;
+  override _isRemoveType: ((message: Message) => message is CastRemoveMessage) | undefined = isCastRemoveMessage;
+  override _postfix: UserMessagePostfix = UserPostfix.CastMessage;
+  override _addMessageType: MessageType = MessageType.CAST_ADD;
+  override _removeMessageType: MessageType | undefined = MessageType.CAST_REMOVE;
+  override async findMergeAddConflicts(message: CastAddMessage): HubAsyncResult<void> {
+    // Look up the remove tsHash for this cast
+    const castRemoveTsHash = await ResultAsync.fromPromise(
+      this._db.get(this.makeRemoveKey(message as unknown as CastRemoveMessage)),
+      () => undefined
+    );
+
+    // If remove tsHash exists, fail because this cast has already been removed
+    if (castRemoveTsHash.isOk()) {
+      throw new HubError('bad_request.conflict', 'message conflicts with a CastRemove');
+    }
+
+    // Look up the add tsHash for this cast
+    const castAddTsHash = await ResultAsync.fromPromise(this._db.get(this.makeAddKey(message)), () => undefined);
+
+    // If add tsHash exists, no-op because this cast has already been added
+    if (castAddTsHash.isOk()) {
+      throw new HubError('bad_request.duplicate', 'message has already been merged');
+    }
+
+    return ok(undefined);
+  }
+  override async findMergeRemoveConflicts(message: CastRemoveMessage): HubAsyncResult<void> {
+    // Look up the remove tsHash for this cast
+    const castRemoveTsHash = await ResultAsync.fromPromise(
+      this._db.get(this.makeRemoveKey(message as unknown as CastRemoveMessage)),
+      () => undefined
+    );
+
+    // If remove tsHash exists, fail because this cast has already been removed
+    if (castRemoveTsHash.isOk()) {
+      throw new HubError('bad_request.conflict', 'message conflicts with a CastRemove');
+    }
+
+    return ok(undefined);
+  }
+  override async validateAdd(message: CastAddMessage): HubAsyncResult<void> {
+    // Look up the remove tsHash for this cast
+    const castRemoveTsHash = await ResultAsync.fromPromise(
+      this._db.get(this.makeRemoveKey(message as unknown as CastRemoveMessage)),
+      () => undefined
+    );
+
+    // If remove tsHash exists, fail because this cast has already been removed
+    if (castRemoveTsHash.isOk()) {
+      throw new HubError('bad_request.conflict', 'message conflicts with a CastRemove');
+    }
+
+    // Look up the add tsHash for this cast
+    const castAddTsHash = await ResultAsync.fromPromise(this._db.get(this.makeAddKey(message)), () => undefined);
+
+    // If add tsHash exists, no-op because this cast has already been added
+    if (castAddTsHash.isOk()) {
+      throw new HubError('bad_request.duplicate', 'message has already been merged');
+    }
+
+    return ok(undefined);
+  }
+  override validateRemove(_remove: CastRemoveMessage): HubAsyncResult<void> {
+    throw new Error('Method not implemented.');
+  }
+  override async buildSecondaryIndices(_txn: Transaction, _add: CastAddMessage): HubAsyncResult<void> {
+    return ok(undefined);
+  }
+  override async deleteSecondaryIndices(_txn: Transaction, _add: CastAddMessage): HubAsyncResult<void> {
+    return ok(undefined);
+  }
+}
+
+describe('store', () => {
+  test('creates keys following declared order', async () => {
+    const privKey = ed.utils.randomPrivateKey();
+    const ed25519Signer = new NobleEd25519Signer(privKey);
+    const castAdd = await makeCastAdd(
+      {
+        text: '',
+        embeds: [],
+        embedsDeprecated: [],
+        mentions: [],
+        mentionsPositions: [],
+      },
+      { fid: 1, network: 2 },
+      ed25519Signer
+    );
+
+    const store = new TestStore(db, eventHandler, {
+      pruneSizeLimit: 100,
+      pruneTimeLimit: 100,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    await store.merge(castAdd._unsafeUnwrap());
+
+    await store.getAdd({ hash: castAdd._unsafeUnwrap().hash, data: { fid: castAdd._unsafeUnwrap().data.fid } });
+  });
+});

--- a/apps/hubble/src/storage/stores/store.ts
+++ b/apps/hubble/src/storage/stores/store.ts
@@ -1,0 +1,645 @@
+import {
+  HubAsyncResult,
+  HubError,
+  HubEventType,
+  Message,
+  MessageType,
+  bytesCompare,
+  getFarcasterTime,
+  isHubError,
+} from '@farcaster/hub-nodejs';
+import {
+  deleteMessageTransaction,
+  getManyMessages,
+  getMessage,
+  getMessagesPageByPrefix,
+  getMessagesPruneIterator,
+  getNextMessageFromIterator,
+  getPageIteratorByPrefix,
+  makeMessagePrimaryKey,
+  makeTsHash,
+  putMessageTransaction,
+} from '../db/message.js';
+import RocksDB, { Iterator, Transaction } from '../db/rocksdb.js';
+import StoreEventHandler, { HubEventArgs } from './storeEventHandler.js';
+import { MERGE_TIMEOUT_DEFAULT, MessagesPage, PAGE_SIZE_MAX, PageOptions, StorePruneOptions } from './types.js';
+import AsyncLock from 'async-lock';
+import { TSHASH_LENGTH, UserMessagePostfix } from '../db/types.js';
+import { ResultAsync, err, ok } from 'neverthrow';
+import { logger } from '../../utils/logger.js';
+
+export type DeepPartial<T> = T extends object
+  ? {
+      [P in keyof T]?: DeepPartial<T[P]>;
+    }
+  : T;
+
+const deepPartialEquals = <T>(partial: DeepPartial<T>, whole: T) => {
+  if (typeof partial === 'object') {
+    for (const key in partial) {
+      // eslint-disable-next-line security/detect-object-injection
+      if (partial[key] !== undefined) {
+        // eslint-disable-next-line security/detect-object-injection
+        if (!deepPartialEquals(partial[key] as any, whole[key as keyof T] as any)) {
+          return false;
+        }
+      }
+    }
+  } else {
+    return partial === whole;
+  }
+
+  return true;
+};
+
+export abstract class Store<TAdd extends Message, TRemove extends Message> {
+  protected _db: RocksDB;
+  protected _eventHandler: StoreEventHandler;
+  private _pruneSizeLimit: number;
+  protected _pruneTimeLimit: number | undefined;
+  private _mergeLock: AsyncLock;
+
+  protected PRUNE_SIZE_LIMIT_DEFAULT = 10000;
+  protected PRUNE_TIME_LIMIT_DEFAULT: number | undefined;
+
+  abstract _postfix: UserMessagePostfix;
+
+  abstract makeAddKey(data: DeepPartial<TAdd>): Buffer;
+  abstract makeRemoveKey(data: DeepPartial<TRemove>): Buffer;
+  abstract _isAddType: (message: Message) => message is TAdd;
+  abstract _isRemoveType: ((message: Message) => message is TRemove) | undefined;
+  abstract _addMessageType: MessageType;
+  abstract _removeMessageType: MessageType | undefined;
+  abstract findMergeAddConflicts(message: TAdd): HubAsyncResult<void>;
+  abstract findMergeRemoveConflicts(message: TRemove): HubAsyncResult<void>;
+
+  async validateAdd(add: TAdd): HubAsyncResult<void> {
+    if (!add.data) {
+      return err(new HubError('bad_request.invalid_param', 'data null'));
+    }
+
+    const tsHash = makeTsHash(add.data.timestamp, add.hash);
+    if (tsHash.isErr()) {
+      return err(tsHash.error);
+    }
+
+    return ok(undefined);
+  }
+
+  async validateRemove(remove: TRemove): HubAsyncResult<void> {
+    if (!remove.data) {
+      return err(new HubError('bad_request.invalid_param', 'data null'));
+    }
+
+    const tsHash = makeTsHash(remove.data.timestamp, remove.hash);
+    if (tsHash.isErr()) {
+      return err(tsHash.error);
+    }
+
+    return ok(undefined);
+  }
+
+  async buildSecondaryIndices(_txn: Transaction, _add: TAdd): HubAsyncResult<void> {
+    return ok(undefined);
+  }
+  async deleteSecondaryIndices(_txn: Transaction, _add: TAdd): HubAsyncResult<void> {
+    return ok(undefined);
+  }
+
+  constructor(db: RocksDB, eventHandler: StoreEventHandler, options: StorePruneOptions = {}) {
+    this._db = db;
+    this._eventHandler = eventHandler;
+    this._pruneSizeLimit = options.pruneSizeLimit ?? this.PRUNE_SIZE_LIMIT_DEFAULT;
+    this._pruneTimeLimit = options.pruneTimeLimit ?? this.PRUNE_TIME_LIMIT_DEFAULT;
+    this._mergeLock = new AsyncLock();
+  }
+
+  /** Looks up TAdd message by tsHash */
+  async getAdd(extractible: DeepPartial<TAdd>): Promise<TAdd> {
+    if (!extractible.data?.fid) {
+      throw new HubError('bad_request.invalid_param', 'fid null');
+    }
+
+    const addsKey = this.makeAddKey(extractible);
+    const messageTsHash = await this._db.get(addsKey);
+    return getMessage(this._db, extractible.data.fid, this._postfix, messageTsHash);
+  }
+
+  /** Looks up TRemove message by cast tsHash */
+  async getRemove(extractible: DeepPartial<TRemove>): Promise<TRemove> {
+    if (!this._isRemoveType) {
+      throw new Error('remove type is unsupported for this store');
+    }
+
+    if (!extractible.data?.fid) {
+      throw new HubError('bad_request.invalid_param', 'fid null');
+    }
+
+    const removesKey = this.makeRemoveKey(extractible);
+    const messageTsHash = await this._db.get(removesKey);
+    return getMessage(this._db, extractible.data.fid, this._postfix, messageTsHash);
+  }
+
+  /** Gets all TAdd messages for an fid */
+  async getAddsByFid(extractible: DeepPartial<TAdd>, pageOptions: PageOptions = {}): Promise<MessagesPage<TAdd>> {
+    if (!extractible.data?.fid) {
+      throw new HubError('bad_request.invalid_param', 'fid null');
+    }
+
+    const castMessagesPrefix = makeMessagePrimaryKey(extractible.data.fid, this._postfix);
+    const filter = (message: Message): message is TAdd => {
+      return this._isAddType(message) && deepPartialEquals(extractible, message);
+    };
+    return getMessagesPageByPrefix(this._db, castMessagesPrefix, filter, pageOptions);
+  }
+
+  /** Gets all TRemove messages for an fid */
+  async getRemovesByFid(
+    extractible: DeepPartial<TRemove>,
+    pageOptions: PageOptions = {}
+  ): Promise<MessagesPage<TRemove>> {
+    if (!this._isRemoveType) {
+      throw new Error('remove type is unsupported for this store');
+    }
+
+    if (!extractible.data?.fid) {
+      throw new HubError('bad_request.invalid_param', 'fid null');
+    }
+
+    const castMessagesPrefix = makeMessagePrimaryKey(extractible.data.fid, this._postfix);
+    const filter = (message: Message): message is TRemove => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return this._isRemoveType!(message) && deepPartialEquals(extractible, message);
+    };
+    return getMessagesPageByPrefix(this._db, castMessagesPrefix, filter, pageOptions);
+  }
+
+  async getAllMessagesByFid(fid: number, pageOptions: PageOptions = {}): Promise<MessagesPage<TAdd | TRemove>> {
+    const prefix = makeMessagePrimaryKey(fid, this._postfix);
+    const filter = (message: Message): message is TAdd | TRemove => {
+      return this._isAddType(message) || (!!this._isRemoveType && this._isRemoveType(message));
+    };
+    return getMessagesPageByPrefix(this._db, prefix, filter, pageOptions);
+  }
+
+  /** Merges a TAdd or TRemove message into the Store */
+  async merge(message: Message): Promise<number> {
+    if (!this._isAddType(message) && (!this._isRemoveType || !this._isRemoveType(message))) {
+      throw new HubError('bad_request.validation_failure', 'invalid message type');
+    }
+
+    if (!message.data) {
+      throw new HubError('bad_request.invalid_param', 'data null');
+    }
+
+    return this._mergeLock
+      .acquire(
+        message.data.fid.toString(),
+        async () => {
+          const prunableResult = await this._eventHandler.isPrunable(
+            message as any,
+            this._postfix,
+            this._pruneSizeLimit,
+            this._pruneTimeLimit
+          );
+          if (prunableResult.isErr()) {
+            throw prunableResult.error;
+          } else if (prunableResult.value) {
+            throw new HubError('bad_request.prunable', 'message would be pruned');
+          }
+
+          if (this._isAddType(message)) {
+            return this.mergeAdd(message);
+          } else if (this._isRemoveType && this._isRemoveType(message)) {
+            return this.mergeRemove(message);
+          } else {
+            throw new HubError('bad_request.validation_failure', 'invalid message type');
+          }
+        },
+        { timeout: MERGE_TIMEOUT_DEFAULT }
+      )
+      .catch((e: any) => {
+        throw isHubError(e) ? e : new HubError('unavailable.storage_failure', 'merge timed out');
+      });
+  }
+
+  async revoke(message: Message): HubAsyncResult<number> {
+    let txn = this._db.transaction();
+    if (this._isAddType(message)) {
+      const txnMaybe = await this.deleteAddTransaction(txn, message);
+      if (txnMaybe.isErr()) throw txnMaybe.error;
+      txn = txnMaybe.value;
+    } else if (this._isRemoveType && this._isRemoveType(message)) {
+      const txnMaybe = await this.deleteRemoveTransaction(txn, message);
+      if (txnMaybe.isErr()) throw txnMaybe.error;
+      txn = txnMaybe.value;
+    } else {
+      return err(new HubError('bad_request.invalid_param', 'invalid message type'));
+    }
+
+    return this._eventHandler.commitTransaction(txn, {
+      type: HubEventType.REVOKE_MESSAGE,
+      revokeMessageBody: { message },
+    });
+  }
+
+  async pruneMessages(fid: number): HubAsyncResult<number[]> {
+    const commits: number[] = [];
+
+    const cachedCount = await this._eventHandler.getCacheMessageCount(fid, this._postfix);
+
+    // Require storage cache to be synced to prune
+    if (cachedCount.isErr()) {
+      return err(cachedCount.error);
+    }
+
+    // Return immediately if there are no messages to prune
+    if (cachedCount.value === 0) {
+      return ok(commits);
+    }
+
+    const farcasterTime = getFarcasterTime();
+    if (farcasterTime.isErr()) {
+      return err(farcasterTime.error);
+    }
+
+    // Calculate the timestamp cut-off to prune
+    const timestampToPrune =
+      this._pruneTimeLimit === undefined ? undefined : farcasterTime.value - this._pruneTimeLimit;
+
+    // Create a rocksdb iterator for all messages with the given prefix
+    const pruneIterator = getMessagesPruneIterator(this._db, fid, this._postfix);
+
+    const pruneNextMessage = async (): HubAsyncResult<number | undefined> => {
+      const nextMessage = await ResultAsync.fromPromise(getNextMessageFromIterator(pruneIterator), () => undefined);
+      if (nextMessage.isErr()) {
+        return ok(undefined); // Nothing left to prune
+      }
+
+      const count = await this._eventHandler.getCacheMessageCount(fid, this._postfix);
+      if (count.isErr()) {
+        return err(count.error);
+      }
+
+      if (
+        count.value <= this._pruneSizeLimit &&
+        (timestampToPrune === undefined ||
+          (nextMessage.value.data && nextMessage.value.data.timestamp >= timestampToPrune))
+      ) {
+        return ok(undefined);
+      }
+
+      let txn = this._db.transaction();
+
+      if (this._isAddType(nextMessage.value)) {
+        const txnMaybe = await this.deleteAddTransaction(txn, nextMessage.value);
+        if (txnMaybe.isErr()) throw txnMaybe.error;
+        txn = txnMaybe.value;
+      } else if (this._isRemoveType && this._isRemoveType(nextMessage.value)) {
+        const txnMaybe = await this.deleteRemoveTransaction(txn, nextMessage.value);
+        if (txnMaybe.isErr()) throw txnMaybe.error;
+        txn = txnMaybe.value;
+      } else {
+        return err(new HubError('unknown', 'invalid message type'));
+      }
+
+      return this._eventHandler.commitTransaction(txn, {
+        type: HubEventType.PRUNE_MESSAGE,
+        pruneMessageBody: { message: nextMessage.value },
+      });
+    };
+
+    let pruneResult = await pruneNextMessage();
+    while (!(pruneResult.isOk() && pruneResult.value === undefined)) {
+      pruneResult.match(
+        (commit) => {
+          if (commit) {
+            commits.push(commit);
+          }
+        },
+        (e) => {
+          logger.error({ errCode: e.errCode }, `error pruning message for fid ${fid}: ${e.message}`);
+        }
+      );
+
+      pruneResult = await pruneNextMessage();
+    }
+
+    await pruneIterator.end();
+
+    return ok(commits);
+  }
+
+  protected async getBySecondaryIndex(prefix: Buffer, pageOptions: PageOptions = {}): Promise<MessagesPage<TAdd>> {
+    const iterator = getPageIteratorByPrefix(this._db, prefix, pageOptions);
+
+    const limit = pageOptions.pageSize || PAGE_SIZE_MAX;
+
+    const messageKeys: Buffer[] = [];
+
+    // Custom method to retrieve message key from key
+    const getNextIteratorRecord = async (iterator: Iterator): Promise<[Buffer, Buffer]> => {
+      const [key] = await iterator.next();
+      const fid = Number((key as Buffer).readUint32BE(prefix.length + TSHASH_LENGTH));
+      const tsHash = Uint8Array.from(key as Buffer).subarray(prefix.length, prefix.length + TSHASH_LENGTH);
+      const messagePrimaryKey = makeMessagePrimaryKey(fid, this._postfix, tsHash);
+      return [key as Buffer, messagePrimaryKey];
+    };
+
+    let iteratorFinished = false;
+    let lastPageToken: Uint8Array | undefined;
+    do {
+      const result = await ResultAsync.fromPromise(getNextIteratorRecord(iterator), (e) => e as HubError);
+      if (result.isErr()) {
+        iteratorFinished = true;
+        break;
+      }
+
+      const [key, messageKey] = result.value;
+      lastPageToken = Uint8Array.from(key.subarray(prefix.length));
+      messageKeys.push(messageKey);
+    } while (messageKeys.length < limit);
+
+    const messages = await getManyMessages<TAdd>(this._db, messageKeys);
+
+    if (!iteratorFinished) {
+      await iterator.end(); // clear iterator if it has not finished
+      return { messages, nextPageToken: lastPageToken };
+    } else {
+      return { messages, nextPageToken: undefined };
+    }
+  }
+
+  /* -------------------------------------------------------------------------- */
+  /*                               Private Methods                              */
+  /* -------------------------------------------------------------------------- */
+
+  private async mergeAdd(message: TAdd): Promise<number> {
+    const mergeConflicts = await this.getMergeConflicts(message);
+    if (mergeConflicts.isErr()) {
+      throw mergeConflicts.error;
+    }
+
+    // Create rocksdb transaction to delete the merge conflicts
+    let txn = await this.deleteManyTransaction(this._db.transaction(), mergeConflicts.value);
+
+    // Add ops to store the message by messageKey and index the the messageKey by set and by target
+    const addTxn = await this.putAddTransaction(txn, message);
+    if (addTxn.isErr()) {
+      throw addTxn.error;
+    }
+
+    txn = addTxn.value;
+
+    const hubEvent: HubEventArgs = {
+      type: HubEventType.MERGE_MESSAGE,
+      mergeMessageBody: { message, deletedMessages: mergeConflicts.value },
+    };
+
+    // Commit the RocksDB transaction
+    const result = await this._eventHandler.commitTransaction(txn, hubEvent);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    return result.value;
+  }
+
+  private async mergeRemove(message: TRemove): Promise<number> {
+    const mergeConflicts = await this.getMergeConflicts(message);
+
+    if (mergeConflicts.isErr()) {
+      throw mergeConflicts.error;
+    }
+
+    // Create rocksdb transaction to delete the merge conflicts
+    let txn = await this.deleteManyTransaction(this._db.transaction(), mergeConflicts.value);
+
+    // Add ops to store the message by messageKey and index the the messageKey by set
+    const txnRemove = await this.putRemoveTransaction(txn, message);
+    if (txnRemove.isErr()) {
+      throw txnRemove.error;
+    }
+
+    txn = txnRemove.value;
+
+    const hubEvent: HubEventArgs = {
+      type: HubEventType.MERGE_MESSAGE,
+      mergeMessageBody: { message, deletedMessages: mergeConflicts.value },
+    };
+
+    // Commit the RocksDB transaction
+    const result = await this._eventHandler.commitTransaction(txn, hubEvent);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    return result.value;
+  }
+
+  protected messageCompare(aType: MessageType, aTsHash: Uint8Array, bType: MessageType, bTsHash: Uint8Array): number {
+    // Compare timestamps (first 4 bytes of tsHash) to enforce Last-Write-Wins
+    const timestampOrder = bytesCompare(aTsHash.subarray(0, 4), bTsHash.subarray(0, 4));
+    if (timestampOrder !== 0) {
+      return timestampOrder;
+    }
+
+    // Compare message types to enforce that RemoveWins in case of LWW ties.
+    if (aType === this._removeMessageType && bType === this._addMessageType) {
+      return 1;
+    } else if (aType === this._addMessageType && bType === this._removeMessageType) {
+      return -1;
+    }
+
+    // Compare hashes (last 4 bytes of tsHash) to break ties between messages of the same type and timestamp
+    return bytesCompare(aTsHash.subarray(4), bTsHash.subarray(4));
+  }
+
+  /**
+   * Determines the RocksDB keys that must be modified to settle merge conflicts as a result of
+   * adding a Message to the Store.
+   *
+   * @returns a RocksDB transaction if keys must be added or removed, undefined otherwise
+   */
+  private async getMergeConflicts(message: TAdd | TRemove): HubAsyncResult<(TAdd | TRemove)[]> {
+    const validateResult = await (this._isAddType(message) ? this.validateAdd(message) : this.validateRemove(message));
+
+    if (validateResult.isErr()) {
+      return err(validateResult.error);
+    }
+
+    const checkResult = await (this._isAddType(message)
+      ? this.findMergeAddConflicts(message)
+      : this.findMergeRemoveConflicts(message));
+
+    if (checkResult.isErr()) {
+      return err(checkResult.error);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const tsHash = makeTsHash(message.data!.timestamp, message.hash);
+    if (tsHash.isErr()) {
+      throw tsHash.error;
+    }
+
+    const conflicts: (TAdd | TRemove)[] = [];
+
+    if (this._isRemoveType) {
+      // Checks if there is a remove timestamp hash for this
+      const removeKey = this.makeRemoveKey(message as any);
+      const removeTsHash = await ResultAsync.fromPromise(this._db.get(removeKey), () => undefined);
+
+      if (removeTsHash.isOk()) {
+        const removeCompare = this.messageCompare(
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          this._removeMessageType!,
+          new Uint8Array(removeTsHash.value),
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          message.data!.type,
+          tsHash.value
+        );
+        if (removeCompare > 0) {
+          return err(new HubError('bad_request.conflict', 'message conflicts with a more recent remove'));
+        } else if (removeCompare === 0) {
+          return err(new HubError('bad_request.duplicate', 'message has already been merged'));
+        } else {
+          // If the existing remove has a lower order than the new message, retrieve the full
+          // TRemove message and delete it as part of the RocksDB transaction
+          const existingRemove = await getMessage<TRemove>(
+            this._db,
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            message.data!.fid,
+            this._postfix,
+            removeTsHash.value
+          );
+          conflicts.push(existingRemove);
+        }
+      }
+    }
+    // Checks if there is an add timestamp hash for this
+    const addKey = this.makeAddKey(message as any);
+    const addTsHash = await ResultAsync.fromPromise(this._db.get(addKey), () => undefined);
+
+    if (addTsHash.isOk()) {
+      const addCompare = this.messageCompare(
+        this._addMessageType,
+        new Uint8Array(addTsHash.value),
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        message.data!.type,
+        tsHash.value
+      );
+      if (addCompare > 0) {
+        return err(new HubError('bad_request.conflict', 'message conflicts with a more recent add'));
+      } else if (addCompare === 0) {
+        return err(new HubError('bad_request.duplicate', 'message has already been merged'));
+      } else {
+        // If the existing add has a lower order than the new message, retrieve the full
+        // TAdd message and delete it as part of the RocksDB transaction
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const existingAdd = await getMessage<TAdd>(this._db, message.data!.fid, this._postfix, addTsHash.value);
+        conflicts.push(existingAdd);
+      }
+    }
+
+    return ok(conflicts);
+  }
+
+  private async deleteManyTransaction(txn: Transaction, messages: (TAdd | TRemove)[]): Promise<Transaction> {
+    for (const message of messages) {
+      if (this._isAddType(message)) {
+        const txnMaybe = await this.deleteAddTransaction(txn, message);
+        if (txnMaybe.isErr()) throw txnMaybe.error;
+        txn = txnMaybe.value;
+      } else if (this._isRemoveType && this._isRemoveType(message)) {
+        const txnMaybe = await this.deleteRemoveTransaction(txn, message);
+        if (txnMaybe.isErr()) throw txnMaybe.error;
+        txn = txnMaybe.value;
+      }
+    }
+    return txn;
+  }
+
+  /* Builds a RocksDB transaction to insert a TAdd message and construct its indices */
+  private async putAddTransaction(txn: Transaction, message: TAdd): HubAsyncResult<Transaction> {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const tsHash = makeTsHash(message.data!.timestamp, message.hash);
+    if (tsHash.isErr()) {
+      throw tsHash.error;
+    }
+
+    // Puts the message into the database
+    txn = putMessageTransaction(txn, message);
+
+    // Puts the message into the TAdds Set index
+    const addsKey = this.makeAddKey(message as any);
+    txn = txn.put(addsKey, Buffer.from(tsHash.value));
+
+    const build = await this.buildSecondaryIndices(txn, message);
+    if (build.isErr()) {
+      return err(build.error);
+    }
+
+    return ok(txn);
+  }
+
+  /* Builds a RocksDB transaction to remove a TAdd message and delete its indices */
+  private async deleteAddTransaction(txn: Transaction, message: TAdd): HubAsyncResult<Transaction> {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const tsHash = makeTsHash(message.data!.timestamp, message.hash);
+    if (tsHash.isErr()) {
+      throw tsHash.error;
+    }
+
+    const build = await this.deleteSecondaryIndices(txn, message);
+    if (build.isErr()) {
+      return err(build.error);
+    }
+
+    // Delete the message key from TAdds Set index
+    const addsKey = this.makeAddKey(message as any);
+    txn = txn.del(addsKey);
+
+    // Delete the message
+    return ok(deleteMessageTransaction(txn, message));
+  }
+
+  /* Builds a RocksDB transaction to insert a TRemove message and construct its indices */
+  private async putRemoveTransaction(txn: Transaction, message: TRemove): HubAsyncResult<Transaction> {
+    if (!this._isRemoveType) {
+      throw new Error('remove type is unsupported for this store');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const tsHash = makeTsHash(message.data!.timestamp, message.hash);
+    if (tsHash.isErr()) {
+      throw tsHash.error;
+    }
+
+    // Puts the message
+    txn = putMessageTransaction(txn, message);
+
+    // Puts message key into the TRemoves Set index
+    const removesKey = this.makeRemoveKey(message as any);
+    txn = txn.put(removesKey, Buffer.from(tsHash.value));
+
+    return ok(txn);
+  }
+
+  /* Builds a RocksDB transaction to remove a TRemove message and delete its indices */
+  private async deleteRemoveTransaction(txn: Transaction, message: TRemove): HubAsyncResult<Transaction> {
+    if (!this._isRemoveType) {
+      throw new Error('remove type is unsupported for this store');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const tsHash = makeTsHash(message.data!.timestamp, message.hash);
+    if (tsHash.isErr()) {
+      throw tsHash.error;
+    }
+
+    // Delete message key from TRemoves Set index
+    const removesKey = this.makeRemoveKey(message as any);
+    txn = txn.del(removesKey);
+
+    // Delete the message
+    return ok(deleteMessageTransaction(txn, message));
+  }
+}

--- a/apps/hubble/src/storage/stores/storeEventHandler.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.ts
@@ -245,6 +245,7 @@ class StoreEventHandler extends TypedEmitter<StoreEvents> {
     if (messageCount.isErr()) {
       return err(messageCount.error);
     }
+
     if (messageCount.value < sizeLimit) {
       return ok(false);
     }

--- a/apps/hubble/src/storage/stores/userDataStore.test.ts
+++ b/apps/hubble/src/storage/stores/userDataStore.test.ts
@@ -168,7 +168,7 @@ describe('merge', () => {
       test('fails with an earlier timestamp', async () => {
         await set.merge(addPfpLater);
         await expect(set.merge(addPfp)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent UserDataAdd')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent add')
         );
 
         await assertUserDataDoesNotExist(addPfp);
@@ -202,7 +202,7 @@ describe('merge', () => {
       test('fails with a lower hash', async () => {
         await set.merge(addPfpLater);
         await expect(set.merge(addPfp)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent UserDataAdd')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent add')
         );
 
         await assertUserDataDoesNotExist(addPfp);

--- a/apps/hubble/src/storage/stores/verificationStore.test.ts
+++ b/apps/hubble/src/storage/stores/verificationStore.test.ts
@@ -192,7 +192,7 @@ describe('merge', () => {
       test('fails with an earlier timestamp', async () => {
         await set.merge(verificationAddLater);
         await expect(set.merge(verificationAdd)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent VerificationAddEthAddress')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent add')
         );
         await assertVerificationDoesNotExist(verificationAdd);
         await assertVerificationAddWins(verificationAddLater);
@@ -224,7 +224,7 @@ describe('merge', () => {
       test('fails with a lower hash', async () => {
         await set.merge(verificationAddLater);
         await expect(set.merge(verificationAdd)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent VerificationAddEthAddress')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent add')
         );
         await assertVerificationDoesNotExist(verificationAdd);
         await assertVerificationAddWins(verificationAddLater);
@@ -250,7 +250,7 @@ describe('merge', () => {
       test('fails with an earlier timestamp', async () => {
         await set.merge(verificationRemove);
         await expect(set.merge(verificationAdd)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent VerificationRemove')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent remove')
         );
         await assertVerificationRemoveWins(verificationRemove);
         await assertVerificationDoesNotExist(verificationAdd);
@@ -266,7 +266,7 @@ describe('merge', () => {
 
         await set.merge(verificationRemoveLater);
         await expect(set.merge(verificationAdd)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent VerificationRemove')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent remove')
         );
         await assertVerificationRemoveWins(verificationRemoveLater);
         await assertVerificationDoesNotExist(verificationAdd);
@@ -281,7 +281,7 @@ describe('merge', () => {
 
         await set.merge(verificationRemoveEarlier);
         await expect(set.merge(verificationAdd)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent VerificationRemove')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent remove')
         );
         await assertVerificationRemoveWins(verificationRemoveEarlier);
         await assertVerificationDoesNotExist(verificationAdd);
@@ -329,7 +329,7 @@ describe('merge', () => {
       test('fails with an earlier timestamp', async () => {
         await set.merge(verificationRemoveLater);
         await expect(set.merge(verificationRemove)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent VerificationRemove')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent remove')
         );
         await assertVerificationDoesNotExist(verificationRemove);
         await assertVerificationRemoveWins(verificationRemoveLater);
@@ -361,7 +361,7 @@ describe('merge', () => {
       test('fails with a lower hash', async () => {
         await set.merge(verificationRemoveLater);
         await expect(set.merge(verificationRemove)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent VerificationRemove')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent remove')
         );
         await assertVerificationDoesNotExist(verificationRemove);
         await assertVerificationRemoveWins(verificationRemoveLater);
@@ -388,7 +388,7 @@ describe('merge', () => {
 
         await set.merge(verificationAddLater);
         await expect(set.merge(verificationRemove)).rejects.toEqual(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent VerificationAddEthAddress')
+          new HubError('bad_request.conflict', 'message conflicts with a more recent add')
         );
         await assertVerificationAddWins(verificationAddLater);
         await assertVerificationDoesNotExist(verificationRemove);

--- a/apps/hubble/src/storage/stores/verificationStore.ts
+++ b/apps/hubble/src/storage/stores/verificationStore.ts
@@ -1,34 +1,16 @@
 import {
-  bytesCompare,
   HubAsyncResult,
-  HubError,
-  HubEventType,
-  isHubError,
   isVerificationAddEthAddressMessage,
   isVerificationRemoveMessage,
-  Message,
   MessageType,
   VerificationAddEthAddressMessage,
   VerificationRemoveMessage,
 } from '@farcaster/hub-nodejs';
-import AsyncLock from 'async-lock';
-import { err, ok, ResultAsync } from 'neverthrow';
-import {
-  deleteMessageTransaction,
-  getMessage,
-  getMessagesPageByPrefix,
-  getMessagesPruneIterator,
-  getNextMessageFromIterator,
-  makeMessagePrimaryKey,
-  makeTsHash,
-  makeUserKey,
-  putMessageTransaction,
-} from '../db/message.js';
-import RocksDB, { Transaction } from '../db/rocksdb.js';
-import { UserPostfix } from '../db/types.js';
-import StoreEventHandler, { HubEventArgs } from './storeEventHandler.js';
-import { MERGE_TIMEOUT_DEFAULT, MessagesPage, PageOptions, StorePruneOptions } from './types.js';
-import { logger } from '../../utils/logger.js';
+import { ok } from 'neverthrow';
+import { makeUserKey } from '../db/message.js';
+import { UserMessagePostfix, UserPostfix } from '../db/types.js';
+import { MessagesPage, PageOptions } from './types.js';
+import { Store } from './store.js';
 
 const PRUNE_SIZE_LIMIT_DEFAULT = 50;
 
@@ -81,18 +63,36 @@ const makeVerificationRemovesKey = (fid: number, address?: Uint8Array): Buffer =
  * 2. fid:set:address -> fid:tsHash (Set Index)
  */
 
-class VerificationStore {
-  private _db: RocksDB;
-  private _eventHandler: StoreEventHandler;
-  private _pruneSizeLimit: number;
-  private _mergeLock: AsyncLock;
+class VerificationStore extends Store<VerificationAddEthAddressMessage, VerificationRemoveMessage> {
+  override _postfix: UserMessagePostfix = UserPostfix.VerificationMessage;
 
-  constructor(db: RocksDB, eventHandler: StoreEventHandler, options: StorePruneOptions = {}) {
-    this._db = db;
-    this._eventHandler = eventHandler;
-    this._pruneSizeLimit = options.pruneSizeLimit ?? PRUNE_SIZE_LIMIT_DEFAULT;
-    this._mergeLock = new AsyncLock();
+  override makeAddKey(msg: VerificationAddEthAddressMessage) {
+    return makeVerificationAddsKey(
+      msg.data.fid,
+      (msg.data.verificationAddEthAddressBody || msg.data.verificationRemoveBody).address
+    ) as Buffer;
   }
+
+  override makeRemoveKey(msg: VerificationRemoveMessage) {
+    return makeVerificationRemovesKey(
+      msg.data.fid,
+      (msg.data.verificationAddEthAddressBody || msg.data.verificationRemoveBody).address
+    );
+  }
+
+  override async findMergeAddConflicts(_message: VerificationAddEthAddressMessage): HubAsyncResult<void> {
+    return ok(undefined);
+  }
+
+  override async findMergeRemoveConflicts(_message: VerificationRemoveMessage): HubAsyncResult<void> {
+    return ok(undefined);
+  }
+
+  override _isAddType = isVerificationAddEthAddressMessage;
+  override _isRemoveType = isVerificationRemoveMessage;
+  override _addMessageType = MessageType.VERIFICATION_ADD_ETH_ADDRESS;
+  override _removeMessageType = MessageType.VERIFICATION_REMOVE;
+  protected override PRUNE_SIZE_LIMIT_DEFAULT = PRUNE_SIZE_LIMIT_DEFAULT;
 
   /**
    * Finds a VerificationAdds Message by checking the adds-set's index
@@ -103,9 +103,7 @@ class VerificationStore {
    * @returns the VerificationAddEthAddressModel if it exists, throws HubError otherwise
    */
   async getVerificationAdd(fid: number, address: Uint8Array): Promise<VerificationAddEthAddressMessage> {
-    const addsKey = makeVerificationAddsKey(fid, address);
-    const messageTsHash = await this._db.get(addsKey);
-    return getMessage<VerificationAddEthAddressMessage>(this._db, fid, UserPostfix.VerificationMessage, messageTsHash);
+    return await this.getAdd({ data: { fid, verificationAddEthAddressBody: { address } } });
   }
 
   /**
@@ -116,9 +114,7 @@ class VerificationStore {
    * @returns the VerificationRemoveEthAddress if it exists, throws HubError otherwise
    */
   async getVerificationRemove(fid: number, address: Uint8Array): Promise<VerificationRemoveMessage> {
-    const removesKey = makeVerificationRemovesKey(fid, address);
-    const messageTsHash = await this._db.get(removesKey);
-    return getMessage<VerificationRemoveMessage>(this._db, fid, UserPostfix.VerificationMessage, messageTsHash);
+    return await this.getRemove({ data: { fid, verificationRemoveBody: { address } } });
   }
 
   /**
@@ -131,8 +127,7 @@ class VerificationStore {
     fid: number,
     pageOptions: PageOptions = {}
   ): Promise<MessagesPage<VerificationAddEthAddressMessage>> {
-    const prefix = makeMessagePrimaryKey(fid, UserPostfix.VerificationMessage);
-    return getMessagesPageByPrefix(this._db, prefix, isVerificationAddEthAddressMessage, pageOptions);
+    return await this.getAddsByFid({ data: { fid } }, pageOptions);
   }
 
   /**
@@ -145,370 +140,14 @@ class VerificationStore {
     fid: number,
     pageOptions: PageOptions = {}
   ): Promise<MessagesPage<VerificationRemoveMessage>> {
-    const prefix = makeMessagePrimaryKey(fid, UserPostfix.VerificationMessage);
-    return getMessagesPageByPrefix(this._db, prefix, isVerificationRemoveMessage, pageOptions);
+    return await this.getRemovesByFid({ data: { fid } }, pageOptions);
   }
 
   async getAllVerificationMessagesByFid(
     fid: number,
     pageOptions: PageOptions = {}
   ): Promise<MessagesPage<VerificationAddEthAddressMessage | VerificationRemoveMessage>> {
-    const prefix = makeMessagePrimaryKey(fid, UserPostfix.VerificationMessage);
-    const filter = (message: Message): message is VerificationAddEthAddressMessage | VerificationRemoveMessage => {
-      return isVerificationAddEthAddressMessage(message) || isVerificationRemoveMessage(message);
-    };
-    return getMessagesPageByPrefix(this._db, prefix, filter, pageOptions);
-  }
-
-  /** Merge a VerificationAdd or VerificationRemove message into the VerificationStore */
-  async merge(message: Message): Promise<number> {
-    if (!isVerificationRemoveMessage(message) && !isVerificationAddEthAddressMessage(message)) {
-      throw new HubError('bad_request.validation_failure', 'invalid message type');
-    }
-
-    return this._mergeLock
-      .acquire(
-        message.data.fid.toString(),
-        async () => {
-          const prunableResult = await this._eventHandler.isPrunable(
-            message,
-            UserPostfix.VerificationMessage,
-            this._pruneSizeLimit
-          );
-          if (prunableResult.isErr()) {
-            throw prunableResult.error;
-          } else if (prunableResult.value) {
-            throw new HubError('bad_request.prunable', 'message would be pruned');
-          }
-          if (isVerificationAddEthAddressMessage(message)) {
-            return this.mergeAdd(message);
-          } else if (isVerificationRemoveMessage(message)) {
-            return this.mergeRemove(message);
-          } else {
-            throw new HubError('bad_request.validation_failure', 'invalid message type');
-          }
-        },
-        { timeout: MERGE_TIMEOUT_DEFAULT }
-      )
-      .catch((e: any) => {
-        throw isHubError(e) ? e : new HubError('unavailable.storage_failure', 'merge timed out');
-      });
-  }
-
-  async revoke(message: Message): HubAsyncResult<number> {
-    let txn = this._db.transaction();
-    if (isVerificationAddEthAddressMessage(message)) {
-      txn = this.deleteVerificationAddTransaction(txn, message);
-    } else if (isVerificationRemoveMessage(message)) {
-      txn = this.deleteVerificationRemoveTransaction(txn, message);
-    } else {
-      return err(new HubError('bad_request.invalid_param', 'invalid message type'));
-    }
-
-    return this._eventHandler.commitTransaction(txn, {
-      type: HubEventType.REVOKE_MESSAGE,
-      revokeMessageBody: { message },
-    });
-  }
-
-  async pruneMessages(fid: number): HubAsyncResult<number[]> {
-    const commits: number[] = [];
-
-    const cachedCount = await this._eventHandler.getCacheMessageCount(fid, UserPostfix.VerificationMessage);
-
-    // Require storage cache to be synced to prune
-    if (cachedCount.isErr()) {
-      return err(cachedCount.error);
-    }
-
-    // Return immediately if there are no messages to prune
-    if (cachedCount.value === 0) {
-      return ok(commits);
-    }
-
-    // Create a rocksdb iterator for all messages with the given prefix
-    const pruneIterator = getMessagesPruneIterator(this._db, fid, UserPostfix.VerificationMessage);
-
-    const pruneNextMessage = async (): HubAsyncResult<number | undefined> => {
-      const nextMessage = await ResultAsync.fromPromise(getNextMessageFromIterator(pruneIterator), () => undefined);
-      if (nextMessage.isErr()) {
-        return ok(undefined); // Nothing left to prune
-      }
-
-      const count = await this._eventHandler.getCacheMessageCount(fid, UserPostfix.VerificationMessage);
-      if (count.isErr()) {
-        return err(count.error);
-      }
-
-      if (count.value <= this._pruneSizeLimit) {
-        return ok(undefined);
-      }
-
-      let txn = this._db.transaction();
-
-      if (isVerificationAddEthAddressMessage(nextMessage.value)) {
-        txn = this.deleteVerificationAddTransaction(txn, nextMessage.value);
-      } else if (isVerificationRemoveMessage(nextMessage.value)) {
-        txn = this.deleteVerificationRemoveTransaction(txn, nextMessage.value);
-      } else {
-        return err(new HubError('unknown', 'invalid message type'));
-      }
-
-      return this._eventHandler.commitTransaction(txn, {
-        type: HubEventType.PRUNE_MESSAGE,
-        pruneMessageBody: { message: nextMessage.value },
-      });
-    };
-
-    let pruneResult = await pruneNextMessage();
-    while (!(pruneResult.isOk() && pruneResult.value === undefined)) {
-      pruneResult.match(
-        (commit) => {
-          if (commit) {
-            commits.push(commit);
-          }
-        },
-        (e) => {
-          logger.error({ errCode: e.errCode }, `error pruning verification message for fid ${fid}: ${e.message}`);
-        }
-      );
-
-      pruneResult = await pruneNextMessage();
-    }
-
-    await pruneIterator.end();
-
-    return ok(commits);
-  }
-
-  /* -------------------------------------------------------------------------- */
-  /*                               Private Methods                              */
-  /* -------------------------------------------------------------------------- */
-
-  private async mergeAdd(message: VerificationAddEthAddressMessage): Promise<number> {
-    // Define address for lookups
-    const address = message.data.verificationAddEthAddressBody.address;
-    if (!address) {
-      throw new HubError('bad_request.validation_failure', 'address was missing');
-    }
-
-    const mergeConflicts = await this.getMergeConflicts(address, message);
-    if (mergeConflicts.isErr()) {
-      throw mergeConflicts.error;
-    }
-
-    // Create rocksdb transaction to delete the merge conflicts
-    let txn = this.deleteManyTransaction(this._db.transaction(), mergeConflicts.value);
-
-    // Add putVerificationAdd operations to the RocksDB transaction
-    txn = this.putVerificationAddTransaction(txn, message);
-
-    const hubEvent: HubEventArgs = {
-      type: HubEventType.MERGE_MESSAGE,
-      mergeMessageBody: { message, deletedMessages: mergeConflicts.value },
-    };
-
-    // Commit the RocksDB transaction
-    const result = await this._eventHandler.commitTransaction(txn, hubEvent);
-    if (result.isErr()) {
-      throw result.error;
-    }
-    return result.value;
-  }
-
-  private async mergeRemove(message: VerificationRemoveMessage): Promise<number> {
-    // Define address for lookups
-    const address = message.data.verificationRemoveBody.address;
-    if (!address) {
-      throw new HubError('bad_request.validation_failure', 'address was missing');
-    }
-
-    const mergeConflicts = await this.getMergeConflicts(address, message);
-    if (mergeConflicts.isErr()) {
-      throw mergeConflicts.error;
-    }
-
-    // Create rocksdb transaction to delete the merge conflicts
-    let txn = this.deleteManyTransaction(this._db.transaction(), mergeConflicts.value);
-
-    // Add putVerificationRemove operations to the RocksDB transaction
-    txn = this.putVerificationRemoveTransaction(txn, message);
-
-    const hubEvent: HubEventArgs = {
-      type: HubEventType.MERGE_MESSAGE,
-      mergeMessageBody: { message, deletedMessages: mergeConflicts.value },
-    };
-
-    // Commit the RocksDB transaction
-    const result = await this._eventHandler.commitTransaction(txn, hubEvent);
-    if (result.isErr()) {
-      throw result.error;
-    }
-    return result.value;
-  }
-
-  private verificationMessageCompare(
-    aType: MessageType.VERIFICATION_ADD_ETH_ADDRESS | MessageType.VERIFICATION_REMOVE,
-    aTsHash: Uint8Array,
-    bType: MessageType.VERIFICATION_ADD_ETH_ADDRESS | MessageType.VERIFICATION_REMOVE,
-    bTsHash: Uint8Array
-  ): number {
-    // Compare timestamps (first 4 bytes of tsHash) to enforce Last-Write-Wins
-    const timestampOrder = bytesCompare(aTsHash.subarray(0, 4), bTsHash.subarray(0, 4));
-    if (timestampOrder !== 0) {
-      return timestampOrder;
-    }
-
-    if (aType === MessageType.VERIFICATION_REMOVE && bType === MessageType.VERIFICATION_ADD_ETH_ADDRESS) {
-      return 1;
-    } else if (aType === MessageType.VERIFICATION_ADD_ETH_ADDRESS && bType === MessageType.VERIFICATION_REMOVE) {
-      return -1;
-    }
-
-    // Compare hashes (last 4 bytes of tsHash) to break ties between messages of the same type and timestamp
-    return bytesCompare(aTsHash.subarray(4), bTsHash.subarray(4));
-  }
-
-  private async getMergeConflicts(
-    address: Uint8Array,
-    message: VerificationAddEthAddressMessage | VerificationRemoveMessage
-  ): HubAsyncResult<(VerificationAddEthAddressMessage | VerificationRemoveMessage)[]> {
-    const conflicts: (VerificationAddEthAddressMessage | VerificationRemoveMessage)[] = [];
-
-    const tsHash = makeTsHash(message.data.timestamp, message.hash);
-    if (tsHash.isErr()) {
-      return err(tsHash.error);
-    }
-
-    // Look up the remove tsHash for this address
-    const removeTsHash = await ResultAsync.fromPromise(
-      this._db.get(makeVerificationRemovesKey(message.data.fid, address)),
-      () => undefined
-    );
-
-    if (removeTsHash.isOk()) {
-      const removeCompare = this.verificationMessageCompare(
-        MessageType.VERIFICATION_REMOVE,
-        removeTsHash.value,
-        message.data.type,
-        tsHash.value
-      );
-      if (removeCompare > 0) {
-        return err(new HubError('bad_request.conflict', 'message conflicts with a more recent VerificationRemove'));
-      } else if (removeCompare === 0) {
-        return err(new HubError('bad_request.duplicate', 'message has already been merged'));
-      } else {
-        // If the existing remove has a lower order than the new message, retrieve the full
-        // VerificationRemove message and delete it as part of the RocksDB transaction
-        const existingRemove = await getMessage<VerificationRemoveMessage>(
-          this._db,
-          message.data.fid,
-          UserPostfix.VerificationMessage,
-          removeTsHash.value
-        );
-        conflicts.push(existingRemove);
-      }
-    }
-
-    // Look up the add tsHash for this address
-    const addTsHash = await ResultAsync.fromPromise(
-      this._db.get(makeVerificationAddsKey(message.data.fid, address)),
-      () => undefined
-    );
-
-    if (addTsHash.isOk()) {
-      const addCompare = this.verificationMessageCompare(
-        MessageType.VERIFICATION_ADD_ETH_ADDRESS,
-        addTsHash.value,
-        message.data.type,
-        tsHash.value
-      );
-      if (addCompare > 0) {
-        return err(
-          new HubError('bad_request.conflict', 'message conflicts with a more recent VerificationAddEthAddress')
-        );
-      } else if (addCompare === 0) {
-        return err(new HubError('bad_request.duplicate', 'message has already been merged'));
-      } else {
-        // If the existing add has a lower order than the new message, retrieve the full
-        // VerificationAdd* message and delete it as part of the RocksDB transaction
-        const existingAdd = await getMessage<VerificationAddEthAddressMessage>(
-          this._db,
-          message.data.fid,
-          UserPostfix.VerificationMessage,
-          addTsHash.value
-        );
-        conflicts.push(existingAdd);
-      }
-    }
-
-    return ok(conflicts);
-  }
-
-  private deleteManyTransaction(
-    txn: Transaction,
-    messages: (VerificationAddEthAddressMessage | VerificationRemoveMessage)[]
-  ): Transaction {
-    for (const message of messages) {
-      if (isVerificationAddEthAddressMessage(message)) {
-        txn = this.deleteVerificationAddTransaction(txn, message);
-      } else if (isVerificationRemoveMessage(message)) {
-        txn = this.deleteVerificationRemoveTransaction(txn, message);
-      }
-    }
-    return txn;
-  }
-
-  private putVerificationAddTransaction(txn: Transaction, message: VerificationAddEthAddressMessage): Transaction {
-    const tsHash = makeTsHash(message.data.timestamp, message.hash);
-    if (tsHash.isErr()) {
-      throw tsHash.error;
-    }
-
-    // Put message and index by signer
-    txn = putMessageTransaction(txn, message);
-
-    // Put verificationAdds index
-    txn = txn.put(
-      makeVerificationAddsKey(message.data.fid, message.data.verificationAddEthAddressBody.address),
-      Buffer.from(tsHash.value)
-    );
-
-    return txn;
-  }
-
-  private deleteVerificationAddTransaction(txn: Transaction, message: VerificationAddEthAddressMessage): Transaction {
-    // Delete from verificationAdds
-    txn = txn.del(makeVerificationAddsKey(message.data.fid, message.data.verificationAddEthAddressBody.address));
-
-    // Delete message
-    return deleteMessageTransaction(txn, message);
-  }
-
-  private putVerificationRemoveTransaction(txn: Transaction, message: VerificationRemoveMessage): Transaction {
-    const tsHash = makeTsHash(message.data.timestamp, message.hash);
-    if (tsHash.isErr()) {
-      throw tsHash.error;
-    }
-
-    // Add to db
-    txn = putMessageTransaction(txn, message);
-
-    // Add to verificationRemoves
-    txn = txn.put(
-      makeVerificationRemovesKey(message.data.fid, message.data.verificationRemoveBody.address),
-      Buffer.from(tsHash.value)
-    );
-
-    return txn;
-  }
-
-  private deleteVerificationRemoveTransaction(txn: Transaction, message: VerificationRemoveMessage): Transaction {
-    // Delete from verificationRemoves
-    txn = txn.del(makeVerificationRemovesKey(message.data.fid, message.data.verificationRemoveBody.address));
-
-    // Delete message
-    return deleteMessageTransaction(txn, message);
+    return await this.getAllMessagesByFid(fid, pageOptions);
   }
 }
 

--- a/apps/hubble/src/test/e2e/gossipNetwork.test.ts
+++ b/apps/hubble/src/test/e2e/gossipNetwork.test.ts
@@ -40,6 +40,7 @@ describe('gossip network tests', () => {
         const result = await n.connect(nodes[0] as GossipNode);
         expect(result.isOk()).toBeTruthy();
       }
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const primaryTopic = nodes[0]!.primaryTopic();
       // Subscribe each node to the test topic
       nodes.forEach((n) => n.gossip?.subscribe(primaryTopic));

--- a/apps/hubble/src/utils/versions.test.ts
+++ b/apps/hubble/src/utils/versions.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import semver from 'semver';
 import {
   getMinFarcasterVersion,

--- a/packages/hub-nodejs/docs/Builders.md
+++ b/packages/hub-nodejs/docs/Builders.md
@@ -19,7 +19,7 @@ Builders are factory methods that construct and sign Farcaster Messages which ca
 
 ## Prerequisites
 
-Before you can build messages, you'll need construct the following objects:
+Before you can build messages, you'll need to construct the following objects:
 
 - An `ed25519Signer`, used to sign most messages.
 - A `eip712Signer`, used to sign some messages.
@@ -419,6 +419,6 @@ const verificationRemoveMessage = await makeVerificationRemove(verificationRemov
 
 | Name          | Type                                                             | Description                                                          |
 | :------------ | :--------------------------------------------------------------- | :------------------------------------------------------------------- |
-| `body`        | [`VerificationRemoveBody`](./Messages.md#verificationremovebody) | An object which contains data about the Verification being removed . |
+| `body`        | [`VerificationRemoveBody`](./Messages.md#verificationremovebody) | An object which contains data about the Verification being removed. |
 | `dataOptions` | [`DataOptions`](#data-options)                                   | Optional metadata to construct the message.                          |
 | `signer`      | [`Ed25519Signer`](./signers/NobleEd25519Signer.md)               | A currently valid Signer for the fid.                                |

--- a/packages/hub-nodejs/docs/Utils.md
+++ b/packages/hub-nodejs/docs/Utils.md
@@ -227,7 +227,7 @@ import {
 } from '@farcaster/hub-nodejs';
 import { Wallet } from 'ethers';
 
-// Create a valid Eip712Signer from the Etherum Address making the claim
+// Create a valid Eip712Signer from the Ethereum Address making the claim
 const mnemonic = 'ordinary long coach bounce thank quit become youth belt pretty diet caught attract melt bargain';
 const wallet = Wallet.fromPhrase(mnemonic);
 const eip712Signer = new EthersEip712Signer(wallet);


### PR DESCRIPTION
## Motivation

Add a peerid for farcaster mainnet hubs.

## Change Summary

- Added a new allowed peer to the `allowedPeers.mainnet.ts` file in the `apps/hubble/src` directory.
- The new peer has the following address: `12D3KooWNLshuXk4x2gacFTMEJjMGGFxPjpHg5KcV88KoqJP7dDR`.
- No other changes were made.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds minor changes and fixes to various files in the Hubble app and Hub NodeJS package.

### Detailed summary
- Added handling for peers with no messages in status command
- Refactored stores to use a generic implementation for easier addition of types
- Fixed typos and minor wording changes in documentation
- Changed error messages in various store tests to be more clear

> The following files were skipped due to too many changes: `apps/hubble/src/storage/stores/reactionStore.test.ts`, `apps/hubble/src/storage/stores/verificationStore.test.ts`, `CONTRIBUTING.md`, `apps/hubble/src/storage/stores/store.test.ts`, `apps/hubble/src/storage/stores/userDataStore.ts`, `apps/hubble/src/storage/stores/signerStore.ts`, `apps/hubble/src/storage/stores/verificationStore.ts`, `apps/hubble/src/storage/stores/linkStore.ts`, `apps/hubble/src/storage/stores/store.ts`, `apps/hubble/src/storage/stores/reactionStore.ts`, `apps/hubble/src/storage/stores/castStore.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->