### PR TITLE
chore: add peerid @silent

### DIFF
--- a/apps/hubble/src/allowedPeers.mainnet.ts
+++ b/apps/hubble/src/allowedPeers.mainnet.ts
@@ -41,4 +41,5 @@ export const MAINNET_ALLOWED_PEERS = [
   '12D3KooWJtEEh7Bcx9T2oKUpcMb9K8xuMFFk5BQNNdJ63Rsx853C', // Jam.so Hub 4
   '12D3KooWH3FAGri9Ki4j7xBBjghav9nRTyu8jVVBsRh55odGxraM', // @kencodes
   '12D3KooWPsSJu7jPS2UcroV4R1Ed1VJKVBxBkuNs4haDTEUnYBvm', // @sheldon
+  '12D3KooWR5qBN6GraBd4DzAJVaGzVk9TZgUYFusoPhxt5suPFtqH', // @silent
 ];


### PR DESCRIPTION
## Motivation

Add a peerid for farcaster mainnet hubs.

## Change Summary

* Added a new allowed peer to the allowedPeers.mainnet.ts file in the apps/hubble/src directory.
* The new peer has the following address: 12D3KooWR5qBN6GraBd4DzAJVaGzVk9TZgUYFusoPhxt5suPFtqH
* No other changes were made.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)



<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new allowed peer (`@silent`) to the `allowedPeers.mainnet.ts` file in the `hubble` app.

### Detailed summary
- Added a new allowed peer (`@silent`) to the `allowedPeers.mainnet.ts` file in the `hubble` app.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->