### PR TITLE
chore: add peerid @razzle

### DIFF
--- a/apps/hubble/src/allowedPeers.mainnet.ts
+++ b/apps/hubble/src/allowedPeers.mainnet.ts
@@ -39,4 +39,5 @@ export const MAINNET_ALLOWED_PEERS = [
   '12D3KooWSJj9pDSX5sEFoZum1fsdHuCJnoxwgHKhCg5rrLU7Gepe', // @pfista
   '12D3KooWDXSemEhSAidFCZT1HyRhTHayunCokg68VSuwStf8UEU5', // @98967eth
   '12D3KooWHcViME8KUZXo1wStoRF2jmg4edWidexGy5utVyoxNNnn', // @parthkohli
+  '12D3KooWDfxjnmTTk2nb89dBZZrCQ7g71BoJELKnVpUQUTt4YcL4', // Razzle.eth
 ];


### PR DESCRIPTION

## Motivation

Add a peerid for farcaster mainnet hubs.

## Change Summary

- Added a new allowed peer to the allowedPeers.mainnet.ts file in the apps/hubble/src directory. 
- The new peer has the following address: 12D3KooWDfxjnmTTk2nb89dBZZrCQ7g71BoJELKnVpUQUTt4YcL4 
- No other changes were made.



<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new allowed peer in the `allowedPeers.mainnet.ts` file.

### Detailed summary
- A new allowed peer `Razzle.eth` has been added to the `allowedPeers.mainnet.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->