### PR TITLE
Update allowedPeers.mainnet.ts

### DIFF
--- a/apps/hubble/src/allowedPeers.mainnet.ts
+++ b/apps/hubble/src/allowedPeers.mainnet.ts
@@ -46,4 +46,5 @@ export const MAINNET_ALLOWED_PEERS = [
   '12D3KooWRDvjugV5fhkTA2BBmrLXmKyBXLe4V7YJyMXyLQGj1PAM', // @rysiman
   '12D3KooWNLshuXk4x2gacFTMEJjMGGFxPjpHg5KcV88KoqJP7dDR', // @bhgomes
   '12D3KooWS39hrt41rMuD5ZfPFMxUVycxVwz7w15CxZVhxP4AZDGr', // @rozhnovskiyigor
+  '12D3KooWHXZkdEYWb5RCajv7YbffasjYNSEP1U68DMR1JeZ4QiXH', // @fedecastelli
 ];


### PR DESCRIPTION
Add my custom peerId to be allowed to use Farcaster Hub on Mainnet

## Motivation

I need to integrate Farcaster on the project I'm developing and I need to be allowed to sync Farcaster events from Mainnet.
