### PR TITLE
chore: release 1.3.1

### DIFF
--- a/.changeset/cool-emus-decide.md
+++ b/.changeset/cool-emus-decide.md
@@ -1,5 +1,0 @@
----
-'@farcaster/hubble': patch
----
-
-Refactored stores to use a generic implementation for easier addition of types

--- a/.changeset/curvy-hotels-joke.md
+++ b/.changeset/curvy-hotels-joke.md
@@ -1,5 +1,0 @@
----
-'@farcaster/hubble': patch
----
-
-Handle peers with no messages in status command

--- a/.changeset/funny-masks-explode.md
+++ b/.changeset/funny-masks-explode.md
@@ -1,8 +1,0 @@
----
-'@farcaster/hub-nodejs': patch
-'@farcaster/hub-web': patch
-'@farcaster/core': patch
-'@farcaster/hubble': patch
----
-
-Fetch, validate and store username proofs from fname registry

--- a/.changeset/many-birds-remember.md
+++ b/.changeset/many-birds-remember.md
@@ -1,5 +1,0 @@
----
-'@farcaster/hubble': patch
----
-
-Fix server hanging due to slow subscribers in certain conditions

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @farcaster/hubble
 
+## 1.3.1
+
+### Patch Changes
+
+- 7dabc0b: Refactored stores to use a generic implementation for easier addition of types
+- 6667748: Handle peers with no messages in status command
+- f1c6b25: Fetch, validate and store username proofs from fname registry
+- c6fc422: Fix server hanging due to slow subscribers in certain conditions
+- Updated dependencies [f1c6b25]
+  - @farcaster/hub-nodejs@0.8.1
+
 ## 1.3.0
 
 ### Minor Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -51,7 +51,7 @@
     "@chainsafe/libp2p-gossipsub": "6.1.0",
     "@chainsafe/libp2p-noise": "^11.0.0 ",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.8.0",
+    "@farcaster/hub-nodejs": "^0.8.1",
     "@farcaster/rocksdb": "^5.5.0",
     "@grpc/grpc-js": "~1.8.7",
     "@libp2p/interface-connection": "^3.0.2",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/core
 
+## 0.9.1
+
+### Patch Changes
+
+- f1c6b25: Fetch, validate and store username proofs from fname registry
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hub-nodejs
 
+## 0.8.1
+
+### Patch Changes
+
+- f1c6b25: Fetch, validate and store username proofs from fname registry
+- Updated dependencies [f1c6b25]
+  - @farcaster/core@0.9.1
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@farcaster/core": "0.9.0",
+    "@farcaster/core": "0.9.1",
     "@grpc/grpc-js": "^1.8.13",
     "@noble/hashes": "^1.3.0",
     "ethers": "~6.2.1",

--- a/packages/hub-web/CHANGELOG.md
+++ b/packages/hub-web/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hub-web
 
+## 0.3.6
+
+### Patch Changes
+
+- f1c6b25: Fetch, validate and store username proofs from fname registry
+- Updated dependencies [f1c6b25]
+  - @farcaster/core@0.9.1
+
 ## 0.3.5
 
 ### Patch Changes

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-web",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -29,7 +29,7 @@
     "ts-proto": "^1.146.0"
   },
   "dependencies": {
-    "@farcaster/core": "^0.9.0",
+    "@farcaster/core": "^0.9.1",
     "@improbable-eng/grpc-web": "^0.15.0",
     "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
     "rxjs": "^7.8.0"


### PR DESCRIPTION
## Motivation

Release `1.3.1`

## Change Summary

See changelog

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates several dependencies and includes a patch for fetching and storing username proofs from the fname registry. 

### Detailed summary
- Updates @farcaster/core to version 0.9.1 in packages/core and hub-* packages
- Updates @farcaster/hub-nodejs to version 0.8.1 in apps/hubble
- Adds patch changes to fetch, validate, and store username proofs from fname registry in packages/core and hub-* packages
- Refactors stores to use a generic implementation for easier addition of types in apps/hubble
- Handles peers with no messages in status command in apps/hubble
- Fixes server hanging due to slow subscribers in certain conditions in apps/hubble

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->