### PR TITLE
chore: add links support in the replicate to postgres example

### DIFF
--- a/packages/hub-nodejs/examples/replicate-data-postgres/db.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/db.ts
@@ -119,6 +119,7 @@ export interface Database {
   };
 
   links: {
+    id: GeneratedAlways<string>;
     fid: number;
     targetFid: number | null;
     type: string;

--- a/packages/hub-nodejs/examples/replicate-data-postgres/db.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/db.ts
@@ -117,6 +117,17 @@ export interface Database {
     custodyAddress: Uint8Array;
     expiresAt: Date;
   };
+
+  links: {
+    fid: number;
+    targetFid: number | null;
+    type: string;
+    timestamp: Date;
+    createdAt: Generated<Date>;
+    updatedAt: Generated<Date>;
+    displayTimestamp: Date | null;
+    deletedAt: Date | null;
+  };
 }
 
 export const getDbClient = (connectionString: string) => {

--- a/packages/hub-nodejs/examples/replicate-data-postgres/hubReplicator.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/hubReplicator.ts
@@ -9,6 +9,8 @@ import {
   ReactionRemoveMessage,
   SignerAddMessage,
   SignerRemoveMessage,
+  LinkAddMessage,
+  LinkRemoveMessage,
   UserDataAddMessage,
   VerificationAddEthAddressMessage,
   VerificationRemoveMessage,
@@ -24,6 +26,8 @@ import {
   isSignerAddMessage,
   isSignerRemoveMessage,
   isUserDataAddMessage,
+  isLinkAddMessage,
+  isLinkRemoveMessage,
   isVerificationAddEthAddressMessage,
   isVerificationRemoveMessage,
   getSSLHubRpcClient,
@@ -91,13 +95,13 @@ export class HubReplicator {
   }
 
   public async start() {
-    const infoResult = await this.client.getInfo({ syncStats: true });
+    const infoResult = await this.client.getInfo({ dbStats: true });
 
-    if (infoResult.isErr() || infoResult.value.syncStats === undefined) {
+    if (infoResult.isErr() || infoResult.value.dbStats === undefined) {
       throw new Error(`Unable to get information about hub ${this.hubAddress}`);
     }
 
-    const { numMessages } = infoResult.value.syncStats;
+    const { numMessages } = infoResult.value.dbStats;
 
     // Not technically true, since hubs don't return CastRemove/etc. messages,
     // but at least gives a rough ballpark of order of magnitude.
@@ -359,6 +363,10 @@ export class HubReplicator {
       await this.onSignerRemove(messages as SignerRemoveMessage[]);
     } else if (isUserDataAddMessage(firstMessage)) {
       await this.onUserDataAdd(messages as UserDataAddMessage[], isInitialCreation);
+    } else if (isLinkAddMessage(firstMessage)) {
+      await this.onLinkAdd(messages as LinkAddMessage[], isInitialCreation);
+    } else if (isLinkRemoveMessage(firstMessage)) {
+      await this.onLinkRemove(messages as LinkRemoveMessage[]);
     }
   }
 
@@ -588,6 +596,43 @@ export class HubReplicator {
       if (isInitialCreation[bytesToHex(message.hash)]) {
         // TODO: Execute any one-time side effects
       }
+    }
+  }
+
+  private async onLinkAdd(messages: LinkAddMessage[], isInitialCreation: Record<string, boolean>) {
+    await this.db
+      .insertInto('links')
+      .values(
+        messages.map((message) => ({
+          timestamp: farcasterTimeToDate(message.data.timestamp),
+          // type assertion due to a problem with the type definitions. This field is infact required and present in all valid messages
+          targetFid: message.data.linkBody.targetFid!,
+          type: message.data.linkBody.type,
+          fid: message.data.fid,
+          displayTimestamp: farcasterTimeToDate(message.data.linkBody.displayTimestamp),
+        }))
+      )
+      .execute();
+
+    for (const message of messages) {
+      if (isInitialCreation[bytesToHex(message.hash)]) {
+        // TODO: Execute any one-time side effects
+      }
+    }
+  }
+
+  private async onLinkRemove(messages: LinkRemoveMessage[]) {
+    for (const message of messages) {
+      await this.db
+        .updateTable('links')
+        .where('fid', '=', message.data.fid)
+        // type assertion due to a problem with the type definitions. This field is infact required and present in all valid messages
+        .where('targetFid', '=', message.data.linkBody.targetFid!)
+        .where('type', '=', message.data.linkBody.type)
+        .set({ deletedAt: farcasterTimeToDate(message.data.timestamp) })
+        .execute();
+
+      // TODO: Execute any cleanup side effects to remove the cast
     }
   }
 }

--- a/packages/hub-nodejs/examples/replicate-data-postgres/migrations/001_initial_migration.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/migrations/001_initial_migration.ts
@@ -178,6 +178,7 @@ export const up = async (db: Kysely<any>) => {
 
   await db.schema
     .createTable('links')
+    .addColumn('id', 'bigint', (col) => col.generatedAlwaysAsIdentity().primaryKey())
     .addColumn('fid', 'bigint')
     .addColumn('targetFid', 'bigint')
     .addColumn('timestamp', 'timestamp', (col) => col.notNull())

--- a/packages/hub-nodejs/examples/replicate-data-postgres/migrations/001_initial_migration.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/migrations/001_initial_migration.ts
@@ -175,9 +175,24 @@ export const up = async (db: Kysely<any>) => {
     .addColumn('custodyAddress', sql`bytea`, (col) => col.notNull())
     .addColumn('expiresAt', 'timestamp', (col) => col.notNull())
     .execute();
+
+  await db.schema
+    .createTable('links')
+    .addColumn('fid', 'bigint')
+    .addColumn('targetFid', 'bigint')
+    .addColumn('timestamp', 'timestamp', (col) => col.notNull())
+    .addColumn('createdAt', 'timestamp', (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn('updatedAt', 'timestamp', (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn('deletedAt', 'timestamp')
+    .addColumn('type', 'text')
+    .addColumn('displayTimestamp', 'timestamp')
+    .execute();
 };
 
 export const down = async (db: Kysely<any>) => {
+  await db.schema.dropTable('links').ifExists().execute();
+  await db.schema.dropTable('fnames').ifExists().execute();
+  await db.schema.dropTable('fids').ifExists().execute();
   await db.schema.dropTable('casts').ifExists().execute();
   await db.schema.dropTable('reactions').ifExists().execute();
   await db.schema.dropTable('signers').ifExists().execute();

--- a/packages/hub-nodejs/examples/replicate-data-postgres/package.json
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/package.json
@@ -7,8 +7,11 @@
   "scripts": {
     "start": "tsx index.ts"
   },
+  "engines": {
+    "node": ">=16"
+  },
   "dependencies": {
-    "@farcaster/hub-nodejs": "^0.7.1",
+    "@farcaster/hub-nodejs": "^0.8.0",
     "fastq": "^1.15.0",
     "kysely": "^0.24.2",
     "kysely-postgres-js": "^1.1.1",

--- a/packages/hub-nodejs/examples/replicate-data-postgres/yarn.lock
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/yarn.lock
@@ -288,30 +288,24 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
-"@faker-js/faker@^7.6.0":
-  version "7.6.0"
-  resolved "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz#9ea331766084288634a9247fcd8b84f16ff4ba07"
-  integrity sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==
-
-"@farcaster/core@0.7.1":
-  version "0.7.1"
-  resolved "https://registry.npmjs.org/@farcaster/core/-/core-0.7.1.tgz#69525a1cf4485dd5e0a24395daf1ae35fd0e38cb"
-  integrity sha512-2hVRWSgMDnoHFsuCzKhaTmsp7XWMk1QSE0RLjHarQYbosz6fILHB8F57fEZ0unAi0vDqgoMabvNLdkqQiO6HCQ==
+"@farcaster/core@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.npmjs.org/@farcaster/core/-/core-0.9.0.tgz#54972cbbb7b84fb0985bd4b4bb1c12e3089010a3"
+  integrity sha512-RJPYG6y7an3316avmEwRi2hSKsgxza/9hOQOz0YYgRukOu6qfobt7awQHnDIgV8NUrVtHM0q5UYat5s0N/4UnA==
   dependencies:
     "@ethersproject/abstract-signer" "^5.7.0"
-    "@faker-js/faker" "^7.6.0"
-    "@noble/ed25519" "^1.7.3"
+    "@noble/curves" "^1.0.0"
     "@noble/hashes" "^1.3.0"
     ethers "~6.2.1"
     neverthrow "^6.0.0"
     viem "^0.3.2"
 
-"@farcaster/hub-nodejs@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.npmjs.org/@farcaster/hub-nodejs/-/hub-nodejs-0.7.1.tgz#5ebe822890ebc4fe48f2ba2d58d5e2a78778ac65"
-  integrity sha512-w9U619g041RAuNlL+QXB52fLygBVBGClhbDP+28LbosDLShCPxxdpMC3Wtr5YiwusinXtiqR46yYTFuQBsEGag==
+"@farcaster/hub-nodejs@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.npmjs.org/@farcaster/hub-nodejs/-/hub-nodejs-0.8.0.tgz#f999edd94e4a39213c9e85da41b25bb77f198c90"
+  integrity sha512-wTKx5TZOLDnzQcuNHhXWiQ53pltwy+5Z42OIrx9TIVppLJJNvVdnZYRQ9ttvL/desmNIc/oo+9GNYPq+i8BkuQ==
   dependencies:
-    "@farcaster/core" "0.7.1"
+    "@farcaster/core" "0.9.0"
     "@grpc/grpc-js" "^1.8.13"
     "@noble/hashes" "^1.3.0"
     ethers "~6.2.1"
@@ -343,17 +337,19 @@
   dependencies:
     "@noble/hashes" "1.3.0"
 
+"@noble/curves@^1.0.0":
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/@noble/curves/-/curves-1.1.0.tgz#f13fc667c89184bc04cccb9b11e8e7bae27d8c3d"
+  integrity sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==
+  dependencies:
+    "@noble/hashes" "1.3.1"
+
 "@noble/curves@~0.8.3":
   version "0.8.3"
   resolved "https://registry.npmjs.org/@noble/curves/-/curves-0.8.3.tgz#ad6d48baf2599cf1d58dcb734c14d5225c8996e0"
   integrity sha512-OqaOf4RWDaCRuBKJLDURrgVxjLmneGsiCXGuzYB5y95YithZMA6w4uk34DHSm0rKMrrYiaeZj48/81EvaAScLQ==
   dependencies:
     "@noble/hashes" "1.3.0"
-
-"@noble/ed25519@^1.7.3":
-  version "1.7.3"
-  resolved "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz#57e1677bf6885354b466c38e2b620c62f45a7123"
-  integrity sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==
 
 "@noble/hashes@1.1.2":
   version "1.1.2"
@@ -364,6 +360,11 @@
   version "1.3.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz#085fd70f6d7d9d109671090ccae1d3bec62554a1"
   integrity sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==
+
+"@noble/hashes@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz#8831ef002114670c603c458ab8b11328406953a9"
+  integrity sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==
 
 "@noble/secp256k1@1.7.1":
   version "1.7.1"


### PR DESCRIPTION
## Motivation

Updates the `replicate-hub-to-postgres` example to includes links, added in the latest protocol release

## Change Summary

- adds a `links` table to the postgres schema, and syncs `LinkAddMessage` and `LinkRemoveMessage` events
- fixes outdated use of `syncStats` which was renamed to `dbStats` in https://github.com/farcasterxyz/hub-monorepo/pull/944
- adds the explicit `node >= 16` dependency created by `@noble/hashes@1.3.1`
- updates version of `@farcaster/hub-nodejs` to `^0.8.0` for Links types
- adds missing migrate down tables

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

none

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `@farcaster/hub-nodejs` dependency to version `0.8.0` and adds a new `links` table to the database schema.

### Detailed summary
- Updated `@farcaster/hub-nodejs` to version `0.8.0`
- Added a new `links` table to the database schema with columns `id`, `fid`, `targetFid`, `type`, `timestamp`, `createdAt`, `updatedAt`, `displayTimestamp`, and `deletedAt`
- Implemented methods to handle `LinkAddMessage` and `LinkRemoveMessage` messages in `hubReplicator.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->