### PR TITLE
fix: prune limits on store subclasses

### DIFF
--- a/.changeset/pink-ears-learn.md
+++ b/.changeset/pink-ears-learn.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Fixed bug with prune limits

--- a/apps/hubble/src/storage/stores/castStore.ts
+++ b/apps/hubble/src/storage/stores/castStore.ts
@@ -18,11 +18,10 @@ import {
   makeTsHash,
   makeUserKey,
 } from '../db/message.js';
-import RocksDB, { Transaction } from '../db/rocksdb.js';
+import { Transaction } from '../db/rocksdb.js';
 import { RootPrefix, TRUE_VALUE, UserMessagePostfix, UserPostfix } from '../db/types.js';
-import { MessagesPage, PageOptions, StorePruneOptions } from '../stores/types.js';
+import { MessagesPage, PageOptions } from '../stores/types.js';
 import { Store } from './store.js';
-import StoreEventHandler from './storeEventHandler.js';
 
 /**
  * Generates unique keys used to store or fetch CastAdd messages in the adds set index
@@ -131,12 +130,13 @@ class CastStore extends Store<CastAddMessage, CastRemoveMessage> {
   override _isRemoveType = isCastRemoveMessage;
   override _addMessageType = MessageType.CAST_ADD;
   override _removeMessageType = MessageType.CAST_REMOVE;
-  protected override PRUNE_SIZE_LIMIT_DEFAULT = 10_000;
-  protected override PRUNE_TIME_LIMIT_DEFAULT = 60 * 60 * 24 * 365; // 1 year
 
-  constructor(db: RocksDB, eventHandler: StoreEventHandler, options: StorePruneOptions = {}) {
-    super(db, eventHandler, options);
-    this._pruneTimeLimit = options.pruneTimeLimit ?? this.PRUNE_TIME_LIMIT_DEFAULT;
+  protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
+    return 10_000;
+  }
+
+  protected override get PRUNE_TIME_LIMIT_DEFAULT() {
+    return 60 * 60 * 24 * 365; // 1 year
   }
 
   override async buildSecondaryIndices(txn: Transaction, message: CastAddMessage): HubAsyncResult<void> {

--- a/apps/hubble/src/storage/stores/linkStore.ts
+++ b/apps/hubble/src/storage/stores/linkStore.ts
@@ -150,7 +150,10 @@ class LinkStore extends Store<LinkAddMessage, LinkRemoveMessage> {
   override _isRemoveType = isLinkRemoveMessage;
   override _addMessageType = MessageType.LINK_ADD;
   override _removeMessageType = MessageType.LINK_REMOVE;
-  protected override PRUNE_SIZE_LIMIT_DEFAULT = PRUNE_SIZE_LIMIT_DEFAULT;
+
+  protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
+    return PRUNE_SIZE_LIMIT_DEFAULT;
+  }
 
   override async buildSecondaryIndices(txn: Transaction, message: LinkAddMessage): HubAsyncResult<void> {
     const tsHash = makeTsHash(message.data.timestamp, message.hash);

--- a/apps/hubble/src/storage/stores/reactionStore.ts
+++ b/apps/hubble/src/storage/stores/reactionStore.ts
@@ -19,10 +19,9 @@ import {
   makeTsHash,
   makeUserKey,
 } from '../db/message.js';
-import RocksDB, { Transaction } from '../db/rocksdb.js';
+import { Transaction } from '../db/rocksdb.js';
 import { RootPrefix, TSHASH_LENGTH, UserMessagePostfix, UserPostfix } from '../db/types.js';
-import StoreEventHandler from '../stores/storeEventHandler.js';
-import { MessagesPage, PAGE_SIZE_MAX, PageOptions, StorePruneOptions } from '../stores/types.js';
+import { MessagesPage, PAGE_SIZE_MAX, PageOptions } from '../stores/types.js';
 import { Store } from './store.js';
 
 const PRUNE_SIZE_LIMIT_DEFAULT = 5_000;
@@ -146,12 +145,13 @@ class ReactionStore extends Store<ReactionAddMessage, ReactionRemoveMessage> {
   override _isRemoveType = isReactionRemoveMessage;
   override _addMessageType = MessageType.REACTION_ADD;
   override _removeMessageType = MessageType.REACTION_REMOVE;
-  protected override PRUNE_SIZE_LIMIT_DEFAULT = PRUNE_SIZE_LIMIT_DEFAULT;
-  protected override PRUNE_TIME_LIMIT_DEFAULT = PRUNE_TIME_LIMIT_DEFAULT;
 
-  constructor(db: RocksDB, eventHandler: StoreEventHandler, options: StorePruneOptions = {}) {
-    super(db, eventHandler, options);
-    this._pruneTimeLimit = options.pruneTimeLimit ?? this.PRUNE_TIME_LIMIT_DEFAULT;
+  protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
+    return PRUNE_SIZE_LIMIT_DEFAULT;
+  }
+
+  protected override get PRUNE_TIME_LIMIT_DEFAULT() {
+    return PRUNE_TIME_LIMIT_DEFAULT;
   }
 
   override async findMergeAddConflicts(_message: ReactionAddMessage): HubAsyncResult<void> {

--- a/apps/hubble/src/storage/stores/signerStore.test.ts
+++ b/apps/hubble/src/storage/stores/signerStore.test.ts
@@ -1134,3 +1134,9 @@ describe('pruneMessages', () => {
     });
   });
 });
+
+describe('sizeLimit', () => {
+  test('defaults to 100', () => {
+    expect(set.sizeLimit).toBe(100);
+  });
+});

--- a/apps/hubble/src/storage/stores/signerStore.test.ts
+++ b/apps/hubble/src/storage/stores/signerStore.test.ts
@@ -1137,6 +1137,6 @@ describe('pruneMessages', () => {
 
 describe('sizeLimit', () => {
   test('defaults to 100', () => {
-    expect(set.sizeLimit).toBe(100);
+    expect(set.pruneSizeLimit).toBe(100);
   });
 });

--- a/apps/hubble/src/storage/stores/signerStore.ts
+++ b/apps/hubble/src/storage/stores/signerStore.ts
@@ -96,7 +96,10 @@ class SignerStore extends Store<SignerAddMessage, SignerRemoveMessage> {
   override _isRemoveType = isSignerRemoveMessage;
   override _addMessageType = MessageType.SIGNER_ADD;
   override _removeMessageType = MessageType.SIGNER_REMOVE;
-  protected override PRUNE_SIZE_LIMIT_DEFAULT = PRUNE_SIZE_LIMIT_DEFAULT;
+
+  protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
+    return PRUNE_SIZE_LIMIT_DEFAULT;
+  }
 
   override async findMergeAddConflicts(_message: SignerAddMessage): HubAsyncResult<void> {
     return ok(undefined);

--- a/apps/hubble/src/storage/stores/store.ts
+++ b/apps/hubble/src/storage/stores/store.ts
@@ -59,9 +59,6 @@ export abstract class Store<TAdd extends Message, TRemove extends Message> {
   protected _pruneTimeLimit: number | undefined;
   private _mergeLock: AsyncLock;
 
-  protected PRUNE_SIZE_LIMIT_DEFAULT = 10000;
-  protected PRUNE_TIME_LIMIT_DEFAULT: number | undefined;
-
   abstract _postfix: UserMessagePostfix;
 
   abstract makeAddKey(data: DeepPartial<TAdd>): Buffer;
@@ -328,6 +325,22 @@ export abstract class Store<TAdd extends Message, TRemove extends Message> {
     await pruneIterator.end();
 
     return ok(commits);
+  }
+
+  get pruneSizeLimit(): number {
+    return this._pruneSizeLimit;
+  }
+
+  get pruneTimeLimit(): number | undefined {
+    return this._pruneTimeLimit;
+  }
+
+  protected get PRUNE_SIZE_LIMIT_DEFAULT(): number {
+    return 10000;
+  }
+
+  protected get PRUNE_TIME_LIMIT_DEFAULT(): number | undefined {
+    return undefined;
   }
 
   protected async getBySecondaryIndex(prefix: Buffer, pageOptions: PageOptions = {}): Promise<MessagesPage<TAdd>> {

--- a/apps/hubble/src/storage/stores/userDataStore.ts
+++ b/apps/hubble/src/storage/stores/userDataStore.ts
@@ -83,7 +83,10 @@ class UserDataStore extends Store<UserDataAddMessage, never> {
   override _isRemoveType = undefined;
   override _addMessageType = MessageType.USER_DATA_ADD;
   override _removeMessageType = undefined;
-  protected override PRUNE_SIZE_LIMIT_DEFAULT = PRUNE_SIZE_LIMIT_DEFAULT;
+
+  protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
+    return PRUNE_SIZE_LIMIT_DEFAULT;
+  }
 
   /**
    * Finds a UserDataAdd Message by checking the adds set index

--- a/apps/hubble/src/storage/stores/verificationStore.ts
+++ b/apps/hubble/src/storage/stores/verificationStore.ts
@@ -92,7 +92,10 @@ class VerificationStore extends Store<VerificationAddEthAddressMessage, Verifica
   override _isRemoveType = isVerificationRemoveMessage;
   override _addMessageType = MessageType.VERIFICATION_ADD_ETH_ADDRESS;
   override _removeMessageType = MessageType.VERIFICATION_REMOVE;
-  protected override PRUNE_SIZE_LIMIT_DEFAULT = PRUNE_SIZE_LIMIT_DEFAULT;
+
+  protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
+    return PRUNE_SIZE_LIMIT_DEFAULT;
+  }
 
   /**
    * Finds a VerificationAdds Message by checking the adds-set's index


### PR DESCRIPTION
Overriding class fields in Javascript is tricky as they are not available in the parent constructor.

Refactored into getters since these will be available.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a bug related to prune limits in the `hubble` module. 

### Detailed summary
- Fixed bug with prune limits in `signerStore`, `userDataStore`, `verificationStore`, `linkStore`, `store`, `castStore`, and `reactionStore`
- Added `sizeLimit` test in `signerStore`
- Updated `PRUNE_SIZE_LIMIT_DEFAULT` getter in `userDataStore`, `verificationStore`, `signerStore`, `linkStore`, `store`, `castStore`, and `reactionStore`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->