### PR TITLE
fix: Close open db iterators from job queues

### DIFF
--- a/apps/hubble/src/storage/db/rocksdb.ts
+++ b/apps/hubble/src/storage/db/rocksdb.ts
@@ -107,7 +107,8 @@ class RocksDB {
         } else {
           if (now - entry.openTimestamp >= MAX_DB_ITERATOR_OPEN_MILLISECONDS) {
             log.warn(
-              `RocksDB iterator with options ${entry.options} open
+              entry.options,
+              `RocksDB iterator with open
                 for more than ${MAX_DB_ITERATOR_OPEN_MILLISECONDS} ms`
             );
           }

--- a/apps/hubble/src/storage/db/rocksdb.ts
+++ b/apps/hubble/src/storage/db/rocksdb.ts
@@ -108,7 +108,7 @@ class RocksDB {
           if (now - entry.openTimestamp >= MAX_DB_ITERATOR_OPEN_MILLISECONDS) {
             log.warn(
               entry.options,
-              `RocksDB iterator with open
+              `RocksDB iterator open
                 for more than ${MAX_DB_ITERATOR_OPEN_MILLISECONDS} ms`
             );
           }

--- a/apps/hubble/src/storage/jobs/revokeMessagesBySignerJob.ts
+++ b/apps/hubble/src/storage/jobs/revokeMessagesBySignerJob.ts
@@ -157,6 +157,7 @@ export class RevokeMessagesBySignerJobQueue extends TypedEmitter<JobQueueEvents>
 
     const result = await ResultAsync.fromPromise(iterator.value.next(), (e) => e as HubError);
     if (result.isErr()) {
+      await iterator.value.end();
       return err(result.error);
     }
 

--- a/apps/hubble/src/storage/jobs/updateNameRegistryEventExpiryJob.ts
+++ b/apps/hubble/src/storage/jobs/updateNameRegistryEventExpiryJob.ts
@@ -217,6 +217,7 @@ export class UpdateNameRegistryEventExpiryJobQueue extends TypedEmitter<JobQueue
 
     const result = await ResultAsync.fromPromise(iterator.value.next(), (e) => e as HubError);
     if (result.isErr()) {
+      await iterator.value.end();
       return err(result.error);
     }
 


### PR DESCRIPTION
## Motivation

After the fix for #883 we are still seeing some open iterators [here](https://app.datadoghq.com/logs?query=%40aws.awslogs.logStream%3A%28testnet1%2Fhubble%2F%2A%20OR%20testnet2%2Fhubble%2F%2A%29%20%22RocksDB%20iterator%20with%20options%22%20&agg_q=%40peerId&cols=%40peerId%2C%40inSync%2C%40peerNetwork%2C%40peerVersion&index=&messageDisplay=inline&sort_m=&sort_t=&stream_sort=time%2Cdesc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1686857889359&to_ts=1686858789359&live=true).

## Change Summary

This change makes sure db iterators created via `UpdateNameRegistryEventExpiryJobWorker` and `RevokeMessagesBySignerJobQueue` are always closed. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a call to `iterator.value.end()` when an error occurs during iteration, and updates a log message in `rocksdb.ts`. 

### Detailed summary
- Added a call to `iterator.value.end()` when an error occurs during iteration in `revokeMessagesBySignerJob.ts` and `updateNameRegistryEventExpiryJob.ts`
- Updated log message in `rocksdb.ts` to only include `entry.options` and specify the duration of the iterator being open

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->