### PR TITLE
chore: add @pseudobun peerId to allowedPeers.mainnet.ts

### DIFF
--- a/apps/hubble/src/allowedPeers.mainnet.ts
+++ b/apps/hubble/src/allowedPeers.mainnet.ts
@@ -48,4 +48,5 @@ export const MAINNET_ALLOWED_PEERS = [
   '12D3KooWS39hrt41rMuD5ZfPFMxUVycxVwz7w15CxZVhxP4AZDGr', // @rozhnovskiyigor
   '12D3KooWHXZkdEYWb5RCajv7YbffasjYNSEP1U68DMR1JeZ4QiXH', // @fedecastelli
   '12D3KooWCPdo8CNq3pu7oyJQYFzV6d4GbHUH8HTUbtHM6jpv6buy', // @cameron
+  '12D3KooWEoXRpLMjiRo9KxVHqg8Ng5gJxkJdd9uDotSNfYy8jFNv', // @pseudobun
 ];


### PR DESCRIPTION
## Motivation

Add a peerid for farcaster mainnet hubs.

## Change Summary

Added a new allowed peer to the allowedPeers.mainnet.ts file in the apps/hubble/src directory.
The new peer has the following address: 12D3KooWEoXRpLMjiRo9KxVHqg8Ng5gJxkJdd9uDotSNfYy8jFNv
No other changes were made.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new allowed peer for the mainnet. 

### Detailed summary
- Added a new allowed peer for the mainnet: `12D3KooWEoXRpLMjiRo9KxVHqg8Ng5gJxkJdd9uDotSNfYy8jFNv` (pseudobun)

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->