### PR TITLE
fix: Better error if hub config is misspecified

### DIFF
--- a/.changeset/six-eyes-drive.md
+++ b/.changeset/six-eyes-drive.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Better error messages for config file

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -165,7 +165,18 @@ app
     }, PROCESS_SHUTDOWN_FILE_CHECK_INTERVAL_MS);
 
     // try to load the config file
-    const hubConfig = cliOptions.config ? (await import(resolve(cliOptions.config))).Config : DefaultConfig;
+    let hubConfig: any = DefaultConfig;
+    if (cliOptions.config) {
+      if (!cliOptions.config.endsWith('.js')) {
+        throw new Error(`Config file ${cliOptions.config} must be a .js file`);
+      }
+
+      if (!fs.existsSync(resolve(cliOptions.config))) {
+        throw new Error(`Config file ${cliOptions.config} does not exist`);
+      }
+
+      hubConfig = (await import(resolve(cliOptions.config))).Config;
+    }
 
     // Read PeerID from 1. CLI option, 2. Environment variable, 3. Config file
     let peerId;


### PR DESCRIPTION
## Motivation

Show better error if config file is missing or has the wrong extension

## Change Summary

The config file specified needs to have a .js extension, which is not obvious. New error message fixes that. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error messages for the config file in the `hubble` app.

### Detailed summary
- Added better error messages for the config file in the `hubble` app.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->