### PR TITLE
feat: Support fname registry server and store user name proofs

### DIFF
--- a/.changeset/funny-masks-explode.md
+++ b/.changeset/funny-masks-explode.md
@@ -1,0 +1,8 @@
+---
+'@farcaster/hub-nodejs': patch
+'@farcaster/hub-web': patch
+'@farcaster/core': patch
+'@farcaster/hubble': patch
+---
+
+Fetch, validate and store username proofs from fname registry

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -64,6 +64,7 @@
     "@multiformats/multiaddr": "^11.0.0",
     "@noble/curves": "^1.0.0",
     "async-lock": "^1.4.0",
+    "axios": "^1.4.0",
     "commander": "~10.0.0",
     "ethers": "~6.2.1",
     "libp2p": "0.42.2",

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -56,6 +56,7 @@ app
   .option('--fir-address <address>', 'The address of the Farcaster ID Registry contract')
   .option('--fnr-address <address>', 'The address of the Farcaster Name Registry contract')
   .option('--first-block <number>', 'The block number to begin syncing events from Farcaster contracts', parseNumber)
+  .option('--fname-server-url <url>', 'The URL for the FName registry server')
   .option(
     '--chunk-size <number>',
     'The number of blocks to batch when syncing historical events from Farcaster contracts. (default: 10000)',
@@ -87,6 +88,7 @@ app
   .option('--db-name <name>', 'The name of the RocksDB instance')
   .option('--rebuild-sync-trie', 'Rebuilds the sync trie before starting')
   .option('--resync-eth-events', 'Resyncs events from the Farcaster contracts before starting')
+  .option('--resync-fname-events', 'Resyncs events from the FName registry server before starting')
   .option('--commit-lock-timeout <number>', 'Commit lock timeout in milliseconds (default: 500)', parseNumber)
   .option('--commit-lock-max-pending <number>', 'Commit lock max pending jobs (default: 1000)', parseNumber)
   .option('-i, --id <filepath>', 'Path to the PeerId file')
@@ -293,6 +295,7 @@ app
       gossipPort: hubAddressInfo.value.port,
       network,
       ethRpcUrl: cliOptions.ethRpcUrl ?? hubConfig.ethRpcUrl,
+      fnameServerUrl: cliOptions.fnameServerUrl ?? hubConfig.fnameServerUrl,
       idRegistryAddress: cliOptions.firAddress ?? hubConfig.firAddress,
       nameRegistryAddress: cliOptions.fnrAddress ?? hubConfig.fnrAddress,
       firstBlock: cliOptions.firstBlock ?? hubConfig.firstBlock,
@@ -305,6 +308,7 @@ app
       resetDB,
       rebuildSyncTrie,
       resyncEthEvents: cliOptions.resyncEthEvents ?? hubConfig.resyncEthEvents ?? false,
+      resyncFNameEvents: cliOptions.resyncFNameEvents ?? hubConfig.resyncFNameEvents ?? false,
       commitLockTimeout: cliOptions.commitLockTimeout ?? hubConfig.commitLockTimeout,
       commitLockMaxPending: cliOptions.commitLockMaxPending ?? hubConfig.commitLockMaxPending,
       adminServerEnabled: cliOptions.adminServerEnabled ?? hubConfig.adminServerEnabled,

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -88,7 +88,7 @@ app
   .option('--db-name <name>', 'The name of the RocksDB instance')
   .option('--rebuild-sync-trie', 'Rebuilds the sync trie before starting')
   .option('--resync-eth-events', 'Resyncs events from the Farcaster contracts before starting')
-  .option('--resync-fname-events', 'Resyncs events from the FName registry server before starting')
+  .option('--resync-name-events', 'Resyncs events from the FName registry server before starting')
   .option('--commit-lock-timeout <number>', 'Commit lock timeout in milliseconds (default: 500)', parseNumber)
   .option('--commit-lock-max-pending <number>', 'Commit lock max pending jobs (default: 1000)', parseNumber)
   .option('-i, --id <filepath>', 'Path to the PeerId file')
@@ -308,7 +308,7 @@ app
       resetDB,
       rebuildSyncTrie,
       resyncEthEvents: cliOptions.resyncEthEvents ?? hubConfig.resyncEthEvents ?? false,
-      resyncFNameEvents: cliOptions.resyncFNameEvents ?? hubConfig.resyncFNameEvents ?? false,
+      resyncNameEvents: cliOptions.resyncNameEvents ?? hubConfig.resyncNameEvents ?? false,
       commitLockTimeout: cliOptions.commitLockTimeout ?? hubConfig.commitLockTimeout,
       commitLockMaxPending: cliOptions.commitLockMaxPending ?? hubConfig.commitLockMaxPending,
       adminServerEnabled: cliOptions.adminServerEnabled ?? hubConfig.adminServerEnabled,

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -30,6 +30,7 @@ const DEFAULT_PEER_ID_DIR = './.hub';
 const DEFAULT_PEER_ID_FILENAME = `default_${PEER_ID_FILENAME}`;
 const DEFAULT_PEER_ID_LOCATION = `${DEFAULT_PEER_ID_DIR}/${DEFAULT_PEER_ID_FILENAME}`;
 const DEFAULT_CHUNK_SIZE = 10000;
+const DEFAULT_FNAME_SERVER_URL = 'https://fnames.farcaster.xyz';
 
 const DEFAULT_GOSSIP_PORT = 2282;
 const DEFAULT_RPC_PORT = 2283;
@@ -295,7 +296,7 @@ app
       gossipPort: hubAddressInfo.value.port,
       network,
       ethRpcUrl: cliOptions.ethRpcUrl ?? hubConfig.ethRpcUrl,
-      fnameServerUrl: cliOptions.fnameServerUrl ?? hubConfig.fnameServerUrl,
+      fnameServerUrl: cliOptions.fnameServerUrl ?? hubConfig.fnameServerUrl ?? DEFAULT_FNAME_SERVER_URL,
       idRegistryAddress: cliOptions.firAddress ?? hubConfig.firAddress,
       nameRegistryAddress: cliOptions.fnrAddress ?? hubConfig.fnrAddress,
       firstBlock: cliOptions.firstBlock ?? hubConfig.firstBlock,

--- a/apps/hubble/src/defaultConfig.ts
+++ b/apps/hubble/src/defaultConfig.ts
@@ -14,6 +14,8 @@ export const Config = {
   id: './.hub/default_id.protobuf',
   /** Network URL of the IdRegistry Contract */
   // ethRpcUrl: '',
+  /** FName Registry Server URL */
+  // fnameServerUrl: '';
   /** Address of the IdRegistry Contract  */
   // firAddress: '',
   /** A list of MultiAddrs to use for bootstrapping */

--- a/apps/hubble/src/eth/ethEventsProvider.ts
+++ b/apps/hubble/src/eth/ethEventsProvider.ts
@@ -3,7 +3,6 @@ import {
   hexStringToBytes,
   HubAsyncResult,
   HubError,
-  HubState,
   IdRegistryEvent,
   IdRegistryEventType,
   NameRegistryEvent,
@@ -476,8 +475,13 @@ export class EthEventsProvider {
 
     // Update the last synced block if all the historical events have been synced
     if (this._isHistoricalSyncDone) {
-      const hubState = HubState.create({ lastEthBlock: blockNumber });
-      await this._hub.putHubState(hubState);
+      const hubState = await this._hub.getHubState();
+      if (hubState.isOk()) {
+        hubState.value.lastEthBlock = blockNumber;
+        await this._hub.putHubState(hubState.value);
+      } else {
+        log.error({ errCode: hubState.error.errCode }, `failed to get hub state: ${hubState.error.message}`);
+      }
     }
 
     this._lastBlockNumber = blockNumber;

--- a/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
+++ b/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
@@ -1,4 +1,8 @@
-import { FNameRegistryEventsProvider } from './fnameRegistryEventsProvider.js';
+import {
+  FNameRegistryClientInterface,
+  FNameRegistryEventsProvider,
+  FNameTransfer,
+} from './fnameRegistryEventsProvider.js';
 import { jestRocksDB } from '../storage/db/jestUtils.js';
 import Engine from '../storage/engine/index.js';
 import { FarcasterNetwork } from '@farcaster/hub-nodejs';
@@ -6,20 +10,77 @@ import { MockHub } from '../test/mocks.js';
 import { getUserNameProof } from '../storage/db/nameRegistryEvent.js';
 import { utf8ToBytes } from '@noble/curves/abstract/utils';
 
+class MockFnameRegistryClient implements FNameRegistryClientInterface {
+  private transfersToReturn: FNameTransfer[][] = [];
+  private minimumSince = 0;
+
+  setTransfersToReturn(transfers: FNameTransfer[][]) {
+    this.transfersToReturn = transfers;
+  }
+
+  setMinimumSince(minimumSince: number) {
+    this.minimumSince = minimumSince;
+  }
+
+  async getTransfers(since: 0): Promise<FNameTransfer[]> {
+    expect(since).toBeGreaterThanOrEqual(this.minimumSince);
+    const transfers = this.transfersToReturn.shift();
+    if (!transfers) {
+      return Promise.resolve([]);
+    }
+    return Promise.resolve(transfers);
+  }
+}
+
 describe('fnameRegistryEventsProvider', () => {
-  const db = jestRocksDB('protobufs.ethEventsProvider.test');
+  const db = jestRocksDB('protobufs.fnameRegistry.test');
   const engine = new Engine(db, FarcasterNetwork.TESTNET);
   const hub = new MockHub(db, engine);
   let provider: FNameRegistryEventsProvider;
+  let mockFnameRegistryClient: MockFnameRegistryClient;
+  const transferEvents: FNameTransfer[] = [
+    { username: 'test1', from: 0, to: 1, timestamp: 1686291736947, owner: '', signature: '' },
+    { username: 'test2', from: 0, to: 2, timestamp: 1686291740231, owner: '', signature: '' },
+    { username: 'test3', from: 0, to: 3, timestamp: 1686291751362, owner: '', signature: '' },
+    { username: 'test3', from: 3, to: 0, timestamp: 1686291752129, owner: '', signature: '' },
+  ];
 
   beforeEach(() => {
-    provider = new FNameRegistryEventsProvider('http://localhost:2284', hub);
+    mockFnameRegistryClient = new MockFnameRegistryClient();
+    mockFnameRegistryClient.setTransfersToReturn([
+      transferEvents.slice(0, 1),
+      transferEvents.slice(1, 2),
+      transferEvents.slice(2),
+    ]);
+    provider = new FNameRegistryEventsProvider(mockFnameRegistryClient, hub);
+  });
+
+  afterEach(async () => {
+    await provider.stop();
   });
 
   describe('syncHistoricalEvents', () => {
     it('fetches all events from the beginning', async () => {
       await provider.start();
       expect(await getUserNameProof(db, utf8ToBytes('test1'))).toBeTruthy();
+      expect(await getUserNameProof(db, utf8ToBytes('test2'))).toBeTruthy();
+      await expect(getUserNameProof(db, utf8ToBytes('test4'))).rejects.toThrowError('NotFound');
+      expect((await hub.getHubState())._unsafeUnwrap().lastFnameProof).toEqual(transferEvents[3]!.timestamp);
+    });
+
+    it('fetches events from where it left off', async () => {
+      await hub.putHubState({ lastFnameProof: transferEvents[0]!.timestamp, lastEthBlock: 0 });
+      mockFnameRegistryClient.setMinimumSince(transferEvents[0]!.timestamp);
+      await provider.start();
+      expect(await getUserNameProof(db, utf8ToBytes('test2'))).toBeTruthy();
+      expect((await hub.getHubState())._unsafeUnwrap().lastFnameProof).toEqual(transferEvents[3]!.timestamp);
+    });
+  });
+
+  describe('handles events', () => {
+    it('deletes a proof from the db when a username is unregistered', async () => {
+      await provider.start();
+      await expect(getUserNameProof(db, utf8ToBytes('test3'))).rejects.toThrowError('NotFound');
     });
   });
 });

--- a/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
+++ b/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
@@ -39,10 +39,10 @@ describe('fnameRegistryEventsProvider', () => {
   let provider: FNameRegistryEventsProvider;
   let mockFnameRegistryClient: MockFnameRegistryClient;
   const transferEvents: FNameTransfer[] = [
-    { username: 'test1', from: 0, to: 1, timestamp: 1686291736947, owner: '', signature: '' },
-    { username: 'test2', from: 0, to: 2, timestamp: 1686291740231, owner: '', signature: '' },
-    { username: 'test3', from: 0, to: 3, timestamp: 1686291751362, owner: '', signature: '' },
-    { username: 'test3', from: 3, to: 0, timestamp: 1686291752129, owner: '', signature: '' },
+    { id: 1, username: 'test1', from: 0, to: 1, timestamp: 1686291736947, owner: '', server_signature: '' },
+    { id: 2, username: 'test2', from: 0, to: 2, timestamp: 1686291740231, owner: '', server_signature: '' },
+    { id: 3, username: 'test3', from: 0, to: 3, timestamp: 1686291751362, owner: '', server_signature: '' },
+    { id: 4, username: 'test3', from: 3, to: 0, timestamp: 1686291752129, owner: '', server_signature: '' },
   ];
 
   beforeEach(() => {

--- a/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
+++ b/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
@@ -6,17 +6,39 @@ import {
 import { jestRocksDB } from '../storage/db/jestUtils.js';
 import Engine from '../storage/engine/index.js';
 import { FarcasterNetwork } from '@farcaster/hub-nodejs';
+import { eip712 } from '@farcaster/core';
 import { MockHub } from '../test/mocks.js';
 import { getUserNameProof } from '../storage/db/nameRegistryEvent.js';
 import { utf8ToBytes } from '@noble/curves/abstract/utils';
+import { Signer, Wallet } from 'ethers';
 
 class MockFnameRegistryClient implements FNameRegistryClientInterface {
   private transfersToReturn: FNameTransfer[][] = [];
   private minimumSince = 0;
   private timesToThrow = 0;
+  private signer: Signer;
+
+  constructor(signer: Signer) {
+    this.signer = signer;
+  }
 
   setTransfersToReturn(transfers: FNameTransfer[][]) {
     this.transfersToReturn = transfers;
+    this.transfersToReturn.flat(2).forEach(async (t) => {
+      if (t.server_signature === '') {
+        t.server_signature = await this.signer.signTypedData(
+          eip712.EIP_712_USERNAME_DOMAIN,
+          {
+            UserNameProof: eip712.EIP_712_USERNAME_PROOF,
+          },
+          {
+            name: t.username,
+            owner: t.owner,
+            timestamp: t.timestamp,
+          }
+        );
+      }
+    });
   }
 
   setMinimumSince(minimumSince: number) {
@@ -39,6 +61,10 @@ class MockFnameRegistryClient implements FNameRegistryClientInterface {
     }
     return Promise.resolve(transfers);
   }
+
+  async getSigner(): Promise<string> {
+    return this.signer.getAddress();
+  }
 }
 
 describe('fnameRegistryEventsProvider', () => {
@@ -47,15 +73,17 @@ describe('fnameRegistryEventsProvider', () => {
   const hub = new MockHub(db, engine);
   let provider: FNameRegistryEventsProvider;
   let mockFnameRegistryClient: MockFnameRegistryClient;
+  const signer = Wallet.createRandom();
+
   const transferEvents: FNameTransfer[] = [
-    { id: 1, username: 'test1', from: 0, to: 1, timestamp: 1686291736947, owner: '', server_signature: '' },
-    { id: 2, username: 'test2', from: 0, to: 2, timestamp: 1686291740231, owner: '', server_signature: '' },
-    { id: 3, username: 'test3', from: 0, to: 3, timestamp: 1686291751362, owner: '', server_signature: '' },
-    { id: 4, username: 'test3', from: 3, to: 0, timestamp: 1686291752129, owner: '', server_signature: '' },
+    { id: 1, username: 'test1', from: 0, to: 1, timestamp: 1686291736947, owner: signer.address, server_signature: '' },
+    { id: 2, username: 'test2', from: 0, to: 2, timestamp: 1686291740231, owner: signer.address, server_signature: '' },
+    { id: 3, username: 'test3', from: 0, to: 3, timestamp: 1686291751362, owner: signer.address, server_signature: '' },
+    { id: 4, username: 'test3', from: 3, to: 0, timestamp: 1686291752129, owner: signer.address, server_signature: '' },
   ];
 
   beforeEach(() => {
-    mockFnameRegistryClient = new MockFnameRegistryClient();
+    mockFnameRegistryClient = new MockFnameRegistryClient(signer);
     mockFnameRegistryClient.setTransfersToReturn([
       transferEvents.slice(0, 1),
       transferEvents.slice(1, 2),
@@ -74,15 +102,15 @@ describe('fnameRegistryEventsProvider', () => {
       expect(await getUserNameProof(db, utf8ToBytes('test1'))).toBeTruthy();
       expect(await getUserNameProof(db, utf8ToBytes('test2'))).toBeTruthy();
       await expect(getUserNameProof(db, utf8ToBytes('test4'))).rejects.toThrowError('NotFound');
-      expect((await hub.getHubState())._unsafeUnwrap().lastFnameProof).toEqual(transferEvents[3]!.timestamp);
+      expect((await hub.getHubState())._unsafeUnwrap().lastFnameProof).toEqual(transferEvents[3]!.id);
     });
 
     it('fetches events from where it left off', async () => {
-      await hub.putHubState({ lastFnameProof: transferEvents[0]!.timestamp, lastEthBlock: 0 });
-      mockFnameRegistryClient.setMinimumSince(transferEvents[0]!.timestamp);
+      await hub.putHubState({ lastFnameProof: transferEvents[0]!.id, lastEthBlock: 0 });
+      mockFnameRegistryClient.setMinimumSince(transferEvents[0]!.id);
       await provider.start();
       expect(await getUserNameProof(db, utf8ToBytes('test2'))).toBeTruthy();
-      expect((await hub.getHubState())._unsafeUnwrap().lastFnameProof).toEqual(transferEvents[3]!.timestamp);
+      expect((await hub.getHubState())._unsafeUnwrap().lastFnameProof).toEqual(transferEvents[3]!.id);
     });
 
     it('does not fail on errors', async () => {
@@ -91,7 +119,7 @@ describe('fnameRegistryEventsProvider', () => {
     });
   });
 
-  describe('merges events', () => {
+  describe('mergeTransfers', () => {
     it('deletes a proof from the db when a username is unregistered', async () => {
       await provider.start();
       await expect(getUserNameProof(db, utf8ToBytes('test3'))).rejects.toThrowError('NotFound');
@@ -101,6 +129,23 @@ describe('fnameRegistryEventsProvider', () => {
       // Return duplicate events
       mockFnameRegistryClient.setTransfersToReturn([transferEvents, transferEvents]);
       await provider.start();
+      expect(await getUserNameProof(db, utf8ToBytes('test2'))).toBeTruthy();
+    });
+
+    it('does not merge when the signature is invalid', async () => {
+      const invalidEvent: FNameTransfer = {
+        id: 1,
+        username: 'test1',
+        from: 0,
+        to: 1,
+        timestamp: 1686291736947,
+        owner: signer.address,
+        server_signature: '',
+      };
+      invalidEvent.server_signature = '0x8773442740c17c9d0f0b87022c722f9a136206ed';
+      mockFnameRegistryClient.setTransfersToReturn([[invalidEvent]]);
+      await provider.start();
+      await expect(getUserNameProof(db, utf8ToBytes('test1'))).rejects.toThrowError('NotFound');
     });
   });
 });

--- a/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
+++ b/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
@@ -1,0 +1,25 @@
+import { FNameRegistryEventsProvider } from './fnameRegistryEventsProvider.js';
+import { jestRocksDB } from '../storage/db/jestUtils.js';
+import Engine from '../storage/engine/index.js';
+import { FarcasterNetwork } from '@farcaster/hub-nodejs';
+import { MockHub } from '../test/mocks.js';
+import { getUserNameProof } from '../storage/db/nameRegistryEvent.js';
+import { utf8ToBytes } from '@noble/curves/abstract/utils';
+
+describe('fnameRegistryEventsProvider', () => {
+  const db = jestRocksDB('protobufs.ethEventsProvider.test');
+  const engine = new Engine(db, FarcasterNetwork.TESTNET);
+  const hub = new MockHub(db, engine);
+  let provider: FNameRegistryEventsProvider;
+
+  beforeEach(() => {
+    provider = new FNameRegistryEventsProvider('http://localhost:2284', hub);
+  });
+
+  describe('syncHistoricalEvents', () => {
+    it('fetches all events from the beginning', async () => {
+      await provider.start();
+      expect(await getUserNameProof(db, utf8ToBytes('test1'))).toBeTruthy();
+    });
+  });
+});

--- a/apps/hubble/src/eth/fnameRegistryEventsProvider.ts
+++ b/apps/hubble/src/eth/fnameRegistryEventsProvider.ts
@@ -1,0 +1,50 @@
+import axios from 'axios';
+import { logger } from '../utils/logger.js';
+import { HubInterface } from '../hubble.js';
+import { hexStringToBytes, UserNameProof, UserNameType, utf8StringToBytes } from '@farcaster/hub-nodejs';
+import { Result } from 'neverthrow';
+
+const log = logger.child({
+  component: 'FNameRegistryEventsProvider',
+});
+
+export class FNameRegistryEventsProvider {
+  private url: string;
+  private hub: HubInterface;
+
+  constructor(url: string, hub: HubInterface) {
+    this.url = url;
+    this.hub = hub;
+  }
+
+  public async start() {
+    return this.syncHistoricalEvents();
+  }
+
+  private async syncHistoricalEvents() {
+    const response = await axios.get(`${this.url}/transfers`);
+    for (const transfer of response.data) {
+      const serialized = Result.combine([
+        utf8StringToBytes(transfer.username),
+        hexStringToBytes(transfer.owner),
+        hexStringToBytes(transfer.signature),
+      ]);
+      if (serialized.isErr()) {
+        log.error(`Failed to serialize username proof for ${transfer.username}: ${serialized.error}`);
+        continue;
+      }
+      const [username, owner, signature] = serialized.value;
+      const usernameProof = UserNameProof.create({
+        timestamp: transfer.timestamp,
+        name: username,
+        owner: owner,
+        signature: signature,
+        type: UserNameType.USERNAME_TYPE_FNAME,
+      });
+      const res = await this.hub.submitUserNameProof(usernameProof, 'fname-registry');
+      if (res.isErr()) {
+        throw new Error(`Failed to submit username proof: ${res.error}`);
+      }
+    }
+  }
+}

--- a/apps/hubble/src/eth/fnameRegistryEventsProvider.ts
+++ b/apps/hubble/src/eth/fnameRegistryEventsProvider.ts
@@ -4,26 +4,102 @@ import { HubInterface } from '../hubble.js';
 import { hexStringToBytes, UserNameProof, UserNameType, utf8StringToBytes } from '@farcaster/hub-nodejs';
 import { Result } from 'neverthrow';
 
+const DEFAULT_POLL_TIMEOUT_IN_MS = 10_000;
+
 const log = logger.child({
   component: 'FNameRegistryEventsProvider',
 });
 
-export class FNameRegistryEventsProvider {
-  private url: string;
-  private hub: HubInterface;
+export type FNameTransfer = {
+  username: string;
+  owner: string;
+  signature: string;
+  timestamp: number;
+  from: number;
+  to: number;
+};
 
-  constructor(url: string, hub: HubInterface) {
+export interface FNameRegistryClientInterface {
+  getTransfers(since: number): Promise<FNameTransfer[]>;
+}
+
+export class FNameRegistryClient implements FNameRegistryClientInterface {
+  private url: string;
+  constructor(url: string) {
     this.url = url;
+  }
+
+  public async getTransfers(since = 0): Promise<FNameTransfer[]> {
+    const response = await axios.get(`${this.url}/transfers?since=${since}`);
+    return response.data;
+  }
+}
+
+export class FNameRegistryEventsProvider {
+  private client: FNameRegistryClientInterface;
+  private hub: HubInterface;
+  private lastTransferTimestamp = 0;
+  private resyncEvents: boolean;
+  private pollTimeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  constructor(fnameRegistryClient: FNameRegistryClientInterface, hub: HubInterface, resyncEvents = false) {
+    this.client = fnameRegistryClient;
     this.hub = hub;
+    this.resyncEvents = resyncEvents;
   }
 
   public async start() {
-    return this.syncHistoricalEvents();
+    const result = await this.hub.getHubState();
+    if (result.isErr()) {
+      log.error(`Failed to get hub state: ${result.error}, defaulting to the beginning`);
+      this.lastTransferTimestamp = 0;
+    } else {
+      this.lastTransferTimestamp = result.value.lastFnameProof;
+    }
+    if (this.resyncEvents) {
+      log.error(`Resyncing fname events from the beginning`);
+      this.lastTransferTimestamp = 0;
+    }
+    log.info(`Starting fname events provider from ${this.lastTransferTimestamp}`);
+    return this.pollForNewEvents();
   }
 
-  private async syncHistoricalEvents() {
-    const response = await axios.get(`${this.url}/transfers`);
-    for (const transfer of response.data) {
+  public async stop() {
+    if (this.pollTimeoutId) {
+      clearTimeout(this.pollTimeoutId);
+    }
+  }
+
+  private async pollForNewEvents() {
+    await this.fetchAndMergeTransfers(this.lastTransferTimestamp);
+    this.pollTimeoutId = setTimeout(this.pollForNewEvents.bind(this), DEFAULT_POLL_TIMEOUT_IN_MS);
+  }
+
+  private async fetchAndMergeTransfers(since: number) {
+    let transfers = await this.client.getTransfers(since);
+    let transfersCount = 0;
+    while (transfers.length > 0) {
+      transfersCount += transfers.length;
+      await this.mergeTransfers(transfers);
+      const lastTransfer = transfers[transfers.length - 1];
+      if (!lastTransfer) {
+        break;
+      }
+      this.lastTransferTimestamp = lastTransfer.timestamp;
+      transfers = await this.client.getTransfers(lastTransfer.timestamp);
+    }
+    log.info(`Fetch ${transfersCount} upto ${this.lastTransferTimestamp}`);
+    const result = await this.hub.getHubState();
+    if (result.isOk()) {
+      result.value.lastFnameProof = this.lastTransferTimestamp;
+      await this.hub.putHubState(result.value);
+    } else {
+      log.error({ errCode: result.error.errCode }, `failed to get hub state: ${result.error.message}`);
+    }
+  }
+
+  private async mergeTransfers(transfers: FNameTransfer[]) {
+    for (const transfer of transfers) {
       const serialized = Result.combine([
         utf8StringToBytes(transfer.username),
         hexStringToBytes(transfer.owner),
@@ -39,6 +115,7 @@ export class FNameRegistryEventsProvider {
         name: username,
         owner: owner,
         signature: signature,
+        fid: transfer.to,
         type: UserNameType.USERNAME_TYPE_FNAME,
       });
       const res = await this.hub.submitUserNameProof(usernameProof, 'fname-registry');

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -148,7 +148,7 @@ export interface HubOptions {
   resyncEthEvents?: boolean;
 
   /** Resync fname events */
-  resyncFNameEvents?: boolean;
+  resyncNameEvents?: boolean;
 
   /** Name of the RocksDB instance */
   rocksDBName?: string;
@@ -249,7 +249,7 @@ export class Hub implements HubInterface {
       this.fNameRegistryEventsProvider = new FNameRegistryEventsProvider(
         new FNameRegistryClient(options.fnameServerUrl),
         this,
-        options.resyncFNameEvents ?? false
+        options.resyncNameEvents ?? false
       );
     } else {
       log.warn('No FName Registry URL provided, not syncing with fname events');
@@ -850,9 +850,7 @@ export class Hub implements HubInterface {
         logEvent.info(
           `submitUserNameProof success ${eventId}: fname ${bytesToUtf8String(
             usernameProof.name
-          )._unsafeUnwrap()} assigned to ${bytesToHexString(usernameProof.owner)._unsafeUnwrap()} at timestamp ${
-            usernameProof.timestamp
-          }`
+          )._unsafeUnwrap()} assigned to fid: ${usernameProof.fid} at timestamp ${usernameProof.timestamp}`
         );
       },
       (e) => {

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -245,7 +245,7 @@ export class Hub implements HubInterface {
       log.warn('No ETH RPC URL provided, not syncing with ETH contract events');
     }
 
-    if (options.fnameServerUrl) {
+    if (options.fnameServerUrl && options.fnameServerUrl !== '') {
       this.fNameRegistryEventsProvider = new FNameRegistryEventsProvider(
         new FNameRegistryClient(options.fnameServerUrl),
         this,

--- a/apps/hubble/src/storage/db/nameRegistryEvent.ts
+++ b/apps/hubble/src/storage/db/nameRegistryEvent.ts
@@ -1,4 +1,4 @@
-import { NameRegistryEvent } from '@farcaster/hub-nodejs';
+import { NameRegistryEvent, UserNameProof } from '@farcaster/hub-nodejs';
 import RocksDB, { Iterator, Transaction } from '../db/rocksdb.js';
 import { RootPrefix } from '../db/types.js';
 
@@ -6,6 +6,10 @@ const EXPIRY_BYTES = 4;
 
 export const makeNameRegistryEventPrimaryKey = (fname: Uint8Array): Buffer => {
   return Buffer.concat([Buffer.from([RootPrefix.NameRegistryEvent]), Buffer.from(fname)]);
+};
+
+export const makeUserNameProofPrimaryKey = (name: Uint8Array): Buffer => {
+  return Buffer.concat([Buffer.from([RootPrefix.UserNameProof]), Buffer.from(name)]);
 };
 
 export const makeNameRegistryEventByExpiryKey = (expiry: number, fname?: Uint8Array): Buffer => {
@@ -22,6 +26,12 @@ export const getNameRegistryEvent = async (db: RocksDB, fname: Uint8Array): Prom
   const primaryKey = makeNameRegistryEventPrimaryKey(fname);
   const buffer = await db.get(primaryKey);
   return NameRegistryEvent.decode(new Uint8Array(buffer));
+};
+
+export const getUserNameProof = async (db: RocksDB, name: Uint8Array): Promise<UserNameProof> => {
+  const primaryKey = makeUserNameProofPrimaryKey(name);
+  const buffer = await db.get(primaryKey);
+  return UserNameProof.decode(new Uint8Array(buffer));
 };
 
 export const getNameRegistryEventsByExpiryIterator = (db: RocksDB): Iterator => {
@@ -54,6 +64,15 @@ export const putNameRegistryEventTransaction = (txn: Transaction, event: NameReg
     const byExpiryKey = makeNameRegistryEventByExpiryKey(event.expiry, event.fname);
     txn = txn.put(byExpiryKey, eventBuffer);
   }
+
+  return txn;
+};
+
+export const putUserNameProofTransaction = (txn: Transaction, usernameProof: UserNameProof): Transaction => {
+  const eventBuffer = Buffer.from(UserNameProof.encode(usernameProof).finish());
+
+  const primaryKey = makeUserNameProofPrimaryKey(usernameProof.name);
+  txn = txn.put(primaryKey, eventBuffer);
 
   return txn;
 };

--- a/apps/hubble/src/storage/db/nameRegistryEvent.ts
+++ b/apps/hubble/src/storage/db/nameRegistryEvent.ts
@@ -69,10 +69,17 @@ export const putNameRegistryEventTransaction = (txn: Transaction, event: NameReg
 };
 
 export const putUserNameProofTransaction = (txn: Transaction, usernameProof: UserNameProof): Transaction => {
-  const eventBuffer = Buffer.from(UserNameProof.encode(usernameProof).finish());
+  const proofBuffer = Buffer.from(UserNameProof.encode(usernameProof).finish());
 
   const primaryKey = makeUserNameProofPrimaryKey(usernameProof.name);
-  txn = txn.put(primaryKey, eventBuffer);
+  txn = txn.put(primaryKey, proofBuffer);
+
+  return txn;
+};
+
+export const deleteUserNameProofTransaction = (txn: Transaction, usernameProof: UserNameProof): Transaction => {
+  const primaryKey = makeUserNameProofPrimaryKey(usernameProof.name);
+  txn = txn.del(primaryKey);
 
   return txn;
 };

--- a/apps/hubble/src/storage/db/types.ts
+++ b/apps/hubble/src/storage/db/types.ts
@@ -53,6 +53,8 @@ export enum RootPrefix {
   HubEvents = 15,
   /* The network ID that the rocksDB was created with */
   Network = 16,
+  /* Used to store name proofs */
+  UserNameProof = 17,
 }
 
 /**

--- a/apps/hubble/src/storage/engine/index.test.ts
+++ b/apps/hubble/src/storage/engine/index.test.ts
@@ -35,6 +35,7 @@ import { getMessage, makeTsHash, typeToSetPostfix } from '../db/message.js';
 import { StoreEvents } from '../stores/storeEventHandler.js';
 import { makeVerificationEthAddressClaim } from '@farcaster/core';
 import { setReferenceDateForTest } from '../../utils/versions.js';
+import { getUserNameProof } from '../db/nameRegistryEvent.js';
 
 const db = jestRocksDB('protobufs.engine.test');
 const network = FarcasterNetwork.TESTNET;
@@ -112,6 +113,14 @@ describe('mergeNameRegistryEvent', () => {
     const invalidEvent = Factories.NameRegistryEvent.build({ type: 10 as unknown as NameRegistryEventType });
     const result = await engine.mergeNameRegistryEvent(invalidEvent);
     expect(result._unsafeUnwrapErr()).toEqual(new HubError('bad_request.validation_failure', 'invalid event type'));
+  });
+});
+
+describe('mergeUserNameProof', () => {
+  test('succeeds', async () => {
+    const userNameProof = Factories.UserNameProof.build();
+    await expect(engine.mergeUserNameProof(userNameProof)).resolves.toBeInstanceOf(Ok);
+    expect(await getUserNameProof(db, userNameProof.name)).toBeTruthy();
   });
 });
 

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -227,6 +227,7 @@ class Engine {
   }
 
   async mergeUserNameProof(usernameProof: UserNameProof): HubAsyncResult<number> {
+    // TODO: Validate signature
     return ResultAsync.fromPromise(this._userDataStore.mergeUserNameProof(usernameProof), (e) => e as HubError);
   }
 

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -227,7 +227,7 @@ class Engine {
   }
 
   async mergeUserNameProof(usernameProof: UserNameProof): HubAsyncResult<number> {
-    // TODO: Validate signature
+    // TODO: Validate signature here instead of the fname event provider
     return ResultAsync.fromPromise(this._userDataStore.mergeUserNameProof(usernameProof), (e) => e as HubError);
   }
 

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -21,6 +21,7 @@ import {
   MergeNameRegistryEventHubEvent,
   Message,
   NameRegistryEvent,
+  UserNameProof,
   NameRegistryEventType,
   PruneMessageHubEvent,
   ReactionAddMessage,
@@ -223,6 +224,10 @@ class Engine {
     }
 
     return err(new HubError('bad_request.validation_failure', 'invalid event type'));
+  }
+
+  async mergeUserNameProof(usernameProof: UserNameProof): HubAsyncResult<number> {
+    return ResultAsync.fromPromise(this._userDataStore.mergeUserNameProof(usernameProof), (e) => e as HubError);
   }
 
   async revokeMessagesBySigner(fid: number, signer: Uint8Array): HubAsyncResult<void> {

--- a/apps/hubble/src/storage/stores/utils.ts
+++ b/apps/hubble/src/storage/stores/utils.ts
@@ -1,4 +1,11 @@
-import { IdRegistryEvent, NameRegistryEvent, HubError, bytesCompare, bytesIncrement } from '@farcaster/hub-nodejs';
+import {
+  IdRegistryEvent,
+  NameRegistryEvent,
+  UserNameProof,
+  HubError,
+  bytesCompare,
+  bytesIncrement,
+} from '@farcaster/hub-nodejs';
 
 type Event = IdRegistryEvent | NameRegistryEvent;
 
@@ -30,6 +37,17 @@ export const eventCompare = (a: Event, b: Event): number => {
   }
 
   return 0;
+};
+
+export const usernameProofCompare = (a: UserNameProof, b: UserNameProof): number => {
+  // Compare timestamps
+  if (a.timestamp < b.timestamp) {
+    return -1;
+  } else if (a.timestamp > b.timestamp) {
+    return 1;
+  }
+
+  throw new HubError('bad_request.validation_failure', 'proofs have the same timestamp');
 };
 
 export const makeEndPrefix = (prefix: Buffer): Buffer | undefined => {

--- a/apps/hubble/src/test/mocks.ts
+++ b/apps/hubble/src/test/mocks.ts
@@ -9,7 +9,7 @@ import {
   NameRegistryEvent,
   UserNameProof,
 } from '@farcaster/hub-nodejs';
-import { err, ok } from 'neverthrow';
+import { ok, ResultAsync } from 'neverthrow';
 import { HubInterface, HubSubmitSource } from '../hubble.js';
 import { GossipNode } from '../network/p2p/gossipNode.js';
 import RocksDB from '../storage/db/rocksdb.js';
@@ -17,6 +17,7 @@ import Engine from '../storage/engine/index.js';
 import { AbstractProvider, Block, BlockTag, Network, Networkish, TransactionRequest } from 'ethers';
 import { PeerId } from '@libp2p/interface-peer-id';
 import { ContactInfoContent } from '@farcaster/core';
+import { getHubState, putHubState } from '../storage/db/hubState.js';
 
 export class MockHub implements HubInterface {
   public db: RocksDB;
@@ -53,15 +54,17 @@ export class MockHub implements HubInterface {
   }
 
   async getHubState(): HubAsyncResult<HubState> {
-    // return ResultAsync.fromPromise(HubState.get(this.db), (e) => e as HubError);
-    return err(new HubError('unavailable', 'Not implemented'));
+    const result = await ResultAsync.fromPromise(getHubState(this.db), (e) => e as HubError);
+    if (result.isErr() && result.error.errCode === 'not_found') {
+      const hubState = HubState.create({ lastEthBlock: 0, lastFnameProof: 0 });
+      await putHubState(this.db, hubState);
+      return ok(hubState);
+    }
+    return result;
   }
 
-  async putHubState(_hubState: HubState): HubAsyncResult<void> {
-    // const txn = this.db.transaction();
-    // HubStateModel.putTransaction(txn, hubState);
-    // return await ResultAsync.fromPromise(this.db.commit(txn), (e) => e as HubError);
-    return err(new HubError('unavailable', 'Not implemented'));
+  async putHubState(hubState: HubState): HubAsyncResult<void> {
+    return await ResultAsync.fromPromise(putHubState(this.db, hubState), (e) => e as HubError);
   }
 
   async gossipContactInfo(): HubAsyncResult<void> {

--- a/apps/hubble/src/test/mocks.ts
+++ b/apps/hubble/src/test/mocks.ts
@@ -7,6 +7,7 @@ import {
   IdRegistryEvent,
   Message,
   NameRegistryEvent,
+  UserNameProof,
 } from '@farcaster/hub-nodejs';
 import { err, ok } from 'neverthrow';
 import { HubInterface, HubSubmitSource } from '../hubble.js';
@@ -45,6 +46,10 @@ export class MockHub implements HubInterface {
 
   async submitNameRegistryEvent(event: NameRegistryEvent): HubAsyncResult<number> {
     return this.engine.mergeNameRegistryEvent(event);
+  }
+
+  async submitUserNameProof(proof: UserNameProof): HubAsyncResult<number> {
+    return this.engine.mergeUserNameProof(proof);
   }
 
   async getHubState(): HubAsyncResult<HubState> {

--- a/apps/hubble/src/utils/logger.ts
+++ b/apps/hubble/src/utils/logger.ts
@@ -5,6 +5,7 @@ import {
   Message,
   MessageType,
   NameRegistryEvent,
+  UserNameProof,
 } from '@farcaster/hub-nodejs';
 import pino from 'pino';
 
@@ -75,5 +76,13 @@ export const nameRegistryEventToLog = (event: NameRegistryEvent) => {
     blockNumber: event.blockNumber,
     fname: Buffer.from(event.fname).toString('utf-8').replace(/\0/g, ''),
     to: bytesToHexString(event.to)._unsafeUnwrap(),
+  };
+};
+
+export const usernameProofToLog = (usernameProof: UserNameProof) => {
+  return {
+    timestamp: usernameProof.timestamp,
+    name: Buffer.from(usernameProof.name).toString('utf-8').replace(/\0/g, ''),
+    owner: bytesToHexString(usernameProof.owner)._unsafeUnwrap(),
   };
 };

--- a/packages/core/src/crypto/eip712.test.ts
+++ b/packages/core/src/crypto/eip712.test.ts
@@ -6,6 +6,7 @@ import { bytesToHexString, hexStringToBytes } from '../bytes';
 import { Factories } from '../factories';
 import { VerificationEthAddressClaim } from '../verifications';
 import * as eip712 from './eip712';
+import { UserNameProofClaim } from './eip712';
 
 const wallet = Wallet.createRandom();
 const fid = Factories.Fid.build();
@@ -61,5 +62,23 @@ describe('signMessageHash', () => {
     expect(signature.isOk()).toBeTruthy();
     const recoveredAddress = eip712.verifyMessageHashSignature(hash, signature._unsafeUnwrap());
     expect(recoveredAddress).toEqual(ok(hexStringToBytes(wallet.address)._unsafeUnwrap()));
+  });
+});
+
+describe('verifyUserNameProof', () => {
+  test('succeeds for a known proof', async () => {
+    const nameProof: UserNameProofClaim = {
+      owner: '0x8773442740c17c9d0f0b87022c722f9a136206ed',
+      name: 'farcaster',
+      timestamp: 1628882891,
+    };
+    const signature = hexStringToBytes(
+      '0xb7181760f14eda0028e0b647ff15f45235526ced3b4ae07fcce06141b73d32960d3253776e62f761363fb8137087192047763f4af838950a96f3885f3c2289c41b'
+    );
+    expect(signature.isOk()).toBeTruthy();
+    const recoveredAddress = eip712.verifyUserNameProof(nameProof, signature._unsafeUnwrap());
+    expect(recoveredAddress).toEqual(
+      ok(hexStringToBytes('0xBc5274eFc266311015793d89E9B591fa46294741')._unsafeUnwrap())
+    );
   });
 });

--- a/packages/core/src/crypto/eip712.ts
+++ b/packages/core/src/crypto/eip712.ts
@@ -1,5 +1,4 @@
-import type { Signer } from 'ethers';
-import { recoverAddress, TypedDataEncoder } from 'ethers';
+import { recoverAddress, TypedDataEncoder, Signer, TypedDataDomain, TypedDataField } from 'ethers';
 import { err, Result, ResultAsync } from 'neverthrow';
 import { bytesToHexString, hexStringToBytes } from '../bytes';
 import { HubAsyncResult, HubError, HubResult } from '../errors';
@@ -40,6 +39,19 @@ export const EIP_712_FARCASTER_MESSAGE_DATA = [
   },
 ];
 
+export const EIP_712_USERNAME_DOMAIN = {
+  name: 'Farcaster name verification',
+  version: '1',
+  chainId: 1,
+  verifyingContract: '0xe3be01d99baa8db9905b33a3ca391238234b79d1', // name registry contract, will be the farcaster ENS CCIP contract later
+};
+
+export const EIP_712_USERNAME_PROOF = [
+  { name: 'name', type: 'string' },
+  { name: 'timestamp', type: 'uint256' },
+  { name: 'owner', type: 'address' },
+];
+
 export const getSignerKey = async (signer: MinimalEthersSigner): HubAsyncResult<Uint8Array> => {
   return ResultAsync.fromPromise(signer.getAddress(), (e) => new HubError('unknown', e as Error)).andThen(
     hexStringToBytes
@@ -63,27 +75,22 @@ export const verifyVerificationEthAddressClaimSignature = (
   claim: VerificationEthAddressClaim,
   signature: Uint8Array
 ): HubResult<Uint8Array> => {
-  const signatureHexResult = bytesToHexString(signature);
-  if (signatureHexResult.isErr()) {
-    return err(signatureHexResult.error);
-  }
+  return recoverSignature(
+    EIP_712_FARCASTER_DOMAIN,
+    { VerificationClaim: EIP_712_FARCASTER_VERIFICATION_CLAIM },
+    claim,
+    signature
+  );
+};
 
-  // Recover address from signature
-  const recoveredHexAddress = Result.fromThrowable(
-    () =>
-      recoverAddress(
-        TypedDataEncoder.hash(
-          EIP_712_FARCASTER_DOMAIN,
-          { VerificationClaim: EIP_712_FARCASTER_VERIFICATION_CLAIM },
-          claim
-        ),
-        signatureHexResult.value
-      ),
-    (e) => new HubError('bad_request.invalid_param', e as Error)
-  )();
+export type UserNameProofClaim = {
+  name: string;
+  timestamp: number;
+  owner: string; // hex address
+};
 
-  // Convert hex recovered address to bytes
-  return recoveredHexAddress.andThen((hex) => hexStringToBytes(hex));
+export const verifyUserNameProof = (nameProof: UserNameProofClaim, signature: Uint8Array): HubResult<Uint8Array> => {
+  return recoverSignature(EIP_712_USERNAME_DOMAIN, { UserNameProof: EIP_712_USERNAME_PROOF }, nameProof, signature);
 };
 
 export const signMessageHash = async (hash: Uint8Array, signer: MinimalEthersSigner): HubAsyncResult<Uint8Array> => {
@@ -97,19 +104,28 @@ export const signMessageHash = async (hash: Uint8Array, signer: MinimalEthersSig
 };
 
 export const verifyMessageHashSignature = (hash: Uint8Array, signature: Uint8Array): HubResult<Uint8Array> => {
-  const signatureHexResult = bytesToHexString(signature);
+  return recoverSignature(
+    EIP_712_FARCASTER_DOMAIN,
+    { MessageData: EIP_712_FARCASTER_MESSAGE_DATA },
+    { hash },
+    signature
+  );
+};
 
+const recoverSignature = (
+  domain: TypedDataDomain,
+  types: Record<string, Array<TypedDataField>>,
+  claim: Record<string, any>,
+  signature: Uint8Array
+): HubResult<Uint8Array> => {
+  const signatureHexResult = bytesToHexString(signature);
   if (signatureHexResult.isErr()) {
     return err(signatureHexResult.error);
   }
 
   // Recover address from signature
   const recoveredHexAddress = Result.fromThrowable(
-    () =>
-      recoverAddress(
-        TypedDataEncoder.hash(EIP_712_FARCASTER_DOMAIN, { MessageData: EIP_712_FARCASTER_MESSAGE_DATA }, { hash }),
-        signatureHexResult.value
-      ),
+    () => recoverAddress(TypedDataEncoder.hash(domain, types, claim), signatureHexResult.value),
     (e) => new HubError('bad_request.invalid_param', e as Error)
   )();
 

--- a/packages/core/src/factories.ts
+++ b/packages/core/src/factories.ts
@@ -582,6 +582,17 @@ const NameRegistryEventFactory = Factory.define<protobufs.NameRegistryEvent>(() 
   });
 });
 
+const UserNameProofFactory = Factory.define<protobufs.UserNameProof>(() => {
+  return protobufs.UserNameProof.create({
+    timestamp: Date.now(),
+    signature: Eip712SignatureFactory.build(),
+    owner: EthAddressFactory.build(),
+    name: FnameFactory.build(),
+    fid: FidFactory.build(),
+    type: protobufs.UserNameType.USERNAME_TYPE_FNAME,
+  });
+});
+
 export const Factories = {
   Fid: FidFactory,
   Fname: FnameFactory,
@@ -641,4 +652,5 @@ export const Factories = {
   IdRegistryEvent: IdRegistryEventFactory,
   NameRegistryEventType: NameRegistryEventTypeFactory,
   NameRegistryEvent: NameRegistryEventFactory,
+  UserNameProof: UserNameProofFactory,
 };

--- a/packages/core/src/protobufs/generated/hub_event.ts
+++ b/packages/core/src/protobufs/generated/hub_event.ts
@@ -4,6 +4,7 @@ import _m0 from 'protobufjs/minimal';
 import { IdRegistryEvent } from './id_registry_event';
 import { Message } from './message';
 import { NameRegistryEvent } from './name_registry_event';
+import { UserNameProof } from './username_proof';
 
 export enum HubEventType {
   NONE = 0,
@@ -12,6 +13,7 @@ export enum HubEventType {
   REVOKE_MESSAGE = 3,
   MERGE_ID_REGISTRY_EVENT = 4,
   MERGE_NAME_REGISTRY_EVENT = 5,
+  MERGE_USERNAME_PROOF = 6,
 }
 
 export function hubEventTypeFromJSON(object: any): HubEventType {
@@ -34,6 +36,9 @@ export function hubEventTypeFromJSON(object: any): HubEventType {
     case 5:
     case 'HUB_EVENT_TYPE_MERGE_NAME_REGISTRY_EVENT':
       return HubEventType.MERGE_NAME_REGISTRY_EVENT;
+    case 6:
+    case 'HUB_EVENT_TYPE_MERGE_USERNAME_PROOF':
+      return HubEventType.MERGE_USERNAME_PROOF;
     default:
       throw new tsProtoGlobalThis.Error('Unrecognized enum value ' + object + ' for enum HubEventType');
   }
@@ -53,6 +58,8 @@ export function hubEventTypeToJSON(object: HubEventType): string {
       return 'HUB_EVENT_TYPE_MERGE_ID_REGISTRY_EVENT';
     case HubEventType.MERGE_NAME_REGISTRY_EVENT:
       return 'HUB_EVENT_TYPE_MERGE_NAME_REGISTRY_EVENT';
+    case HubEventType.MERGE_USERNAME_PROOF:
+      return 'HUB_EVENT_TYPE_MERGE_USERNAME_PROOF';
     default:
       throw new tsProtoGlobalThis.Error('Unrecognized enum value ' + object + ' for enum HubEventType');
   }
@@ -79,6 +86,10 @@ export interface MergeNameRegistryEventBody {
   nameRegistryEvent: NameRegistryEvent | undefined;
 }
 
+export interface MergeUserNameProofBody {
+  usernameProof: UserNameProof | undefined;
+}
+
 export interface HubEvent {
   type: HubEventType;
   id: number;
@@ -87,6 +98,7 @@ export interface HubEvent {
   revokeMessageBody?: RevokeMessageBody | undefined;
   mergeIdRegistryEventBody?: MergeIdRegistryEventBody | undefined;
   mergeNameRegistryEventBody?: MergeNameRegistryEventBody | undefined;
+  mergeUsernameProofBody?: MergeUserNameProofBody | undefined;
 }
 
 function createBaseMergeMessageBody(): MergeMessageBody {
@@ -409,6 +421,66 @@ export const MergeNameRegistryEventBody = {
   },
 };
 
+function createBaseMergeUserNameProofBody(): MergeUserNameProofBody {
+  return { usernameProof: undefined };
+}
+
+export const MergeUserNameProofBody = {
+  encode(message: MergeUserNameProofBody, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.usernameProof !== undefined) {
+      UserNameProof.encode(message.usernameProof, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MergeUserNameProofBody {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMergeUserNameProofBody();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.usernameProof = UserNameProof.decode(reader, reader.uint32());
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MergeUserNameProofBody {
+    return { usernameProof: isSet(object.usernameProof) ? UserNameProof.fromJSON(object.usernameProof) : undefined };
+  },
+
+  toJSON(message: MergeUserNameProofBody): unknown {
+    const obj: any = {};
+    message.usernameProof !== undefined &&
+      (obj.usernameProof = message.usernameProof ? UserNameProof.toJSON(message.usernameProof) : undefined);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<MergeUserNameProofBody>, I>>(base?: I): MergeUserNameProofBody {
+    return MergeUserNameProofBody.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MergeUserNameProofBody>, I>>(object: I): MergeUserNameProofBody {
+    const message = createBaseMergeUserNameProofBody();
+    message.usernameProof =
+      object.usernameProof !== undefined && object.usernameProof !== null
+        ? UserNameProof.fromPartial(object.usernameProof)
+        : undefined;
+    return message;
+  },
+};
+
 function createBaseHubEvent(): HubEvent {
   return {
     type: 0,
@@ -418,6 +490,7 @@ function createBaseHubEvent(): HubEvent {
     revokeMessageBody: undefined,
     mergeIdRegistryEventBody: undefined,
     mergeNameRegistryEventBody: undefined,
+    mergeUsernameProofBody: undefined,
   };
 }
 
@@ -443,6 +516,9 @@ export const HubEvent = {
     }
     if (message.mergeNameRegistryEventBody !== undefined) {
       MergeNameRegistryEventBody.encode(message.mergeNameRegistryEventBody, writer.uint32(58).fork()).ldelim();
+    }
+    if (message.mergeUsernameProofBody !== undefined) {
+      MergeUserNameProofBody.encode(message.mergeUsernameProofBody, writer.uint32(66).fork()).ldelim();
     }
     return writer;
   },
@@ -503,6 +579,13 @@ export const HubEvent = {
 
           message.mergeNameRegistryEventBody = MergeNameRegistryEventBody.decode(reader, reader.uint32());
           continue;
+        case 8:
+          if (tag != 66) {
+            break;
+          }
+
+          message.mergeUsernameProofBody = MergeUserNameProofBody.decode(reader, reader.uint32());
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -527,6 +610,9 @@ export const HubEvent = {
       mergeNameRegistryEventBody: isSet(object.mergeNameRegistryEventBody)
         ? MergeNameRegistryEventBody.fromJSON(object.mergeNameRegistryEventBody)
         : undefined,
+      mergeUsernameProofBody: isSet(object.mergeUsernameProofBody)
+        ? MergeUserNameProofBody.fromJSON(object.mergeUsernameProofBody)
+        : undefined,
     };
   },
 
@@ -549,6 +635,10 @@ export const HubEvent = {
     message.mergeNameRegistryEventBody !== undefined &&
       (obj.mergeNameRegistryEventBody = message.mergeNameRegistryEventBody
         ? MergeNameRegistryEventBody.toJSON(message.mergeNameRegistryEventBody)
+        : undefined);
+    message.mergeUsernameProofBody !== undefined &&
+      (obj.mergeUsernameProofBody = message.mergeUsernameProofBody
+        ? MergeUserNameProofBody.toJSON(message.mergeUsernameProofBody)
         : undefined);
     return obj;
   },
@@ -580,6 +670,10 @@ export const HubEvent = {
     message.mergeNameRegistryEventBody =
       object.mergeNameRegistryEventBody !== undefined && object.mergeNameRegistryEventBody !== null
         ? MergeNameRegistryEventBody.fromPartial(object.mergeNameRegistryEventBody)
+        : undefined;
+    message.mergeUsernameProofBody =
+      object.mergeUsernameProofBody !== undefined && object.mergeUsernameProofBody !== null
+        ? MergeUserNameProofBody.fromPartial(object.mergeUsernameProofBody)
         : undefined;
     return message;
   },

--- a/packages/core/src/protobufs/generated/hub_state.ts
+++ b/packages/core/src/protobufs/generated/hub_state.ts
@@ -1,18 +1,23 @@
 /* eslint-disable */
+import Long from 'long';
 import _m0 from 'protobufjs/minimal';
 
 export interface HubState {
   lastEthBlock: number;
+  lastFnameProof: number;
 }
 
 function createBaseHubState(): HubState {
-  return { lastEthBlock: 0 };
+  return { lastEthBlock: 0, lastFnameProof: 0 };
 }
 
 export const HubState = {
   encode(message: HubState, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.lastEthBlock !== 0) {
       writer.uint32(8).uint32(message.lastEthBlock);
+    }
+    if (message.lastFnameProof !== 0) {
+      writer.uint32(16).uint64(message.lastFnameProof);
     }
     return writer;
   },
@@ -31,6 +36,13 @@ export const HubState = {
 
           message.lastEthBlock = reader.uint32();
           continue;
+        case 2:
+          if (tag != 16) {
+            break;
+          }
+
+          message.lastFnameProof = longToNumber(reader.uint64() as Long);
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -41,12 +53,16 @@ export const HubState = {
   },
 
   fromJSON(object: any): HubState {
-    return { lastEthBlock: isSet(object.lastEthBlock) ? Number(object.lastEthBlock) : 0 };
+    return {
+      lastEthBlock: isSet(object.lastEthBlock) ? Number(object.lastEthBlock) : 0,
+      lastFnameProof: isSet(object.lastFnameProof) ? Number(object.lastFnameProof) : 0,
+    };
   },
 
   toJSON(message: HubState): unknown {
     const obj: any = {};
     message.lastEthBlock !== undefined && (obj.lastEthBlock = Math.round(message.lastEthBlock));
+    message.lastFnameProof !== undefined && (obj.lastFnameProof = Math.round(message.lastFnameProof));
     return obj;
   },
 
@@ -57,9 +73,29 @@ export const HubState = {
   fromPartial<I extends Exact<DeepPartial<HubState>, I>>(object: I): HubState {
     const message = createBaseHubState();
     message.lastEthBlock = object.lastEthBlock ?? 0;
+    message.lastFnameProof = object.lastFnameProof ?? 0;
     return message;
   },
 };
+
+declare var self: any | undefined;
+declare var window: any | undefined;
+declare var global: any | undefined;
+var tsProtoGlobalThis: any = (() => {
+  if (typeof globalThis !== 'undefined') {
+    return globalThis;
+  }
+  if (typeof self !== 'undefined') {
+    return self;
+  }
+  if (typeof window !== 'undefined') {
+    return window;
+  }
+  if (typeof global !== 'undefined') {
+    return global;
+  }
+  throw 'Unable to locate global object';
+})();
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 
@@ -77,6 +113,18 @@ type KeysOfUnion<T> = T extends T ? keyof T : never;
 type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
+
+function longToNumber(long: Long): number {
+  if (long.gt(Number.MAX_SAFE_INTEGER)) {
+    throw new tsProtoGlobalThis.Error('Value is larger than Number.MAX_SAFE_INTEGER');
+  }
+  return long.toNumber();
+}
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;

--- a/packages/core/src/protobufs/generated/message.ts
+++ b/packages/core/src/protobufs/generated/message.ts
@@ -446,7 +446,7 @@ export interface VerificationRemoveBody {
 export interface LinkBody {
   /** Type of link, <= 8 characters */
   type: string;
-  /** User-defined timestamp to preserve original time */
+  /** User-defined timestamp that preserves original timestamp when message.data.timestamp needs to be updated for compaction */
   displayTimestamp?: number | undefined;
   /** The fid the link relates to */
   targetFid?: number | undefined;

--- a/packages/core/src/protobufs/generated/username_proof.ts
+++ b/packages/core/src/protobufs/generated/username_proof.ts
@@ -1,0 +1,217 @@
+/* eslint-disable */
+import _m0 from 'protobufjs/minimal';
+
+export enum UserNameType {
+  USERNAME_TYPE_NONE = 0,
+  USERNAME_TYPE_FNAME = 1,
+}
+
+export function userNameTypeFromJSON(object: any): UserNameType {
+  switch (object) {
+    case 0:
+    case 'USERNAME_TYPE_NONE':
+      return UserNameType.USERNAME_TYPE_NONE;
+    case 1:
+    case 'USERNAME_TYPE_FNAME':
+      return UserNameType.USERNAME_TYPE_FNAME;
+    default:
+      throw new tsProtoGlobalThis.Error('Unrecognized enum value ' + object + ' for enum UserNameType');
+  }
+}
+
+export function userNameTypeToJSON(object: UserNameType): string {
+  switch (object) {
+    case UserNameType.USERNAME_TYPE_NONE:
+      return 'USERNAME_TYPE_NONE';
+    case UserNameType.USERNAME_TYPE_FNAME:
+      return 'USERNAME_TYPE_FNAME';
+    default:
+      throw new tsProtoGlobalThis.Error('Unrecognized enum value ' + object + ' for enum UserNameType');
+  }
+}
+
+export interface UserNameProof {
+  timestamp: number;
+  name: Uint8Array;
+  owner: Uint8Array;
+  signature: Uint8Array;
+  type: UserNameType;
+}
+
+function createBaseUserNameProof(): UserNameProof {
+  return { timestamp: 0, name: new Uint8Array(), owner: new Uint8Array(), signature: new Uint8Array(), type: 0 };
+}
+
+export const UserNameProof = {
+  encode(message: UserNameProof, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.timestamp !== 0) {
+      writer.uint32(8).uint32(message.timestamp);
+    }
+    if (message.name.length !== 0) {
+      writer.uint32(18).bytes(message.name);
+    }
+    if (message.owner.length !== 0) {
+      writer.uint32(26).bytes(message.owner);
+    }
+    if (message.signature.length !== 0) {
+      writer.uint32(34).bytes(message.signature);
+    }
+    if (message.type !== 0) {
+      writer.uint32(40).int32(message.type);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): UserNameProof {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseUserNameProof();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.timestamp = reader.uint32();
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.name = reader.bytes();
+          continue;
+        case 3:
+          if (tag != 26) {
+            break;
+          }
+
+          message.owner = reader.bytes();
+          continue;
+        case 4:
+          if (tag != 34) {
+            break;
+          }
+
+          message.signature = reader.bytes();
+          continue;
+        case 5:
+          if (tag != 40) {
+            break;
+          }
+
+          message.type = reader.int32() as any;
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): UserNameProof {
+    return {
+      timestamp: isSet(object.timestamp) ? Number(object.timestamp) : 0,
+      name: isSet(object.name) ? bytesFromBase64(object.name) : new Uint8Array(),
+      owner: isSet(object.owner) ? bytesFromBase64(object.owner) : new Uint8Array(),
+      signature: isSet(object.signature) ? bytesFromBase64(object.signature) : new Uint8Array(),
+      type: isSet(object.type) ? userNameTypeFromJSON(object.type) : 0,
+    };
+  },
+
+  toJSON(message: UserNameProof): unknown {
+    const obj: any = {};
+    message.timestamp !== undefined && (obj.timestamp = Math.round(message.timestamp));
+    message.name !== undefined &&
+      (obj.name = base64FromBytes(message.name !== undefined ? message.name : new Uint8Array()));
+    message.owner !== undefined &&
+      (obj.owner = base64FromBytes(message.owner !== undefined ? message.owner : new Uint8Array()));
+    message.signature !== undefined &&
+      (obj.signature = base64FromBytes(message.signature !== undefined ? message.signature : new Uint8Array()));
+    message.type !== undefined && (obj.type = userNameTypeToJSON(message.type));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UserNameProof>, I>>(base?: I): UserNameProof {
+    return UserNameProof.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<UserNameProof>, I>>(object: I): UserNameProof {
+    const message = createBaseUserNameProof();
+    message.timestamp = object.timestamp ?? 0;
+    message.name = object.name ?? new Uint8Array();
+    message.owner = object.owner ?? new Uint8Array();
+    message.signature = object.signature ?? new Uint8Array();
+    message.type = object.type ?? 0;
+    return message;
+  },
+};
+
+declare var self: any | undefined;
+declare var window: any | undefined;
+declare var global: any | undefined;
+var tsProtoGlobalThis: any = (() => {
+  if (typeof globalThis !== 'undefined') {
+    return globalThis;
+  }
+  if (typeof self !== 'undefined') {
+    return self;
+  }
+  if (typeof window !== 'undefined') {
+    return window;
+  }
+  if (typeof global !== 'undefined') {
+    return global;
+  }
+  throw 'Unable to locate global object';
+})();
+
+function bytesFromBase64(b64: string): Uint8Array {
+  if (tsProtoGlobalThis.Buffer) {
+    return Uint8Array.from(tsProtoGlobalThis.Buffer.from(b64, 'base64'));
+  } else {
+    const bin = tsProtoGlobalThis.atob(b64);
+    const arr = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; ++i) {
+      arr[i] = bin.charCodeAt(i);
+    }
+    return arr;
+  }
+}
+
+function base64FromBytes(arr: Uint8Array): string {
+  if (tsProtoGlobalThis.Buffer) {
+    return tsProtoGlobalThis.Buffer.from(arr).toString('base64');
+  } else {
+    const bin: string[] = [];
+    arr.forEach((byte) => {
+      bin.push(String.fromCharCode(byte));
+    });
+    return tsProtoGlobalThis.btoa(bin.join(''));
+  }
+}
+
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
+
+type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Array<infer U>
+  ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U>
+  ? ReadonlyArray<DeepPartial<U>>
+  : T extends {}
+  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/packages/core/src/protobufs/generated/username_proof.ts
+++ b/packages/core/src/protobufs/generated/username_proof.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import Long from 'long';
 import _m0 from 'protobufjs/minimal';
 
 export enum UserNameType {
@@ -35,17 +36,25 @@ export interface UserNameProof {
   name: Uint8Array;
   owner: Uint8Array;
   signature: Uint8Array;
+  fid: number;
   type: UserNameType;
 }
 
 function createBaseUserNameProof(): UserNameProof {
-  return { timestamp: 0, name: new Uint8Array(), owner: new Uint8Array(), signature: new Uint8Array(), type: 0 };
+  return {
+    timestamp: 0,
+    name: new Uint8Array(),
+    owner: new Uint8Array(),
+    signature: new Uint8Array(),
+    fid: 0,
+    type: 0,
+  };
 }
 
 export const UserNameProof = {
   encode(message: UserNameProof, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.timestamp !== 0) {
-      writer.uint32(8).uint32(message.timestamp);
+      writer.uint32(8).uint64(message.timestamp);
     }
     if (message.name.length !== 0) {
       writer.uint32(18).bytes(message.name);
@@ -56,8 +65,11 @@ export const UserNameProof = {
     if (message.signature.length !== 0) {
       writer.uint32(34).bytes(message.signature);
     }
+    if (message.fid !== 0) {
+      writer.uint32(40).uint64(message.fid);
+    }
     if (message.type !== 0) {
-      writer.uint32(40).int32(message.type);
+      writer.uint32(48).int32(message.type);
     }
     return writer;
   },
@@ -74,7 +86,7 @@ export const UserNameProof = {
             break;
           }
 
-          message.timestamp = reader.uint32();
+          message.timestamp = longToNumber(reader.uint64() as Long);
           continue;
         case 2:
           if (tag != 18) {
@@ -102,6 +114,13 @@ export const UserNameProof = {
             break;
           }
 
+          message.fid = longToNumber(reader.uint64() as Long);
+          continue;
+        case 6:
+          if (tag != 48) {
+            break;
+          }
+
           message.type = reader.int32() as any;
           continue;
       }
@@ -119,6 +138,7 @@ export const UserNameProof = {
       name: isSet(object.name) ? bytesFromBase64(object.name) : new Uint8Array(),
       owner: isSet(object.owner) ? bytesFromBase64(object.owner) : new Uint8Array(),
       signature: isSet(object.signature) ? bytesFromBase64(object.signature) : new Uint8Array(),
+      fid: isSet(object.fid) ? Number(object.fid) : 0,
       type: isSet(object.type) ? userNameTypeFromJSON(object.type) : 0,
     };
   },
@@ -132,6 +152,7 @@ export const UserNameProof = {
       (obj.owner = base64FromBytes(message.owner !== undefined ? message.owner : new Uint8Array()));
     message.signature !== undefined &&
       (obj.signature = base64FromBytes(message.signature !== undefined ? message.signature : new Uint8Array()));
+    message.fid !== undefined && (obj.fid = Math.round(message.fid));
     message.type !== undefined && (obj.type = userNameTypeToJSON(message.type));
     return obj;
   },
@@ -146,6 +167,7 @@ export const UserNameProof = {
     message.name = object.name ?? new Uint8Array();
     message.owner = object.owner ?? new Uint8Array();
     message.signature = object.signature ?? new Uint8Array();
+    message.fid = object.fid ?? 0;
     message.type = object.type ?? 0;
     return message;
   },
@@ -211,6 +233,18 @@ type KeysOfUnion<T> = T extends T ? keyof T : never;
 type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
+
+function longToNumber(long: Long): number {
+  if (long.gt(Number.MAX_SAFE_INTEGER)) {
+    throw new tsProtoGlobalThis.Error('Value is larger than Number.MAX_SAFE_INTEGER');
+  }
+  return long.toNumber();
+}
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;

--- a/packages/core/src/protobufs/index.ts
+++ b/packages/core/src/protobufs/index.ts
@@ -5,6 +5,7 @@ export * from './generated/id_registry_event';
 export * from './generated/job';
 export * from './generated/message';
 export * from './generated/name_registry_event';
+export * from './generated/username_proof';
 export * from './generated/sync_trie';
 export * from './generated/request_response';
 export * from './typeguards';

--- a/packages/hub-nodejs/src/generated/hub_event.ts
+++ b/packages/hub-nodejs/src/generated/hub_event.ts
@@ -4,6 +4,7 @@ import _m0 from 'protobufjs/minimal';
 import { IdRegistryEvent } from './id_registry_event';
 import { Message } from './message';
 import { NameRegistryEvent } from './name_registry_event';
+import { UserNameProof } from './username_proof';
 
 export enum HubEventType {
   NONE = 0,
@@ -12,6 +13,7 @@ export enum HubEventType {
   REVOKE_MESSAGE = 3,
   MERGE_ID_REGISTRY_EVENT = 4,
   MERGE_NAME_REGISTRY_EVENT = 5,
+  MERGE_USERNAME_PROOF = 6,
 }
 
 export function hubEventTypeFromJSON(object: any): HubEventType {
@@ -34,6 +36,9 @@ export function hubEventTypeFromJSON(object: any): HubEventType {
     case 5:
     case 'HUB_EVENT_TYPE_MERGE_NAME_REGISTRY_EVENT':
       return HubEventType.MERGE_NAME_REGISTRY_EVENT;
+    case 6:
+    case 'HUB_EVENT_TYPE_MERGE_USERNAME_PROOF':
+      return HubEventType.MERGE_USERNAME_PROOF;
     default:
       throw new tsProtoGlobalThis.Error('Unrecognized enum value ' + object + ' for enum HubEventType');
   }
@@ -53,6 +58,8 @@ export function hubEventTypeToJSON(object: HubEventType): string {
       return 'HUB_EVENT_TYPE_MERGE_ID_REGISTRY_EVENT';
     case HubEventType.MERGE_NAME_REGISTRY_EVENT:
       return 'HUB_EVENT_TYPE_MERGE_NAME_REGISTRY_EVENT';
+    case HubEventType.MERGE_USERNAME_PROOF:
+      return 'HUB_EVENT_TYPE_MERGE_USERNAME_PROOF';
     default:
       throw new tsProtoGlobalThis.Error('Unrecognized enum value ' + object + ' for enum HubEventType');
   }
@@ -79,6 +86,10 @@ export interface MergeNameRegistryEventBody {
   nameRegistryEvent: NameRegistryEvent | undefined;
 }
 
+export interface MergeUserNameProofBody {
+  usernameProof: UserNameProof | undefined;
+}
+
 export interface HubEvent {
   type: HubEventType;
   id: number;
@@ -87,6 +98,7 @@ export interface HubEvent {
   revokeMessageBody?: RevokeMessageBody | undefined;
   mergeIdRegistryEventBody?: MergeIdRegistryEventBody | undefined;
   mergeNameRegistryEventBody?: MergeNameRegistryEventBody | undefined;
+  mergeUsernameProofBody?: MergeUserNameProofBody | undefined;
 }
 
 function createBaseMergeMessageBody(): MergeMessageBody {
@@ -409,6 +421,66 @@ export const MergeNameRegistryEventBody = {
   },
 };
 
+function createBaseMergeUserNameProofBody(): MergeUserNameProofBody {
+  return { usernameProof: undefined };
+}
+
+export const MergeUserNameProofBody = {
+  encode(message: MergeUserNameProofBody, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.usernameProof !== undefined) {
+      UserNameProof.encode(message.usernameProof, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MergeUserNameProofBody {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMergeUserNameProofBody();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.usernameProof = UserNameProof.decode(reader, reader.uint32());
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MergeUserNameProofBody {
+    return { usernameProof: isSet(object.usernameProof) ? UserNameProof.fromJSON(object.usernameProof) : undefined };
+  },
+
+  toJSON(message: MergeUserNameProofBody): unknown {
+    const obj: any = {};
+    message.usernameProof !== undefined &&
+      (obj.usernameProof = message.usernameProof ? UserNameProof.toJSON(message.usernameProof) : undefined);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<MergeUserNameProofBody>, I>>(base?: I): MergeUserNameProofBody {
+    return MergeUserNameProofBody.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MergeUserNameProofBody>, I>>(object: I): MergeUserNameProofBody {
+    const message = createBaseMergeUserNameProofBody();
+    message.usernameProof =
+      object.usernameProof !== undefined && object.usernameProof !== null
+        ? UserNameProof.fromPartial(object.usernameProof)
+        : undefined;
+    return message;
+  },
+};
+
 function createBaseHubEvent(): HubEvent {
   return {
     type: 0,
@@ -418,6 +490,7 @@ function createBaseHubEvent(): HubEvent {
     revokeMessageBody: undefined,
     mergeIdRegistryEventBody: undefined,
     mergeNameRegistryEventBody: undefined,
+    mergeUsernameProofBody: undefined,
   };
 }
 
@@ -443,6 +516,9 @@ export const HubEvent = {
     }
     if (message.mergeNameRegistryEventBody !== undefined) {
       MergeNameRegistryEventBody.encode(message.mergeNameRegistryEventBody, writer.uint32(58).fork()).ldelim();
+    }
+    if (message.mergeUsernameProofBody !== undefined) {
+      MergeUserNameProofBody.encode(message.mergeUsernameProofBody, writer.uint32(66).fork()).ldelim();
     }
     return writer;
   },
@@ -503,6 +579,13 @@ export const HubEvent = {
 
           message.mergeNameRegistryEventBody = MergeNameRegistryEventBody.decode(reader, reader.uint32());
           continue;
+        case 8:
+          if (tag != 66) {
+            break;
+          }
+
+          message.mergeUsernameProofBody = MergeUserNameProofBody.decode(reader, reader.uint32());
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -527,6 +610,9 @@ export const HubEvent = {
       mergeNameRegistryEventBody: isSet(object.mergeNameRegistryEventBody)
         ? MergeNameRegistryEventBody.fromJSON(object.mergeNameRegistryEventBody)
         : undefined,
+      mergeUsernameProofBody: isSet(object.mergeUsernameProofBody)
+        ? MergeUserNameProofBody.fromJSON(object.mergeUsernameProofBody)
+        : undefined,
     };
   },
 
@@ -549,6 +635,10 @@ export const HubEvent = {
     message.mergeNameRegistryEventBody !== undefined &&
       (obj.mergeNameRegistryEventBody = message.mergeNameRegistryEventBody
         ? MergeNameRegistryEventBody.toJSON(message.mergeNameRegistryEventBody)
+        : undefined);
+    message.mergeUsernameProofBody !== undefined &&
+      (obj.mergeUsernameProofBody = message.mergeUsernameProofBody
+        ? MergeUserNameProofBody.toJSON(message.mergeUsernameProofBody)
         : undefined);
     return obj;
   },
@@ -580,6 +670,10 @@ export const HubEvent = {
     message.mergeNameRegistryEventBody =
       object.mergeNameRegistryEventBody !== undefined && object.mergeNameRegistryEventBody !== null
         ? MergeNameRegistryEventBody.fromPartial(object.mergeNameRegistryEventBody)
+        : undefined;
+    message.mergeUsernameProofBody =
+      object.mergeUsernameProofBody !== undefined && object.mergeUsernameProofBody !== null
+        ? MergeUserNameProofBody.fromPartial(object.mergeUsernameProofBody)
         : undefined;
     return message;
   },

--- a/packages/hub-nodejs/src/generated/message.ts
+++ b/packages/hub-nodejs/src/generated/message.ts
@@ -446,7 +446,7 @@ export interface VerificationRemoveBody {
 export interface LinkBody {
   /** Type of link, <= 8 characters */
   type: string;
-  /** User-defined timestamp to preserve original time */
+  /** User-defined timestamp that preserves original timestamp when message.data.timestamp needs to be updated for compaction */
   displayTimestamp?: number | undefined;
   /** The fid the link relates to */
   targetFid?: number | undefined;

--- a/packages/hub-nodejs/src/generated/username_proof.ts
+++ b/packages/hub-nodejs/src/generated/username_proof.ts
@@ -1,0 +1,217 @@
+/* eslint-disable */
+import _m0 from 'protobufjs/minimal';
+
+export enum UserNameType {
+  USERNAME_TYPE_NONE = 0,
+  USERNAME_TYPE_FNAME = 1,
+}
+
+export function userNameTypeFromJSON(object: any): UserNameType {
+  switch (object) {
+    case 0:
+    case 'USERNAME_TYPE_NONE':
+      return UserNameType.USERNAME_TYPE_NONE;
+    case 1:
+    case 'USERNAME_TYPE_FNAME':
+      return UserNameType.USERNAME_TYPE_FNAME;
+    default:
+      throw new tsProtoGlobalThis.Error('Unrecognized enum value ' + object + ' for enum UserNameType');
+  }
+}
+
+export function userNameTypeToJSON(object: UserNameType): string {
+  switch (object) {
+    case UserNameType.USERNAME_TYPE_NONE:
+      return 'USERNAME_TYPE_NONE';
+    case UserNameType.USERNAME_TYPE_FNAME:
+      return 'USERNAME_TYPE_FNAME';
+    default:
+      throw new tsProtoGlobalThis.Error('Unrecognized enum value ' + object + ' for enum UserNameType');
+  }
+}
+
+export interface UserNameProof {
+  timestamp: number;
+  name: Uint8Array;
+  owner: Uint8Array;
+  signature: Uint8Array;
+  type: UserNameType;
+}
+
+function createBaseUserNameProof(): UserNameProof {
+  return { timestamp: 0, name: new Uint8Array(), owner: new Uint8Array(), signature: new Uint8Array(), type: 0 };
+}
+
+export const UserNameProof = {
+  encode(message: UserNameProof, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.timestamp !== 0) {
+      writer.uint32(8).uint32(message.timestamp);
+    }
+    if (message.name.length !== 0) {
+      writer.uint32(18).bytes(message.name);
+    }
+    if (message.owner.length !== 0) {
+      writer.uint32(26).bytes(message.owner);
+    }
+    if (message.signature.length !== 0) {
+      writer.uint32(34).bytes(message.signature);
+    }
+    if (message.type !== 0) {
+      writer.uint32(40).int32(message.type);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): UserNameProof {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseUserNameProof();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.timestamp = reader.uint32();
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.name = reader.bytes();
+          continue;
+        case 3:
+          if (tag != 26) {
+            break;
+          }
+
+          message.owner = reader.bytes();
+          continue;
+        case 4:
+          if (tag != 34) {
+            break;
+          }
+
+          message.signature = reader.bytes();
+          continue;
+        case 5:
+          if (tag != 40) {
+            break;
+          }
+
+          message.type = reader.int32() as any;
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): UserNameProof {
+    return {
+      timestamp: isSet(object.timestamp) ? Number(object.timestamp) : 0,
+      name: isSet(object.name) ? bytesFromBase64(object.name) : new Uint8Array(),
+      owner: isSet(object.owner) ? bytesFromBase64(object.owner) : new Uint8Array(),
+      signature: isSet(object.signature) ? bytesFromBase64(object.signature) : new Uint8Array(),
+      type: isSet(object.type) ? userNameTypeFromJSON(object.type) : 0,
+    };
+  },
+
+  toJSON(message: UserNameProof): unknown {
+    const obj: any = {};
+    message.timestamp !== undefined && (obj.timestamp = Math.round(message.timestamp));
+    message.name !== undefined &&
+      (obj.name = base64FromBytes(message.name !== undefined ? message.name : new Uint8Array()));
+    message.owner !== undefined &&
+      (obj.owner = base64FromBytes(message.owner !== undefined ? message.owner : new Uint8Array()));
+    message.signature !== undefined &&
+      (obj.signature = base64FromBytes(message.signature !== undefined ? message.signature : new Uint8Array()));
+    message.type !== undefined && (obj.type = userNameTypeToJSON(message.type));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UserNameProof>, I>>(base?: I): UserNameProof {
+    return UserNameProof.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<UserNameProof>, I>>(object: I): UserNameProof {
+    const message = createBaseUserNameProof();
+    message.timestamp = object.timestamp ?? 0;
+    message.name = object.name ?? new Uint8Array();
+    message.owner = object.owner ?? new Uint8Array();
+    message.signature = object.signature ?? new Uint8Array();
+    message.type = object.type ?? 0;
+    return message;
+  },
+};
+
+declare var self: any | undefined;
+declare var window: any | undefined;
+declare var global: any | undefined;
+var tsProtoGlobalThis: any = (() => {
+  if (typeof globalThis !== 'undefined') {
+    return globalThis;
+  }
+  if (typeof self !== 'undefined') {
+    return self;
+  }
+  if (typeof window !== 'undefined') {
+    return window;
+  }
+  if (typeof global !== 'undefined') {
+    return global;
+  }
+  throw 'Unable to locate global object';
+})();
+
+function bytesFromBase64(b64: string): Uint8Array {
+  if (tsProtoGlobalThis.Buffer) {
+    return Uint8Array.from(tsProtoGlobalThis.Buffer.from(b64, 'base64'));
+  } else {
+    const bin = tsProtoGlobalThis.atob(b64);
+    const arr = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; ++i) {
+      arr[i] = bin.charCodeAt(i);
+    }
+    return arr;
+  }
+}
+
+function base64FromBytes(arr: Uint8Array): string {
+  if (tsProtoGlobalThis.Buffer) {
+    return tsProtoGlobalThis.Buffer.from(arr).toString('base64');
+  } else {
+    const bin: string[] = [];
+    arr.forEach((byte) => {
+      bin.push(String.fromCharCode(byte));
+    });
+    return tsProtoGlobalThis.btoa(bin.join(''));
+  }
+}
+
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
+
+type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Array<infer U>
+  ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U>
+  ? ReadonlyArray<DeepPartial<U>>
+  : T extends {}
+  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/packages/hub-nodejs/src/generated/username_proof.ts
+++ b/packages/hub-nodejs/src/generated/username_proof.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import Long from 'long';
 import _m0 from 'protobufjs/minimal';
 
 export enum UserNameType {
@@ -35,17 +36,25 @@ export interface UserNameProof {
   name: Uint8Array;
   owner: Uint8Array;
   signature: Uint8Array;
+  fid: number;
   type: UserNameType;
 }
 
 function createBaseUserNameProof(): UserNameProof {
-  return { timestamp: 0, name: new Uint8Array(), owner: new Uint8Array(), signature: new Uint8Array(), type: 0 };
+  return {
+    timestamp: 0,
+    name: new Uint8Array(),
+    owner: new Uint8Array(),
+    signature: new Uint8Array(),
+    fid: 0,
+    type: 0,
+  };
 }
 
 export const UserNameProof = {
   encode(message: UserNameProof, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.timestamp !== 0) {
-      writer.uint32(8).uint32(message.timestamp);
+      writer.uint32(8).uint64(message.timestamp);
     }
     if (message.name.length !== 0) {
       writer.uint32(18).bytes(message.name);
@@ -56,8 +65,11 @@ export const UserNameProof = {
     if (message.signature.length !== 0) {
       writer.uint32(34).bytes(message.signature);
     }
+    if (message.fid !== 0) {
+      writer.uint32(40).uint64(message.fid);
+    }
     if (message.type !== 0) {
-      writer.uint32(40).int32(message.type);
+      writer.uint32(48).int32(message.type);
     }
     return writer;
   },
@@ -74,7 +86,7 @@ export const UserNameProof = {
             break;
           }
 
-          message.timestamp = reader.uint32();
+          message.timestamp = longToNumber(reader.uint64() as Long);
           continue;
         case 2:
           if (tag != 18) {
@@ -102,6 +114,13 @@ export const UserNameProof = {
             break;
           }
 
+          message.fid = longToNumber(reader.uint64() as Long);
+          continue;
+        case 6:
+          if (tag != 48) {
+            break;
+          }
+
           message.type = reader.int32() as any;
           continue;
       }
@@ -119,6 +138,7 @@ export const UserNameProof = {
       name: isSet(object.name) ? bytesFromBase64(object.name) : new Uint8Array(),
       owner: isSet(object.owner) ? bytesFromBase64(object.owner) : new Uint8Array(),
       signature: isSet(object.signature) ? bytesFromBase64(object.signature) : new Uint8Array(),
+      fid: isSet(object.fid) ? Number(object.fid) : 0,
       type: isSet(object.type) ? userNameTypeFromJSON(object.type) : 0,
     };
   },
@@ -132,6 +152,7 @@ export const UserNameProof = {
       (obj.owner = base64FromBytes(message.owner !== undefined ? message.owner : new Uint8Array()));
     message.signature !== undefined &&
       (obj.signature = base64FromBytes(message.signature !== undefined ? message.signature : new Uint8Array()));
+    message.fid !== undefined && (obj.fid = Math.round(message.fid));
     message.type !== undefined && (obj.type = userNameTypeToJSON(message.type));
     return obj;
   },
@@ -146,6 +167,7 @@ export const UserNameProof = {
     message.name = object.name ?? new Uint8Array();
     message.owner = object.owner ?? new Uint8Array();
     message.signature = object.signature ?? new Uint8Array();
+    message.fid = object.fid ?? 0;
     message.type = object.type ?? 0;
     return message;
   },
@@ -211,6 +233,18 @@ type KeysOfUnion<T> = T extends T ? keyof T : never;
 type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
+
+function longToNumber(long: Long): number {
+  if (long.gt(Number.MAX_SAFE_INTEGER)) {
+    throw new tsProtoGlobalThis.Error('Value is larger than Number.MAX_SAFE_INTEGER');
+  }
+  return long.toNumber();
+}
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;

--- a/packages/hub-web/src/generated/hub_event.ts
+++ b/packages/hub-web/src/generated/hub_event.ts
@@ -4,6 +4,7 @@ import _m0 from 'protobufjs/minimal';
 import { IdRegistryEvent } from './id_registry_event';
 import { Message } from './message';
 import { NameRegistryEvent } from './name_registry_event';
+import { UserNameProof } from './username_proof';
 
 export enum HubEventType {
   NONE = 0,
@@ -12,6 +13,7 @@ export enum HubEventType {
   REVOKE_MESSAGE = 3,
   MERGE_ID_REGISTRY_EVENT = 4,
   MERGE_NAME_REGISTRY_EVENT = 5,
+  MERGE_USERNAME_PROOF = 6,
 }
 
 export function hubEventTypeFromJSON(object: any): HubEventType {
@@ -34,6 +36,9 @@ export function hubEventTypeFromJSON(object: any): HubEventType {
     case 5:
     case 'HUB_EVENT_TYPE_MERGE_NAME_REGISTRY_EVENT':
       return HubEventType.MERGE_NAME_REGISTRY_EVENT;
+    case 6:
+    case 'HUB_EVENT_TYPE_MERGE_USERNAME_PROOF':
+      return HubEventType.MERGE_USERNAME_PROOF;
     default:
       throw new tsProtoGlobalThis.Error('Unrecognized enum value ' + object + ' for enum HubEventType');
   }
@@ -53,6 +58,8 @@ export function hubEventTypeToJSON(object: HubEventType): string {
       return 'HUB_EVENT_TYPE_MERGE_ID_REGISTRY_EVENT';
     case HubEventType.MERGE_NAME_REGISTRY_EVENT:
       return 'HUB_EVENT_TYPE_MERGE_NAME_REGISTRY_EVENT';
+    case HubEventType.MERGE_USERNAME_PROOF:
+      return 'HUB_EVENT_TYPE_MERGE_USERNAME_PROOF';
     default:
       throw new tsProtoGlobalThis.Error('Unrecognized enum value ' + object + ' for enum HubEventType');
   }
@@ -79,6 +86,10 @@ export interface MergeNameRegistryEventBody {
   nameRegistryEvent: NameRegistryEvent | undefined;
 }
 
+export interface MergeUserNameProofBody {
+  usernameProof: UserNameProof | undefined;
+}
+
 export interface HubEvent {
   type: HubEventType;
   id: number;
@@ -87,6 +98,7 @@ export interface HubEvent {
   revokeMessageBody?: RevokeMessageBody | undefined;
   mergeIdRegistryEventBody?: MergeIdRegistryEventBody | undefined;
   mergeNameRegistryEventBody?: MergeNameRegistryEventBody | undefined;
+  mergeUsernameProofBody?: MergeUserNameProofBody | undefined;
 }
 
 function createBaseMergeMessageBody(): MergeMessageBody {
@@ -409,6 +421,66 @@ export const MergeNameRegistryEventBody = {
   },
 };
 
+function createBaseMergeUserNameProofBody(): MergeUserNameProofBody {
+  return { usernameProof: undefined };
+}
+
+export const MergeUserNameProofBody = {
+  encode(message: MergeUserNameProofBody, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.usernameProof !== undefined) {
+      UserNameProof.encode(message.usernameProof, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MergeUserNameProofBody {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMergeUserNameProofBody();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.usernameProof = UserNameProof.decode(reader, reader.uint32());
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MergeUserNameProofBody {
+    return { usernameProof: isSet(object.usernameProof) ? UserNameProof.fromJSON(object.usernameProof) : undefined };
+  },
+
+  toJSON(message: MergeUserNameProofBody): unknown {
+    const obj: any = {};
+    message.usernameProof !== undefined &&
+      (obj.usernameProof = message.usernameProof ? UserNameProof.toJSON(message.usernameProof) : undefined);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<MergeUserNameProofBody>, I>>(base?: I): MergeUserNameProofBody {
+    return MergeUserNameProofBody.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MergeUserNameProofBody>, I>>(object: I): MergeUserNameProofBody {
+    const message = createBaseMergeUserNameProofBody();
+    message.usernameProof =
+      object.usernameProof !== undefined && object.usernameProof !== null
+        ? UserNameProof.fromPartial(object.usernameProof)
+        : undefined;
+    return message;
+  },
+};
+
 function createBaseHubEvent(): HubEvent {
   return {
     type: 0,
@@ -418,6 +490,7 @@ function createBaseHubEvent(): HubEvent {
     revokeMessageBody: undefined,
     mergeIdRegistryEventBody: undefined,
     mergeNameRegistryEventBody: undefined,
+    mergeUsernameProofBody: undefined,
   };
 }
 
@@ -443,6 +516,9 @@ export const HubEvent = {
     }
     if (message.mergeNameRegistryEventBody !== undefined) {
       MergeNameRegistryEventBody.encode(message.mergeNameRegistryEventBody, writer.uint32(58).fork()).ldelim();
+    }
+    if (message.mergeUsernameProofBody !== undefined) {
+      MergeUserNameProofBody.encode(message.mergeUsernameProofBody, writer.uint32(66).fork()).ldelim();
     }
     return writer;
   },
@@ -503,6 +579,13 @@ export const HubEvent = {
 
           message.mergeNameRegistryEventBody = MergeNameRegistryEventBody.decode(reader, reader.uint32());
           continue;
+        case 8:
+          if (tag != 66) {
+            break;
+          }
+
+          message.mergeUsernameProofBody = MergeUserNameProofBody.decode(reader, reader.uint32());
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -527,6 +610,9 @@ export const HubEvent = {
       mergeNameRegistryEventBody: isSet(object.mergeNameRegistryEventBody)
         ? MergeNameRegistryEventBody.fromJSON(object.mergeNameRegistryEventBody)
         : undefined,
+      mergeUsernameProofBody: isSet(object.mergeUsernameProofBody)
+        ? MergeUserNameProofBody.fromJSON(object.mergeUsernameProofBody)
+        : undefined,
     };
   },
 
@@ -549,6 +635,10 @@ export const HubEvent = {
     message.mergeNameRegistryEventBody !== undefined &&
       (obj.mergeNameRegistryEventBody = message.mergeNameRegistryEventBody
         ? MergeNameRegistryEventBody.toJSON(message.mergeNameRegistryEventBody)
+        : undefined);
+    message.mergeUsernameProofBody !== undefined &&
+      (obj.mergeUsernameProofBody = message.mergeUsernameProofBody
+        ? MergeUserNameProofBody.toJSON(message.mergeUsernameProofBody)
         : undefined);
     return obj;
   },
@@ -580,6 +670,10 @@ export const HubEvent = {
     message.mergeNameRegistryEventBody =
       object.mergeNameRegistryEventBody !== undefined && object.mergeNameRegistryEventBody !== null
         ? MergeNameRegistryEventBody.fromPartial(object.mergeNameRegistryEventBody)
+        : undefined;
+    message.mergeUsernameProofBody =
+      object.mergeUsernameProofBody !== undefined && object.mergeUsernameProofBody !== null
+        ? MergeUserNameProofBody.fromPartial(object.mergeUsernameProofBody)
         : undefined;
     return message;
   },

--- a/packages/hub-web/src/generated/request_response.ts
+++ b/packages/hub-web/src/generated/request_response.ts
@@ -159,6 +159,28 @@ export interface SignerRequest {
   signer: Uint8Array;
 }
 
+export interface LinkRequest {
+  fid: number;
+  linkType: string;
+  targetFid?: number | undefined;
+}
+
+export interface LinksByFidRequest {
+  fid: number;
+  linkType?: string | undefined;
+  pageSize?: number | undefined;
+  pageToken?: Uint8Array | undefined;
+  reverse?: boolean | undefined;
+}
+
+export interface LinksByTargetRequest {
+  targetFid?: number | undefined;
+  linkType?: string | undefined;
+  pageSize?: number | undefined;
+  pageToken?: Uint8Array | undefined;
+  reverse?: boolean | undefined;
+}
+
 export interface IdRegistryEventRequest {
   fid: number;
 }
@@ -2300,6 +2322,312 @@ export const SignerRequest = {
     const message = createBaseSignerRequest();
     message.fid = object.fid ?? 0;
     message.signer = object.signer ?? new Uint8Array();
+    return message;
+  },
+};
+
+function createBaseLinkRequest(): LinkRequest {
+  return { fid: 0, linkType: '', targetFid: undefined };
+}
+
+export const LinkRequest = {
+  encode(message: LinkRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.fid !== 0) {
+      writer.uint32(8).uint64(message.fid);
+    }
+    if (message.linkType !== '') {
+      writer.uint32(18).string(message.linkType);
+    }
+    if (message.targetFid !== undefined) {
+      writer.uint32(24).uint64(message.targetFid);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): LinkRequest {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseLinkRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.fid = longToNumber(reader.uint64() as Long);
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.linkType = reader.string();
+          continue;
+        case 3:
+          if (tag != 24) {
+            break;
+          }
+
+          message.targetFid = longToNumber(reader.uint64() as Long);
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): LinkRequest {
+    return {
+      fid: isSet(object.fid) ? Number(object.fid) : 0,
+      linkType: isSet(object.linkType) ? String(object.linkType) : '',
+      targetFid: isSet(object.targetFid) ? Number(object.targetFid) : undefined,
+    };
+  },
+
+  toJSON(message: LinkRequest): unknown {
+    const obj: any = {};
+    message.fid !== undefined && (obj.fid = Math.round(message.fid));
+    message.linkType !== undefined && (obj.linkType = message.linkType);
+    message.targetFid !== undefined && (obj.targetFid = Math.round(message.targetFid));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<LinkRequest>, I>>(base?: I): LinkRequest {
+    return LinkRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<LinkRequest>, I>>(object: I): LinkRequest {
+    const message = createBaseLinkRequest();
+    message.fid = object.fid ?? 0;
+    message.linkType = object.linkType ?? '';
+    message.targetFid = object.targetFid ?? undefined;
+    return message;
+  },
+};
+
+function createBaseLinksByFidRequest(): LinksByFidRequest {
+  return { fid: 0, linkType: undefined, pageSize: undefined, pageToken: undefined, reverse: undefined };
+}
+
+export const LinksByFidRequest = {
+  encode(message: LinksByFidRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.fid !== 0) {
+      writer.uint32(8).uint64(message.fid);
+    }
+    if (message.linkType !== undefined) {
+      writer.uint32(18).string(message.linkType);
+    }
+    if (message.pageSize !== undefined) {
+      writer.uint32(24).uint32(message.pageSize);
+    }
+    if (message.pageToken !== undefined) {
+      writer.uint32(34).bytes(message.pageToken);
+    }
+    if (message.reverse !== undefined) {
+      writer.uint32(40).bool(message.reverse);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): LinksByFidRequest {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseLinksByFidRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.fid = longToNumber(reader.uint64() as Long);
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.linkType = reader.string();
+          continue;
+        case 3:
+          if (tag != 24) {
+            break;
+          }
+
+          message.pageSize = reader.uint32();
+          continue;
+        case 4:
+          if (tag != 34) {
+            break;
+          }
+
+          message.pageToken = reader.bytes();
+          continue;
+        case 5:
+          if (tag != 40) {
+            break;
+          }
+
+          message.reverse = reader.bool();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): LinksByFidRequest {
+    return {
+      fid: isSet(object.fid) ? Number(object.fid) : 0,
+      linkType: isSet(object.linkType) ? String(object.linkType) : undefined,
+      pageSize: isSet(object.pageSize) ? Number(object.pageSize) : undefined,
+      pageToken: isSet(object.pageToken) ? bytesFromBase64(object.pageToken) : undefined,
+      reverse: isSet(object.reverse) ? Boolean(object.reverse) : undefined,
+    };
+  },
+
+  toJSON(message: LinksByFidRequest): unknown {
+    const obj: any = {};
+    message.fid !== undefined && (obj.fid = Math.round(message.fid));
+    message.linkType !== undefined && (obj.linkType = message.linkType);
+    message.pageSize !== undefined && (obj.pageSize = Math.round(message.pageSize));
+    message.pageToken !== undefined &&
+      (obj.pageToken = message.pageToken !== undefined ? base64FromBytes(message.pageToken) : undefined);
+    message.reverse !== undefined && (obj.reverse = message.reverse);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<LinksByFidRequest>, I>>(base?: I): LinksByFidRequest {
+    return LinksByFidRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<LinksByFidRequest>, I>>(object: I): LinksByFidRequest {
+    const message = createBaseLinksByFidRequest();
+    message.fid = object.fid ?? 0;
+    message.linkType = object.linkType ?? undefined;
+    message.pageSize = object.pageSize ?? undefined;
+    message.pageToken = object.pageToken ?? undefined;
+    message.reverse = object.reverse ?? undefined;
+    return message;
+  },
+};
+
+function createBaseLinksByTargetRequest(): LinksByTargetRequest {
+  return { targetFid: undefined, linkType: undefined, pageSize: undefined, pageToken: undefined, reverse: undefined };
+}
+
+export const LinksByTargetRequest = {
+  encode(message: LinksByTargetRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.targetFid !== undefined) {
+      writer.uint32(8).uint64(message.targetFid);
+    }
+    if (message.linkType !== undefined) {
+      writer.uint32(18).string(message.linkType);
+    }
+    if (message.pageSize !== undefined) {
+      writer.uint32(24).uint32(message.pageSize);
+    }
+    if (message.pageToken !== undefined) {
+      writer.uint32(34).bytes(message.pageToken);
+    }
+    if (message.reverse !== undefined) {
+      writer.uint32(40).bool(message.reverse);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): LinksByTargetRequest {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseLinksByTargetRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.targetFid = longToNumber(reader.uint64() as Long);
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.linkType = reader.string();
+          continue;
+        case 3:
+          if (tag != 24) {
+            break;
+          }
+
+          message.pageSize = reader.uint32();
+          continue;
+        case 4:
+          if (tag != 34) {
+            break;
+          }
+
+          message.pageToken = reader.bytes();
+          continue;
+        case 5:
+          if (tag != 40) {
+            break;
+          }
+
+          message.reverse = reader.bool();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): LinksByTargetRequest {
+    return {
+      targetFid: isSet(object.targetFid) ? Number(object.targetFid) : undefined,
+      linkType: isSet(object.linkType) ? String(object.linkType) : undefined,
+      pageSize: isSet(object.pageSize) ? Number(object.pageSize) : undefined,
+      pageToken: isSet(object.pageToken) ? bytesFromBase64(object.pageToken) : undefined,
+      reverse: isSet(object.reverse) ? Boolean(object.reverse) : undefined,
+    };
+  },
+
+  toJSON(message: LinksByTargetRequest): unknown {
+    const obj: any = {};
+    message.targetFid !== undefined && (obj.targetFid = Math.round(message.targetFid));
+    message.linkType !== undefined && (obj.linkType = message.linkType);
+    message.pageSize !== undefined && (obj.pageSize = Math.round(message.pageSize));
+    message.pageToken !== undefined &&
+      (obj.pageToken = message.pageToken !== undefined ? base64FromBytes(message.pageToken) : undefined);
+    message.reverse !== undefined && (obj.reverse = message.reverse);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<LinksByTargetRequest>, I>>(base?: I): LinksByTargetRequest {
+    return LinksByTargetRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<LinksByTargetRequest>, I>>(object: I): LinksByTargetRequest {
+    const message = createBaseLinksByTargetRequest();
+    message.targetFid = object.targetFid ?? undefined;
+    message.linkType = object.linkType ?? undefined;
+    message.pageSize = object.pageSize ?? undefined;
+    message.pageToken = object.pageToken ?? undefined;
+    message.reverse = object.reverse ?? undefined;
     return message;
   },
 };

--- a/packages/hub-web/src/generated/rpc.ts
+++ b/packages/hub-web/src/generated/rpc.ts
@@ -1,5 +1,6 @@
 /* eslint-disable */
-import { grpc } from '@improbable-eng/grpc-web';
+// This must be manually change to a default import right now
+import grpcWeb from '@improbable-eng/grpc-web';
 import { BrowserHeaders } from 'browser-headers';
 import { Observable } from 'rxjs';
 import { share } from 'rxjs/operators';
@@ -40,72 +41,99 @@ import {
 
 export interface HubService {
   /** Submit Methods */
-  submitMessage(request: DeepPartial<Message>, metadata?: grpc.Metadata): Promise<Message>;
+  submitMessage(request: DeepPartial<Message>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
   /** Event Methods */
-  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpc.Metadata): Observable<HubEvent>;
-  getEvent(request: DeepPartial<EventRequest>, metadata?: grpc.Metadata): Promise<HubEvent>;
+  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpcWeb.grpc.Metadata): Observable<HubEvent>;
+  getEvent(request: DeepPartial<EventRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubEvent>;
   /** Casts */
-  getCast(request: DeepPartial<CastId>, metadata?: grpc.Metadata): Promise<Message>;
-  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
-  getCastsByParent(request: DeepPartial<CastsByParentRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
-  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getCast(request: DeepPartial<CastId>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
+  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getCastsByParent(
+    request: DeepPartial<CastsByParentRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse>;
+  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
   /** Reactions */
-  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpc.Metadata): Promise<Message>;
-  getReactionsByFid(request: DeepPartial<ReactionsByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
+  getReactionsByFid(
+    request: DeepPartial<ReactionsByFidRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse>;
   /** To be deprecated */
   getReactionsByCast(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<MessagesResponse>;
   getReactionsByTarget(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<MessagesResponse>;
   /** User Data */
-  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpc.Metadata): Promise<Message>;
-  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
+  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
   getNameRegistryEvent(
     request: DeepPartial<NameRegistryEventRequest>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<NameRegistryEvent>;
   /** Verifications */
-  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpc.Metadata): Promise<Message>;
-  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
+  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
   /** Signer */
-  getSigner(request: DeepPartial<SignerRequest>, metadata?: grpc.Metadata): Promise<Message>;
-  getSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
-  getIdRegistryEvent(request: DeepPartial<IdRegistryEventRequest>, metadata?: grpc.Metadata): Promise<IdRegistryEvent>;
+  getSigner(request: DeepPartial<SignerRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
+  getSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getIdRegistryEvent(
+    request: DeepPartial<IdRegistryEventRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<IdRegistryEvent>;
   getIdRegistryEventByAddress(
     request: DeepPartial<IdRegistryEventByAddressRequest>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<IdRegistryEvent>;
-  getFids(request: DeepPartial<FidsRequest>, metadata?: grpc.Metadata): Promise<FidsResponse>;
+  getFids(request: DeepPartial<FidsRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<FidsResponse>;
   /** Links */
-  getLink(request: DeepPartial<LinkRequest>, metadata?: grpc.Metadata): Promise<Message>;
-  getLinksByFid(request: DeepPartial<LinksByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
-  getLinksByTarget(request: DeepPartial<LinksByTargetRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getLink(request: DeepPartial<LinkRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
+  getLinksByFid(request: DeepPartial<LinksByFidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getLinksByTarget(
+    request: DeepPartial<LinksByTargetRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse>;
   /** Bulk Methods */
-  getAllCastMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
-  getAllReactionMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getAllCastMessagesByFid(
+    request: DeepPartial<FidRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse>;
+  getAllReactionMessagesByFid(
+    request: DeepPartial<FidRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse>;
   getAllVerificationMessagesByFid(
     request: DeepPartial<FidRequest>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<MessagesResponse>;
-  getAllSignerMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
-  getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
-  getAllLinkMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getAllSignerMessagesByFid(
+    request: DeepPartial<FidRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse>;
+  getAllUserDataMessagesByFid(
+    request: DeepPartial<FidRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse>;
+  getAllLinkMessagesByFid(
+    request: DeepPartial<FidRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse>;
   /** Sync Methods */
-  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpc.Metadata): Promise<HubInfoResponse>;
-  getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpc.Metadata): Promise<SyncStatusResponse>;
-  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpc.Metadata): Promise<SyncIds>;
-  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubInfoResponse>;
+  getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncStatusResponse>;
+  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncIds>;
+  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
   getSyncMetadataByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<TrieNodeMetadataResponse>;
   getSyncSnapshotByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<TrieNodeSnapshotResponse>;
 }
 
@@ -152,94 +180,103 @@ export class HubServiceClientImpl implements HubService {
     this.getSyncSnapshotByPrefix = this.getSyncSnapshotByPrefix.bind(this);
   }
 
-  submitMessage(request: DeepPartial<Message>, metadata?: grpc.Metadata): Promise<Message> {
+  submitMessage(request: DeepPartial<Message>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceSubmitMessageDesc, Message.fromPartial(request), metadata);
   }
 
-  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpc.Metadata): Observable<HubEvent> {
+  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpcWeb.grpc.Metadata): Observable<HubEvent> {
     return this.rpc.invoke(HubServiceSubscribeDesc, SubscribeRequest.fromPartial(request), metadata);
   }
 
-  getEvent(request: DeepPartial<EventRequest>, metadata?: grpc.Metadata): Promise<HubEvent> {
+  getEvent(request: DeepPartial<EventRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubEvent> {
     return this.rpc.unary(HubServiceGetEventDesc, EventRequest.fromPartial(request), metadata);
   }
 
-  getCast(request: DeepPartial<CastId>, metadata?: grpc.Metadata): Promise<Message> {
+  getCast(request: DeepPartial<CastId>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetCastDesc, CastId.fromPartial(request), metadata);
   }
 
-  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetCastsByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getCastsByParent(request: DeepPartial<CastsByParentRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getCastsByParent(
+    request: DeepPartial<CastsByParentRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetCastsByParentDesc, CastsByParentRequest.fromPartial(request), metadata);
   }
 
-  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetCastsByMentionDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpc.Metadata): Promise<Message> {
+  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetReactionDesc, ReactionRequest.fromPartial(request), metadata);
   }
 
-  getReactionsByFid(request: DeepPartial<ReactionsByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getReactionsByFid(
+    request: DeepPartial<ReactionsByFidRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetReactionsByFidDesc, ReactionsByFidRequest.fromPartial(request), metadata);
   }
 
   getReactionsByCast(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetReactionsByCastDesc, ReactionsByTargetRequest.fromPartial(request), metadata);
   }
 
   getReactionsByTarget(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetReactionsByTargetDesc, ReactionsByTargetRequest.fromPartial(request), metadata);
   }
 
-  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpc.Metadata): Promise<Message> {
+  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetUserDataDesc, UserDataRequest.fromPartial(request), metadata);
   }
 
-  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetUserDataByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
   getNameRegistryEvent(
     request: DeepPartial<NameRegistryEventRequest>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<NameRegistryEvent> {
     return this.rpc.unary(HubServiceGetNameRegistryEventDesc, NameRegistryEventRequest.fromPartial(request), metadata);
   }
 
-  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpc.Metadata): Promise<Message> {
+  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetVerificationDesc, VerificationRequest.fromPartial(request), metadata);
   }
 
-  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetVerificationsByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getSigner(request: DeepPartial<SignerRequest>, metadata?: grpc.Metadata): Promise<Message> {
+  getSigner(request: DeepPartial<SignerRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetSignerDesc, SignerRequest.fromPartial(request), metadata);
   }
 
-  getSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetSignersByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getIdRegistryEvent(request: DeepPartial<IdRegistryEventRequest>, metadata?: grpc.Metadata): Promise<IdRegistryEvent> {
+  getIdRegistryEvent(
+    request: DeepPartial<IdRegistryEventRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<IdRegistryEvent> {
     return this.rpc.unary(HubServiceGetIdRegistryEventDesc, IdRegistryEventRequest.fromPartial(request), metadata);
   }
 
   getIdRegistryEventByAddress(
     request: DeepPartial<IdRegistryEventByAddressRequest>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<IdRegistryEvent> {
     return this.rpc.unary(
       HubServiceGetIdRegistryEventByAddressDesc,
@@ -248,75 +285,96 @@ export class HubServiceClientImpl implements HubService {
     );
   }
 
-  getFids(request: DeepPartial<FidsRequest>, metadata?: grpc.Metadata): Promise<FidsResponse> {
+  getFids(request: DeepPartial<FidsRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<FidsResponse> {
     return this.rpc.unary(HubServiceGetFidsDesc, FidsRequest.fromPartial(request), metadata);
   }
 
-  getLink(request: DeepPartial<LinkRequest>, metadata?: grpc.Metadata): Promise<Message> {
+  getLink(request: DeepPartial<LinkRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetLinkDesc, LinkRequest.fromPartial(request), metadata);
   }
 
-  getLinksByFid(request: DeepPartial<LinksByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getLinksByFid(request: DeepPartial<LinksByFidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetLinksByFidDesc, LinksByFidRequest.fromPartial(request), metadata);
   }
 
-  getLinksByTarget(request: DeepPartial<LinksByTargetRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getLinksByTarget(
+    request: DeepPartial<LinksByTargetRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetLinksByTargetDesc, LinksByTargetRequest.fromPartial(request), metadata);
   }
 
-  getAllCastMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getAllCastMessagesByFid(
+    request: DeepPartial<FidRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllCastMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getAllReactionMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getAllReactionMessagesByFid(
+    request: DeepPartial<FidRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllReactionMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
   getAllVerificationMessagesByFid(
     request: DeepPartial<FidRequest>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllVerificationMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getAllSignerMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getAllSignerMessagesByFid(
+    request: DeepPartial<FidRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllSignerMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getAllUserDataMessagesByFid(
+    request: DeepPartial<FidRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllUserDataMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getAllLinkMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getAllLinkMessagesByFid(
+    request: DeepPartial<FidRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllLinkMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpc.Metadata): Promise<HubInfoResponse> {
+  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubInfoResponse> {
     return this.rpc.unary(HubServiceGetInfoDesc, HubInfoRequest.fromPartial(request), metadata);
   }
 
-  getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpc.Metadata): Promise<SyncStatusResponse> {
+  getSyncStatus(
+    request: DeepPartial<SyncStatusRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<SyncStatusResponse> {
     return this.rpc.unary(HubServiceGetSyncStatusDesc, SyncStatusRequest.fromPartial(request), metadata);
   }
 
-  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpc.Metadata): Promise<SyncIds> {
+  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncIds> {
     return this.rpc.unary(HubServiceGetAllSyncIdsByPrefixDesc, TrieNodePrefix.fromPartial(request), metadata);
   }
 
-  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllMessagesBySyncIdsDesc, SyncIds.fromPartial(request), metadata);
   }
 
   getSyncMetadataByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<TrieNodeMetadataResponse> {
     return this.rpc.unary(HubServiceGetSyncMetadataByPrefixDesc, TrieNodePrefix.fromPartial(request), metadata);
   }
 
   getSyncSnapshotByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<TrieNodeSnapshotResponse> {
     return this.rpc.unary(HubServiceGetSyncSnapshotByPrefixDesc, TrieNodePrefix.fromPartial(request), metadata);
   }
@@ -1153,12 +1211,15 @@ export const HubServiceGetSyncSnapshotByPrefixDesc: UnaryMethodDefinitionish = {
 };
 
 export interface AdminService {
-  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty>;
-  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty>;
-  submitIdRegistryEvent(request: DeepPartial<IdRegistryEvent>, metadata?: grpc.Metadata): Promise<IdRegistryEvent>;
+  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty>;
+  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty>;
+  submitIdRegistryEvent(
+    request: DeepPartial<IdRegistryEvent>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<IdRegistryEvent>;
   submitNameRegistryEvent(
     request: DeepPartial<NameRegistryEvent>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<NameRegistryEvent>;
 }
 
@@ -1173,21 +1234,24 @@ export class AdminServiceClientImpl implements AdminService {
     this.submitNameRegistryEvent = this.submitNameRegistryEvent.bind(this);
   }
 
-  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty> {
+  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty> {
     return this.rpc.unary(AdminServiceRebuildSyncTrieDesc, Empty.fromPartial(request), metadata);
   }
 
-  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty> {
+  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty> {
     return this.rpc.unary(AdminServiceDeleteAllMessagesFromDbDesc, Empty.fromPartial(request), metadata);
   }
 
-  submitIdRegistryEvent(request: DeepPartial<IdRegistryEvent>, metadata?: grpc.Metadata): Promise<IdRegistryEvent> {
+  submitIdRegistryEvent(
+    request: DeepPartial<IdRegistryEvent>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<IdRegistryEvent> {
     return this.rpc.unary(AdminServiceSubmitIdRegistryEventDesc, IdRegistryEvent.fromPartial(request), metadata);
   }
 
   submitNameRegistryEvent(
     request: DeepPartial<NameRegistryEvent>,
-    metadata?: grpc.Metadata
+    metadata?: grpcWeb.grpc.Metadata
   ): Promise<NameRegistryEvent> {
     return this.rpc.unary(AdminServiceSubmitNameRegistryEventDesc, NameRegistryEvent.fromPartial(request), metadata);
   }
@@ -1287,7 +1351,7 @@ export const AdminServiceSubmitNameRegistryEventDesc: UnaryMethodDefinitionish =
   } as any,
 };
 
-interface UnaryMethodDefinitionishR extends grpc.UnaryMethodDefinition<any, any> {
+interface UnaryMethodDefinitionishR extends grpcWeb.grpc.UnaryMethodDefinition<any, any> {
   requestStream: any;
   responseStream: any;
 }
@@ -1298,32 +1362,32 @@ interface Rpc {
   unary<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     request: any,
-    metadata: grpc.Metadata | undefined
+    metadata: grpcWeb.grpc.Metadata | undefined
   ): Promise<any>;
   invoke<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     request: any,
-    metadata: grpc.Metadata | undefined
+    metadata: grpcWeb.grpc.Metadata | undefined
   ): Observable<any>;
 }
 
 export class GrpcWebImpl {
   private host: string;
   private options: {
-    transport?: grpc.TransportFactory;
-    streamingTransport?: grpc.TransportFactory;
+    transport?: grpcWeb.grpc.TransportFactory;
+    streamingTransport?: grpcWeb.grpc.TransportFactory;
     debug?: boolean;
-    metadata?: grpc.Metadata;
+    metadata?: grpcWeb.grpc.Metadata;
     upStreamRetryCodes?: number[];
   };
 
   constructor(
     host: string,
     options: {
-      transport?: grpc.TransportFactory;
-      streamingTransport?: grpc.TransportFactory;
+      transport?: grpcWeb.grpc.TransportFactory;
+      streamingTransport?: grpcWeb.grpc.TransportFactory;
       debug?: boolean;
-      metadata?: grpc.Metadata;
+      metadata?: grpcWeb.grpc.Metadata;
       upStreamRetryCodes?: number[];
     }
   ) {
@@ -1334,7 +1398,7 @@ export class GrpcWebImpl {
   unary<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     _request: any,
-    metadata: grpc.Metadata | undefined
+    metadata: grpcWeb.grpc.Metadata | undefined
   ): Promise<any> {
     const request = { ..._request, ...methodDesc.requestType };
     const maybeCombinedMetadata =
@@ -1342,14 +1406,14 @@ export class GrpcWebImpl {
         ? new BrowserHeaders({ ...this.options?.metadata.headersMap, ...metadata?.headersMap })
         : metadata || this.options.metadata;
     return new Promise((resolve, reject) => {
-      grpc.unary(methodDesc, {
+      grpcWeb.grpc.unary(methodDesc, {
         request,
         host: this.host,
         metadata: maybeCombinedMetadata,
         transport: this.options.transport,
         debug: this.options.debug,
         onEnd: function (response) {
-          if (response.status === grpc.Code.OK) {
+          if (response.status === grpcWeb.grpc.Code.OK) {
             resolve(response.message!.toObject());
           } else {
             const err = new GrpcWebError(response.statusMessage, response.status, response.trailers);
@@ -1363,7 +1427,7 @@ export class GrpcWebImpl {
   invoke<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     _request: any,
-    metadata: grpc.Metadata | undefined
+    metadata: grpcWeb.grpc.Metadata | undefined
   ): Observable<any> {
     const upStreamCodes = this.options.upStreamRetryCodes || [];
     const DEFAULT_TIMEOUT_TIME: number = 3_000;
@@ -1374,14 +1438,14 @@ export class GrpcWebImpl {
         : metadata || this.options.metadata;
     return new Observable((observer) => {
       const upStream = () => {
-        const client = grpc.invoke(methodDesc, {
+        const client = grpcWeb.grpc.invoke(methodDesc, {
           host: this.host,
           request,
           transport: this.options.streamingTransport || this.options.transport,
           metadata: maybeCombinedMetadata,
           debug: this.options.debug,
           onMessage: (next) => observer.next(next),
-          onEnd: (code: grpc.Code, message: string, trailers: grpc.Metadata) => {
+          onEnd: (code: grpcWeb.grpc.Code, message: string, trailers: grpcWeb.grpc.Metadata) => {
             if (code === 0) {
               observer.complete();
             } else if (upStreamCodes.includes(code)) {
@@ -1437,7 +1501,7 @@ type DeepPartial<T> = T extends Builtin
   : Partial<T>;
 
 export class GrpcWebError extends tsProtoGlobalThis.Error {
-  constructor(message: string, public code: grpc.Code, public metadata: grpc.Metadata) {
+  constructor(message: string, public code: grpcWeb.grpc.Code, public metadata: grpcWeb.grpc.Metadata) {
     super(message);
   }
 }

--- a/packages/hub-web/src/generated/rpc.ts
+++ b/packages/hub-web/src/generated/rpc.ts
@@ -1,6 +1,5 @@
 /* eslint-disable */
-// This must be manually change to a default import right now
-import grpcWeb from '@improbable-eng/grpc-web';
+import { grpc } from '@improbable-eng/grpc-web';
 import { BrowserHeaders } from 'browser-headers';
 import { Observable } from 'rxjs';
 import { share } from 'rxjs/operators';
@@ -19,6 +18,9 @@ import {
   HubInfoResponse,
   IdRegistryEventByAddressRequest,
   IdRegistryEventRequest,
+  LinkRequest,
+  LinksByFidRequest,
+  LinksByTargetRequest,
   MessagesResponse,
   NameRegistryEventRequest,
   ReactionRequest,
@@ -38,88 +40,72 @@ import {
 
 export interface HubService {
   /** Submit Methods */
-  submitMessage(request: DeepPartial<Message>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
+  submitMessage(request: DeepPartial<Message>, metadata?: grpc.Metadata): Promise<Message>;
   /** Event Methods */
-  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpcWeb.grpc.Metadata): Observable<HubEvent>;
-  getEvent(request: DeepPartial<EventRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubEvent>;
+  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpc.Metadata): Observable<HubEvent>;
+  getEvent(request: DeepPartial<EventRequest>, metadata?: grpc.Metadata): Promise<HubEvent>;
   /** Casts */
-  getCast(request: DeepPartial<CastId>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
-  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
-  getCastsByParent(
-    request: DeepPartial<CastsByParentRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse>;
-  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getCast(request: DeepPartial<CastId>, metadata?: grpc.Metadata): Promise<Message>;
+  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getCastsByParent(request: DeepPartial<CastsByParentRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /** Reactions */
-  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
-  getReactionsByFid(
-    request: DeepPartial<ReactionsByFidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse>;
+  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpc.Metadata): Promise<Message>;
+  getReactionsByFid(request: DeepPartial<ReactionsByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /** To be deprecated */
   getReactionsByCast(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<MessagesResponse>;
   getReactionsByTarget(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<MessagesResponse>;
   /** User Data */
-  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
-  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpc.Metadata): Promise<Message>;
+  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   getNameRegistryEvent(
     request: DeepPartial<NameRegistryEventRequest>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<NameRegistryEvent>;
   /** Verifications */
-  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
-  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpc.Metadata): Promise<Message>;
+  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /** Signer */
-  getSigner(request: DeepPartial<SignerRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
-  getSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
-  getIdRegistryEvent(
-    request: DeepPartial<IdRegistryEventRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<IdRegistryEvent>;
+  getSigner(request: DeepPartial<SignerRequest>, metadata?: grpc.Metadata): Promise<Message>;
+  getSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getIdRegistryEvent(request: DeepPartial<IdRegistryEventRequest>, metadata?: grpc.Metadata): Promise<IdRegistryEvent>;
   getIdRegistryEventByAddress(
     request: DeepPartial<IdRegistryEventByAddressRequest>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<IdRegistryEvent>;
-  getFids(request: DeepPartial<FidsRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<FidsResponse>;
+  getFids(request: DeepPartial<FidsRequest>, metadata?: grpc.Metadata): Promise<FidsResponse>;
+  /** Links */
+  getLink(request: DeepPartial<LinkRequest>, metadata?: grpc.Metadata): Promise<Message>;
+  getLinksByFid(request: DeepPartial<LinksByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getLinksByTarget(request: DeepPartial<LinksByTargetRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /** Bulk Methods */
-  getAllCastMessagesByFid(
-    request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse>;
-  getAllReactionMessagesByFid(
-    request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse>;
+  getAllCastMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getAllReactionMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   getAllVerificationMessagesByFid(
     request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<MessagesResponse>;
-  getAllSignerMessagesByFid(
-    request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse>;
-  getAllUserDataMessagesByFid(
-    request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse>;
+  getAllSignerMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getAllLinkMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /** Sync Methods */
-  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubInfoResponse>;
-  getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncStatusResponse>;
-  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncIds>;
-  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpc.Metadata): Promise<HubInfoResponse>;
+  getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpc.Metadata): Promise<SyncStatusResponse>;
+  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpc.Metadata): Promise<SyncIds>;
+  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   getSyncMetadataByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<TrieNodeMetadataResponse>;
   getSyncSnapshotByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<TrieNodeSnapshotResponse>;
 }
 
@@ -149,11 +135,15 @@ export class HubServiceClientImpl implements HubService {
     this.getIdRegistryEvent = this.getIdRegistryEvent.bind(this);
     this.getIdRegistryEventByAddress = this.getIdRegistryEventByAddress.bind(this);
     this.getFids = this.getFids.bind(this);
+    this.getLink = this.getLink.bind(this);
+    this.getLinksByFid = this.getLinksByFid.bind(this);
+    this.getLinksByTarget = this.getLinksByTarget.bind(this);
     this.getAllCastMessagesByFid = this.getAllCastMessagesByFid.bind(this);
     this.getAllReactionMessagesByFid = this.getAllReactionMessagesByFid.bind(this);
     this.getAllVerificationMessagesByFid = this.getAllVerificationMessagesByFid.bind(this);
     this.getAllSignerMessagesByFid = this.getAllSignerMessagesByFid.bind(this);
     this.getAllUserDataMessagesByFid = this.getAllUserDataMessagesByFid.bind(this);
+    this.getAllLinkMessagesByFid = this.getAllLinkMessagesByFid.bind(this);
     this.getInfo = this.getInfo.bind(this);
     this.getSyncStatus = this.getSyncStatus.bind(this);
     this.getAllSyncIdsByPrefix = this.getAllSyncIdsByPrefix.bind(this);
@@ -162,103 +152,94 @@ export class HubServiceClientImpl implements HubService {
     this.getSyncSnapshotByPrefix = this.getSyncSnapshotByPrefix.bind(this);
   }
 
-  submitMessage(request: DeepPartial<Message>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  submitMessage(request: DeepPartial<Message>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceSubmitMessageDesc, Message.fromPartial(request), metadata);
   }
 
-  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpcWeb.grpc.Metadata): Observable<HubEvent> {
+  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpc.Metadata): Observable<HubEvent> {
     return this.rpc.invoke(HubServiceSubscribeDesc, SubscribeRequest.fromPartial(request), metadata);
   }
 
-  getEvent(request: DeepPartial<EventRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubEvent> {
+  getEvent(request: DeepPartial<EventRequest>, metadata?: grpc.Metadata): Promise<HubEvent> {
     return this.rpc.unary(HubServiceGetEventDesc, EventRequest.fromPartial(request), metadata);
   }
 
-  getCast(request: DeepPartial<CastId>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  getCast(request: DeepPartial<CastId>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetCastDesc, CastId.fromPartial(request), metadata);
   }
 
-  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetCastsByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getCastsByParent(
-    request: DeepPartial<CastsByParentRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse> {
+  getCastsByParent(request: DeepPartial<CastsByParentRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetCastsByParentDesc, CastsByParentRequest.fromPartial(request), metadata);
   }
 
-  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetCastsByMentionDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetReactionDesc, ReactionRequest.fromPartial(request), metadata);
   }
 
-  getReactionsByFid(
-    request: DeepPartial<ReactionsByFidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse> {
+  getReactionsByFid(request: DeepPartial<ReactionsByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetReactionsByFidDesc, ReactionsByFidRequest.fromPartial(request), metadata);
   }
 
   getReactionsByCast(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetReactionsByCastDesc, ReactionsByTargetRequest.fromPartial(request), metadata);
   }
 
   getReactionsByTarget(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetReactionsByTargetDesc, ReactionsByTargetRequest.fromPartial(request), metadata);
   }
 
-  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetUserDataDesc, UserDataRequest.fromPartial(request), metadata);
   }
 
-  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetUserDataByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
   getNameRegistryEvent(
     request: DeepPartial<NameRegistryEventRequest>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<NameRegistryEvent> {
     return this.rpc.unary(HubServiceGetNameRegistryEventDesc, NameRegistryEventRequest.fromPartial(request), metadata);
   }
 
-  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetVerificationDesc, VerificationRequest.fromPartial(request), metadata);
   }
 
-  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetVerificationsByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getSigner(request: DeepPartial<SignerRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  getSigner(request: DeepPartial<SignerRequest>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetSignerDesc, SignerRequest.fromPartial(request), metadata);
   }
 
-  getSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetSignersByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getIdRegistryEvent(
-    request: DeepPartial<IdRegistryEventRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<IdRegistryEvent> {
+  getIdRegistryEvent(request: DeepPartial<IdRegistryEventRequest>, metadata?: grpc.Metadata): Promise<IdRegistryEvent> {
     return this.rpc.unary(HubServiceGetIdRegistryEventDesc, IdRegistryEventRequest.fromPartial(request), metadata);
   }
 
   getIdRegistryEventByAddress(
     request: DeepPartial<IdRegistryEventByAddressRequest>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<IdRegistryEvent> {
     return this.rpc.unary(
       HubServiceGetIdRegistryEventByAddressDesc,
@@ -267,74 +248,75 @@ export class HubServiceClientImpl implements HubService {
     );
   }
 
-  getFids(request: DeepPartial<FidsRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<FidsResponse> {
+  getFids(request: DeepPartial<FidsRequest>, metadata?: grpc.Metadata): Promise<FidsResponse> {
     return this.rpc.unary(HubServiceGetFidsDesc, FidsRequest.fromPartial(request), metadata);
   }
 
-  getAllCastMessagesByFid(
-    request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse> {
+  getLink(request: DeepPartial<LinkRequest>, metadata?: grpc.Metadata): Promise<Message> {
+    return this.rpc.unary(HubServiceGetLinkDesc, LinkRequest.fromPartial(request), metadata);
+  }
+
+  getLinksByFid(request: DeepPartial<LinksByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+    return this.rpc.unary(HubServiceGetLinksByFidDesc, LinksByFidRequest.fromPartial(request), metadata);
+  }
+
+  getLinksByTarget(request: DeepPartial<LinksByTargetRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+    return this.rpc.unary(HubServiceGetLinksByTargetDesc, LinksByTargetRequest.fromPartial(request), metadata);
+  }
+
+  getAllCastMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllCastMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getAllReactionMessagesByFid(
-    request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse> {
+  getAllReactionMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllReactionMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
   getAllVerificationMessagesByFid(
     request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllVerificationMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getAllSignerMessagesByFid(
-    request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse> {
+  getAllSignerMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllSignerMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getAllUserDataMessagesByFid(
-    request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<MessagesResponse> {
+  getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllUserDataMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubInfoResponse> {
+  getAllLinkMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+    return this.rpc.unary(HubServiceGetAllLinkMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
+  }
+
+  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpc.Metadata): Promise<HubInfoResponse> {
     return this.rpc.unary(HubServiceGetInfoDesc, HubInfoRequest.fromPartial(request), metadata);
   }
 
-  getSyncStatus(
-    request: DeepPartial<SyncStatusRequest>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<SyncStatusResponse> {
+  getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpc.Metadata): Promise<SyncStatusResponse> {
     return this.rpc.unary(HubServiceGetSyncStatusDesc, SyncStatusRequest.fromPartial(request), metadata);
   }
 
-  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncIds> {
+  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpc.Metadata): Promise<SyncIds> {
     return this.rpc.unary(HubServiceGetAllSyncIdsByPrefixDesc, TrieNodePrefix.fromPartial(request), metadata);
   }
 
-  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllMessagesBySyncIdsDesc, SyncIds.fromPartial(request), metadata);
   }
 
   getSyncMetadataByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<TrieNodeMetadataResponse> {
     return this.rpc.unary(HubServiceGetSyncMetadataByPrefixDesc, TrieNodePrefix.fromPartial(request), metadata);
   }
 
   getSyncSnapshotByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<TrieNodeSnapshotResponse> {
     return this.rpc.unary(HubServiceGetSyncSnapshotByPrefixDesc, TrieNodePrefix.fromPartial(request), metadata);
   }
@@ -825,6 +807,75 @@ export const HubServiceGetFidsDesc: UnaryMethodDefinitionish = {
   } as any,
 };
 
+export const HubServiceGetLinkDesc: UnaryMethodDefinitionish = {
+  methodName: 'GetLink',
+  service: HubServiceDesc,
+  requestStream: false,
+  responseStream: false,
+  requestType: {
+    serializeBinary() {
+      return LinkRequest.encode(this).finish();
+    },
+  } as any,
+  responseType: {
+    deserializeBinary(data: Uint8Array) {
+      const value = Message.decode(data);
+      return {
+        ...value,
+        toObject() {
+          return value;
+        },
+      };
+    },
+  } as any,
+};
+
+export const HubServiceGetLinksByFidDesc: UnaryMethodDefinitionish = {
+  methodName: 'GetLinksByFid',
+  service: HubServiceDesc,
+  requestStream: false,
+  responseStream: false,
+  requestType: {
+    serializeBinary() {
+      return LinksByFidRequest.encode(this).finish();
+    },
+  } as any,
+  responseType: {
+    deserializeBinary(data: Uint8Array) {
+      const value = MessagesResponse.decode(data);
+      return {
+        ...value,
+        toObject() {
+          return value;
+        },
+      };
+    },
+  } as any,
+};
+
+export const HubServiceGetLinksByTargetDesc: UnaryMethodDefinitionish = {
+  methodName: 'GetLinksByTarget',
+  service: HubServiceDesc,
+  requestStream: false,
+  responseStream: false,
+  requestType: {
+    serializeBinary() {
+      return LinksByTargetRequest.encode(this).finish();
+    },
+  } as any,
+  responseType: {
+    deserializeBinary(data: Uint8Array) {
+      const value = MessagesResponse.decode(data);
+      return {
+        ...value,
+        toObject() {
+          return value;
+        },
+      };
+    },
+  } as any,
+};
+
 export const HubServiceGetAllCastMessagesByFidDesc: UnaryMethodDefinitionish = {
   methodName: 'GetAllCastMessagesByFid',
   service: HubServiceDesc,
@@ -919,6 +970,29 @@ export const HubServiceGetAllSignerMessagesByFidDesc: UnaryMethodDefinitionish =
 
 export const HubServiceGetAllUserDataMessagesByFidDesc: UnaryMethodDefinitionish = {
   methodName: 'GetAllUserDataMessagesByFid',
+  service: HubServiceDesc,
+  requestStream: false,
+  responseStream: false,
+  requestType: {
+    serializeBinary() {
+      return FidRequest.encode(this).finish();
+    },
+  } as any,
+  responseType: {
+    deserializeBinary(data: Uint8Array) {
+      const value = MessagesResponse.decode(data);
+      return {
+        ...value,
+        toObject() {
+          return value;
+        },
+      };
+    },
+  } as any,
+};
+
+export const HubServiceGetAllLinkMessagesByFidDesc: UnaryMethodDefinitionish = {
+  methodName: 'GetAllLinkMessagesByFid',
   service: HubServiceDesc,
   requestStream: false,
   responseStream: false,
@@ -1079,15 +1153,12 @@ export const HubServiceGetSyncSnapshotByPrefixDesc: UnaryMethodDefinitionish = {
 };
 
 export interface AdminService {
-  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty>;
-  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty>;
-  submitIdRegistryEvent(
-    request: DeepPartial<IdRegistryEvent>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<IdRegistryEvent>;
+  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty>;
+  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty>;
+  submitIdRegistryEvent(request: DeepPartial<IdRegistryEvent>, metadata?: grpc.Metadata): Promise<IdRegistryEvent>;
   submitNameRegistryEvent(
     request: DeepPartial<NameRegistryEvent>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<NameRegistryEvent>;
 }
 
@@ -1102,24 +1173,21 @@ export class AdminServiceClientImpl implements AdminService {
     this.submitNameRegistryEvent = this.submitNameRegistryEvent.bind(this);
   }
 
-  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty> {
+  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty> {
     return this.rpc.unary(AdminServiceRebuildSyncTrieDesc, Empty.fromPartial(request), metadata);
   }
 
-  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty> {
+  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty> {
     return this.rpc.unary(AdminServiceDeleteAllMessagesFromDbDesc, Empty.fromPartial(request), metadata);
   }
 
-  submitIdRegistryEvent(
-    request: DeepPartial<IdRegistryEvent>,
-    metadata?: grpcWeb.grpc.Metadata
-  ): Promise<IdRegistryEvent> {
+  submitIdRegistryEvent(request: DeepPartial<IdRegistryEvent>, metadata?: grpc.Metadata): Promise<IdRegistryEvent> {
     return this.rpc.unary(AdminServiceSubmitIdRegistryEventDesc, IdRegistryEvent.fromPartial(request), metadata);
   }
 
   submitNameRegistryEvent(
     request: DeepPartial<NameRegistryEvent>,
-    metadata?: grpcWeb.grpc.Metadata
+    metadata?: grpc.Metadata
   ): Promise<NameRegistryEvent> {
     return this.rpc.unary(AdminServiceSubmitNameRegistryEventDesc, NameRegistryEvent.fromPartial(request), metadata);
   }
@@ -1219,7 +1287,7 @@ export const AdminServiceSubmitNameRegistryEventDesc: UnaryMethodDefinitionish =
   } as any,
 };
 
-interface UnaryMethodDefinitionishR extends grpcWeb.grpc.UnaryMethodDefinition<any, any> {
+interface UnaryMethodDefinitionishR extends grpc.UnaryMethodDefinition<any, any> {
   requestStream: any;
   responseStream: any;
 }
@@ -1230,32 +1298,32 @@ interface Rpc {
   unary<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     request: any,
-    metadata: grpcWeb.grpc.Metadata | undefined
+    metadata: grpc.Metadata | undefined
   ): Promise<any>;
   invoke<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     request: any,
-    metadata: grpcWeb.grpc.Metadata | undefined
+    metadata: grpc.Metadata | undefined
   ): Observable<any>;
 }
 
 export class GrpcWebImpl {
   private host: string;
   private options: {
-    transport?: grpcWeb.grpc.TransportFactory;
-    streamingTransport?: grpcWeb.grpc.TransportFactory;
+    transport?: grpc.TransportFactory;
+    streamingTransport?: grpc.TransportFactory;
     debug?: boolean;
-    metadata?: grpcWeb.grpc.Metadata;
+    metadata?: grpc.Metadata;
     upStreamRetryCodes?: number[];
   };
 
   constructor(
     host: string,
     options: {
-      transport?: grpcWeb.grpc.TransportFactory;
-      streamingTransport?: grpcWeb.grpc.TransportFactory;
+      transport?: grpc.TransportFactory;
+      streamingTransport?: grpc.TransportFactory;
       debug?: boolean;
-      metadata?: grpcWeb.grpc.Metadata;
+      metadata?: grpc.Metadata;
       upStreamRetryCodes?: number[];
     }
   ) {
@@ -1266,7 +1334,7 @@ export class GrpcWebImpl {
   unary<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     _request: any,
-    metadata: grpcWeb.grpc.Metadata | undefined
+    metadata: grpc.Metadata | undefined
   ): Promise<any> {
     const request = { ..._request, ...methodDesc.requestType };
     const maybeCombinedMetadata =
@@ -1274,14 +1342,14 @@ export class GrpcWebImpl {
         ? new BrowserHeaders({ ...this.options?.metadata.headersMap, ...metadata?.headersMap })
         : metadata || this.options.metadata;
     return new Promise((resolve, reject) => {
-      grpcWeb.grpc.unary(methodDesc, {
+      grpc.unary(methodDesc, {
         request,
         host: this.host,
         metadata: maybeCombinedMetadata,
         transport: this.options.transport,
         debug: this.options.debug,
         onEnd: function (response) {
-          if (response.status === grpcWeb.grpc.Code.OK) {
+          if (response.status === grpc.Code.OK) {
             resolve(response.message!.toObject());
           } else {
             const err = new GrpcWebError(response.statusMessage, response.status, response.trailers);
@@ -1295,7 +1363,7 @@ export class GrpcWebImpl {
   invoke<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     _request: any,
-    metadata: grpcWeb.grpc.Metadata | undefined
+    metadata: grpc.Metadata | undefined
   ): Observable<any> {
     const upStreamCodes = this.options.upStreamRetryCodes || [];
     const DEFAULT_TIMEOUT_TIME: number = 3_000;
@@ -1306,14 +1374,14 @@ export class GrpcWebImpl {
         : metadata || this.options.metadata;
     return new Observable((observer) => {
       const upStream = () => {
-        const client = grpcWeb.grpc.invoke(methodDesc, {
+        const client = grpc.invoke(methodDesc, {
           host: this.host,
           request,
           transport: this.options.streamingTransport || this.options.transport,
           metadata: maybeCombinedMetadata,
           debug: this.options.debug,
           onMessage: (next) => observer.next(next),
-          onEnd: (code: grpcWeb.grpc.Code, message: string, trailers: grpcWeb.grpc.Metadata) => {
+          onEnd: (code: grpc.Code, message: string, trailers: grpc.Metadata) => {
             if (code === 0) {
               observer.complete();
             } else if (upStreamCodes.includes(code)) {
@@ -1369,7 +1437,7 @@ type DeepPartial<T> = T extends Builtin
   : Partial<T>;
 
 export class GrpcWebError extends tsProtoGlobalThis.Error {
-  constructor(message: string, public code: grpcWeb.grpc.Code, public metadata: grpcWeb.grpc.Metadata) {
+  constructor(message: string, public code: grpc.Code, public metadata: grpc.Metadata) {
     super(message);
   }
 }

--- a/packages/hub-web/src/generated/username_proof.ts
+++ b/packages/hub-web/src/generated/username_proof.ts
@@ -1,0 +1,217 @@
+/* eslint-disable */
+import _m0 from 'protobufjs/minimal';
+
+export enum UserNameType {
+  USERNAME_TYPE_NONE = 0,
+  USERNAME_TYPE_FNAME = 1,
+}
+
+export function userNameTypeFromJSON(object: any): UserNameType {
+  switch (object) {
+    case 0:
+    case 'USERNAME_TYPE_NONE':
+      return UserNameType.USERNAME_TYPE_NONE;
+    case 1:
+    case 'USERNAME_TYPE_FNAME':
+      return UserNameType.USERNAME_TYPE_FNAME;
+    default:
+      throw new tsProtoGlobalThis.Error('Unrecognized enum value ' + object + ' for enum UserNameType');
+  }
+}
+
+export function userNameTypeToJSON(object: UserNameType): string {
+  switch (object) {
+    case UserNameType.USERNAME_TYPE_NONE:
+      return 'USERNAME_TYPE_NONE';
+    case UserNameType.USERNAME_TYPE_FNAME:
+      return 'USERNAME_TYPE_FNAME';
+    default:
+      throw new tsProtoGlobalThis.Error('Unrecognized enum value ' + object + ' for enum UserNameType');
+  }
+}
+
+export interface UserNameProof {
+  timestamp: number;
+  name: Uint8Array;
+  owner: Uint8Array;
+  signature: Uint8Array;
+  type: UserNameType;
+}
+
+function createBaseUserNameProof(): UserNameProof {
+  return { timestamp: 0, name: new Uint8Array(), owner: new Uint8Array(), signature: new Uint8Array(), type: 0 };
+}
+
+export const UserNameProof = {
+  encode(message: UserNameProof, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.timestamp !== 0) {
+      writer.uint32(8).uint32(message.timestamp);
+    }
+    if (message.name.length !== 0) {
+      writer.uint32(18).bytes(message.name);
+    }
+    if (message.owner.length !== 0) {
+      writer.uint32(26).bytes(message.owner);
+    }
+    if (message.signature.length !== 0) {
+      writer.uint32(34).bytes(message.signature);
+    }
+    if (message.type !== 0) {
+      writer.uint32(40).int32(message.type);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): UserNameProof {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseUserNameProof();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.timestamp = reader.uint32();
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.name = reader.bytes();
+          continue;
+        case 3:
+          if (tag != 26) {
+            break;
+          }
+
+          message.owner = reader.bytes();
+          continue;
+        case 4:
+          if (tag != 34) {
+            break;
+          }
+
+          message.signature = reader.bytes();
+          continue;
+        case 5:
+          if (tag != 40) {
+            break;
+          }
+
+          message.type = reader.int32() as any;
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): UserNameProof {
+    return {
+      timestamp: isSet(object.timestamp) ? Number(object.timestamp) : 0,
+      name: isSet(object.name) ? bytesFromBase64(object.name) : new Uint8Array(),
+      owner: isSet(object.owner) ? bytesFromBase64(object.owner) : new Uint8Array(),
+      signature: isSet(object.signature) ? bytesFromBase64(object.signature) : new Uint8Array(),
+      type: isSet(object.type) ? userNameTypeFromJSON(object.type) : 0,
+    };
+  },
+
+  toJSON(message: UserNameProof): unknown {
+    const obj: any = {};
+    message.timestamp !== undefined && (obj.timestamp = Math.round(message.timestamp));
+    message.name !== undefined &&
+      (obj.name = base64FromBytes(message.name !== undefined ? message.name : new Uint8Array()));
+    message.owner !== undefined &&
+      (obj.owner = base64FromBytes(message.owner !== undefined ? message.owner : new Uint8Array()));
+    message.signature !== undefined &&
+      (obj.signature = base64FromBytes(message.signature !== undefined ? message.signature : new Uint8Array()));
+    message.type !== undefined && (obj.type = userNameTypeToJSON(message.type));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UserNameProof>, I>>(base?: I): UserNameProof {
+    return UserNameProof.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<UserNameProof>, I>>(object: I): UserNameProof {
+    const message = createBaseUserNameProof();
+    message.timestamp = object.timestamp ?? 0;
+    message.name = object.name ?? new Uint8Array();
+    message.owner = object.owner ?? new Uint8Array();
+    message.signature = object.signature ?? new Uint8Array();
+    message.type = object.type ?? 0;
+    return message;
+  },
+};
+
+declare var self: any | undefined;
+declare var window: any | undefined;
+declare var global: any | undefined;
+var tsProtoGlobalThis: any = (() => {
+  if (typeof globalThis !== 'undefined') {
+    return globalThis;
+  }
+  if (typeof self !== 'undefined') {
+    return self;
+  }
+  if (typeof window !== 'undefined') {
+    return window;
+  }
+  if (typeof global !== 'undefined') {
+    return global;
+  }
+  throw 'Unable to locate global object';
+})();
+
+function bytesFromBase64(b64: string): Uint8Array {
+  if (tsProtoGlobalThis.Buffer) {
+    return Uint8Array.from(tsProtoGlobalThis.Buffer.from(b64, 'base64'));
+  } else {
+    const bin = tsProtoGlobalThis.atob(b64);
+    const arr = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; ++i) {
+      arr[i] = bin.charCodeAt(i);
+    }
+    return arr;
+  }
+}
+
+function base64FromBytes(arr: Uint8Array): string {
+  if (tsProtoGlobalThis.Buffer) {
+    return tsProtoGlobalThis.Buffer.from(arr).toString('base64');
+  } else {
+    const bin: string[] = [];
+    arr.forEach((byte) => {
+      bin.push(String.fromCharCode(byte));
+    });
+    return tsProtoGlobalThis.btoa(bin.join(''));
+  }
+}
+
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
+
+type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Array<infer U>
+  ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U>
+  ? ReadonlyArray<DeepPartial<U>>
+  : T extends {}
+  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/packages/hub-web/src/generated/username_proof.ts
+++ b/packages/hub-web/src/generated/username_proof.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import Long from 'long';
 import _m0 from 'protobufjs/minimal';
 
 export enum UserNameType {
@@ -35,17 +36,25 @@ export interface UserNameProof {
   name: Uint8Array;
   owner: Uint8Array;
   signature: Uint8Array;
+  fid: number;
   type: UserNameType;
 }
 
 function createBaseUserNameProof(): UserNameProof {
-  return { timestamp: 0, name: new Uint8Array(), owner: new Uint8Array(), signature: new Uint8Array(), type: 0 };
+  return {
+    timestamp: 0,
+    name: new Uint8Array(),
+    owner: new Uint8Array(),
+    signature: new Uint8Array(),
+    fid: 0,
+    type: 0,
+  };
 }
 
 export const UserNameProof = {
   encode(message: UserNameProof, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.timestamp !== 0) {
-      writer.uint32(8).uint32(message.timestamp);
+      writer.uint32(8).uint64(message.timestamp);
     }
     if (message.name.length !== 0) {
       writer.uint32(18).bytes(message.name);
@@ -56,8 +65,11 @@ export const UserNameProof = {
     if (message.signature.length !== 0) {
       writer.uint32(34).bytes(message.signature);
     }
+    if (message.fid !== 0) {
+      writer.uint32(40).uint64(message.fid);
+    }
     if (message.type !== 0) {
-      writer.uint32(40).int32(message.type);
+      writer.uint32(48).int32(message.type);
     }
     return writer;
   },
@@ -74,7 +86,7 @@ export const UserNameProof = {
             break;
           }
 
-          message.timestamp = reader.uint32();
+          message.timestamp = longToNumber(reader.uint64() as Long);
           continue;
         case 2:
           if (tag != 18) {
@@ -102,6 +114,13 @@ export const UserNameProof = {
             break;
           }
 
+          message.fid = longToNumber(reader.uint64() as Long);
+          continue;
+        case 6:
+          if (tag != 48) {
+            break;
+          }
+
           message.type = reader.int32() as any;
           continue;
       }
@@ -119,6 +138,7 @@ export const UserNameProof = {
       name: isSet(object.name) ? bytesFromBase64(object.name) : new Uint8Array(),
       owner: isSet(object.owner) ? bytesFromBase64(object.owner) : new Uint8Array(),
       signature: isSet(object.signature) ? bytesFromBase64(object.signature) : new Uint8Array(),
+      fid: isSet(object.fid) ? Number(object.fid) : 0,
       type: isSet(object.type) ? userNameTypeFromJSON(object.type) : 0,
     };
   },
@@ -132,6 +152,7 @@ export const UserNameProof = {
       (obj.owner = base64FromBytes(message.owner !== undefined ? message.owner : new Uint8Array()));
     message.signature !== undefined &&
       (obj.signature = base64FromBytes(message.signature !== undefined ? message.signature : new Uint8Array()));
+    message.fid !== undefined && (obj.fid = Math.round(message.fid));
     message.type !== undefined && (obj.type = userNameTypeToJSON(message.type));
     return obj;
   },
@@ -146,6 +167,7 @@ export const UserNameProof = {
     message.name = object.name ?? new Uint8Array();
     message.owner = object.owner ?? new Uint8Array();
     message.signature = object.signature ?? new Uint8Array();
+    message.fid = object.fid ?? 0;
     message.type = object.type ?? 0;
     return message;
   },
@@ -211,6 +233,18 @@ type KeysOfUnion<T> = T extends T ? keyof T : never;
 type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
+
+function longToNumber(long: Long): number {
+  if (long.gt(Number.MAX_SAFE_INTEGER)) {
+    throw new tsProtoGlobalThis.Error('Value is larger than Number.MAX_SAFE_INTEGER');
+  }
+  return long.toNumber();
+}
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;

--- a/protobufs/schemas/hub_event.proto
+++ b/protobufs/schemas/hub_event.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 import "message.proto";
 import "id_registry_event.proto";
 import "name_registry_event.proto";
+import "username_proof.proto";
 
 enum HubEventType {
   HUB_EVENT_TYPE_NONE = 0;
@@ -11,6 +12,7 @@ enum HubEventType {
   HUB_EVENT_TYPE_REVOKE_MESSAGE = 3;
   HUB_EVENT_TYPE_MERGE_ID_REGISTRY_EVENT = 4;
   HUB_EVENT_TYPE_MERGE_NAME_REGISTRY_EVENT = 5;
+  HUB_EVENT_TYPE_MERGE_USERNAME_PROOF = 6;
 }
 
 message MergeMessageBody {
@@ -34,6 +36,10 @@ message MergeNameRegistryEventBody {
   NameRegistryEvent name_registry_event = 1;
 }
 
+message MergeUserNameProofBody {
+  UserNameProof username_proof = 1;
+}
+
 message HubEvent {
   HubEventType type = 1;
   uint64 id = 2;
@@ -43,5 +49,6 @@ message HubEvent {
     RevokeMessageBody revoke_message_body = 5;
     MergeIdRegistryEventBody merge_id_registry_event_body = 6;
     MergeNameRegistryEventBody merge_name_registry_event_body = 7;
+    MergeUserNameProofBody merge_username_proof_body = 8;
   };
 }

--- a/protobufs/schemas/hub_state.proto
+++ b/protobufs/schemas/hub_state.proto
@@ -2,4 +2,5 @@ syntax = "proto3";
 
 message HubState {
   uint32 last_eth_block = 1;
+  uint64 last_fname_proof = 2;
 }

--- a/protobufs/schemas/username_proof.proto
+++ b/protobufs/schemas/username_proof.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+enum UserNameType {
+  USERNAME_TYPE_NONE = 0;
+  USERNAME_TYPE_FNAME = 1;
+}
+
+message UserNameProof {
+  uint32 timestamp = 1;
+  bytes name = 2;
+  bytes owner = 3;
+  bytes signature = 4;
+  UserNameType type = 5;
+}

--- a/protobufs/schemas/username_proof.proto
+++ b/protobufs/schemas/username_proof.proto
@@ -6,9 +6,10 @@ enum UserNameType {
 }
 
 message UserNameProof {
-  uint32 timestamp = 1;
+  uint64 timestamp = 1;
   bytes name = 2;
   bytes owner = 3;
   bytes signature = 4;
-  UserNameType type = 5;
+  uint64 fid = 5;
+  UserNameType type = 6;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2915,6 +2915,11 @@ async-lock@^1.4.0:
   resolved "https://registry.npmjs.org/async-lock/-/async-lock-1.4.0.tgz#c8b6630eff68fbbdd8a5b6eb763dac3bfbb8bf02"
   integrity sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 atomic-sleep@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
@@ -2924,6 +2929,15 @@ available-typed-arrays@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
+
+axios@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
+  integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 babel-jest@^29.5.0:
   version "29.5.0"
@@ -3388,6 +3402,13 @@ colorette@^2.0.19, colorette@^2.0.7:
   resolved "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
   integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^10.0.0, commander@~10.0.0:
   version "10.0.0"
   resolved "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz#71797971162cd3cf65f0b9d24eb28f8d303acdf1"
@@ -3574,6 +3595,11 @@ define-properties@^1.1.3, define-properties@^1.1.4:
   dependencies:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 denque@^1.5.0:
   version "1.5.1"
@@ -4390,6 +4416,11 @@ flatted@^3.1.0:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
+follow-redirects@^1.15.0:
+  version "1.15.2"
+  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -4404,6 +4435,15 @@ foreground-child@^3.1.0:
   dependencies:
     cross-spawn "^7.0.0"
     signal-exit "^4.0.1"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 freeport-promise@^2.0.0:
   version "2.0.0"
@@ -6068,10 +6108,17 @@ micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
-mime-db@^1.28.0:
+mime-db@1.52.0, mime-db@^1.28.0:
   version "1.52.0"
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -6787,6 +6834,11 @@ protons-runtime@^4.0.1:
   dependencies:
     protobufjs "^7.0.0"
     uint8arraylist "^2.4.3"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 pseudomap@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Motivation

Support polling fname registry server for fname proofs and store them in the db

## Change Summary

Add Fname registry events provider
Add store for user name proofs

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for username proofs to the Farcaster hub. It includes changes to protobufs, storage, and EIP712 signature verification. 

### Detailed summary
- Added `UserNameProof` protobuf message
- Added `mergeUserNameProof` method to `Engine` class to merge username proofs into the user data store
- Added `submitUserNameProof` method to `HubInterface` to submit username proofs to the hub
- Added `UserNameProofFactory` to `Factories` in `factories.ts` for generating test data
- Added `usernameProofToLog` function to `logger.ts` for logging username proofs
- Added `usernameProofCompare` function to `utils.ts` for comparing username proofs
- Added `UserNameProofClaim` interface to `eip712.ts` for verifying EIP712 signatures of username proofs
- Added `verifyUserNameProof` function to `eip712.ts` for verifying EIP712 signatures of username proofs
- Added `UserNameType` enum to `username_proof.proto`
- Updated `HubEventType` enum in `hub_event.proto` to include `HUB_EVENT_TYPE_MERGE_USERNAME_PROOF`
- Updated `MergeUserNameProofBody` message in `hub_event.proto`
- Updated `Engine` class in `index.ts` to include `mergeUserNameProof` method
- Updated `EthEventsProvider` class in `ethEventsProvider.ts` to include logic for fetching and validating username proofs from the fname registry
- Updated `UserDataStore` class in `userDataStore.ts` to include methods for merging, getting, and deleting username proofs from the user data store
- Updated `utils.ts` to include `UserNameProof` in the import statement and `usernameProofCompare` in the export statement
- Updated `mocks.ts` to include `submitUserNameProof` method in `MockHub` class
- Added tests for `mergeUserNameProof`, `submitUserNameProof`, `verifyUserNameProof`, and related functions

> The following files were skipped due to too many changes: `apps/hubble/src/storage/stores/userDataStore.ts`, `apps/hubble/src/storage/db/nameRegistryEvent.ts`, `apps/hubble/src/cli.ts`, `packages/core/src/protobufs/generated/hub_state.ts`, `apps/hubble/src/storage/stores/userDataStore.test.ts`, `packages/core/src/crypto/eip712.ts`, `apps/hubble/src/hubble.ts`, `apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts`, `apps/hubble/src/eth/fnameRegistryEventsProvider.ts`, `yarn.lock`, `packages/hub-web/src/generated/hub_event.ts`, `packages/hub-nodejs/src/generated/hub_event.ts`, `packages/core/src/protobufs/generated/hub_event.ts`, `packages/hub-web/src/generated/rpc.ts`, `packages/hub-web/src/generated/message.ts`, `packages/hub-web/src/generated/username_proof.ts`, `packages/hub-nodejs/src/generated/username_proof.ts`, `packages/core/src/protobufs/generated/username_proof.ts`, `packages/hub-web/src/generated/request_response.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->