### PR TITLE
fix: Handle peers with zero messages when printing status

### DIFF
--- a/.changeset/curvy-hotels-joke.md
+++ b/.changeset/curvy-hotels-joke.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Handle peers with no messages in status command

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -498,6 +498,9 @@ app
       let isSyncing = false;
       const msgPercents: number[] = [];
       for (const peerStatus of syncResult.value.syncStatus) {
+        if (peerStatus.theirMessages === 0) {
+          continue;
+        }
         const messagePercent = (peerStatus.ourMessages / peerStatus.theirMessages) * 100;
         msgPercents.push(messagePercent);
         if (syncResult.value.isSyncing) {


### PR DESCRIPTION
## Motivation

`yarn status` is printing NaN because there's hub with 0 messages in the network right now.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a patch to handle peers with no messages in the status command of the `@farcaster/hubble` package. 

### Detailed summary
- Added a conditional statement to skip peers with no messages in the `cli.ts` file.
- Calculated message percentage for each peer and pushed it to the `msgPercents` array.
- No other notable changes were made.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->