### PR TITLE
feat: add beckerfelix to mainnet allowed peers

### DIFF
--- a/apps/hubble/src/allowedPeers.mainnet.ts
+++ b/apps/hubble/src/allowedPeers.mainnet.ts
@@ -48,4 +48,5 @@ export const MAINNET_ALLOWED_PEERS = [
   '12D3KooWS39hrt41rMuD5ZfPFMxUVycxVwz7w15CxZVhxP4AZDGr', // @rozhnovskiyigor
   '12D3KooWHXZkdEYWb5RCajv7YbffasjYNSEP1U68DMR1JeZ4QiXH', // @fedecastelli
   '12D3KooWCPdo8CNq3pu7oyJQYFzV6d4GbHUH8HTUbtHM6jpv6buy', // @cameron
+  '12D3KooWGeFmqtwsbmD8X3b1MFizZjYGNYUFZr3Dngn4Q6PT1Sdr', // @BeckerFelix
 ];


### PR DESCRIPTION
## Motivation

Allowing myself to contribute by running a Hubble instance on my homeserver.

## Change Summary

1. added @BeckerFelix peerID to the mainnet allowlist.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new allowed peer for the mainnet.

### Detailed summary
- Added a new allowed peer `12D3KooWGeFmqtwsbmD8X3b1MFizZjYGNYUFZr3Dngn4Q6PT1Sdr` for the mainnet.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->