### PR TITLE
chore: use viem in @farcaster/core

### DIFF
--- a/.changeset/gentle-clouds-give.md
+++ b/.changeset/gentle-clouds-give.md
@@ -10,3 +10,4 @@ Used viem to verify Ethereum signatures
 - Breaking API changes
   - make\*Data functions are now async
   - removed top-level getSignerKey, signVerificationEthAddressClaim, and signMessageHash, use an Eip712Signer class (i.e. EthersEip712Signer or ViemLocalEip712Signer)
+  - rename `verifyUserNameProof` to `verifyUserNameProofClaim`

--- a/.changeset/gentle-clouds-give.md
+++ b/.changeset/gentle-clouds-give.md
@@ -4,4 +4,6 @@
 
 Used viem to verify Ethereum signatures
 
-- Breaking API change: make\*Data functions are now async
+- Breaking API changes
+  - make\*Data functions are now async
+  - removed top-level getSignerKey, signVerificationEthAddressClaim, and signMessageHash, use an Eip712Signer class (i.e. EthersEip712Signer or ViemLocalEip712Signer)

--- a/.changeset/gentle-clouds-give.md
+++ b/.changeset/gentle-clouds-give.md
@@ -4,6 +4,9 @@
 
 Used viem to verify Ethereum signatures
 
+- Added `signUserNameProofClaim` to `Eip712Signer`
+- Added `makeUserNameProofClaim`
+
 - Breaking API changes
   - make\*Data functions are now async
   - removed top-level getSignerKey, signVerificationEthAddressClaim, and signMessageHash, use an Eip712Signer class (i.e. EthersEip712Signer or ViemLocalEip712Signer)

--- a/.changeset/gentle-clouds-give.md
+++ b/.changeset/gentle-clouds-give.md
@@ -1,0 +1,7 @@
+---
+'@farcaster/core': minor
+---
+
+Used viem to verify Ethereum signatures
+
+- Breaking API change: make\*Data functions are now async

