### PR TITLE
chore(hub-web): remove @improbable-eng/grpc-node-http-transport

### DIFF
--- a/.changeset/plenty-buttons-fix.md
+++ b/.changeset/plenty-buttons-fix.md
@@ -1,0 +1,14 @@
+---
+'@farcaster/hub-web': minor
+---
+
+Made RPC client factory functions more flexible
+
+- removed @improbable-eng/grpc-web-node-http-transport as a dependency
+  - this transport can be installed and configured using the `transport`
+    property of the GrpcHubImpl options
+- factory functions no longer take a boolean indicating if the env is a browser
+  or not and instead an object to specify options of the GrpcWeb client
+  - if you need to use this in a node environment, install
+    @improbable-eng/grpc-web-node-http-transport and pass it as the transport,
+    or use @farcaster/hub-node-js

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "@farcaster/core": "^0.9.1",
     "@improbable-eng/grpc-web": "^0.15.0",
-    "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
     "rxjs": "^7.8.0"
   }
 }

--- a/packages/hub-web/src/client.ts
+++ b/packages/hub-web/src/client.ts
@@ -6,7 +6,6 @@ import {
   AdminService,
   AdminServiceClientImpl,
 } from './generated/rpc';
-import { NodeHttpTransport } from '@improbable-eng/grpc-web-node-http-transport';
 
 import grpcWeb from '@improbable-eng/grpc-web';
 import { err, ok } from 'neverthrow';
@@ -92,18 +91,18 @@ const wrapClient = <C extends object>(client: C) => {
 
 export type HubRpcClient = WrappedClient<HubService>;
 
-export const getHubRpcClient = (url: string, isBrowser = true): HubRpcClient => {
-  return wrapClient(new HubServiceClientImpl(getRpcWebClient(url, isBrowser)));
+export const getHubRpcClient = (...args: Parameters<typeof getRpcWebClient>): HubRpcClient => {
+  return wrapClient(new HubServiceClientImpl(getRpcWebClient(...args)));
 };
 
 export type AdminRpcClient = WrappedClient<AdminService>;
 
-export const getAdminRpcClient = (url: string, isBrowser = true): AdminRpcClient => {
-  return wrapClient(new AdminServiceClientImpl(getRpcWebClient(url, isBrowser)));
+export const getAdminRpcClient = (...args: Parameters<typeof getRpcWebClient>): AdminRpcClient => {
+  return wrapClient(new AdminServiceClientImpl(getRpcWebClient(...args)));
 };
 
-const getRpcWebClient = (address: string, isBrowser = true): GrpcWebImpl => {
-  return new GrpcWebImpl(address, isBrowser ? {} : { transport: NodeHttpTransport() });
+const getRpcWebClient = (...args: ConstructorParameters<typeof GrpcWebImpl>): GrpcWebImpl => {
+  return new GrpcWebImpl(...args);
 };
 
 export const getAuthMetadata = (username: string, password: string): grpcWeb.grpc.Metadata => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1201,11 +1201,6 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@improbable-eng/grpc-web-node-http-transport@^0.15.0":
-  version "0.15.0"
-  resolved "https://registry.npmjs.org/@improbable-eng/grpc-web-node-http-transport/-/grpc-web-node-http-transport-0.15.0.tgz#5a064472ef43489cbd075a91fb831c2abeb09d68"
-  integrity sha512-HLgJfVolGGpjc9DWPhmMmXJx8YGzkek7jcCFO1YYkSOoO81MWRZentPOd/JiKiZuU08wtc4BG+WNuGzsQB5jZA==
-
 "@improbable-eng/grpc-web@^0.15.0":
   version "0.15.0"
   resolved "https://registry.npmjs.org/@improbable-eng/grpc-web/-/grpc-web-0.15.0.tgz#3e47e9fdd90381a74abd4b7d26e67422a2a04bef"


### PR DESCRIPTION
## Motivation

There is no reason to include this dependency in hub-web and it prevents this library being used in React Native environments without additional node polyfills. Consumers can use @farcaster/hub-node-js or install and configure this transport like `getRpcWebClient(address, { transport })`.

## Change Summary

Factory functions no longer take a boolean indicating if the env is a browser or not and instead an object to specify options of the GrpcWeb client. Removed @improbable-eng/grpc-web-node-http-transport as a dependency.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `hub-web` package by removing the `@improbable-eng/grpc-web-node-http-transport` dependency and making RPC client factory functions more flexible. 

### Detailed summary
- Removed `@improbable-eng/grpc-web-node-http-transport` as a dependency
- RPC client factory functions no longer take a boolean indicating if the env is a browser or not and instead an object to specify options of the GrpcWeb client
- Made RPC client factory functions more flexible
- If you need to use this in a node environment, install `@improbable-eng/grpc-web-node-http-transport` and pass it as the transport, or use `@farcaster/hub-node-js`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->