### PR TITLE
fix: Pin Docker base Node.js image to 20.2

### DIFF
--- a/Dockerfile.hubble
+++ b/Dockerfile.hubble
@@ -5,7 +5,7 @@
 ############## Stage 1: Create pruned version of monorepo #####################
 ###############################################################################
 
-FROM node:20-alpine AS prune
+FROM node:20.2-alpine AS prune
 
 RUN apk add --no-cache libc6-compat
 
@@ -23,7 +23,7 @@ RUN /home/node/.yarn/bin/turbo prune --scope=@farcaster/hubble --docker
 ############## Stage 2: Build the code using a full node image ################
 ###############################################################################
 
-FROM node:20-alpine AS build
+FROM node:20.2-alpine AS build
 
 # Needed for compilation step
 RUN apk add --no-cache libc6-compat python3 make g++ linux-headers
@@ -53,7 +53,7 @@ RUN rm -rf node_modules && yarn install --production --ignore-scripts --prefer-o
 ########## Stage 3: Copy over the built code to a leaner alpine image #########
 ###############################################################################
 
-FROM node:20-alpine as app
+FROM node:20.2-alpine as app
 
 # Requirement for runtime metrics integrations
 RUN apk add libc6-compat


### PR DESCRIPTION
## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

Latest images are currently having issues (see
https://github.com/nodejs/docker-node/issues/1912).

## Change Summary

For now, pin to a version without that issue.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Dockerfile to use the node:20.2-alpine image instead of node:20-alpine. 

### Detailed summary
- Updated the "prune" stage to use node:20.2-alpine image
- Updated the "build" stage to use node:20.2-alpine image
- Updated the "app" stage to use node:20.2-alpine image

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->