--- a/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
+++ b/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
@@ -6,36 +6,37 @@ import {
 import { jestRocksDB } from '../storage/db/jestUtils.js';
 import Engine from '../storage/engine/index.js';
 import { FarcasterNetwork } from '@farcaster/hub-nodejs';
-import { eip712 } from '@farcaster/core';
+import { ViemLocalEip712Signer } from '@farcaster/core';
 import { MockHub } from '../test/mocks.js';
 import { getUserNameProof } from '../storage/db/nameRegistryEvent.js';
 import { utf8ToBytes } from '@noble/curves/abstract/utils';
-import { Signer, Wallet } from 'ethers';
+import { generatePrivateKey, privateKeyToAccount, PrivateKeyAccount } from 'viem/accounts';
+import { bytesToHex } from 'viem';
 
 class MockFnameRegistryClient implements FNameRegistryClientInterface {
   private transfersToReturn: FNameTransfer[][] = [];
   private minimumSince = 0;
   private timesToThrow = 0;
-  private signer: Signer;
+  private account: PrivateKeyAccount;
+  private signer: ViemLocalEip712Signer;
 
-  constructor(signer: Signer) {
-    this.signer = signer;
+  constructor(account: PrivateKeyAccount) {
+    this.account = account;
+    this.signer = new ViemLocalEip712Signer(account);
   }
 
   setTransfersToReturn(transfers: FNameTransfer[][]) {
     this.transfersToReturn = transfers;
     this.transfersToReturn.flat(2).forEach(async (t) => {
       if (t.server_signature === '') {
-        t.server_signature = await this.signer.signTypedData(
-          eip712.EIP_712_USERNAME_DOMAIN,
-          {
-            UserNameProof: eip712.EIP_712_USERNAME_PROOF,
-          },
-          {
-            name: t.username,
-            owner: t.owner,
-            timestamp: t.timestamp,
-          }
+        t.server_signature = bytesToHex(
+          (
+            await this.signer.signUserNameProof({
+              name: t.username,
+              owner: t.owner,
+              timestamp: t.timestamp,
+            })
+          )._unsafeUnwrap()
         );
       }
     });
@@ -63,7 +64,7 @@ class MockFnameRegistryClient implements FNameRegistryClientInterface {
   }
 
   async getSigner(): Promise<string> {
-    return this.signer.getAddress();
+    return this.account.address;
   }
 }
 
@@ -73,17 +74,49 @@ describe('fnameRegistryEventsProvider', () => {
   const hub = new MockHub(db, engine);
   let provider: FNameRegistryEventsProvider;
   let mockFnameRegistryClient: MockFnameRegistryClient;
-  const signer = Wallet.createRandom();
+  const account = privateKeyToAccount(generatePrivateKey());
 
   const transferEvents: FNameTransfer[] = [
-    { id: 1, username: 'test1', from: 0, to: 1, timestamp: 1686291736947, owner: signer.address, server_signature: '' },
-    { id: 2, username: 'test2', from: 0, to: 2, timestamp: 1686291740231, owner: signer.address, server_signature: '' },
-    { id: 3, username: 'test3', from: 0, to: 3, timestamp: 1686291751362, owner: signer.address, server_signature: '' },
-    { id: 4, username: 'test3', from: 3, to: 0, timestamp: 1686291752129, owner: signer.address, server_signature: '' },
+    {
+      id: 1,
+      username: 'test1',
+      from: 0,
+      to: 1,
+      timestamp: 1686291736947,
+      owner: account.address,
+      server_signature: '',
+    },
+    {
+      id: 2,
+      username: 'test2',
+      from: 0,
+      to: 2,
+      timestamp: 1686291740231,
+      owner: account.address,
+      server_signature: '',
+    },
+    {
+      id: 3,
+      username: 'test3',
+      from: 0,
+      to: 3,
+      timestamp: 1686291751362,
+      owner: account.address,
+      server_signature: '',
+    },
+    {
+      id: 4,
+      username: 'test3',
+      from: 3,
+      to: 0,
+      timestamp: 1686291752129,
+      owner: account.address,
+      server_signature: '',
+    },
   ];
 
   beforeEach(() => {
-    mockFnameRegistryClient = new MockFnameRegistryClient(signer);
+    mockFnameRegistryClient = new MockFnameRegistryClient(account);
     mockFnameRegistryClient.setTransfersToReturn([
       transferEvents.slice(0, 1),
       transferEvents.slice(1, 2),
@@ -102,15 +135,15 @@ describe('fnameRegistryEventsProvider', () => {
       expect(await getUserNameProof(db, utf8ToBytes('test1'))).toBeTruthy();
       expect(await getUserNameProof(db, utf8ToBytes('test2'))).toBeTruthy();
       await expect(getUserNameProof(db, utf8ToBytes('test4'))).rejects.toThrowError('NotFound');
-      expect((await hub.getHubState())._unsafeUnwrap().lastFnameProof).toEqual(transferEvents[3]!.id);
+      expect((await hub.getHubState())._unsafeUnwrap().lastFnameProof).toEqual(transferEvents[3]?.id);
     });
 
     it('fetches events from where it left off', async () => {
-      await hub.putHubState({ lastFnameProof: transferEvents[0]!.id, lastEthBlock: 0 });
-      mockFnameRegistryClient.setMinimumSince(transferEvents[0]!.id);
+      await hub.putHubState({ lastFnameProof: transferEvents[0]?.id ?? 0, lastEthBlock: 0 });
+      mockFnameRegistryClient.setMinimumSince(transferEvents[0]?.id ?? 0);
       await provider.start();
       expect(await getUserNameProof(db, utf8ToBytes('test2'))).toBeTruthy();
-      expect((await hub.getHubState())._unsafeUnwrap().lastFnameProof).toEqual(transferEvents[3]!.id);
+      expect((await hub.getHubState())._unsafeUnwrap().lastFnameProof).toEqual(transferEvents[3]?.id);
     });
 
     it('does not fail on errors', async () => {
@@ -139,7 +172,7 @@ describe('fnameRegistryEventsProvider', () => {
         from: 0,
         to: 1,
         timestamp: 1686291736947,
-        owner: signer.address,
+        owner: account.address,
         server_signature: '',
       };
       invalidEvent.server_signature = '0x8773442740c17c9d0f0b87022c722f9a136206ed';

--- a/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
+++ b/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
@@ -5,8 +5,7 @@ import {
 } from './fnameRegistryEventsProvider.js';
 import { jestRocksDB } from '../storage/db/jestUtils.js';
 import Engine from '../storage/engine/index.js';
-import { FarcasterNetwork } from '@farcaster/hub-nodejs';
-import { ViemLocalEip712Signer } from '@farcaster/core';
+import { ViemLocalEip712Signer, makeUserNameProofClaim, FarcasterNetwork } from '@farcaster/core';
 import { MockHub } from '../test/mocks.js';
 import { getUserNameProof } from '../storage/db/nameRegistryEvent.js';
 import { utf8ToBytes } from '@noble/curves/abstract/utils';
@@ -31,11 +30,13 @@ class MockFnameRegistryClient implements FNameRegistryClientInterface {
       if (t.server_signature === '') {
         t.server_signature = bytesToHex(
           (
-            await this.signer.signUserNameProof({
-              name: t.username,
-              owner: t.owner,
-              timestamp: t.timestamp,
-            })
+            await this.signer.signUserNameProofClaim(
+              makeUserNameProofClaim({
+                name: t.username,
+                owner: t.owner,
+                timestamp: t.timestamp,
+              })
+            )
           )._unsafeUnwrap()
         );
       }

--- a/apps/hubble/src/eth/fnameRegistryEventsProvider.ts
+++ b/apps/hubble/src/eth/fnameRegistryEventsProvider.ts
@@ -1,7 +1,14 @@
 import axios from 'axios';
 import { logger } from '../utils/logger.js';
 import { HubInterface } from '../hubble.js';
-import { eip712, hexStringToBytes, UserNameProof, UserNameType, utf8StringToBytes } from '@farcaster/hub-nodejs';
+import {
+  eip712,
+  hexStringToBytes,
+  UserNameProof,
+  UserNameType,
+  utf8StringToBytes,
+  makeUserNameProofClaim,
+} from '@farcaster/hub-nodejs';
 import { Result } from 'neverthrow';
 
 const DEFAULT_POLL_TIMEOUT_IN_MS = 30_000;
@@ -153,12 +160,12 @@ export class FNameRegistryEventsProvider {
         type: UserNameType.USERNAME_TYPE_FNAME,
       });
       // TODO: Move the validation into the engine
-      const verificationResult = await eip712.verifyUserNameProof(
-        {
+      const verificationResult = await eip712.verifyUserNameProofClaim(
+        makeUserNameProofClaim({
           owner: transfer.owner,
           timestamp: transfer.timestamp,
           name: transfer.username,
-        },
+        }),
         signature,
         owner
       );

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,10 +16,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@ethersproject/abstract-signer": "^5.7.0",
     "@noble/curves": "^1.0.0",
     "@noble/hashes": "^1.3.0",
-    "ethers": "~6.2.1",
     "neverthrow": "^6.0.0",
     "viem": "^1.1.4"
   },
@@ -33,9 +31,11 @@
     "prepublishOnly": "yarn run build"
   },
   "devDependencies": {
+    "@ethersproject/abstract-signer": "^5.7.0",
     "@faker-js/faker": "^7.6.0",
     "@farcaster/fishery": "2.2.3",
     "eslint-config-custom": "*",
+    "ethers": "^6.6.1",
     "ethers5": "npm:ethers@^5.7.0",
     "prettier-config-custom": "*",
     "ts-proto": "^1.146.0"

--- a/packages/core/src/builders.test.ts
+++ b/packages/core/src/builders.test.ts
@@ -271,7 +271,7 @@ describe('makeMessageHash', () => {
     });
     const message = await builders.makeCastAdd(body, { fid, network }, ed25519Signer);
     expect(message.isOk()).toBeTruthy();
-    const data = builders.makeCastAddData(body, { fid, network });
+    const data = await builders.makeCastAddData(body, { fid, network });
     expect(data.isOk()).toBeTruthy();
     const hash = await builders.makeMessageHash(data._unsafeUnwrap());
     expect(hash).toEqual(ok(message._unsafeUnwrap().hash));
@@ -283,7 +283,7 @@ describe('makeMessageWithSignature', () => {
     const body = protobufs.SignerAddBody.create({ signer: signerKey });
     const signerAdd = await builders.makeSignerAdd(body, { fid, network }, eip712Signer);
 
-    const data = builders.makeSignerAddData(body, { fid, network });
+    const data = await builders.makeSignerAddData(body, { fid, network });
     const hash = await builders.makeMessageHash(data._unsafeUnwrap());
     const signature = (await eip712Signer.signMessageHash(hash._unsafeUnwrap()))._unsafeUnwrap();
     const message = await builders.makeMessageWithSignature(data._unsafeUnwrap(), {
@@ -302,7 +302,7 @@ describe('makeMessageWithSignature', () => {
     const signature = hexStringToBytes(
       '0xf8dc77d52468483806addab7d397836e802551bfb692604e2d7df4bc4820556c63524399a63d319ae4b027090ce296ade08286878dc1f414b62412f89e8bc4e01b'
     )._unsafeUnwrap();
-    const data = builders.makeSignerAddData({ signer: signerKey }, { fid, network });
+    const data = await builders.makeSignerAddData({ signer: signerKey }, { fid, network });
     expect(data.isOk()).toBeTruthy();
     const message = await builders.makeMessageWithSignature(data._unsafeUnwrap(), {
       signer: ethSignerKey,

--- a/packages/core/src/builders.test.ts
+++ b/packages/core/src/builders.test.ts
@@ -1,6 +1,5 @@
 import { faker } from '@faker-js/faker';
 import * as protobufs from './protobufs';
-import { Wallet } from 'ethers';
 import { err, ok } from 'neverthrow';
 import * as builders from './builders';
 import { hexStringToBytes } from './bytes';
@@ -13,8 +12,7 @@ const fid = Factories.Fid.build();
 const network = protobufs.FarcasterNetwork.TESTNET;
 
 const ed25519Signer = Factories.Ed25519Signer.build();
-const wallet = Wallet.createRandom();
-const eip712Signer = Factories.Eip712Signer.build({}, { transient: { wallet } });
+const eip712Signer = Factories.Eip712Signer.build();
 let ethSignerKey: Uint8Array;
 let signerKey: Uint8Array;
 

--- a/packages/core/src/builders.ts
+++ b/packages/core/src/builders.ts
@@ -1,7 +1,7 @@
 import * as protobufs from './protobufs';
 import { blake3 } from '@noble/hashes/blake3';
 import { err, ok } from 'neverthrow';
-import { HubAsyncResult, HubResult } from './errors';
+import { HubAsyncResult } from './errors';
 import { Signer } from './signers';
 import { getFarcasterTime } from './time';
 import * as validations from './validations';
@@ -29,11 +29,11 @@ type MessageBodyOptions = Pick<
 
 /** Generic Methods */
 
-const makeMessageData = <TData extends protobufs.MessageData>(
+const makeMessageData = async <TData extends protobufs.MessageData>(
   bodyOptions: MessageBodyOptions,
   messageType: protobufs.MessageType,
   dataOptions: MessageDataOptions
-): HubResult<TData> => {
+): HubAsyncResult<TData> => {
   if (!dataOptions.timestamp) {
     getFarcasterTime().map((timestamp) => {
       dataOptions.timestamp = timestamp;
@@ -107,7 +107,7 @@ export const makeCastAdd = async (
   dataOptions: MessageDataOptions,
   signer: Signer
 ): HubAsyncResult<protobufs.CastAddMessage> => {
-  const data = makeCastAddData(body, dataOptions);
+  const data = await makeCastAddData(body, dataOptions);
   if (data.isErr()) {
     return err(data.error);
   }
@@ -119,24 +119,24 @@ export const makeCastRemove = async (
   dataOptions: MessageDataOptions,
   signer: Signer
 ): HubAsyncResult<protobufs.CastRemoveMessage> => {
-  const data = makeCastRemoveData(body, dataOptions);
+  const data = await makeCastRemoveData(body, dataOptions);
   if (data.isErr()) {
     return err(data.error);
   }
   return makeMessage(data.value, signer);
 };
 
-export const makeCastAddData = (
+export const makeCastAddData = async (
   body: protobufs.CastAddBody,
   dataOptions: MessageDataOptions
-): HubResult<protobufs.CastAddData> => {
+): HubAsyncResult<protobufs.CastAddData> => {
   return makeMessageData({ castAddBody: body }, protobufs.MessageType.CAST_ADD, dataOptions);
 };
 
 export const makeCastRemoveData = (
   body: protobufs.CastRemoveBody,
   dataOptions: MessageDataOptions
-): HubResult<protobufs.CastRemoveData> => {
+): HubAsyncResult<protobufs.CastRemoveData> => {
   return makeMessageData({ castRemoveBody: body }, protobufs.MessageType.CAST_REMOVE, dataOptions);
 };
 
@@ -149,7 +149,7 @@ export const makeLinkAdd = async (
   dataOptions: MessageDataOptions,
   signer: Signer
 ): HubAsyncResult<protobufs.LinkAddMessage> => {
-  const data = makeLinkAddData(body, dataOptions);
+  const data = await makeLinkAddData(body, dataOptions);
   if (data.isErr()) {
     return err(data.error);
   }
@@ -161,7 +161,7 @@ export const makeLinkRemove = async (
   dataOptions: MessageDataOptions,
   signer: Signer
 ): HubAsyncResult<protobufs.LinkRemoveMessage> => {
-  const data = makeLinkRemoveData(body, dataOptions);
+  const data = await makeLinkRemoveData(body, dataOptions);
   if (data.isErr()) {
     return err(data.error);
   }
@@ -171,14 +171,14 @@ export const makeLinkRemove = async (
 export const makeLinkAddData = (
   body: protobufs.LinkBody,
   dataOptions: MessageDataOptions
-): HubResult<protobufs.LinkAddData> => {
+): HubAsyncResult<protobufs.LinkAddData> => {
   return makeMessageData({ linkBody: body }, protobufs.MessageType.LINK_ADD, dataOptions);
 };
 
 export const makeLinkRemoveData = (
   body: protobufs.LinkBody,
   dataOptions: MessageDataOptions
-): HubResult<protobufs.LinkRemoveData> => {
+): HubAsyncResult<protobufs.LinkRemoveData> => {
   return makeMessageData({ linkBody: body }, protobufs.MessageType.LINK_REMOVE, dataOptions);
 };
 
@@ -191,7 +191,7 @@ export const makeReactionAdd = async (
   dataOptions: MessageDataOptions,
   signer: Signer
 ): HubAsyncResult<protobufs.ReactionAddMessage> => {
-  const data = makeReactionAddData(body, dataOptions);
+  const data = await makeReactionAddData(body, dataOptions);
   if (data.isErr()) {
     return err(data.error);
   }
@@ -203,7 +203,7 @@ export const makeReactionRemove = async (
   dataOptions: MessageDataOptions,
   signer: Signer
 ): HubAsyncResult<protobufs.ReactionRemoveMessage> => {
-  const data = makeReactionRemoveData(body, dataOptions);
+  const data = await makeReactionRemoveData(body, dataOptions);
   if (data.isErr()) {
     return err(data.error);
   }
@@ -213,14 +213,14 @@ export const makeReactionRemove = async (
 export const makeReactionAddData = (
   body: protobufs.ReactionBody,
   dataOptions: MessageDataOptions
-): HubResult<protobufs.ReactionAddData> => {
+): HubAsyncResult<protobufs.ReactionAddData> => {
   return makeMessageData({ reactionBody: body }, protobufs.MessageType.REACTION_ADD, dataOptions);
 };
 
 export const makeReactionRemoveData = (
   body: protobufs.ReactionBody,
   dataOptions: MessageDataOptions
-): HubResult<protobufs.ReactionRemoveData> => {
+): HubAsyncResult<protobufs.ReactionRemoveData> => {
   return makeMessageData({ reactionBody: body }, protobufs.MessageType.REACTION_REMOVE, dataOptions);
 };
 
@@ -233,7 +233,7 @@ export const makeVerificationAddEthAddress = async (
   dataOptions: MessageDataOptions,
   signer: Signer
 ): HubAsyncResult<protobufs.VerificationAddEthAddressMessage> => {
-  const data = makeVerificationAddEthAddressData(body, dataOptions);
+  const data = await makeVerificationAddEthAddressData(body, dataOptions);
   if (data.isErr()) {
     return err(data.error);
   }
@@ -245,7 +245,7 @@ export const makeVerificationRemove = async (
   dataOptions: MessageDataOptions,
   signer: Signer
 ): HubAsyncResult<protobufs.VerificationRemoveMessage> => {
-  const data = makeVerificationRemoveData(body, dataOptions);
+  const data = await makeVerificationRemoveData(body, dataOptions);
   if (data.isErr()) {
     return err(data.error);
   }
@@ -255,7 +255,7 @@ export const makeVerificationRemove = async (
 export const makeVerificationAddEthAddressData = (
   body: protobufs.VerificationAddEthAddressBody,
   dataOptions: MessageDataOptions
-): HubResult<protobufs.VerificationAddEthAddressData> => {
+): HubAsyncResult<protobufs.VerificationAddEthAddressData> => {
   return makeMessageData(
     { verificationAddEthAddressBody: body },
     protobufs.MessageType.VERIFICATION_ADD_ETH_ADDRESS,
@@ -266,7 +266,7 @@ export const makeVerificationAddEthAddressData = (
 export const makeVerificationRemoveData = (
   body: protobufs.VerificationRemoveBody,
   dataOptions: MessageDataOptions
-): HubResult<protobufs.VerificationRemoveData> => {
+): HubAsyncResult<protobufs.VerificationRemoveData> => {
   return makeMessageData({ verificationRemoveBody: body }, protobufs.MessageType.VERIFICATION_REMOVE, dataOptions);
 };
 
@@ -279,7 +279,7 @@ export const makeSignerAdd = async (
   dataOptions: MessageDataOptions,
   signer: Signer
 ): HubAsyncResult<protobufs.SignerAddMessage> => {
-  const data = makeSignerAddData(body, dataOptions);
+  const data = await makeSignerAddData(body, dataOptions);
   if (data.isErr()) {
     return err(data.error);
   }
@@ -291,7 +291,7 @@ export const makeSignerRemove = async (
   dataOptions: MessageDataOptions,
   signer: Signer
 ): HubAsyncResult<protobufs.SignerRemoveMessage> => {
-  const data = makeSignerRemoveData(body, dataOptions);
+  const data = await makeSignerRemoveData(body, dataOptions);
   if (data.isErr()) {
     return err(data.error);
   }
@@ -301,14 +301,14 @@ export const makeSignerRemove = async (
 export const makeSignerAddData = (
   body: protobufs.SignerAddBody,
   dataOptions: MessageDataOptions
-): HubResult<protobufs.SignerAddData> => {
+): HubAsyncResult<protobufs.SignerAddData> => {
   return makeMessageData({ signerAddBody: body }, protobufs.MessageType.SIGNER_ADD, dataOptions);
 };
 
 export const makeSignerRemoveData = (
   body: protobufs.SignerRemoveBody,
   dataOptions: MessageDataOptions
-): HubResult<protobufs.SignerRemoveData> => {
+): HubAsyncResult<protobufs.SignerRemoveData> => {
   return makeMessageData({ signerRemoveBody: body }, protobufs.MessageType.SIGNER_REMOVE, dataOptions);
 };
 
@@ -321,7 +321,7 @@ export const makeUserDataAdd = async (
   dataOptions: MessageDataOptions,
   signer: Signer
 ): HubAsyncResult<protobufs.UserDataAddMessage> => {
-  const data = makeUserDataAddData(body, dataOptions);
+  const data = await makeUserDataAddData(body, dataOptions);
   if (data.isErr()) {
     return err(data.error);
   }
@@ -331,6 +331,6 @@ export const makeUserDataAdd = async (
 export const makeUserDataAddData = (
   body: protobufs.UserDataBody,
   dataOptions: MessageDataOptions
-): HubResult<protobufs.UserDataAddData> => {
+): HubAsyncResult<protobufs.UserDataAddData> => {
   return makeMessageData({ userDataBody: body }, protobufs.MessageType.USER_DATA_ADD, dataOptions);
 };

--- a/packages/core/src/bytes.ts
+++ b/packages/core/src/bytes.ts
@@ -1,6 +1,6 @@
 /* eslint-disable security/detect-object-injection */
 import { err, ok, Result } from 'neverthrow';
-import { bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
+import { bytesToHex, hexToBytes } from 'viem';
 import { HubError, HubResult } from './errors';
 
 export const bytesCompare = (a: Uint8Array, b: Uint8Array): number => {
@@ -64,16 +64,16 @@ export const bytesDecrement = (inputBytes: Uint8Array): HubResult<Uint8Array> =>
   return ok(bytes);
 };
 
-export const bytesToHexString = (bytes: Uint8Array): HubResult<string> => {
+export const bytesToHexString = (bytes: Uint8Array): HubResult<`0x${string}`> => {
   return Result.fromThrowable(
-    (bytes: Uint8Array) => '0x' + bytesToHex(bytes),
+    (bytes: Uint8Array) => bytesToHex(bytes),
     (e) => new HubError('unknown', e as Error)
   )(bytes);
 };
 
 export const hexStringToBytes = (hex: string): HubResult<Uint8Array> => {
   return Result.fromThrowable(
-    (hex: string) => hexToBytes(hex.substring(0, 2) === '0x' ? hex.substring(2) : hex),
+    (hex: string) => hexToBytes(hex.startsWith('0x') ? (hex as `0x${string}`) : `0x${hex}`),
     (e) => new HubError('unknown', e as Error)
   )(hex);
 };

--- a/packages/core/src/crypto/ed25519.test.ts
+++ b/packages/core/src/crypto/ed25519.test.ts
@@ -1,7 +1,7 @@
 import * as protobufs from '../protobufs';
 import * as ed from '@noble/ed25519';
 import { blake3 } from '@noble/hashes/blake3';
-import { randomBytes } from 'ethers';
+import { randomBytes } from '@noble/hashes/utils';
 import { HubError } from '../errors';
 import { Factories } from '../factories';
 import * as ed25519 from './ed25519';

--- a/packages/core/src/crypto/eip712.test.ts
+++ b/packages/core/src/crypto/eip712.test.ts
@@ -14,7 +14,7 @@ describe('verifyUserNameProof', () => {
     const nameProof: UserNameProofClaim = {
       owner: '0x8773442740c17c9d0f0b87022c722f9a136206ed',
       name: 'farcaster',
-      timestamp: 1628882891n,
+      timestamp: 1628882891,
     };
     const signature = await signer.signUserNameProof(nameProof);
     expect(signature.isOk()).toBeTruthy();
@@ -30,7 +30,7 @@ describe('verifyUserNameProof', () => {
     const nameProof: UserNameProofClaim = {
       owner: '0x8773442740c17c9d0f0b87022c722f9a136206ed',
       name: 'farcaster',
-      timestamp: 1628882891n,
+      timestamp: 1628882891,
     };
     const signature = hexStringToBytes(
       '0xb7181760f14eda0028e0b647ff15f45235526ced3b4ae07fcce06141b73d32960d3253776e62f761363fb8137087192047763f4af838950a96f3885f3c2289c41b'

--- a/packages/core/src/crypto/eip712.test.ts
+++ b/packages/core/src/crypto/eip712.test.ts
@@ -2,8 +2,8 @@ import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import { ok } from 'neverthrow';
 import { hexStringToBytes } from '../bytes';
 import * as eip712 from './eip712';
-import { UserNameProofClaim } from './eip712';
 import { ViemLocalEip712Signer } from '../signers';
+import { makeUserNameProofClaim } from '../userNameProof';
 
 const privateKey = generatePrivateKey();
 const account = privateKeyToAccount(privateKey);
@@ -11,12 +11,12 @@ const signer = new ViemLocalEip712Signer(account);
 
 describe('verifyUserNameProof', () => {
   test('succeeds with a generated proof', async () => {
-    const nameProof: UserNameProofClaim = {
-      owner: '0x8773442740c17c9d0f0b87022c722f9a136206ed',
+    const nameProof = makeUserNameProofClaim({
       name: 'farcaster',
+      owner: '0x8773442740c17c9d0f0b87022c722f9a136206ed',
       timestamp: 1628882891,
-    };
-    const signature = await signer.signUserNameProof(nameProof);
+    });
+    const signature = await signer.signUserNameProofClaim(nameProof);
     expect(signature.isOk()).toBeTruthy();
     const valid = await eip712.verifyUserNameProof(
       nameProof,
@@ -27,11 +27,11 @@ describe('verifyUserNameProof', () => {
   });
 
   test('succeeds for a known proof', async () => {
-    const nameProof: UserNameProofClaim = {
-      owner: '0x8773442740c17c9d0f0b87022c722f9a136206ed',
+    const nameProof = makeUserNameProofClaim({
       name: 'farcaster',
+      owner: '0x8773442740c17c9d0f0b87022c722f9a136206ed',
       timestamp: 1628882891,
-    };
+    });
     const signature = hexStringToBytes(
       '0xb7181760f14eda0028e0b647ff15f45235526ced3b4ae07fcce06141b73d32960d3253776e62f761363fb8137087192047763f4af838950a96f3885f3c2289c41b'
     );

--- a/packages/core/src/crypto/eip712.test.ts
+++ b/packages/core/src/crypto/eip712.test.ts
@@ -1,84 +1,46 @@
-import * as protobufs from '../protobufs';
-import { blake3 } from '@noble/hashes/blake3';
-import { getAddress, Wallet } from 'ethers';
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import { ok } from 'neverthrow';
-import { bytesToHexString, hexStringToBytes } from '../bytes';
-import { Factories } from '../factories';
-import { VerificationEthAddressClaim } from '../verifications';
+import { hexStringToBytes } from '../bytes';
 import * as eip712 from './eip712';
 import { UserNameProofClaim } from './eip712';
+import { ViemLocalEip712Signer } from '../signers';
 
-const wallet = Wallet.createRandom();
-const fid = Factories.Fid.build();
-
-describe('signVerificationEthAddressClaim', () => {
-  const claim = Factories.VerificationEthAddressClaim.build({ fid });
-  let signature: Uint8Array;
-
-  beforeAll(async () => {
-    const sign = await eip712.signVerificationEthAddressClaim(claim, wallet);
-    expect(sign.isOk()).toBeTruthy();
-    signature = sign._unsafeUnwrap();
-  });
-
-  test('succeeds', async () => {
-    expect(signature).toBeTruthy();
-    const recoveredAddress = eip712.verifyVerificationEthAddressClaimSignature(claim, signature);
-    expect(recoveredAddress).toEqual(ok(hexStringToBytes(wallet.address)._unsafeUnwrap()));
-  });
-
-  test('succeeds when encoding twice', async () => {
-    const claim2: VerificationEthAddressClaim = { ...claim };
-    const signature2 = await eip712.signVerificationEthAddressClaim(claim2, wallet);
-    expect(signature2).toEqual(ok(signature));
-    expect(bytesToHexString(signature2._unsafeUnwrap())).toEqual(ok(bytesToHexString(signature)._unsafeUnwrap()));
-  });
-
-  test('succeeds with lowercased address', async () => {
-    const claim2: VerificationEthAddressClaim = { ...claim, address: claim.address.toLowerCase() };
-    const signature2 = await eip712.signVerificationEthAddressClaim(claim2, wallet);
-    expect(signature2).toEqual(ok(signature));
-  });
-
-  test('succeeds with checksummed address', async () => {
-    const claim2: VerificationEthAddressClaim = { ...claim, address: getAddress(claim.address) };
-    const signature2 = await eip712.signVerificationEthAddressClaim(claim2, wallet);
-    expect(signature2).toEqual(ok(signature));
-  });
-
-  test('fails with uppercased address', async () => {
-    const claim2: VerificationEthAddressClaim = { ...claim, address: claim.address.toUpperCase() };
-    const signature2 = await eip712.signVerificationEthAddressClaim(claim2, wallet);
-    expect(signature2.isErr()).toBeTruthy();
-  });
-});
-
-describe('signMessageHash', () => {
-  test('succeeds', async () => {
-    const messageData = Factories.SignerAddData.build();
-    const bytes = protobufs.MessageData.encode(messageData).finish();
-    const hash = blake3(bytes, { dkLen: 20 });
-    const signature = await eip712.signMessageHash(hash, wallet);
-    expect(signature.isOk()).toBeTruthy();
-    const recoveredAddress = eip712.verifyMessageHashSignature(hash, signature._unsafeUnwrap());
-    expect(recoveredAddress).toEqual(ok(hexStringToBytes(wallet.address)._unsafeUnwrap()));
-  });
-});
+const privateKey = generatePrivateKey();
+const account = privateKeyToAccount(privateKey);
+const signer = new ViemLocalEip712Signer(account);
 
 describe('verifyUserNameProof', () => {
+  test('succeeds with a generated proof', async () => {
+    const nameProof: UserNameProofClaim = {
+      owner: '0x8773442740c17c9d0f0b87022c722f9a136206ed',
+      name: 'farcaster',
+      timestamp: 1628882891n,
+    };
+    const signature = await signer.signUserNameProof(nameProof);
+    expect(signature.isOk()).toBeTruthy();
+    const valid = await eip712.verifyUserNameProof(
+      nameProof,
+      signature._unsafeUnwrap(),
+      (await signer.getSignerKey())._unsafeUnwrap()
+    );
+    expect(valid).toEqual(ok(true));
+  });
+
   test('succeeds for a known proof', async () => {
     const nameProof: UserNameProofClaim = {
       owner: '0x8773442740c17c9d0f0b87022c722f9a136206ed',
       name: 'farcaster',
-      timestamp: 1628882891,
+      timestamp: 1628882891n,
     };
     const signature = hexStringToBytes(
       '0xb7181760f14eda0028e0b647ff15f45235526ced3b4ae07fcce06141b73d32960d3253776e62f761363fb8137087192047763f4af838950a96f3885f3c2289c41b'
     );
     expect(signature.isOk()).toBeTruthy();
-    const recoveredAddress = eip712.verifyUserNameProof(nameProof, signature._unsafeUnwrap());
-    expect(recoveredAddress).toEqual(
-      ok(hexStringToBytes('0xBc5274eFc266311015793d89E9B591fa46294741')._unsafeUnwrap())
+    const valid = await eip712.verifyUserNameProof(
+      nameProof,
+      signature._unsafeUnwrap(),
+      hexStringToBytes('0xBc5274eFc266311015793d89E9B591fa46294741')._unsafeUnwrap()
     );
+    expect(valid).toEqual(ok(true));
   });
 });

--- a/packages/core/src/crypto/eip712.test.ts
+++ b/packages/core/src/crypto/eip712.test.ts
@@ -9,7 +9,7 @@ const privateKey = generatePrivateKey();
 const account = privateKeyToAccount(privateKey);
 const signer = new ViemLocalEip712Signer(account);
 
-describe('verifyUserNameProof', () => {
+describe('verifyUserNameProofClaim', () => {
   test('succeeds with a generated proof', async () => {
     const nameProof = makeUserNameProofClaim({
       name: 'farcaster',
@@ -18,7 +18,7 @@ describe('verifyUserNameProof', () => {
     });
     const signature = await signer.signUserNameProofClaim(nameProof);
     expect(signature.isOk()).toBeTruthy();
-    const valid = await eip712.verifyUserNameProof(
+    const valid = await eip712.verifyUserNameProofClaim(
       nameProof,
       signature._unsafeUnwrap(),
       (await signer.getSignerKey())._unsafeUnwrap()
@@ -36,7 +36,7 @@ describe('verifyUserNameProof', () => {
       '0xb7181760f14eda0028e0b647ff15f45235526ced3b4ae07fcce06141b73d32960d3253776e62f761363fb8137087192047763f4af838950a96f3885f3c2289c41b'
     );
     expect(signature.isOk()).toBeTruthy();
-    const valid = await eip712.verifyUserNameProof(
+    const valid = await eip712.verifyUserNameProofClaim(
       nameProof,
       signature._unsafeUnwrap(),
       hexStringToBytes('0xBc5274eFc266311015793d89E9B591fa46294741')._unsafeUnwrap()

--- a/packages/core/src/crypto/eip712.ts
+++ b/packages/core/src/crypto/eip712.ts
@@ -2,6 +2,7 @@ import { bytesToHex, verifyTypedData } from 'viem';
 import { ResultAsync } from 'neverthrow';
 import { HubAsyncResult, HubError } from '../errors';
 import { VerificationEthAddressClaim } from '../verifications';
+import { UserNameProofClaim } from '../userNameProof';
 
 export const EIP_712_FARCASTER_DOMAIN = {
   name: 'Farcaster Verify Ethereum Address',
@@ -69,12 +70,6 @@ export const verifyVerificationEthAddressClaimSignature = async (
   return valid;
 };
 
-export type UserNameProofClaim = {
-  name: string;
-  timestamp: number;
-  owner: `0x${string}`;
-};
-
 export const verifyUserNameProof = async (
   nameProof: UserNameProofClaim,
   signature: Uint8Array,
@@ -86,10 +81,7 @@ export const verifyUserNameProof = async (
       domain: EIP_712_USERNAME_DOMAIN,
       types: { UserNameProof: EIP_712_USERNAME_PROOF },
       primaryType: 'UserNameProof',
-      message: {
-        ...nameProof,
-        timestamp: BigInt(nameProof.timestamp),
-      },
+      message: nameProof,
       signature,
     }),
     (e) => new HubError('unknown', e as Error)

--- a/packages/core/src/crypto/eip712.ts
+++ b/packages/core/src/crypto/eip712.ts
@@ -71,7 +71,7 @@ export const verifyVerificationEthAddressClaimSignature = async (
 
 export type UserNameProofClaim = {
   name: string;
-  timestamp: bigint;
+  timestamp: number;
   owner: `0x${string}`;
 };
 
@@ -86,7 +86,10 @@ export const verifyUserNameProof = async (
       domain: EIP_712_USERNAME_DOMAIN,
       types: { UserNameProof: EIP_712_USERNAME_PROOF },
       primaryType: 'UserNameProof',
-      message: nameProof,
+      message: {
+        ...nameProof,
+        timestamp: BigInt(nameProof.timestamp),
+      },
       signature,
     }),
     (e) => new HubError('unknown', e as Error)

--- a/packages/core/src/crypto/eip712.ts
+++ b/packages/core/src/crypto/eip712.ts
@@ -1,17 +1,14 @@
-import { recoverAddress, TypedDataEncoder, Signer, TypedDataDomain, TypedDataField } from 'ethers';
-import { err, Result, ResultAsync } from 'neverthrow';
-import { bytesToHexString, hexStringToBytes } from '../bytes';
-import { HubAsyncResult, HubError, HubResult } from '../errors';
+import { bytesToHex, verifyTypedData } from 'viem';
+import { ResultAsync } from 'neverthrow';
+import { HubAsyncResult, HubError } from '../errors';
 import { VerificationEthAddressClaim } from '../verifications';
-
-export type MinimalEthersSigner = Pick<Signer, 'signTypedData' | 'getAddress'>;
 
 export const EIP_712_FARCASTER_DOMAIN = {
   name: 'Farcaster Verify Ethereum Address',
   version: '2.0.0',
   // fixed salt to minimize collisions
-  salt: '0xf2d857f4a3edcb9b78b4d503bfe733db1e3f6cdc2b7971ee739626c97e86a558' as `0x${string}`, // Type cast for viem compatibility
-};
+  salt: '0xf2d857f4a3edcb9b78b4d503bfe733db1e3f6cdc2b7971ee739626c97e86a558',
+} as const;
 
 export const EIP_712_FARCASTER_VERIFICATION_CLAIM = [
   {
@@ -30,105 +27,90 @@ export const EIP_712_FARCASTER_VERIFICATION_CLAIM = [
     name: 'network',
     type: 'uint8',
   },
-];
+] as const;
 
 export const EIP_712_FARCASTER_MESSAGE_DATA = [
   {
     name: 'hash',
     type: 'bytes',
   },
-];
+] as const;
 
 export const EIP_712_USERNAME_DOMAIN = {
   name: 'Farcaster name verification',
   version: '1',
   chainId: 1,
   verifyingContract: '0xe3be01d99baa8db9905b33a3ca391238234b79d1', // name registry contract, will be the farcaster ENS CCIP contract later
-};
+} as const;
 
 export const EIP_712_USERNAME_PROOF = [
   { name: 'name', type: 'string' },
   { name: 'timestamp', type: 'uint256' },
   { name: 'owner', type: 'address' },
-];
+] as const;
 
-export const getSignerKey = async (signer: MinimalEthersSigner): HubAsyncResult<Uint8Array> => {
-  return ResultAsync.fromPromise(signer.getAddress(), (e) => new HubError('unknown', e as Error)).andThen(
-    hexStringToBytes
-  );
-};
-
-export const signVerificationEthAddressClaim = async (
+export const verifyVerificationEthAddressClaimSignature = async (
   claim: VerificationEthAddressClaim,
-  signer: MinimalEthersSigner
-): HubAsyncResult<Uint8Array> => {
-  const hexSignature = await ResultAsync.fromPromise(
-    signer.signTypedData(EIP_712_FARCASTER_DOMAIN, { VerificationClaim: EIP_712_FARCASTER_VERIFICATION_CLAIM }, claim),
-    (e) => new HubError('bad_request.invalid_param', e as Error)
+  signature: Uint8Array,
+  address: Uint8Array
+): HubAsyncResult<boolean> => {
+  const valid = await ResultAsync.fromPromise(
+    verifyTypedData({
+      address: bytesToHex(address),
+      domain: EIP_712_FARCASTER_DOMAIN,
+      types: { VerificationClaim: EIP_712_FARCASTER_VERIFICATION_CLAIM },
+      primaryType: 'VerificationClaim',
+      message: claim,
+      signature,
+    }),
+    (e) => new HubError('unknown', e as Error)
   );
 
-  // Convert hex signature to bytes
-  return hexSignature.andThen((hex) => hexStringToBytes(hex));
-};
-
-export const verifyVerificationEthAddressClaimSignature = (
-  claim: VerificationEthAddressClaim,
-  signature: Uint8Array
-): HubResult<Uint8Array> => {
-  return recoverSignature(
-    EIP_712_FARCASTER_DOMAIN,
-    { VerificationClaim: EIP_712_FARCASTER_VERIFICATION_CLAIM },
-    claim,
-    signature
-  );
+  return valid;
 };
 
 export type UserNameProofClaim = {
   name: string;
-  timestamp: number;
-  owner: string; // hex address
+  timestamp: bigint;
+  owner: `0x${string}`;
 };
 
-export const verifyUserNameProof = (nameProof: UserNameProofClaim, signature: Uint8Array): HubResult<Uint8Array> => {
-  return recoverSignature(EIP_712_USERNAME_DOMAIN, { UserNameProof: EIP_712_USERNAME_PROOF }, nameProof, signature);
-};
-
-export const signMessageHash = async (hash: Uint8Array, signer: MinimalEthersSigner): HubAsyncResult<Uint8Array> => {
-  const hexSignature = await ResultAsync.fromPromise(
-    signer.signTypedData(EIP_712_FARCASTER_DOMAIN, { MessageData: EIP_712_FARCASTER_MESSAGE_DATA }, { hash }),
-    (e) => new HubError('bad_request.invalid_param', e as Error)
+export const verifyUserNameProof = async (
+  nameProof: UserNameProofClaim,
+  signature: Uint8Array,
+  address: Uint8Array
+): HubAsyncResult<boolean> => {
+  const valid = await ResultAsync.fromPromise(
+    verifyTypedData({
+      address: bytesToHex(address),
+      domain: EIP_712_USERNAME_DOMAIN,
+      types: { UserNameProof: EIP_712_USERNAME_PROOF },
+      primaryType: 'UserNameProof',
+      message: nameProof,
+      signature,
+    }),
+    (e) => new HubError('unknown', e as Error)
   );
 
-  // Convert hex signature to bytes
-  return hexSignature.andThen((hex) => hexStringToBytes(hex));
+  return valid;
 };
 
-export const verifyMessageHashSignature = (hash: Uint8Array, signature: Uint8Array): HubResult<Uint8Array> => {
-  return recoverSignature(
-    EIP_712_FARCASTER_DOMAIN,
-    { MessageData: EIP_712_FARCASTER_MESSAGE_DATA },
-    { hash },
-    signature
+export const verifyMessageHashSignature = async (
+  hash: Uint8Array,
+  signature: Uint8Array,
+  address: Uint8Array
+): HubAsyncResult<boolean> => {
+  const valid = await ResultAsync.fromPromise(
+    verifyTypedData({
+      address: bytesToHex(address),
+      domain: EIP_712_FARCASTER_DOMAIN,
+      types: { MessageData: EIP_712_FARCASTER_MESSAGE_DATA },
+      primaryType: 'MessageData',
+      message: { hash: bytesToHex(hash) },
+      signature,
+    }),
+    (e) => new HubError('unknown', e as Error)
   );
-};
 
-const recoverSignature = (
-  domain: TypedDataDomain,
-  types: Record<string, Array<TypedDataField>>,
-  claim: Record<string, any>,
-  signature: Uint8Array
-): HubResult<Uint8Array> => {
-  const signatureHexResult = bytesToHexString(signature);
-  if (signatureHexResult.isErr()) {
-    return err(signatureHexResult.error);
-  }
-
-  // Recover address from signature
-  const recoveredHexAddress = Result.fromThrowable(
-    () => recoverAddress(TypedDataEncoder.hash(domain, types, claim), signatureHexResult.value),
-    (e) => new HubError('bad_request.invalid_param', e as Error)
-  )();
-
-  // Convert hex recovered address to bytes
-  return recoveredHexAddress.andThen((hex) => hexStringToBytes(hex));
+  return valid;
 };

--- a/packages/core/src/crypto/eip712.ts
+++ b/packages/core/src/crypto/eip712.ts
@@ -70,7 +70,7 @@ export const verifyVerificationEthAddressClaimSignature = async (
   return valid;
 };
 
-export const verifyUserNameProof = async (
+export const verifyUserNameProofClaim = async (
   nameProof: UserNameProofClaim,
   signature: Uint8Array,
   address: Uint8Array

--- a/packages/core/src/factories.ts
+++ b/packages/core/src/factories.ts
@@ -2,13 +2,13 @@ import { faker } from '@faker-js/faker';
 import { Factory } from '@farcaster/fishery';
 import { ed25519 } from '@noble/curves/ed25519';
 import { blake3 } from '@noble/hashes/blake3';
+import { randomBytes } from '@noble/hashes/utils';
 import { Wallet } from 'ethers';
 import * as protobufs from './protobufs';
 import { bytesToHexString } from './bytes';
 import { Ed25519Signer, Eip712Signer, EthersEip712Signer, NobleEd25519Signer, Signer } from './signers';
 import { getFarcasterTime } from './time';
 import { VerificationEthAddressClaim } from './verifications';
-import { randomBytes } from '@noble/hashes/utils';
 
 /** Scalars */
 

--- a/packages/core/src/factories.ts
+++ b/packages/core/src/factories.ts
@@ -2,13 +2,14 @@ import { faker } from '@faker-js/faker';
 import { Factory } from '@farcaster/fishery';
 import { ed25519 } from '@noble/curves/ed25519';
 import { blake3 } from '@noble/hashes/blake3';
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import { randomBytes } from '@noble/hashes/utils';
-import { Wallet } from 'ethers';
 import * as protobufs from './protobufs';
 import { bytesToHexString } from './bytes';
-import { Ed25519Signer, Eip712Signer, EthersEip712Signer, NobleEd25519Signer, Signer } from './signers';
+import { Ed25519Signer, Eip712Signer, NobleEd25519Signer, ViemLocalEip712Signer, Signer } from './signers';
 import { getFarcasterTime } from './time';
 import { VerificationEthAddressClaim } from './verifications';
+import { LocalAccount } from 'viem';
 
 /** Scalars */
 
@@ -90,9 +91,9 @@ const Ed25519SignatureFactory = Factory.define<Uint8Array>(() => {
   return BytesFactory.build({}, { transient: { length: 64 } });
 });
 
-const Eip712SignerFactory = Factory.define<Eip712Signer, { wallet: Wallet }>(({ transientParams }) => {
-  const wallet = transientParams.wallet ?? Wallet.createRandom();
-  return new EthersEip712Signer(wallet);
+const Eip712SignerFactory = Factory.define<Eip712Signer, { account: LocalAccount }>(({ transientParams }) => {
+  const account = transientParams.account ?? privateKeyToAccount(generatePrivateKey());
+  return new ViemLocalEip712Signer(account);
 });
 
 const Eip712SignatureFactory = Factory.define<Uint8Array>(() => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,3 +8,4 @@ export * from './signers';
 export * from './time';
 export * as validations from './validations';
 export * from './verifications';
+export * from './userNameProof';

--- a/packages/core/src/signers/eip712Signer.ts
+++ b/packages/core/src/signers/eip712Signer.ts
@@ -2,6 +2,7 @@ import { SignatureScheme } from '../protobufs';
 import { HubAsyncResult } from '../errors';
 import { VerificationEthAddressClaim } from '../verifications';
 import { Signer } from './signer';
+import { UserNameProofClaim } from 'crypto/eip712';
 
 /**
  * Extend this class to implement an EIP712 signer.
@@ -16,4 +17,5 @@ export abstract class Eip712Signer implements Signer {
   public abstract getSignerKey(): HubAsyncResult<Uint8Array>;
   public abstract signMessageHash(hash: Uint8Array): HubAsyncResult<Uint8Array>;
   public abstract signVerificationEthAddressClaim(claim: VerificationEthAddressClaim): HubAsyncResult<Uint8Array>;
+  public abstract signUserNameProof(claim: UserNameProofClaim): HubAsyncResult<Uint8Array>;
 }

--- a/packages/core/src/signers/eip712Signer.ts
+++ b/packages/core/src/signers/eip712Signer.ts
@@ -1,8 +1,8 @@
 import { SignatureScheme } from '../protobufs';
 import { HubAsyncResult } from '../errors';
 import { VerificationEthAddressClaim } from '../verifications';
+import { UserNameProofClaim } from '../userNameProof';
 import { Signer } from './signer';
-import { UserNameProofClaim } from 'crypto/eip712';
 
 /**
  * Extend this class to implement an EIP712 signer.
@@ -17,5 +17,5 @@ export abstract class Eip712Signer implements Signer {
   public abstract getSignerKey(): HubAsyncResult<Uint8Array>;
   public abstract signMessageHash(hash: Uint8Array): HubAsyncResult<Uint8Array>;
   public abstract signVerificationEthAddressClaim(claim: VerificationEthAddressClaim): HubAsyncResult<Uint8Array>;
-  public abstract signUserNameProof(claim: UserNameProofClaim): HubAsyncResult<Uint8Array>;
+  public abstract signUserNameProofClaim(claim: UserNameProofClaim): HubAsyncResult<Uint8Array>;
 }

--- a/packages/core/src/signers/ethersEip712Signer.ts
+++ b/packages/core/src/signers/ethersEip712Signer.ts
@@ -1,25 +1,56 @@
-import { eip712 } from '../crypto';
-import { HubAsyncResult } from '../errors';
+import { ResultAsync } from 'neverthrow';
+import { Signer } from 'ethers';
+import { HubAsyncResult, HubError } from '../errors';
 import { VerificationEthAddressClaim } from '../verifications';
 import { Eip712Signer } from './eip712Signer';
+import { hexStringToBytes } from '../bytes';
+import {
+  EIP_712_FARCASTER_DOMAIN,
+  EIP_712_FARCASTER_MESSAGE_DATA,
+  EIP_712_FARCASTER_VERIFICATION_CLAIM,
+} from '../crypto/eip712';
+
+export type MinimalEthersSigner = Pick<Signer, 'signTypedData' | 'getAddress'>;
 
 export class EthersEip712Signer extends Eip712Signer {
-  private readonly _ethersSigner: eip712.MinimalEthersSigner;
+  private readonly _ethersSigner: MinimalEthersSigner;
 
-  constructor(signer: eip712.MinimalEthersSigner) {
+  constructor(signer: MinimalEthersSigner) {
     super();
     this._ethersSigner = signer;
   }
 
   public async getSignerKey(): HubAsyncResult<Uint8Array> {
-    return eip712.getSignerKey(this._ethersSigner);
+    return ResultAsync.fromPromise(this._ethersSigner.getAddress(), (e) => new HubError('unknown', e as Error)).andThen(
+      hexStringToBytes
+    );
   }
 
   public async signMessageHash(hash: Uint8Array): HubAsyncResult<Uint8Array> {
-    return eip712.signMessageHash(hash, this._ethersSigner);
+    const hexSignature = await ResultAsync.fromPromise(
+      this._ethersSigner.signTypedData(
+        EIP_712_FARCASTER_DOMAIN,
+        { MessageData: [...EIP_712_FARCASTER_MESSAGE_DATA] },
+        { hash }
+      ),
+      (e) => new HubError('bad_request.invalid_param', e as Error)
+    );
+
+    // Convert hex signature to bytes
+    return hexSignature.andThen((hex) => hexStringToBytes(hex));
   }
 
   public async signVerificationEthAddressClaim(claim: VerificationEthAddressClaim): HubAsyncResult<Uint8Array> {
-    return eip712.signVerificationEthAddressClaim(claim, this._ethersSigner);
+    const hexSignature = await ResultAsync.fromPromise(
+      this._ethersSigner.signTypedData(
+        EIP_712_FARCASTER_DOMAIN,
+        { VerificationClaim: [...EIP_712_FARCASTER_VERIFICATION_CLAIM] },
+        claim
+      ),
+      (e) => new HubError('bad_request.invalid_param', e as Error)
+    );
+
+    // Convert hex signature to bytes
+    return hexSignature.andThen((hex) => hexStringToBytes(hex));
   }
 }

--- a/packages/core/src/signers/ethersEip712Signer.ts
+++ b/packages/core/src/signers/ethersEip712Signer.ts
@@ -2,6 +2,7 @@ import { ResultAsync } from 'neverthrow';
 import type { Signer } from 'ethers';
 import { HubAsyncResult, HubError } from '../errors';
 import { VerificationEthAddressClaim } from '../verifications';
+import { UserNameProofClaim } from '../userNameProof';
 import { Eip712Signer } from './eip712Signer';
 import { hexStringToBytes } from '../bytes';
 import {
@@ -10,7 +11,6 @@ import {
   EIP_712_FARCASTER_VERIFICATION_CLAIM,
   EIP_712_USERNAME_DOMAIN,
   EIP_712_USERNAME_PROOF,
-  UserNameProofClaim,
 } from '../crypto/eip712';
 
 export type MinimalEthersSigner = Pick<Signer, 'signTypedData' | 'getAddress'>;
@@ -57,7 +57,7 @@ export class EthersEip712Signer extends Eip712Signer {
     return hexSignature.andThen((hex) => hexStringToBytes(hex));
   }
 
-  public async signUserNameProof(userNameProof: UserNameProofClaim): HubAsyncResult<Uint8Array> {
+  public async signUserNameProofClaim(userNameProof: UserNameProofClaim): HubAsyncResult<Uint8Array> {
     const hexSignature = await ResultAsync.fromPromise(
       this._ethersSigner.signTypedData(
         EIP_712_USERNAME_DOMAIN,

--- a/packages/core/src/signers/ethersEip712Signer.ts
+++ b/packages/core/src/signers/ethersEip712Signer.ts
@@ -1,5 +1,5 @@
 import { ResultAsync } from 'neverthrow';
-import { Signer } from 'ethers';
+import type { Signer } from 'ethers';
 import { HubAsyncResult, HubError } from '../errors';
 import { VerificationEthAddressClaim } from '../verifications';
 import { Eip712Signer } from './eip712Signer';
@@ -8,6 +8,9 @@ import {
   EIP_712_FARCASTER_DOMAIN,
   EIP_712_FARCASTER_MESSAGE_DATA,
   EIP_712_FARCASTER_VERIFICATION_CLAIM,
+  EIP_712_USERNAME_DOMAIN,
+  EIP_712_USERNAME_PROOF,
+  UserNameProofClaim,
 } from '../crypto/eip712';
 
 export type MinimalEthersSigner = Pick<Signer, 'signTypedData' | 'getAddress'>;
@@ -46,6 +49,20 @@ export class EthersEip712Signer extends Eip712Signer {
         EIP_712_FARCASTER_DOMAIN,
         { VerificationClaim: [...EIP_712_FARCASTER_VERIFICATION_CLAIM] },
         claim
+      ),
+      (e) => new HubError('bad_request.invalid_param', e as Error)
+    );
+
+    // Convert hex signature to bytes
+    return hexSignature.andThen((hex) => hexStringToBytes(hex));
+  }
+
+  public async signUserNameProof(userNameProof: UserNameProofClaim): HubAsyncResult<Uint8Array> {
+    const hexSignature = await ResultAsync.fromPromise(
+      this._ethersSigner.signTypedData(
+        EIP_712_USERNAME_DOMAIN,
+        { UserNameProof: [...EIP_712_USERNAME_PROOF] },
+        userNameProof
       ),
       (e) => new HubError('bad_request.invalid_param', e as Error)
     );

--- a/packages/core/src/signers/ethersV5Eip712Signer.ts
+++ b/packages/core/src/signers/ethersV5Eip712Signer.ts
@@ -8,7 +8,7 @@ import { HubAsyncResult, HubError } from '../errors';
 import { eip712 } from '../crypto';
 import { hexStringToBytes } from '../bytes';
 import { VerificationEthAddressClaim } from '../verifications';
-import { UserNameProofClaim } from 'crypto/eip712';
+import { UserNameProofClaim } from '../userNameProof';
 
 export type TypedDataSigner = EthersAbstractSigner & EthersTypedDataSigner;
 
@@ -51,7 +51,7 @@ export class EthersV5Eip712Signer extends Eip712Signer {
     return hexSignature.andThen((hex) => hexStringToBytes(hex));
   }
 
-  public async signUserNameProof(usernameProof: UserNameProofClaim): HubAsyncResult<Uint8Array> {
+  public async signUserNameProofClaim(usernameProof: UserNameProofClaim): HubAsyncResult<Uint8Array> {
     const hexSignature = await ResultAsync.fromPromise(
       this._typedDataSigner._signTypedData(
         eip712.EIP_712_USERNAME_DOMAIN,

--- a/packages/core/src/signers/ethersV5Eip712Signer.ts
+++ b/packages/core/src/signers/ethersV5Eip712Signer.ts
@@ -30,7 +30,7 @@ export class EthersV5Eip712Signer extends Eip712Signer {
     const hexSignature = await ResultAsync.fromPromise(
       this._typedDataSigner._signTypedData(
         eip712.EIP_712_FARCASTER_DOMAIN,
-        { MessageData: eip712.EIP_712_FARCASTER_MESSAGE_DATA },
+        { MessageData: [...eip712.EIP_712_FARCASTER_MESSAGE_DATA] },
         { hash }
       ),
       (e) => new HubError('bad_request.invalid_param', e as Error)
@@ -42,7 +42,7 @@ export class EthersV5Eip712Signer extends Eip712Signer {
     const hexSignature = await ResultAsync.fromPromise(
       this._typedDataSigner._signTypedData(
         eip712.EIP_712_FARCASTER_DOMAIN,
-        { VerificationClaim: eip712.EIP_712_FARCASTER_VERIFICATION_CLAIM },
+        { VerificationClaim: [...eip712.EIP_712_FARCASTER_VERIFICATION_CLAIM] },
         claim
       ),
       (e) => new HubError('bad_request.invalid_param', e as Error)

--- a/packages/core/src/signers/ethersV5Eip712Signer.ts
+++ b/packages/core/src/signers/ethersV5Eip712Signer.ts
@@ -8,6 +8,7 @@ import { HubAsyncResult, HubError } from '../errors';
 import { eip712 } from '../crypto';
 import { hexStringToBytes } from '../bytes';
 import { VerificationEthAddressClaim } from '../verifications';
+import { UserNameProofClaim } from 'crypto/eip712';
 
 export type TypedDataSigner = EthersAbstractSigner & EthersTypedDataSigner;
 
@@ -44,6 +45,18 @@ export class EthersV5Eip712Signer extends Eip712Signer {
         eip712.EIP_712_FARCASTER_DOMAIN,
         { VerificationClaim: [...eip712.EIP_712_FARCASTER_VERIFICATION_CLAIM] },
         claim
+      ),
+      (e) => new HubError('bad_request.invalid_param', e as Error)
+    );
+    return hexSignature.andThen((hex) => hexStringToBytes(hex));
+  }
+
+  public async signUserNameProof(usernameProof: UserNameProofClaim): HubAsyncResult<Uint8Array> {
+    const hexSignature = await ResultAsync.fromPromise(
+      this._typedDataSigner._signTypedData(
+        eip712.EIP_712_USERNAME_DOMAIN,
+        { UserNameProof: [...eip712.EIP_712_USERNAME_PROOF] },
+        usernameProof
       ),
       (e) => new HubError('bad_request.invalid_param', e as Error)
     );

--- a/packages/core/src/signers/nobleEd25519Signer.test.ts
+++ b/packages/core/src/signers/nobleEd25519Signer.test.ts
@@ -1,5 +1,5 @@
 import { blake3 } from '@noble/hashes/blake3';
-import { randomBytes } from 'ethers';
+import { randomBytes } from '@noble/hashes/utils';
 import { Factories } from '../factories';
 import { NobleEd25519Signer } from './nobleEd25519Signer';
 import { ed25519 } from '@noble/curves/ed25519';

--- a/packages/core/src/signers/testUtils.ts
+++ b/packages/core/src/signers/testUtils.ts
@@ -81,7 +81,7 @@ export const testEip712Signer = async (signer: Eip712Signer) => {
     });
 
     test('succeeds', async () => {
-      const valid = await eip712.verifyUserNameProof(claim, signature, signerKey);
+      const valid = await eip712.verifyUserNameProofClaim(claim, signature, signerKey);
       expect(valid).toEqual(ok(true));
     });
 

--- a/packages/core/src/signers/testUtils.ts
+++ b/packages/core/src/signers/testUtils.ts
@@ -54,6 +54,15 @@ export const testEip712Signer = async (signer: Eip712Signer) => {
       expect(signature2).toEqual(ok(signature));
       expect(bytesToHexString(signature2._unsafeUnwrap())).toEqual(bytesToHexString(signature));
     });
+
+    test('fails with HubError', async () => {
+      const result = await signer.signVerificationEthAddressClaim({
+        ...claim,
+        fid: -1n,
+      });
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr().errCode).toBe('bad_request.invalid_param');
+    });
   });
 
   describe('signUserNameProof', () => {
@@ -81,6 +90,15 @@ export const testEip712Signer = async (signer: Eip712Signer) => {
       const signature2 = await signer.signUserNameProof(claim2);
       expect(signature2).toEqual(ok(signature));
       expect(bytesToHexString(signature2._unsafeUnwrap())).toEqual(bytesToHexString(signature));
+    });
+
+    test('fails with HubError', async () => {
+      const result = await signer.signUserNameProof({
+        ...claim,
+        timestamp: -1,
+      });
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr().errCode).toBe('bad_request.invalid_param');
     });
   });
 };

--- a/packages/core/src/signers/testUtils.ts
+++ b/packages/core/src/signers/testUtils.ts
@@ -20,8 +20,8 @@ export const testEip712Signer = async (signer: Eip712Signer) => {
       const hash = blake3(bytes, { dkLen: 20 });
       const signature = await signer.signMessageHash(hash);
       expect(signature.isOk()).toBeTruthy();
-      const recoveredAddress = eip712.verifyMessageHashSignature(hash, signature._unsafeUnwrap());
-      expect(recoveredAddress).toEqual(ok(signerKey));
+      const valid = await eip712.verifyMessageHashSignature(hash, signature._unsafeUnwrap(), signerKey);
+      expect(valid).toEqual(ok(true));
     });
   });
 
@@ -42,8 +42,8 @@ export const testEip712Signer = async (signer: Eip712Signer) => {
     });
 
     test('succeeds', async () => {
-      const recoveredAddress = eip712.verifyVerificationEthAddressClaimSignature(claim, signature);
-      expect(recoveredAddress).toEqual(ok(signerKey));
+      const valid = await eip712.verifyVerificationEthAddressClaimSignature(claim, signature, signerKey);
+      expect(valid).toEqual(ok(true));
     });
 
     test('succeeds when encoding twice', async () => {

--- a/packages/core/src/signers/testUtils.ts
+++ b/packages/core/src/signers/testUtils.ts
@@ -5,8 +5,8 @@ import { eip712 } from '../crypto';
 import { Factories } from '../factories';
 import { FarcasterNetwork } from '../protobufs';
 import { makeVerificationEthAddressClaim, VerificationEthAddressClaim } from '../verifications';
+import { makeUserNameProofClaim, UserNameProofClaim } from '../userNameProof';
 import { Eip712Signer } from './eip712Signer';
-import { UserNameProofClaim } from '../crypto/eip712';
 import { bytesToHex } from 'viem';
 
 export const testEip712Signer = async (signer: Eip712Signer) => {
@@ -65,17 +65,17 @@ export const testEip712Signer = async (signer: Eip712Signer) => {
     });
   });
 
-  describe('signUserNameProof', () => {
+  describe('signUserNameProofClaim', () => {
     let claim: UserNameProofClaim;
     let signature: Uint8Array;
 
     beforeAll(async () => {
-      claim = {
+      claim = makeUserNameProofClaim({
         name: '0x000',
         timestamp: Date.now(),
         owner: bytesToHex(signerKey),
-      };
-      const signatureResult = await signer.signUserNameProof(claim);
+      });
+      const signatureResult = await signer.signUserNameProofClaim(claim);
       expect(signatureResult.isOk()).toBeTruthy();
       signature = signatureResult._unsafeUnwrap();
     });
@@ -87,15 +87,15 @@ export const testEip712Signer = async (signer: Eip712Signer) => {
 
     test('succeeds when encoding twice', async () => {
       const claim2: UserNameProofClaim = { ...claim };
-      const signature2 = await signer.signUserNameProof(claim2);
+      const signature2 = await signer.signUserNameProofClaim(claim2);
       expect(signature2).toEqual(ok(signature));
       expect(bytesToHexString(signature2._unsafeUnwrap())).toEqual(bytesToHexString(signature));
     });
 
     test('fails with HubError', async () => {
-      const result = await signer.signUserNameProof({
+      const result = await signer.signUserNameProofClaim({
         ...claim,
-        timestamp: -1,
+        timestamp: -1n,
       });
       expect(result.isErr()).toBe(true);
       expect(result._unsafeUnwrapErr().errCode).toBe('bad_request.invalid_param');

--- a/packages/core/src/signers/viemLocalEip712Signer.ts
+++ b/packages/core/src/signers/viemLocalEip712Signer.ts
@@ -6,6 +6,9 @@ import {
   EIP_712_FARCASTER_MESSAGE_DATA,
   EIP_712_FARCASTER_VERIFICATION_CLAIM,
   EIP_712_FARCASTER_DOMAIN,
+  UserNameProofClaim,
+  EIP_712_USERNAME_DOMAIN,
+  EIP_712_USERNAME_PROOF,
 } from '../crypto/eip712';
 import { HubAsyncResult, HubError } from '../errors';
 import { VerificationEthAddressClaim } from '../verifications';
@@ -47,9 +50,20 @@ export class ViemLocalEip712Signer extends Eip712Signer {
         domain: EIP_712_FARCASTER_DOMAIN,
         types: { VerificationClaim: EIP_712_FARCASTER_VERIFICATION_CLAIM },
         primaryType: 'VerificationClaim',
-        message: {
-          ...claim,
-        },
+        message: claim,
+      }),
+      (e) => new HubError('bad_request.invalid_param', e as Error)
+    );
+    return hexSignature.andThen((hex) => hexStringToBytes(hex));
+  }
+
+  public async signUserNameProof(userNameProof: UserNameProofClaim): HubAsyncResult<Uint8Array> {
+    const hexSignature = await ResultAsync.fromPromise(
+      this._viemLocalAccount.signTypedData({
+        domain: EIP_712_USERNAME_DOMAIN,
+        types: { UserNameProof: EIP_712_USERNAME_PROOF },
+        primaryType: 'UserNameProof',
+        message: userNameProof,
       }),
       (e) => new HubError('bad_request.invalid_param', e as Error)
     );

--- a/packages/core/src/signers/viemLocalEip712Signer.ts
+++ b/packages/core/src/signers/viemLocalEip712Signer.ts
@@ -6,12 +6,12 @@ import {
   EIP_712_FARCASTER_MESSAGE_DATA,
   EIP_712_FARCASTER_VERIFICATION_CLAIM,
   EIP_712_FARCASTER_DOMAIN,
-  UserNameProofClaim,
   EIP_712_USERNAME_DOMAIN,
   EIP_712_USERNAME_PROOF,
 } from '../crypto/eip712';
 import { HubAsyncResult, HubError } from '../errors';
 import { VerificationEthAddressClaim } from '../verifications';
+import { UserNameProofClaim } from '../userNameProof';
 import { Eip712Signer } from './eip712Signer';
 
 export class ViemLocalEip712Signer extends Eip712Signer {
@@ -57,16 +57,13 @@ export class ViemLocalEip712Signer extends Eip712Signer {
     return hexSignature.andThen((hex) => hexStringToBytes(hex));
   }
 
-  public async signUserNameProof(userNameProof: UserNameProofClaim): HubAsyncResult<Uint8Array> {
+  public async signUserNameProofClaim(userNameProof: UserNameProofClaim): HubAsyncResult<Uint8Array> {
     const hexSignature = await ResultAsync.fromPromise(
       this._viemLocalAccount.signTypedData({
         domain: EIP_712_USERNAME_DOMAIN,
         types: { UserNameProof: EIP_712_USERNAME_PROOF },
         primaryType: 'UserNameProof',
-        message: {
-          ...userNameProof,
-          timestamp: BigInt(userNameProof.timestamp),
-        },
+        message: userNameProof,
       }),
       (e) => new HubError('bad_request.invalid_param', e as Error)
     );

--- a/packages/core/src/signers/viemLocalEip712Signer.ts
+++ b/packages/core/src/signers/viemLocalEip712Signer.ts
@@ -63,7 +63,10 @@ export class ViemLocalEip712Signer extends Eip712Signer {
         domain: EIP_712_USERNAME_DOMAIN,
         types: { UserNameProof: EIP_712_USERNAME_PROOF },
         primaryType: 'UserNameProof',
-        message: userNameProof,
+        message: {
+          ...userNameProof,
+          timestamp: BigInt(userNameProof.timestamp),
+        },
       }),
       (e) => new HubError('bad_request.invalid_param', e as Error)
     );

--- a/packages/core/src/userNameProof.test.ts
+++ b/packages/core/src/userNameProof.test.ts
@@ -1,0 +1,21 @@
+import { Factories } from './factories';
+import { makeUserNameProofClaim } from './userNameProof';
+import { bytesToHexString } from './bytes';
+
+describe('makeUserNameProofClaim', () => {
+  test('succeeds', () => {
+    const ethAddress = Factories.EthAddress.build();
+    const timestamp = Date.now();
+    const name = 'testname';
+    const claim = makeUserNameProofClaim({
+      name,
+      timestamp,
+      owner: bytesToHexString(ethAddress)._unsafeUnwrap(),
+    });
+    expect(claim).toMatchObject({
+      name,
+      timestamp: BigInt(timestamp),
+      owner: bytesToHexString(ethAddress)._unsafeUnwrap(),
+    });
+  });
+});

--- a/packages/core/src/userNameProof.ts
+++ b/packages/core/src/userNameProof.ts
@@ -1,0 +1,29 @@
+export type UserNameProofClaim = {
+  /** Username being claimed **/
+  name: string;
+
+  /** Custody address claiming the username **/
+  owner: `0x${string}`;
+
+  /** Unix timestamp of proof in bigint representation **/
+  timestamp: bigint;
+};
+
+export const makeUserNameProofClaim = ({
+  name,
+  owner,
+  timestamp,
+}: {
+  /** Username being claimed **/
+  name: string;
+  /** Custody address claiming the username **/
+  owner: `0x${string}`;
+  /** Unix timestamp of proof **/
+  timestamp: number;
+}): UserNameProofClaim => {
+  return {
+    name,
+    owner,
+    timestamp: BigInt(timestamp),
+  };
+};

--- a/packages/core/src/verifications.test.ts
+++ b/packages/core/src/verifications.test.ts
@@ -1,11 +1,13 @@
 import { Factories } from './factories';
 import { makeVerificationEthAddressClaim } from './verifications';
 
-test('succeeds', () => {
-  const fid = Factories.Fid.build();
-  const ethAddress = Factories.EthAddress.build();
-  const network = Factories.FarcasterNetwork.build();
-  const blockHash = Factories.BlockHash.build();
-  const claim = makeVerificationEthAddressClaim(fid, ethAddress, network, blockHash);
-  expect(claim.isOk()).toBeTruthy();
+describe('makeVerificationEthAddressClaim', () => {
+  test('succeeds', () => {
+    const fid = Factories.Fid.build();
+    const ethAddress = Factories.EthAddress.build();
+    const network = Factories.FarcasterNetwork.build();
+    const blockHash = Factories.BlockHash.build();
+    const claim = makeVerificationEthAddressClaim(fid, ethAddress, network, blockHash);
+    expect(claim.isOk()).toBeTruthy();
+  });
 });

--- a/packages/core/src/verifications.ts
+++ b/packages/core/src/verifications.ts
@@ -6,9 +6,9 @@ import { validateEthAddress, validateEthBlockHash } from './validations';
 
 export type VerificationEthAddressClaim = {
   fid: bigint;
-  address: string; // Hex string
+  address: `0x${string}`;
   network: FarcasterNetwork;
-  blockHash: string; // Hex string
+  blockHash: `0x${string}`;
 };
 
 export const makeVerificationEthAddressClaim = (

--- a/packages/hub-nodejs/docs/signers/EthersEip712Signer.md
+++ b/packages/hub-nodejs/docs/signers/EthersEip712Signer.md
@@ -60,7 +60,7 @@ Generates a 256-bit signature for a string input and returns the bytes.
 
 ```typescript
 import { blake3 } from '@noble/hashes/blake3';
-import { randomBytes } from 'ethers';
+import { randomBytes } from '@noble/hashes/utils';
 
 const bytes = randomBytes(32);
 const hash = blake3(bytes, { dkLen: 20 });

--- a/packages/hub-nodejs/docs/signers/EthersV5Eip712Signer.md
+++ b/packages/hub-nodejs/docs/signers/EthersV5Eip712Signer.md
@@ -60,7 +60,7 @@ Generates a 256-bit signature for a string input and returns the bytes.
 
 ```typescript
 import { blake3 } from '@noble/hashes/blake3';
-import { randomBytes } from 'ethers';
+import { randomBytes } from '@noble/hashes/utils';
 
 const bytes = randomBytes(32);
 const hash = blake3(bytes, { dkLen: 20 });

--- a/packages/hub-nodejs/docs/signers/EthersV5Eip712Signer.md
+++ b/packages/hub-nodejs/docs/signers/EthersV5Eip712Signer.md
@@ -128,3 +128,38 @@ if (ethereumAddressResult.isOk()) {
 | `claim` | [`VerificationEthAddressClaim`](../modules/types.md#verificationethaddressclaim) | The body of the claim to be signed. |
 
 ---
+
+### signUserNameProofClaim
+
+Generates a 256-bit signature for a UserNameProofClaim and returns the bytes.
+
+#### Usage
+
+```typescript
+import { makeUserNameProofClaim } from '@farcaster/hub-nodejs';
+
+const claim = makeUserNameProofClaim({
+  owner: '0x8773442740c17c9d0f0b87022c722f9a136206ed',
+  name: 'farcaster',
+  timestamp: Date.now(),
+});
+
+const signatureResult = await eip712Signer.signUserNameProofClaim(claim);
+if (signatureResult.isOk()) {
+  console.log(signatureResult.value);
+}
+```
+
+#### Returns
+
+| Value                        | Description                            |
+| :--------------------------- | :------------------------------------- |
+| `HubAsyncResult<Uint8Array>` | The 256-bit signature as a Uint8Array. |
+
+#### Parameters
+
+| Name    | Type                 | Description                         |
+| :------ | :------------------- | :---------------------------------- |
+| `claim` | `UserNameProofClaim` | The body of the claim to be signed. |
+
+---

--- a/packages/hub-nodejs/docs/signers/ViemLocalEip712Signer.md
+++ b/packages/hub-nodejs/docs/signers/ViemLocalEip712Signer.md
@@ -1,6 +1,6 @@
-# EthersEip712Signer
+# ViemLocalEip712Signer
 
-An Eip712Signer that is initialized with an [Ethers v6](https://github.com/ethers-io/ethers.js/) Ethereum wallet and can be used with [Builders](../builders/builders.md) to sign Farcaster Messages. If you're looking for Ethers v5 support, see [this troubleshooting guide](../README.md#ethers-v5).
+An Eip712Signer that is initialized with an [Viem](https://viem.sh/docs) LocalACcount and can be used with [Builders](../builders/builders.md) to sign Farcaster Messages.
 
 ## Properties
 
@@ -10,17 +10,17 @@ An Eip712Signer that is initialized with an [Ethers v6](https://github.com/ether
 
 ## Constructors
 
-### `static` new EthersEip712Signer
+### `static` new ViemLocalEip712Signer
 
 ### Usage
 
 ```typescript
-import { EthersEip712Signer } from '@farcaster/hub-nodejs';
-import { Wallet } from 'ethers';
+import { ViemLocalEip712Signer } from '@farcaster/hub-nodejs';
+import { mnemonicToAccount } from 'viem/accounts';
 
 const mnemonic = 'ordinary long coach bounce thank quit become youth belt pretty diet caught attract melt bargain';
-const wallet = Wallet.fromPhrase(mnemonic);
-const eip712Signer = new EthersEip712Signer(wallet);
+const account = mnemonicToAccount(mnemonic);
+const eip712Signer = new ViemLocalEip712Signer(account);
 ```
 
 #### Parameters
@@ -136,15 +136,15 @@ Generates a 256-bit signature for a UserNameProofClaim and returns the bytes.
 #### Usage
 
 ```typescript
-import { makeUserNameProofClaim } from '@farcaster/hub-nodejs';
+import { UserNameProofClaim } from '@farcaster/hub-nodejs';
 
-const claim = makeUserNameProofClaim({
+const claim: UserNameProofClaim = {
   owner: '0x8773442740c17c9d0f0b87022c722f9a136206ed',
   name: 'farcaster',
-  timestamp: Date.now(),
-});
+  timestamp: 1628882891,
+};
 
-const signatureResult = await eip712Signer.signUserNameProofClaim(claim);
+const signatureResult = await eip712Signer.signUserNameProof(claim);
 if (signatureResult.isOk()) {
   console.log(signatureResult.value);
 }

--- a/packages/hub-nodejs/docs/signers/ViemLocalEip712Signer.md
+++ b/packages/hub-nodejs/docs/signers/ViemLocalEip712Signer.md
@@ -60,7 +60,7 @@ Generates a 256-bit signature for a string input and returns the bytes.
 
 ```typescript
 import { blake3 } from '@noble/hashes/blake3';
-import { randomBytes } from 'ethers';
+import { randomBytes } from '@noble/hashes/utils';
 
 const bytes = randomBytes(32);
 const hash = blake3(bytes, { dkLen: 20 });
@@ -136,15 +136,15 @@ Generates a 256-bit signature for a UserNameProofClaim and returns the bytes.
 #### Usage
 
 ```typescript
-import { UserNameProofClaim } from '@farcaster/hub-nodejs';
+import { makeUserNameProofClaim } from '@farcaster/hub-nodejs';
 
-const claim: UserNameProofClaim = {
+const claim = makeUserNameProofClaim({
   owner: '0x8773442740c17c9d0f0b87022c722f9a136206ed',
   name: 'farcaster',
-  timestamp: 1628882891,
-};
+  timestamp: Date.now(),
+});
 
-const signatureResult = await eip712Signer.signUserNameProof(claim);
+const signatureResult = await eip712Signer.signUserNameProofClaim(claim);
 if (signatureResult.isOk()) {
   console.log(signatureResult.value);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,6 +40,11 @@
   resolved "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.0.tgz#223572538f6bea336750039bb43a4016dcc8182d"
   integrity sha512-iowxq3U30sghZotgl4s/oJRci6WPBfNO5YYgk2cIOMCHr3LeGPcsZjCEr+33Q4N+oV3OABDAtA+pyvWjbvBifQ==
 
+"@adraffy/ens-normalize@1.9.2":
+  version "1.9.2"
+  resolved "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.2.tgz#60111a5d9db45b2e5cbb6231b0bb8d97e8659316"
+  integrity sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg==
+
 "@ampproject/remapping@^2.2.0":
   version "2.2.0"
   resolved "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
@@ -2538,6 +2543,11 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz#f0b991c32cfc6a4e7f3399d6cb4b8cf9a0315014"
   integrity sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==
 
+"@types/node@18.15.13":
+  version "18.15.13"
+  resolved "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz#f64277c341150c979e42b00e4ac289290c9df469"
+  integrity sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==
+
 "@types/node@>=12.12.47", "@types/node@>=13.7.0":
   version "18.11.19"
   resolved "https://registry.npmjs.org/@types/node/-/node-18.11.19.tgz#35e26df9ec441ab99d73e99e9aca82935eea216d"
@@ -2781,6 +2791,11 @@ aes-js@4.0.0-beta.3:
   version "4.0.0-beta.3"
   resolved "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.3.tgz#da2253f0ff03a0b3a9e445c8cbdf78e7fda7d48c"
   integrity sha512-/xJX0/VTPcbc5xQE2VUP91y1xN8q/rDfhEzLm+vLc3hYvb5+qHCnpJRuFcrKn63zumK/sCwYYzhG8HP78JYSTA==
+
+aes-js@4.0.0-beta.5:
+  version "4.0.0-beta.5"
+  resolved "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz#8d2452c52adedebc3a3e28465d858c11ca315873"
+  integrity sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -4141,6 +4156,19 @@ esutils@^2.0.2:
     "@ethersproject/wallet" "5.7.0"
     "@ethersproject/web" "5.7.1"
     "@ethersproject/wordlists" "5.7.0"
+
+ethers@^6.6.1:
+  version "6.6.1"
+  resolved "https://registry.npmjs.org/ethers/-/ethers-6.6.1.tgz#c3c80cdc10190fa5457d5eced25aa16940e73f6b"
+  integrity sha512-bjNPf/EU4l1jQlAslOmOlyHqjOnM0W7LRPuSf0Kt0tYV4RpUEZsdGWDhvFXfogIhfzXJ/v2tPz4HqXwBt5T8mA==
+  dependencies:
+    "@adraffy/ens-normalize" "1.9.2"
+    "@noble/hashes" "1.1.2"
+    "@noble/secp256k1" "1.7.1"
+    "@types/node" "18.15.13"
+    aes-js "4.0.0-beta.5"
+    tslib "2.4.0"
+    ws "8.5.0"
 
 ethers@~6.2.1:
   version "6.2.1"


### PR DESCRIPTION
## Motivation
See [why viem](https://viem.sh/docs/introduction.html).

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for signing and verifying `UserNameProofClaim` objects, removes some deprecated methods, and includes other minor changes.

### Detailed summary
- Adds `UserNameProofClaim` type and `makeUserNameProofClaim` function.
- Adds `signUserNameProofClaim` method to `Eip712Signer`.
- Removes `getSignerKey`, `signVerificationEthAddressClaim`, and `signMessageHash` methods from `Eip712Signer`.
- Changes `makeVerificationEthAddressClaim` to accept a `bigint` for `timestamp`.
- Updates dependencies and imports.

> The following files were skipped due to too many changes: `packages/core/src/factories.ts`, `apps/hubble/src/eth/fnameRegistryEventsProvider.ts`, `packages/core/src/signers/ethersV5Eip712Signer.ts`, `packages/core/src/builders.test.ts`, `yarn.lock`, `packages/core/src/signers/ethersEip712Signer.ts`, `packages/core/src/signers/testUtils.ts`, `packages/core/src/validations.ts`, `packages/core/src/crypto/eip712.test.ts`, `apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts`, `packages/hub-nodejs/docs/signers/ViemLocalEip712Signer.md`, `packages/core/src/crypto/eip712.ts`, `packages/core/src/validations.test.ts`, `packages/core/src/builders.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->