### PR TITLE
fix: Backfill links in replicate-data-postgres example

### DIFF
--- a/packages/hub-nodejs/examples/replicate-data-postgres/docker-compose.yml
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   app:
-    image: 'node:20-alpine'
+    image: 'node:20.2-alpine'
     restart: unless-stopped
     command: ["sh", "-c", "yarn install && exec yarn start"]
     init: true

--- a/packages/hub-nodejs/examples/replicate-data-postgres/hubReplicator.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/hubReplicator.ts
@@ -165,6 +165,7 @@ export class HubReplicator {
     for (const fn of [
       this.getCastsByFidInBatchesOf,
       this.getReactionsByFidInBatchesOf,
+      this.getLinksByFidInBatchesOf,
       this.getSignersByFidInBatchesOf,
       this.getVerificationsByFidInBatchesOf,
       this.getUserDataByFidInBatchesOf,
@@ -204,6 +205,22 @@ export class HubReplicator {
 
       if (!pageToken?.length) break;
       result = await this.client.getReactionsByFid({ pageSize, pageToken, fid });
+    }
+  }
+
+  private async *getLinksByFidInBatchesOf(fid: number, pageSize: number) {
+    let result = await this.client.getLinksByFid({ pageSize, fid });
+    for (;;) {
+      if (result.isErr()) {
+        throw new Error('Unable to backfill', { cause: result.error });
+      }
+
+      const { messages, nextPageToken: pageToken } = result.value;
+
+      yield messages;
+
+      if (!pageToken?.length) break;
+      result = await this.client.getLinksByFid({ pageSize, pageToken, fid });
     }
   }
 


### PR DESCRIPTION
# Motivation

This was missed in #1022.

## Change Summary

Add support for backfilling links (e.g. follows) data.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `node` Docker image version and adds a new function to retrieve links by ID in batches.

### Detailed summary
- Updated `node` Docker image version to `20.2-alpine`.
- Added `getLinksByFidInBatchesOf` function to retrieve links by ID in batches.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->