### PR TITLE
docs: update schema in the postgres example

### DIFF
--- a/packages/hub-nodejs/examples/replicate-data-postgres/README.md
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/README.md
@@ -187,7 +187,7 @@ Column Name | Data Type | Description
 id | `bigint` | Generic identifier specific to this DB (a.k.a. [surrogate key](https://en.wikipedia.org/wiki/Surrogate_key))
 created_at | `timestamp without time zone` | When the row was first created in this DB (not the same as the message timestamp!)
 updated_at | `timestamp without time zone` | When the row was last updated.
-deleted_at | `timestamp without time zone` | When the cast was considered deleted by the hub (e.g. in response to a `CastRemove` message, etc.)
+deleted_at | `timestamp without time zone` | When the reaction was considered deleted by the hub (e.g. in response to a `ReactionRemove` message, etc.)
 timestamp | `timestamp without time zone` | Message timestamp in UTC.
 fid | `bigint` | FID of the user that signed the message.
 reaction_type | `smallint` | Type of reaction.
@@ -205,7 +205,7 @@ Column Name | Data Type | Description
 id | `bigint` | Generic identifier specific to this DB (a.k.a. [surrogate key](https://en.wikipedia.org/wiki/Surrogate_key))
 created_at | `timestamp without time zone` | When the row was first created in this DB (not the same as the message timestamp!)
 updated_at | `timestamp without time zone` | When the row was last updated.
-deleted_at | `timestamp without time zone` | When the cast was considered deleted by the hub (e.g. in response to a `CastRemove` message, etc.)
+deleted_at | `timestamp without time zone` | When the verification was considered deleted by the hub (e.g. in response to a `VerificationRemove` message, etc.)
 timestamp | `timestamp without time zone` | Message timestamp in UTC.
 fid | `bigint` | FID of the user that signed the message.
 hash | `bytea` | Message hash.
@@ -220,7 +220,7 @@ Column Name | Data Type | Description
 id | `bigint` | Generic identifier specific to this DB (a.k.a. [surrogate key](https://en.wikipedia.org/wiki/Surrogate_key))
 created_at | `timestamp without time zone` | When the row was first created in this DB (not the same as the message timestamp!)
 updated_at | `timestamp without time zone` | When the row was last updated.
-deleted_at | `timestamp without time zone` | When the cast was considered deleted by the hub (e.g. in response to a `CastRemove` message, etc.)
+deleted_at | `timestamp without time zone` | When the signer was considered deleted by the hub (e.g. in response to a `SignerRemove` message, etc.)
 timestamp | `timestamp without time zone` | Message timestamp in UTC.
 fid | `bigint` | FID of the user that signed the message.
 hash | `bytea` | Message hash.
@@ -237,7 +237,7 @@ Column Name | Data Type | Description
 id | `bigint` | Generic identifier specific to this DB (a.k.a. [surrogate key](https://en.wikipedia.org/wiki/Surrogate_key))
 created_at | `timestamp without time zone` | When the row was first created in this DB (not the same as the message timestamp!)
 updated_at | `timestamp without time zone` | When the row was last updated.
-deleted_at | `timestamp without time zone` | When the cast was considered deleted by the hub (e.g. in response to a `CastRemove` message, etc.)
+deleted_at | `timestamp without time zone` | When the data was considered deleted by the hub
 timestamp | `timestamp without time zone` | Message timestamp in UTC.
 fid | `bigint` | FID of the user that signed the message.
 hash | `bytea` | Message hash.
@@ -254,3 +254,19 @@ fid | `bigint` | Farcaster ID (the user ID)
 created_at | `timestamp without time zone` | When the row was first created in this DB (not the same as when the user was created!)
 updated_at | `timestamp without time zone` | When the row was last updated.
 custody_address | `bytea` | ETH address of the wallet that owns the FID.
+
+### `links`
+
+Represents a link between two FIDs (e.g. a follow, subscription, etc.)
+
+Column Name | Data Type | Description
+-- | -- | --
+id | `string` | Generic identifier specific to this DB (a.k.a. [surrogate key](https://en.wikipedia.org/wiki/Surrogate_key))
+fid | `bigint` | Farcaster ID (the user ID)
+target_fid | `bigint` | Farcaster ID of the target user
+type | `string` | Type of connection between users like `follow`
+timestamp | `timestamp without time zone` | Message timestamp in UTC.
+created_at | `timestamp without time zone` | When the row was first created in this DB
+updated_at | `timestamp without time zone` | When the row was last updated
+display_timestamp | `timestamp without time zone` | When the row was last updated
+deleted_at | `timestamp without time zone` | When the link was considered deleted by the hub (e.g. in response to a `LinkRemoveMessage` message, etc.)


### PR DESCRIPTION
## Motivation

Update the schema in README.md for the `replicate-hub-to-postgres` example to align with the database.

## Change Summary

- Add the `links` schema added in #1022
- Corrected some descriptions on other tables

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

Same as https://github.com/farcasterxyz/hub-monorepo/pull/1061 but with signed commits


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- This PR updates the README.md file in the `replicate-data-postgres` example of the `hub-nodejs` package.
- It changes the description of the `deleted_at` column in three different tables (`cast`, `verification`, and `signer`) to reflect the correct deletion event.
- It adds a new table (`links`) with columns representing a link between two FIDs.
- It updates the description of the `deleted_at` column in the `links` table to reflect the correct deletion event.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->