### PR TITLE
feat: Switch from name events to username proofs

### DIFF
--- a/.changeset/seven-adults-sing.md
+++ b/.changeset/seven-adults-sing.md
@@ -1,0 +1,8 @@
+---
+'@farcaster/hub-nodejs': patch
+'@farcaster/hub-web': patch
+'@farcaster/core': patch
+'@farcaster/hubble': patch
+---
+
+Switch fnames from contract events to fname server proofs

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -35,6 +35,7 @@ import {
   VerificationRemoveMessage,
   SyncStatusResponse,
   SyncStatus,
+  UserNameProof,
 } from '@farcaster/hub-nodejs';
 import { err, ok, Result, ResultAsync } from 'neverthrow';
 import { APP_NICKNAME, APP_VERSION, HubInterface } from '../hubble.js';
@@ -633,6 +634,19 @@ export default class Server {
         nameRegistryEventResult?.match(
           (nameRegistryEvent: NameRegistryEvent) => {
             callback(null, nameRegistryEvent);
+          },
+          (err: HubError) => {
+            callback(toServiceError(err));
+          }
+        );
+      },
+      getUsernameProof: async (call, callback) => {
+        const request = call.request;
+
+        const usernameProofResult = await this.engine?.getUserNameProof(request.name);
+        usernameProofResult?.match(
+          (usernameProof: UserNameProof) => {
+            callback(null, usernameProof);
           },
           (err: HubError) => {
             callback(toServiceError(err));

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -911,6 +911,7 @@ export default class Server {
           this.engine?.eventHandler.off('revokeMessage', eventListener);
           this.engine?.eventHandler.off('mergeIdRegistryEvent', eventListener);
           this.engine?.eventHandler.off('mergeNameRegistryEvent', eventListener);
+          this.engine?.eventHandler.off('mergeUsernameProofEvent', eventListener);
         });
 
         // If the user wants to start from a specific event, we'll start from there first
@@ -980,6 +981,7 @@ export default class Server {
           this.engine?.eventHandler.on('revokeMessage', eventListener);
           this.engine?.eventHandler.on('mergeIdRegistryEvent', eventListener);
           this.engine?.eventHandler.on('mergeNameRegistryEvent', eventListener);
+          this.engine?.eventHandler.on('mergeUsernameProofEvent', eventListener);
         } else {
           for (const eventType of request.eventTypes) {
             if (eventType === HubEventType.MERGE_MESSAGE) {
@@ -992,6 +994,8 @@ export default class Server {
               this.engine?.eventHandler.on('mergeIdRegistryEvent', eventListener);
             } else if (eventType === HubEventType.MERGE_NAME_REGISTRY_EVENT) {
               this.engine?.eventHandler.on('mergeNameRegistryEvent', eventListener);
+            } else if (eventType === HubEventType.MERGE_USERNAME_PROOF) {
+              this.engine?.eventHandler.on('mergeUsernameProofEvent', eventListener);
             }
           }
         }

--- a/apps/hubble/src/rpc/test/userDataService.test.ts
+++ b/apps/hubble/src/rpc/test/userDataService.test.ts
@@ -104,8 +104,8 @@ describe('getUserData', () => {
     const display = await client.getUserData(UserDataRequest.create({ fid, userDataType: UserDataType.DISPLAY }));
     expect(Message.toJSON(display._unsafeUnwrap())).toEqual(Message.toJSON(displayAdd));
 
-    const nameRegistryEvent = Factories.NameRegistryEvent.build({ fname, to: custodySignerKey });
-    await engine.mergeNameRegistryEvent(nameRegistryEvent);
+    const nameProof = Factories.UserNameProof.build({ name: fname, owner: custodySignerKey });
+    await engine.mergeUserNameProof(nameProof);
 
     expect(await engine.mergeMessage(addFname)).toBeInstanceOf(Ok);
     const fnameData = await client.getUserData(UserDataRequest.create({ fid, userDataType: UserDataType.FNAME }));

--- a/apps/hubble/src/rpc/test/userDataService.test.ts
+++ b/apps/hubble/src/rpc/test/userDataService.test.ts
@@ -12,6 +12,8 @@ import {
   HubError,
   getInsecureHubRpcClient,
   HubRpcClient,
+  UsernameProofRequest,
+  UserNameProof,
 } from '@farcaster/hub-nodejs';
 import { Ok } from 'neverthrow';
 import SyncEngine from '../../network/sync/syncEngine.js';
@@ -110,6 +112,9 @@ describe('getUserData', () => {
     expect(await engine.mergeMessage(addFname)).toBeInstanceOf(Ok);
     const fnameData = await client.getUserData(UserDataRequest.create({ fid, userDataType: UserDataType.FNAME }));
     expect(Message.toJSON(fnameData._unsafeUnwrap())).toEqual(Message.toJSON(addFname));
+
+    const usernameProof = await client.getUsernameProof(UsernameProofRequest.create({ name: nameProof.name }));
+    expect(UserNameProof.toJSON(usernameProof._unsafeUnwrap())).toEqual(UserNameProof.toJSON(nameProof));
   });
 
   test('fails when user data is missing', async () => {

--- a/apps/hubble/src/storage/stores/storeEventHandler.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.ts
@@ -8,12 +8,13 @@ import {
   HubEvent,
   isMergeIdRegistryEventHubEvent,
   isMergeMessageHubEvent,
-  isMergeNameRegistryEventHubEvent,
+  isMergeUsernameProofHubEvent,
   isPruneMessageHubEvent,
   isRevokeMessageHubEvent,
   MergeIdRegistryEventHubEvent,
   MergeMessageHubEvent,
   MergeNameRegistryEventHubEvent,
+  MergeUsernameProofHubEvent,
   PruneMessageHubEvent,
   RevokeMessageHubEvent,
 } from '@farcaster/hub-nodejs';
@@ -89,6 +90,12 @@ export type StoreEvents = {
    * is merged into the UserDataStore.
    */
   mergeNameRegistryEvent: (event: MergeNameRegistryEventHubEvent) => void;
+
+  /**
+   * mergeUsernameProofEvent is emitted when a username proof from the fname server
+   * is merged into the UserDataStore.
+   */
+  mergeUsernameProofEvent: (event: MergeUsernameProofHubEvent) => void;
 };
 
 export type HubEventArgs = Omit<HubEvent, 'id'>;
@@ -320,8 +327,8 @@ class StoreEventHandler extends TypedEmitter<StoreEvents> {
       this.emit('revokeMessage', event);
     } else if (isMergeIdRegistryEventHubEvent(event)) {
       this.emit('mergeIdRegistryEvent', event);
-    } else if (isMergeNameRegistryEventHubEvent(event)) {
-      this.emit('mergeNameRegistryEvent', event);
+    } else if (isMergeUsernameProofHubEvent(event)) {
+      this.emit('mergeUsernameProofEvent', event);
     } else {
       return err(new HubError('bad_request.invalid_param', 'invalid event type'));
     }

--- a/apps/hubble/src/storage/stores/userDataStore.ts
+++ b/apps/hubble/src/storage/stores/userDataStore.ts
@@ -149,7 +149,10 @@ class UserDataStore extends Store<UserDataAddMessage, never> {
 
     const result = await this._eventHandler.commitTransaction(txn, {
       type: HubEventType.MERGE_USERNAME_PROOF,
-      mergeUsernameProofBody: { usernameProof: usernameProof },
+      mergeUsernameProofBody: {
+        usernameProof: usernameProof,
+        deletedUsernameProof: existingProof.isOk() ? existingProof.value : undefined,
+      },
     });
 
     if (result.isErr()) {

--- a/packages/core/src/protobufs/generated/hub_event.ts
+++ b/packages/core/src/protobufs/generated/hub_event.ts
@@ -88,6 +88,7 @@ export interface MergeNameRegistryEventBody {
 
 export interface MergeUserNameProofBody {
   usernameProof: UserNameProof | undefined;
+  deletedUsernameProof: UserNameProof | undefined;
 }
 
 export interface HubEvent {
@@ -422,13 +423,16 @@ export const MergeNameRegistryEventBody = {
 };
 
 function createBaseMergeUserNameProofBody(): MergeUserNameProofBody {
-  return { usernameProof: undefined };
+  return { usernameProof: undefined, deletedUsernameProof: undefined };
 }
 
 export const MergeUserNameProofBody = {
   encode(message: MergeUserNameProofBody, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.usernameProof !== undefined) {
       UserNameProof.encode(message.usernameProof, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.deletedUsernameProof !== undefined) {
+      UserNameProof.encode(message.deletedUsernameProof, writer.uint32(18).fork()).ldelim();
     }
     return writer;
   },
@@ -447,6 +451,13 @@ export const MergeUserNameProofBody = {
 
           message.usernameProof = UserNameProof.decode(reader, reader.uint32());
           continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.deletedUsernameProof = UserNameProof.decode(reader, reader.uint32());
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -457,13 +468,22 @@ export const MergeUserNameProofBody = {
   },
 
   fromJSON(object: any): MergeUserNameProofBody {
-    return { usernameProof: isSet(object.usernameProof) ? UserNameProof.fromJSON(object.usernameProof) : undefined };
+    return {
+      usernameProof: isSet(object.usernameProof) ? UserNameProof.fromJSON(object.usernameProof) : undefined,
+      deletedUsernameProof: isSet(object.deletedUsernameProof)
+        ? UserNameProof.fromJSON(object.deletedUsernameProof)
+        : undefined,
+    };
   },
 
   toJSON(message: MergeUserNameProofBody): unknown {
     const obj: any = {};
     message.usernameProof !== undefined &&
       (obj.usernameProof = message.usernameProof ? UserNameProof.toJSON(message.usernameProof) : undefined);
+    message.deletedUsernameProof !== undefined &&
+      (obj.deletedUsernameProof = message.deletedUsernameProof
+        ? UserNameProof.toJSON(message.deletedUsernameProof)
+        : undefined);
     return obj;
   },
 
@@ -476,6 +496,10 @@ export const MergeUserNameProofBody = {
     message.usernameProof =
       object.usernameProof !== undefined && object.usernameProof !== null
         ? UserNameProof.fromPartial(object.usernameProof)
+        : undefined;
+    message.deletedUsernameProof =
+      object.deletedUsernameProof !== undefined && object.deletedUsernameProof !== null
+        ? UserNameProof.fromPartial(object.deletedUsernameProof)
         : undefined;
     return message;
   },

--- a/packages/core/src/protobufs/generated/request_response.ts
+++ b/packages/core/src/protobufs/generated/request_response.ts
@@ -149,6 +149,10 @@ export interface NameRegistryEventRequest {
   name: Uint8Array;
 }
 
+export interface UsernameProofRequest {
+  name: Uint8Array;
+}
+
 export interface VerificationRequest {
   fid: number;
   address: Uint8Array;
@@ -2177,6 +2181,63 @@ export const NameRegistryEventRequest = {
 
   fromPartial<I extends Exact<DeepPartial<NameRegistryEventRequest>, I>>(object: I): NameRegistryEventRequest {
     const message = createBaseNameRegistryEventRequest();
+    message.name = object.name ?? new Uint8Array();
+    return message;
+  },
+};
+
+function createBaseUsernameProofRequest(): UsernameProofRequest {
+  return { name: new Uint8Array() };
+}
+
+export const UsernameProofRequest = {
+  encode(message: UsernameProofRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.name.length !== 0) {
+      writer.uint32(10).bytes(message.name);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): UsernameProofRequest {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseUsernameProofRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.name = reader.bytes();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): UsernameProofRequest {
+    return { name: isSet(object.name) ? bytesFromBase64(object.name) : new Uint8Array() };
+  },
+
+  toJSON(message: UsernameProofRequest): unknown {
+    const obj: any = {};
+    message.name !== undefined &&
+      (obj.name = base64FromBytes(message.name !== undefined ? message.name : new Uint8Array()));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UsernameProofRequest>, I>>(base?: I): UsernameProofRequest {
+    return UsernameProofRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<UsernameProofRequest>, I>>(object: I): UsernameProofRequest {
+    const message = createBaseUsernameProofRequest();
     message.name = object.name ?? new Uint8Array();
     return message;
   },

--- a/packages/core/src/protobufs/typeguards.ts
+++ b/packages/core/src/protobufs/typeguards.ts
@@ -188,3 +188,13 @@ export const isMergeNameRegistryEventHubEvent = (
     typeof event.mergeNameRegistryEventBody.nameRegistryEvent !== 'undefined'
   );
 };
+
+export const isMergeUsernameProofHubEvent = (
+  event: hubEventProtobufs.HubEvent
+): event is types.MergeUsernameProofHubEvent => {
+  return (
+    event.type === hubEventProtobufs.HubEventType.MERGE_USERNAME_PROOF &&
+    typeof event.mergeUsernameProofBody !== 'undefined' &&
+    typeof event.mergeUsernameProofBody.usernameProof !== 'undefined'
+  );
+};

--- a/packages/core/src/protobufs/types.ts
+++ b/packages/core/src/protobufs/types.ts
@@ -2,6 +2,7 @@ import { IdRegistryEvent } from './generated/id_registry_event';
 import { NameRegistryEvent } from './generated/name_registry_event';
 import * as hubEventProtobufs from './generated/hub_event';
 import * as protobufs from './generated/message';
+import { UserNameProof } from './generated/username_proof';
 
 /** Message types */
 
@@ -149,5 +150,12 @@ export type MergeNameRegistryEventHubEvent = hubEventProtobufs.HubEvent & {
   type: hubEventProtobufs.HubEventType.MERGE_NAME_REGISTRY_EVENT;
   mergeNameRegistryEventBody: hubEventProtobufs.MergeNameRegistryEventBody & {
     nameRegistryEvent: NameRegistryEvent;
+  };
+};
+
+export type MergeUsernameProofHubEvent = hubEventProtobufs.HubEvent & {
+  type: hubEventProtobufs.HubEventType.MERGE_USERNAME_PROOF;
+  mergeUsernameProofBody: hubEventProtobufs.MergeUserNameProofBody & {
+    usernameProof: UserNameProof;
   };
 };

--- a/packages/hub-nodejs/src/generated/hub_event.ts
+++ b/packages/hub-nodejs/src/generated/hub_event.ts
@@ -88,6 +88,7 @@ export interface MergeNameRegistryEventBody {
 
 export interface MergeUserNameProofBody {
   usernameProof: UserNameProof | undefined;
+  deletedUsernameProof: UserNameProof | undefined;
 }
 
 export interface HubEvent {
@@ -422,13 +423,16 @@ export const MergeNameRegistryEventBody = {
 };
 
 function createBaseMergeUserNameProofBody(): MergeUserNameProofBody {
-  return { usernameProof: undefined };
+  return { usernameProof: undefined, deletedUsernameProof: undefined };
 }
 
 export const MergeUserNameProofBody = {
   encode(message: MergeUserNameProofBody, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.usernameProof !== undefined) {
       UserNameProof.encode(message.usernameProof, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.deletedUsernameProof !== undefined) {
+      UserNameProof.encode(message.deletedUsernameProof, writer.uint32(18).fork()).ldelim();
     }
     return writer;
   },
@@ -447,6 +451,13 @@ export const MergeUserNameProofBody = {
 
           message.usernameProof = UserNameProof.decode(reader, reader.uint32());
           continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.deletedUsernameProof = UserNameProof.decode(reader, reader.uint32());
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -457,13 +468,22 @@ export const MergeUserNameProofBody = {
   },
 
   fromJSON(object: any): MergeUserNameProofBody {
-    return { usernameProof: isSet(object.usernameProof) ? UserNameProof.fromJSON(object.usernameProof) : undefined };
+    return {
+      usernameProof: isSet(object.usernameProof) ? UserNameProof.fromJSON(object.usernameProof) : undefined,
+      deletedUsernameProof: isSet(object.deletedUsernameProof)
+        ? UserNameProof.fromJSON(object.deletedUsernameProof)
+        : undefined,
+    };
   },
 
   toJSON(message: MergeUserNameProofBody): unknown {
     const obj: any = {};
     message.usernameProof !== undefined &&
       (obj.usernameProof = message.usernameProof ? UserNameProof.toJSON(message.usernameProof) : undefined);
+    message.deletedUsernameProof !== undefined &&
+      (obj.deletedUsernameProof = message.deletedUsernameProof
+        ? UserNameProof.toJSON(message.deletedUsernameProof)
+        : undefined);
     return obj;
   },
 
@@ -476,6 +496,10 @@ export const MergeUserNameProofBody = {
     message.usernameProof =
       object.usernameProof !== undefined && object.usernameProof !== null
         ? UserNameProof.fromPartial(object.usernameProof)
+        : undefined;
+    message.deletedUsernameProof =
+      object.deletedUsernameProof !== undefined && object.deletedUsernameProof !== null
+        ? UserNameProof.fromPartial(object.deletedUsernameProof)
         : undefined;
     return message;
   },

--- a/packages/hub-nodejs/src/generated/request_response.ts
+++ b/packages/hub-nodejs/src/generated/request_response.ts
@@ -149,6 +149,10 @@ export interface NameRegistryEventRequest {
   name: Uint8Array;
 }
 
+export interface UsernameProofRequest {
+  name: Uint8Array;
+}
+
 export interface VerificationRequest {
   fid: number;
   address: Uint8Array;
@@ -2177,6 +2181,63 @@ export const NameRegistryEventRequest = {
 
   fromPartial<I extends Exact<DeepPartial<NameRegistryEventRequest>, I>>(object: I): NameRegistryEventRequest {
     const message = createBaseNameRegistryEventRequest();
+    message.name = object.name ?? new Uint8Array();
+    return message;
+  },
+};
+
+function createBaseUsernameProofRequest(): UsernameProofRequest {
+  return { name: new Uint8Array() };
+}
+
+export const UsernameProofRequest = {
+  encode(message: UsernameProofRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.name.length !== 0) {
+      writer.uint32(10).bytes(message.name);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): UsernameProofRequest {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseUsernameProofRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.name = reader.bytes();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): UsernameProofRequest {
+    return { name: isSet(object.name) ? bytesFromBase64(object.name) : new Uint8Array() };
+  },
+
+  toJSON(message: UsernameProofRequest): unknown {
+    const obj: any = {};
+    message.name !== undefined &&
+      (obj.name = base64FromBytes(message.name !== undefined ? message.name : new Uint8Array()));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UsernameProofRequest>, I>>(base?: I): UsernameProofRequest {
+    return UsernameProofRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<UsernameProofRequest>, I>>(object: I): UsernameProofRequest {
+    const message = createBaseUsernameProofRequest();
     message.name = object.name ?? new Uint8Array();
     return message;
   },

--- a/packages/hub-nodejs/src/generated/rpc.ts
+++ b/packages/hub-nodejs/src/generated/rpc.ts
@@ -45,8 +45,10 @@ import {
   TrieNodePrefix,
   TrieNodeSnapshotResponse,
   UserDataRequest,
+  UsernameProofRequest,
   VerificationRequest,
 } from './request_response';
+import { UserNameProof } from './username_proof';
 
 export type HubServiceService = typeof HubServiceService;
 export const HubServiceService = {
@@ -181,6 +183,15 @@ export const HubServiceService = {
     requestDeserialize: (value: Buffer) => NameRegistryEventRequest.decode(value),
     responseSerialize: (value: NameRegistryEvent) => Buffer.from(NameRegistryEvent.encode(value).finish()),
     responseDeserialize: (value: Buffer) => NameRegistryEvent.decode(value),
+  },
+  getUsernameProof: {
+    path: '/HubService/GetUsernameProof',
+    requestStream: false,
+    responseStream: false,
+    requestSerialize: (value: UsernameProofRequest) => Buffer.from(UsernameProofRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => UsernameProofRequest.decode(value),
+    responseSerialize: (value: UserNameProof) => Buffer.from(UserNameProof.encode(value).finish()),
+    responseDeserialize: (value: Buffer) => UserNameProof.decode(value),
   },
   /** Verifications */
   getVerification: {
@@ -411,6 +422,7 @@ export interface HubServiceServer extends UntypedServiceImplementation {
   getUserData: handleUnaryCall<UserDataRequest, Message>;
   getUserDataByFid: handleUnaryCall<FidRequest, MessagesResponse>;
   getNameRegistryEvent: handleUnaryCall<NameRegistryEventRequest, NameRegistryEvent>;
+  getUsernameProof: handleUnaryCall<UsernameProofRequest, UserNameProof>;
   /** Verifications */
   getVerification: handleUnaryCall<VerificationRequest, Message>;
   getVerificationsByFid: handleUnaryCall<FidRequest, MessagesResponse>;
@@ -638,6 +650,21 @@ export interface HubServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: NameRegistryEvent) => void
+  ): ClientUnaryCall;
+  getUsernameProof(
+    request: UsernameProofRequest,
+    callback: (error: ServiceError | null, response: UserNameProof) => void
+  ): ClientUnaryCall;
+  getUsernameProof(
+    request: UsernameProofRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: UserNameProof) => void
+  ): ClientUnaryCall;
+  getUsernameProof(
+    request: UsernameProofRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: UserNameProof) => void
   ): ClientUnaryCall;
   /** Verifications */
   getVerification(

--- a/packages/hub-web/src/generated/hub_event.ts
+++ b/packages/hub-web/src/generated/hub_event.ts
@@ -88,6 +88,7 @@ export interface MergeNameRegistryEventBody {
 
 export interface MergeUserNameProofBody {
   usernameProof: UserNameProof | undefined;
+  deletedUsernameProof: UserNameProof | undefined;
 }
 
 export interface HubEvent {
@@ -422,13 +423,16 @@ export const MergeNameRegistryEventBody = {
 };
 
 function createBaseMergeUserNameProofBody(): MergeUserNameProofBody {
-  return { usernameProof: undefined };
+  return { usernameProof: undefined, deletedUsernameProof: undefined };
 }
 
 export const MergeUserNameProofBody = {
   encode(message: MergeUserNameProofBody, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.usernameProof !== undefined) {
       UserNameProof.encode(message.usernameProof, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.deletedUsernameProof !== undefined) {
+      UserNameProof.encode(message.deletedUsernameProof, writer.uint32(18).fork()).ldelim();
     }
     return writer;
   },
@@ -447,6 +451,13 @@ export const MergeUserNameProofBody = {
 
           message.usernameProof = UserNameProof.decode(reader, reader.uint32());
           continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.deletedUsernameProof = UserNameProof.decode(reader, reader.uint32());
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -457,13 +468,22 @@ export const MergeUserNameProofBody = {
   },
 
   fromJSON(object: any): MergeUserNameProofBody {
-    return { usernameProof: isSet(object.usernameProof) ? UserNameProof.fromJSON(object.usernameProof) : undefined };
+    return {
+      usernameProof: isSet(object.usernameProof) ? UserNameProof.fromJSON(object.usernameProof) : undefined,
+      deletedUsernameProof: isSet(object.deletedUsernameProof)
+        ? UserNameProof.fromJSON(object.deletedUsernameProof)
+        : undefined,
+    };
   },
 
   toJSON(message: MergeUserNameProofBody): unknown {
     const obj: any = {};
     message.usernameProof !== undefined &&
       (obj.usernameProof = message.usernameProof ? UserNameProof.toJSON(message.usernameProof) : undefined);
+    message.deletedUsernameProof !== undefined &&
+      (obj.deletedUsernameProof = message.deletedUsernameProof
+        ? UserNameProof.toJSON(message.deletedUsernameProof)
+        : undefined);
     return obj;
   },
 
@@ -476,6 +496,10 @@ export const MergeUserNameProofBody = {
     message.usernameProof =
       object.usernameProof !== undefined && object.usernameProof !== null
         ? UserNameProof.fromPartial(object.usernameProof)
+        : undefined;
+    message.deletedUsernameProof =
+      object.deletedUsernameProof !== undefined && object.deletedUsernameProof !== null
+        ? UserNameProof.fromPartial(object.deletedUsernameProof)
         : undefined;
     return message;
   },

--- a/packages/hub-web/src/generated/request_response.ts
+++ b/packages/hub-web/src/generated/request_response.ts
@@ -149,6 +149,10 @@ export interface NameRegistryEventRequest {
   name: Uint8Array;
 }
 
+export interface UsernameProofRequest {
+  name: Uint8Array;
+}
+
 export interface VerificationRequest {
   fid: number;
   address: Uint8Array;
@@ -2177,6 +2181,63 @@ export const NameRegistryEventRequest = {
 
   fromPartial<I extends Exact<DeepPartial<NameRegistryEventRequest>, I>>(object: I): NameRegistryEventRequest {
     const message = createBaseNameRegistryEventRequest();
+    message.name = object.name ?? new Uint8Array();
+    return message;
+  },
+};
+
+function createBaseUsernameProofRequest(): UsernameProofRequest {
+  return { name: new Uint8Array() };
+}
+
+export const UsernameProofRequest = {
+  encode(message: UsernameProofRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.name.length !== 0) {
+      writer.uint32(10).bytes(message.name);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): UsernameProofRequest {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseUsernameProofRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.name = reader.bytes();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): UsernameProofRequest {
+    return { name: isSet(object.name) ? bytesFromBase64(object.name) : new Uint8Array() };
+  },
+
+  toJSON(message: UsernameProofRequest): unknown {
+    const obj: any = {};
+    message.name !== undefined &&
+      (obj.name = base64FromBytes(message.name !== undefined ? message.name : new Uint8Array()));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UsernameProofRequest>, I>>(base?: I): UsernameProofRequest {
+    return UsernameProofRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<UsernameProofRequest>, I>>(object: I): UsernameProofRequest {
+    const message = createBaseUsernameProofRequest();
     message.name = object.name ?? new Uint8Array();
     return message;
   },

--- a/packages/hub-web/src/generated/rpc.ts
+++ b/packages/hub-web/src/generated/rpc.ts
@@ -36,8 +36,10 @@ import {
   TrieNodePrefix,
   TrieNodeSnapshotResponse,
   UserDataRequest,
+  UsernameProofRequest,
   VerificationRequest,
 } from './request_response';
+import { UserNameProof } from './username_proof';
 
 export interface HubService {
   /** Submit Methods */
@@ -75,6 +77,10 @@ export interface HubService {
     request: DeepPartial<NameRegistryEventRequest>,
     metadata?: grpcWeb.grpc.Metadata
   ): Promise<NameRegistryEvent>;
+  getUsernameProof(
+    request: DeepPartial<UsernameProofRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<UserNameProof>;
   /** Verifications */
   getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
   getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
@@ -156,6 +162,7 @@ export class HubServiceClientImpl implements HubService {
     this.getUserData = this.getUserData.bind(this);
     this.getUserDataByFid = this.getUserDataByFid.bind(this);
     this.getNameRegistryEvent = this.getNameRegistryEvent.bind(this);
+    this.getUsernameProof = this.getUsernameProof.bind(this);
     this.getVerification = this.getVerification.bind(this);
     this.getVerificationsByFid = this.getVerificationsByFid.bind(this);
     this.getSigner = this.getSigner.bind(this);
@@ -249,6 +256,13 @@ export class HubServiceClientImpl implements HubService {
     metadata?: grpcWeb.grpc.Metadata
   ): Promise<NameRegistryEvent> {
     return this.rpc.unary(HubServiceGetNameRegistryEventDesc, NameRegistryEventRequest.fromPartial(request), metadata);
+  }
+
+  getUsernameProof(
+    request: DeepPartial<UsernameProofRequest>,
+    metadata?: grpcWeb.grpc.Metadata
+  ): Promise<UserNameProof> {
+    return this.rpc.unary(HubServiceGetUsernameProofDesc, UsernameProofRequest.fromPartial(request), metadata);
   }
 
   getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
@@ -694,6 +708,29 @@ export const HubServiceGetNameRegistryEventDesc: UnaryMethodDefinitionish = {
   responseType: {
     deserializeBinary(data: Uint8Array) {
       const value = NameRegistryEvent.decode(data);
+      return {
+        ...value,
+        toObject() {
+          return value;
+        },
+      };
+    },
+  } as any,
+};
+
+export const HubServiceGetUsernameProofDesc: UnaryMethodDefinitionish = {
+  methodName: 'GetUsernameProof',
+  service: HubServiceDesc,
+  requestStream: false,
+  responseStream: false,
+  requestType: {
+    serializeBinary() {
+      return UsernameProofRequest.encode(this).finish();
+    },
+  } as any,
+  responseType: {
+    deserializeBinary(data: Uint8Array) {
+      const value = UserNameProof.decode(data);
       return {
         ...value,
         toObject() {

--- a/protobufs/schemas/hub_event.proto
+++ b/protobufs/schemas/hub_event.proto
@@ -38,6 +38,7 @@ message MergeNameRegistryEventBody {
 
 message MergeUserNameProofBody {
   UserNameProof username_proof = 1;
+  UserNameProof deleted_username_proof = 2;
 }
 
 message HubEvent {

--- a/protobufs/schemas/request_response.proto
+++ b/protobufs/schemas/request_response.proto
@@ -145,6 +145,10 @@ message NameRegistryEventRequest {
   bytes name = 1;
 }
 
+message UsernameProofRequest {
+  bytes name = 1;
+}
+
 message VerificationRequest {
   uint64 fid = 1;
   bytes address = 2;

--- a/protobufs/schemas/rpc.proto
+++ b/protobufs/schemas/rpc.proto
@@ -5,6 +5,7 @@ import "id_registry_event.proto";
 import "name_registry_event.proto";
 import "hub_event.proto";
 import "request_response.proto";
+import "username_proof.proto";
 
 service HubService {
   // Submit Methods
@@ -30,6 +31,7 @@ service HubService {
   rpc GetUserData(UserDataRequest) returns (Message);
   rpc GetUserDataByFid(FidRequest) returns (MessagesResponse);
   rpc GetNameRegistryEvent(NameRegistryEventRequest) returns (NameRegistryEvent);
+  rpc GetUsernameProof(UsernameProofRequest) returns (UserNameProof);
 
   // Verifications
   rpc GetVerification(VerificationRequest) returns (Message);


### PR DESCRIPTION
## Motivation

Switch the source of truth for fnames from NameRegistryEvents to fname server UsernameProofs. See https://github.com/farcasterxyz/protocol/discussions/90

NameRegistryEvents will be deprecated in a followup when ENS name support is added.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new message type `UsernameProofRequest` and related changes to support merging username proofs into the UserDataStore. 

### Detailed summary
- Added `UsernameProofRequest` message type in `request_response.proto`
- Added `UsernameProofRequest` import in `rpc.proto`
- Added `UsernameProofRequest` import in `hub_event.proto`
- Added `UsernameProofRequest` import in `username_proof.proto`
- Added `UsernameProofRequest` import in `storeEventHandler.ts`
- Added `MergeUsernameProofHubEvent` type in `types.ts`
- Added `mergeUsernameProofEvent` event handler in `storeEventHandler.ts`
- Added `getUsernameProof` RPC method in `HubService` in `rpc.proto`
- Added `getUsernameProof` method implementation in `Server` in `server.ts`
- Added `getUsernameProof` method implementation in `userDataService.test.ts`

> The following files were skipped due to too many changes: `packages/core/src/protobufs/generated/request_response.ts`, `apps/hubble/src/eth/fnameRegistryEventsProvider.ts`, `apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts`, `packages/hub-nodejs/src/generated/rpc.ts`, `packages/hub-web/src/generated/hub_event.ts`, `packages/hub-nodejs/src/generated/hub_event.ts`, `packages/core/src/protobufs/generated/hub_event.ts`, `packages/hub-web/src/generated/rpc.ts`, `apps/hubble/src/rpc/test/eventService.test.ts`, `apps/hubble/src/storage/engine/index.test.ts`, `apps/hubble/src/storage/engine/index.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->