### PR TITLE
chore: run rome format --write on  examples in packages

### DIFF
--- a/packages/hub-nodejs/examples/chron-feed/index.ts
+++ b/packages/hub-nodejs/examples/chron-feed/index.ts
@@ -9,19 +9,19 @@ import {
   isCastAddMessage,
   isUserDataAddMessage,
   UserDataType,
-} from '@farcaster/hub-nodejs';
-import TimeAgo from 'javascript-time-ago';
-import en from 'javascript-time-ago/locale/en';
-import { err, ok, Result } from 'neverthrow';
+} from "@farcaster/hub-nodejs";
+import TimeAgo from "javascript-time-ago";
+import en from "javascript-time-ago/locale/en";
+import { err, ok, Result } from "neverthrow";
 
 TimeAgo.addDefaultLocale(en);
-const timeAgo = new TimeAgo('en-US');
+const timeAgo = new TimeAgo("en-US");
 
 /**
  * Populate the following constants with your own values
  */
 
-const HUB_URL = 'nemes.farcaster.xyz:2283'; // URL of the Hub
+const HUB_URL = "nemes.farcaster.xyz:2283"; // URL of the Hub
 const FIDS = [2, 3]; // User IDs to fetch casts for
 
 /**
@@ -47,7 +47,7 @@ const getFnameFromFid = async (fid: number, client: HubRpcClient): HubAsyncResul
     if (isUserDataAddMessage(message)) {
       return message.data.userDataBody.value;
     } else {
-      return '';
+      return "";
     }
   });
 };
@@ -81,7 +81,7 @@ const castToString = async (cast: CastAddMessage, nameMapping: Map<number, strin
   const bytes = encoder.encode(text);
 
   const decoder = new TextDecoder();
-  let textWithMentions = '';
+  let textWithMentions = "";
   let indexBytes = 0;
   for (let i = 0; i < mentions.length; i++) {
     textWithMentions += decoder.decode(bytes.slice(indexBytes, mentionsPositions[i]));
@@ -92,7 +92,7 @@ const castToString = async (cast: CastAddMessage, nameMapping: Map<number, strin
   textWithMentions += decoder.decode(bytes.slice(indexBytes));
 
   // Remove newlines from the message text
-  const textNoLineBreaks = textWithMentions.replace(/(\r\n|\n|\r)/gm, ' ');
+  const textNoLineBreaks = textWithMentions.replace(/(\r\n|\n|\r)/gm, " ");
 
   return `${fname}: ${textNoLineBreaks}\n${dateString}\n`;
 };
@@ -108,7 +108,7 @@ const castToString = async (cast: CastAddMessage, nameMapping: Map<number, strin
   const fnameResults = Result.combine(await Promise.all(fnameResultPromises));
 
   if (fnameResults.isErr()) {
-    console.error('Fetching fnames failed');
+    console.error("Fetching fnames failed");
     console.error(fnameResults.error);
     return;
   }
@@ -120,7 +120,7 @@ const castToString = async (cast: CastAddMessage, nameMapping: Map<number, strin
         const fname = uData.data.userDataBody.value;
         fidToFname.set(fid, fname);
       }
-    })
+    }),
   );
 
   // 2. Fetch primary casts for each fid and print them
@@ -128,7 +128,7 @@ const castToString = async (cast: CastAddMessage, nameMapping: Map<number, strin
   const castsResult = Result.combine(await Promise.all(castResultPromises));
 
   if (castsResult.isErr()) {
-    console.error('Fetching casts failed');
+    console.error("Fetching casts failed");
     console.error(castsResult.error);
     return;
   }

--- a/packages/hub-nodejs/examples/make-cast/index.ts
+++ b/packages/hub-nodejs/examples/make-cast/index.ts
@@ -5,9 +5,9 @@ import {
   getSSLHubRpcClient,
   makeCastAdd,
   makeSignerAdd,
-} from '@farcaster/hub-nodejs';
-import * as ed from '@noble/ed25519';
-import { Wallet } from 'ethers';
+} from "@farcaster/hub-nodejs";
+import * as ed from "@noble/ed25519";
+import { Wallet } from "ethers";
 
 /* eslint no-console: 0 */
 
@@ -16,13 +16,13 @@ import { Wallet } from 'ethers';
  */
 
 // Recovery phrase of the custody address and the
-const MNEMONIC = 'ordinary long coach bounce thank quit become youth belt pretty diet caught attract melt bargain';
+const MNEMONIC = "ordinary long coach bounce thank quit become youth belt pretty diet caught attract melt bargain";
 
 // Fid owned by the custody address
 const FID = 2;
 
 // Testnet Configuration
-const HUB_URL = 'testnet1.farcaster.xyz:2283'; // URL + Port of the Hub
+const HUB_URL = "testnet1.farcaster.xyz:2283"; // URL + Port of the Hub
 const NETWORK = FarcasterNetwork.TESTNET; // Network of the Hub
 
 (async () => {
@@ -76,14 +76,14 @@ const NETWORK = FarcasterNetwork.TESTNET; // Network of the Hub
 
   const cast = await makeCastAdd(
     {
-      text: 'This is a cast with no mentions',
+      text: "This is a cast with no mentions",
       embeds: [],
       embedsDeprecated: [],
       mentions: [],
       mentionsPositions: [],
     },
     dataOptions,
-    ed25519Signer
+    ed25519Signer,
   );
   castResults.push(cast);
 
@@ -94,14 +94,14 @@ const NETWORK = FarcasterNetwork.TESTNET; // Network of the Hub
    */
   const castWithMentions = await makeCastAdd(
     {
-      text: ' and  are big fans of ',
+      text: " and  are big fans of ",
       embeds: [],
       embedsDeprecated: [],
       mentions: [3, 2, 1],
       mentionsPositions: [0, 5, 22],
     },
     dataOptions,
-    ed25519Signer
+    ed25519Signer,
   );
   castResults.push(castWithMentions);
 
@@ -112,14 +112,14 @@ const NETWORK = FarcasterNetwork.TESTNET; // Network of the Hub
    */
   const castWithMentionsAndAttachment = await makeCastAdd(
     {
-      text: 'Hey , check this out!',
-      embeds: [{ url: 'https://farcaster.xyz' }],
+      text: "Hey , check this out!",
+      embeds: [{ url: "https://farcaster.xyz" }],
       embedsDeprecated: [],
       mentions: [3],
       mentionsPositions: [4],
     },
     dataOptions,
-    ed25519Signer
+    ed25519Signer,
   );
   castResults.push(castWithMentionsAndAttachment);
 
@@ -130,14 +130,14 @@ const NETWORK = FarcasterNetwork.TESTNET; // Network of the Hub
    */
   const castWithMentionsAttachmentLink = await makeCastAdd(
     {
-      text: 'Hey , check out https://farcaster.xyz!',
-      embeds: [{ url: 'https://farcaster.xyz' }],
+      text: "Hey , check out https://farcaster.xyz!",
+      embeds: [{ url: "https://farcaster.xyz" }],
       embedsDeprecated: [],
       mentions: [3],
       mentionsPositions: [4],
     },
     dataOptions,
-    ed25519Signer
+    ed25519Signer,
   );
   castResults.push(castWithMentionsAttachmentLink);
 
@@ -149,14 +149,14 @@ const NETWORK = FarcasterNetwork.TESTNET; // Network of the Hub
 
   const castWithMultipleMentions = await makeCastAdd(
     {
-      text: 'You can mention  multiple times:   ',
+      text: "You can mention  multiple times:   ",
       embeds: [],
       embedsDeprecated: [],
       mentions: [2, 2, 2, 2],
       mentionsPositions: [16, 33, 34, 35],
     },
     dataOptions,
-    ed25519Signer
+    ed25519Signer,
   );
   castResults.push(castWithMultipleMentions);
 
@@ -167,14 +167,14 @@ const NETWORK = FarcasterNetwork.TESTNET; // Network of the Hub
    */
   const castWithEmojiAndMentions = await makeCastAdd(
     {
-      text: '🤓 can mention immediately after emoji',
+      text: "🤓 can mention immediately after emoji",
       embeds: [],
       embedsDeprecated: [],
       mentions: [1],
       mentionsPositions: [4],
     },
     dataOptions,
-    ed25519Signer
+    ed25519Signer,
   );
   castResults.push(castWithEmojiAndMentions);
 
@@ -186,14 +186,14 @@ const NETWORK = FarcasterNetwork.TESTNET; // Network of the Hub
 
   const castWithEmojiLinkAttachmnent = await makeCastAdd(
     {
-      text: '🤓https://url-after-unicode.com can include URL immediately after emoji',
-      embeds: [{ url: 'https://url-after-unicode.com' }],
+      text: "🤓https://url-after-unicode.com can include URL immediately after emoji",
+      embeds: [{ url: "https://url-after-unicode.com" }],
       embedsDeprecated: [],
       mentions: [],
       mentionsPositions: [],
     },
     dataOptions,
-    ed25519Signer
+    ed25519Signer,
   );
   castResults.push(castWithEmojiLinkAttachmnent);
 
@@ -205,15 +205,15 @@ const NETWORK = FarcasterNetwork.TESTNET; // Network of the Hub
 
   const castReplyingToAUrl = await makeCastAdd(
     {
-      text: 'I think this is a great protocol 🚀',
+      text: "I think this is a great protocol 🚀",
       embeds: [],
       embedsDeprecated: [],
       mentions: [],
       mentionsPositions: [],
-      parentUrl: 'https://www.farcaster.xyz/',
+      parentUrl: "https://www.farcaster.xyz/",
     },
     dataOptions,
-    ed25519Signer
+    ed25519Signer,
   );
   castResults.push(castReplyingToAUrl);
 

--- a/packages/hub-nodejs/examples/replicate-data-postgres/db.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/db.ts
@@ -1,12 +1,12 @@
-import { Kysely, CamelCasePlugin, Generated, GeneratedAlways, Migrator, FileMigrationProvider } from 'kysely';
-import { PostgresJSDialect } from 'kysely-postgres-js';
-import postgres from 'postgres';
-import { MessageType, ReactionType, UserDataType, HashScheme, SignatureScheme } from '@farcaster/hub-nodejs';
-import * as path from 'path';
-import { promises as fs } from 'fs';
-import { fileURLToPath } from 'url';
-import { Logger } from './log';
-import { err, ok, Result } from 'neverthrow';
+import { Kysely, CamelCasePlugin, Generated, GeneratedAlways, Migrator, FileMigrationProvider } from "kysely";
+import { PostgresJSDialect } from "kysely-postgres-js";
+import postgres from "postgres";
+import { MessageType, ReactionType, UserDataType, HashScheme, SignatureScheme } from "@farcaster/hub-nodejs";
+import * as path from "path";
+import { promises as fs } from "fs";
+import { fileURLToPath } from "url";
+import { Logger } from "./log";
+import { err, ok, Result } from "neverthrow";
 
 export interface Database {
   hubSubscriptions: {
@@ -160,22 +160,22 @@ export const migrateToLatest = async (db: Kysely<any>, log: Logger): Promise<Res
     provider: new FileMigrationProvider({
       fs,
       path,
-      migrationFolder: path.join(path.dirname(fileURLToPath(import.meta.url)), 'migrations'),
+      migrationFolder: path.join(path.dirname(fileURLToPath(import.meta.url)), "migrations"),
     }),
   });
 
   const { error, results } = await migrator.migrateToLatest();
 
   results?.forEach((it) => {
-    if (it.status === 'Success') {
+    if (it.status === "Success") {
       log.info(`migration "${it.migrationName}" was executed successfully`);
-    } else if (it.status === 'Error') {
+    } else if (it.status === "Error") {
       log.error(`failed to execute migration "${it.migrationName}"`);
     }
   });
 
   if (error) {
-    log.error('failed to migrate');
+    log.error("failed to migrate");
     log.error(error);
     return err(error);
   }

--- a/packages/hub-nodejs/examples/replicate-data-postgres/hubReplicator.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/hubReplicator.ts
@@ -32,25 +32,25 @@ import {
   isVerificationRemoveMessage,
   getSSLHubRpcClient,
   getInsecureHubRpcClient,
-} from '@farcaster/hub-nodejs';
-import { HubSubscriber } from './hubSubscriber';
-import { Logger } from 'pino';
-import { Database } from './db';
-import { Kysely, sql } from 'kysely';
-import { bytesToHex, farcasterTimeToDate } from './util';
-import * as fastq from 'fastq';
-import type { queueAsPromised } from 'fastq';
-import prettyMilliseconds from 'pretty-ms';
-import os from 'node:os';
+} from "@farcaster/hub-nodejs";
+import { HubSubscriber } from "./hubSubscriber";
+import { Logger } from "pino";
+import { Database } from "./db";
+import { Kysely, sql } from "kysely";
+import { bytesToHex, farcasterTimeToDate } from "./util";
+import * as fastq from "fastq";
+import type { queueAsPromised } from "fastq";
+import prettyMilliseconds from "pretty-ms";
+import os from "node:os";
 
-type StoreMessageOperation = 'merge' | 'delete' | 'prune' | 'revoke';
+type StoreMessageOperation = "merge" | "delete" | "prune" | "revoke";
 
 // If you're hitting out-of-memory errors, try decreasing this to reduce overall
 // memory usage.
 const MAX_PAGE_SIZE = 3_000;
 
 // Max FIDs to fetch in parallel
-const MAX_JOB_CONCURRENCY = Number(process.env['MAX_CONCURRENCY']) || os.cpus().length;
+const MAX_JOB_CONCURRENCY = Number(process.env["MAX_CONCURRENCY"]) || os.cpus().length;
 
 export class HubReplicator {
   private client: HubRpcClient;
@@ -60,11 +60,11 @@ export class HubReplicator {
     this.client = this.ssl ? getSSLHubRpcClient(hubAddress) : getInsecureHubRpcClient(hubAddress);
     this.subscriber = new HubSubscriber(this.client, log);
 
-    this.subscriber.on('event', async (hubEvent) => {
+    this.subscriber.on("event", async (hubEvent) => {
       if (isMergeMessageHubEvent(hubEvent)) {
         this.log.info(`[Sync] Processing merge event ${hubEvent.id} from stream`);
         await this.onMergeMessages([hubEvent.mergeMessageBody.message]);
-        await this.storeMessages(hubEvent.mergeMessageBody.deletedMessages, 'delete');
+        await this.storeMessages(hubEvent.mergeMessageBody.deletedMessages, "delete");
       } else if (isPruneMessageHubEvent(hubEvent)) {
         this.log.info(`[Sync] Processing prune event ${hubEvent.id}`);
         await this.onPruneMessages([hubEvent.pruneMessageBody.message]);
@@ -83,12 +83,12 @@ export class HubReplicator {
 
       // Keep track of how many events we've processed.
       await this.db
-        .insertInto('hubSubscriptions')
+        .insertInto("hubSubscriptions")
         .values({ host: this.hubAddress, lastEventId: hubEvent.id })
         .onConflict((oc) =>
-          oc.columns(['host']).doUpdateSet({
+          oc.columns(["host"]).doUpdateSet({
             lastEventId: hubEvent.id,
-          })
+          }),
         )
         .execute();
     });
@@ -110,9 +110,9 @@ export class HubReplicator {
     // Process live events going forward, starting from the last event we
     // processed (if there was one).
     const subscription = await this.db
-      .selectFrom('hubSubscriptions')
-      .where('host', '=', this.hubAddress)
-      .select('lastEventId')
+      .selectFrom("hubSubscriptions")
+      .where("host", "=", this.hubAddress)
+      .select("lastEventId")
       .executeTakeFirst();
     this.subscriber.start(subscription?.lastEventId);
 
@@ -130,7 +130,7 @@ export class HubReplicator {
 
   private async backfill() {
     const maxFidResult = await this.client.getFids({ pageSize: 1, reverse: true });
-    if (maxFidResult.isErr()) throw new Error('Unable to backfill', { cause: maxFidResult.error });
+    if (maxFidResult.isErr()) throw new Error("Unable to backfill", { cause: maxFidResult.error });
 
     const maxFid = maxFidResult.value.fids[0];
     let totalProcessed = 0;
@@ -142,7 +142,7 @@ export class HubReplicator {
       const elapsedMs = Date.now() - startTime;
       const millisRemaining = Math.ceil((elapsedMs / totalProcessed) * (maxFid - totalProcessed));
       this.log.info(
-        `[Backfill] Completed FID ${fid}/${maxFid}. Estimated time remaining: ${prettyMilliseconds(millisRemaining)}`
+        `[Backfill] Completed FID ${fid}/${maxFid}. Estimated time remaining: ${prettyMilliseconds(millisRemaining)}`,
       );
     }, MAX_JOB_CONCURRENCY);
 
@@ -180,7 +180,7 @@ export class HubReplicator {
     let result = await this.client.getCastsByFid({ pageSize, fid });
     for (;;) {
       if (result.isErr()) {
-        throw new Error('Unable to backfill', { cause: result.error });
+        throw new Error("Unable to backfill", { cause: result.error });
       }
 
       const { messages, nextPageToken: pageToken } = result.value;
@@ -196,7 +196,7 @@ export class HubReplicator {
     let result = await this.client.getReactionsByFid({ pageSize, fid });
     for (;;) {
       if (result.isErr()) {
-        throw new Error('Unable to backfill', { cause: result.error });
+        throw new Error("Unable to backfill", { cause: result.error });
       }
 
       const { messages, nextPageToken: pageToken } = result.value;
@@ -212,7 +212,7 @@ export class HubReplicator {
     let result = await this.client.getLinksByFid({ pageSize, fid });
     for (;;) {
       if (result.isErr()) {
-        throw new Error('Unable to backfill', { cause: result.error });
+        throw new Error("Unable to backfill", { cause: result.error });
       }
 
       const { messages, nextPageToken: pageToken } = result.value;
@@ -228,7 +228,7 @@ export class HubReplicator {
     let result = await this.client.getSignersByFid({ pageSize, fid });
     for (;;) {
       if (result.isErr()) {
-        throw new Error('Unable to backfill', { cause: result.error });
+        throw new Error("Unable to backfill", { cause: result.error });
       }
 
       const { messages, nextPageToken: pageToken } = result.value;
@@ -244,7 +244,7 @@ export class HubReplicator {
     let result = await this.client.getVerificationsByFid({ pageSize, fid });
     for (;;) {
       if (result.isErr()) {
-        throw new Error('Unable to backfill', { cause: result.error });
+        throw new Error("Unable to backfill", { cause: result.error });
       }
 
       const { messages, nextPageToken: pageToken } = result.value;
@@ -260,7 +260,7 @@ export class HubReplicator {
     let result = await this.client.getUserDataByFid({ pageSize, fid });
     for (;;) {
       if (result.isErr()) {
-        throw new Error('Unable to backfill', { cause: result.error });
+        throw new Error("Unable to backfill", { cause: result.error });
       }
 
       const { messages, nextPageToken: pageToken } = result.value;
@@ -278,10 +278,10 @@ export class HubReplicator {
     const now = new Date();
 
     const messageRows = await this.db
-      .insertInto('messages')
+      .insertInto("messages")
       .values(
         messages.map((message) => {
-          if (!message.data) throw new Error('Message missing data!'); // Shouldn't happen
+          if (!message.data) throw new Error("Message missing data!"); // Shouldn't happen
           return {
             createdAt: now,
             updatedAt: now,
@@ -294,38 +294,38 @@ export class HubReplicator {
             signatureScheme: message.signatureScheme,
             signer: message.signer,
             raw: Message.encode(message).finish(),
-            deletedAt: operation === 'delete' ? now : null,
-            prunedAt: operation === 'prune' ? now : null,
-            revokedAt: operation === 'revoke' ? now : null,
+            deletedAt: operation === "delete" ? now : null,
+            prunedAt: operation === "prune" ? now : null,
+            revokedAt: operation === "revoke" ? now : null,
           };
-        })
+        }),
       )
       .onConflict((oc) =>
         oc
-          .columns(['hash'])
+          .columns(["hash"])
           .doUpdateSet(({ ref }) => ({
             updatedAt: now,
             // Only the signer or message state could have changed
-            signature: ref('excluded.signature'),
-            signatureScheme: ref('excluded.signatureScheme'),
-            signer: ref('excluded.signer'),
-            deletedAt: operation === 'delete' ? now : null,
-            prunedAt: operation === 'prune' ? now : null,
-            revokedAt: operation === 'revoke' ? now : null,
+            signature: ref("excluded.signature"),
+            signatureScheme: ref("excluded.signatureScheme"),
+            signer: ref("excluded.signer"),
+            deletedAt: operation === "delete" ? now : null,
+            prunedAt: operation === "prune" ? now : null,
+            revokedAt: operation === "revoke" ? now : null,
           }))
           .where(({ or, cmpr, ref }) =>
             // Only update if a value has actually changed
             or([
-              cmpr('excluded.signature', '!=', ref('messages.signature')),
-              cmpr('excluded.signatureScheme', '!=', ref('messages.signatureScheme')),
-              cmpr('excluded.signer', '!=', ref('messages.signer')),
-              cmpr('excluded.deletedAt', 'is', sql`distinct from ${ref('messages.deletedAt')}`),
-              cmpr('excluded.prunedAt', 'is', sql`distinct from ${ref('messages.prunedAt')}`),
-              cmpr('excluded.revokedAt', 'is', sql`distinct from ${ref('messages.revokedAt')}`),
-            ])
-          )
+              cmpr("excluded.signature", "!=", ref("messages.signature")),
+              cmpr("excluded.signatureScheme", "!=", ref("messages.signatureScheme")),
+              cmpr("excluded.signer", "!=", ref("messages.signer")),
+              cmpr("excluded.deletedAt", "is", sql`distinct from ${ref("messages.deletedAt")}`),
+              cmpr("excluded.prunedAt", "is", sql`distinct from ${ref("messages.prunedAt")}`),
+              cmpr("excluded.revokedAt", "is", sql`distinct from ${ref("messages.revokedAt")}`),
+            ]),
+          ),
       )
-      .returning(['hash', 'updatedAt', 'createdAt'])
+      .returning(["hash", "updatedAt", "createdAt"])
       .execute();
 
     // Return map indicating whether a given hash is a new message.
@@ -335,9 +335,9 @@ export class HubReplicator {
 
   private async onIdRegistryEvent(event: IdRegistryEvent) {
     await this.db
-      .insertInto('fids')
+      .insertInto("fids")
       .values({ fid: event.fid, custodyAddress: event.to })
-      .onConflict((oc) => oc.columns(['fid']).doUpdateSet({ custodyAddress: event.to, updatedAt: new Date() }))
+      .onConflict((oc) => oc.columns(["fid"]).doUpdateSet({ custodyAddress: event.to, updatedAt: new Date() }))
       .execute();
   }
 
@@ -346,13 +346,13 @@ export class HubReplicator {
     const expiresAt = farcasterTimeToDate(event.expiry);
 
     await this.db
-      .insertInto('fnames')
+      .insertInto("fnames")
       .values({
-        fname: Buffer.from(event.fname).toString('utf8'),
+        fname: Buffer.from(event.fname).toString("utf8"),
         custodyAddress,
         expiresAt,
       })
-      .onConflict((oc) => oc.columns(['fname']).doUpdateSet({ custodyAddress, expiresAt, updatedAt: new Date() }))
+      .onConflict((oc) => oc.columns(["fname"]).doUpdateSet({ custodyAddress, expiresAt, updatedAt: new Date() }))
       .execute();
   }
 
@@ -360,7 +360,7 @@ export class HubReplicator {
     if (!messages?.length) return;
 
     const firstMessage = messages[0]; // All messages will have the same type as the first
-    const isInitialCreation = await this.storeMessages(messages, 'merge');
+    const isInitialCreation = await this.storeMessages(messages, "merge");
 
     if (isCastAddMessage(firstMessage)) {
       await this.onCastAdd(messages as CastAddMessage[], isInitialCreation);
@@ -388,16 +388,16 @@ export class HubReplicator {
   }
 
   private async onPruneMessages(messages: Message[]) {
-    this.storeMessages(messages, 'prune');
+    this.storeMessages(messages, "prune");
   }
 
   private async onRevokeMessages(messages: Message[]) {
-    this.storeMessages(messages, 'revoke');
+    this.storeMessages(messages, "revoke");
   }
 
   private async onCastAdd(messages: CastAddMessage[], isInitialCreation: Record<string, boolean>) {
     await this.db
-      .insertInto('casts')
+      .insertInto("casts")
       .values(
         messages.map((message) => ({
           timestamp: farcasterTimeToDate(message.data.timestamp),
@@ -410,10 +410,10 @@ export class HubReplicator {
           embeds: message.data.castAddBody.embedsDeprecated,
           mentions: message.data.castAddBody.mentions,
           mentionsPositions: message.data.castAddBody.mentionsPositions,
-        }))
+        })),
       )
       // Do nothing on conflict since nothing should have changed if hash is the same.
-      .onConflict((oc) => oc.columns(['hash']).doNothing())
+      .onConflict((oc) => oc.columns(["hash"]).doNothing())
       .execute();
 
     for (const message of messages) {
@@ -427,9 +427,9 @@ export class HubReplicator {
   private async onCastRemove(messages: CastRemoveMessage[]) {
     for (const message of messages) {
       await this.db
-        .updateTable('casts')
-        .where('fid', '=', message.data.fid)
-        .where('hash', '=', message.data.castRemoveBody.targetHash)
+        .updateTable("casts")
+        .where("fid", "=", message.data.fid)
+        .where("hash", "=", message.data.castRemoveBody.targetHash)
         .set({ deletedAt: farcasterTimeToDate(message.data.timestamp) })
         .execute();
 
@@ -439,7 +439,7 @@ export class HubReplicator {
 
   private async onReactionAdd(messages: ReactionAddMessage[], isInitialCreation: Record<string, boolean>) {
     await this.db
-      .insertInto('reactions')
+      .insertInto("reactions")
       .values(
         messages.map((message) => ({
           fid: message.data.fid,
@@ -449,10 +449,10 @@ export class HubReplicator {
           targetHash: message.data.reactionBody.targetCastId?.hash,
           targetFid: message.data.reactionBody.targetCastId?.fid,
           targetUrl: message.data.reactionBody.targetUrl,
-        }))
+        })),
       )
       // Do nothing on conflict since nothing should have changed if hash is the same.
-      .onConflict((oc) => oc.columns(['hash']).doNothing())
+      .onConflict((oc) => oc.columns(["hash"]).doNothing())
       .execute();
 
     for (const message of messages) {
@@ -466,18 +466,18 @@ export class HubReplicator {
   private async onReactionRemove(messages: ReactionRemoveMessage[]) {
     for (const message of messages) {
       await this.db
-        .updateTable('reactions')
-        .where('fid', '=', message.data.fid)
+        .updateTable("reactions")
+        .where("fid", "=", message.data.fid)
         .where((eb) => {
           // Search based on the type of reaction
           if (message.data.reactionBody.targetUrl) {
-            return eb.where('targetUrl', '=', message.data.reactionBody.targetUrl);
+            return eb.where("targetUrl", "=", message.data.reactionBody.targetUrl);
           } else if (message.data.reactionBody.targetCastId) {
             return eb
-              .where('targetFid', '=', message.data.reactionBody.targetCastId.fid)
-              .where('targetHash', '=', message.data.reactionBody.targetCastId.hash);
+              .where("targetFid", "=", message.data.reactionBody.targetCastId.fid)
+              .where("targetHash", "=", message.data.reactionBody.targetCastId.hash);
           } else {
-            throw new Error('Reaction had neither targetUrl nor targetCastId');
+            throw new Error("Reaction had neither targetUrl nor targetCastId");
           }
         })
         .set({ deletedAt: farcasterTimeToDate(message.data.timestamp) })
@@ -489,10 +489,10 @@ export class HubReplicator {
 
   private async onVerificationAddEthAddress(
     messages: VerificationAddEthAddressMessage[],
-    isInitialCreation: Record<string, boolean>
+    isInitialCreation: Record<string, boolean>,
   ) {
     await this.db
-      .insertInto('verifications')
+      .insertInto("verifications")
       .values(
         messages.map((message) => ({
           fid: message.data.fid,
@@ -503,10 +503,10 @@ export class HubReplicator {
             ethSignature: bytesToHex(message.data.verificationAddEthAddressBody.ethSignature),
             blockHash: bytesToHex(message.data.verificationAddEthAddressBody.blockHash),
           },
-        }))
+        })),
       )
       // Do nothing on conflict since nothing should have changed if hash is the same.
-      .onConflict((oc) => oc.columns(['hash']).doNothing())
+      .onConflict((oc) => oc.columns(["hash"]).doNothing())
       .execute();
 
     for (const message of messages) {
@@ -524,9 +524,9 @@ export class HubReplicator {
   private async onVerificationRemove(messages: VerificationRemoveMessage[]) {
     for (const message of messages) {
       await this.db
-        .updateTable('verifications')
-        .where('fid', '=', message.data.fid)
-        .where(sql`claim ->> 'address'`, '=', bytesToHex(message.data.verificationRemoveBody.address))
+        .updateTable("verifications")
+        .where("fid", "=", message.data.fid)
+        .where(sql`claim ->> 'address'`, "=", bytesToHex(message.data.verificationRemoveBody.address))
         .set({ deletedAt: farcasterTimeToDate(message.data.timestamp) })
         .execute();
 
@@ -536,7 +536,7 @@ export class HubReplicator {
 
   private async onSignerAdd(messages: SignerAddMessage[], isInitialCreation: Record<string, boolean>) {
     await this.db
-      .insertInto('signers')
+      .insertInto("signers")
       .values(
         messages.map((message) => {
           const signerName = message.data.signerAddBody.name;
@@ -548,10 +548,10 @@ export class HubReplicator {
             signer: message.data.signerAddBody.signer,
             name: signerName?.length ? signerName : null, // Treat empty string signer names as not specified
           };
-        })
+        }),
       )
       // Do nothing on conflict since nothing should have changed if hash is the same.
-      .onConflict((oc) => oc.columns(['hash']).doNothing())
+      .onConflict((oc) => oc.columns(["hash"]).doNothing())
       .execute();
 
     for (const message of messages) {
@@ -564,9 +564,9 @@ export class HubReplicator {
   private async onSignerRemove(messages: SignerRemoveMessage[]) {
     for (const message of messages) {
       await this.db
-        .updateTable('signers')
-        .where('fid', '=', message.data.fid)
-        .where('signer', '=', message.data.signerRemoveBody.signer)
+        .updateTable("signers")
+        .where("fid", "=", message.data.fid)
+        .where("signer", "=", message.data.signerRemoveBody.signer)
         .set({ deletedAt: farcasterTimeToDate(message.data.timestamp) })
         .execute();
 
@@ -578,7 +578,7 @@ export class HubReplicator {
     const now = new Date();
 
     await this.db
-      .insertInto('userData')
+      .insertInto("userData")
       .values(
         messages.map((message) => ({
           timestamp: farcasterTimeToDate(message.data.timestamp),
@@ -586,26 +586,26 @@ export class HubReplicator {
           hash: message.hash,
           type: message.data.userDataBody.type,
           value: message.data.userDataBody.value,
-        }))
+        })),
       )
       .onConflict((oc) =>
         oc
-          .columns(['fid', 'type'])
+          .columns(["fid", "type"])
           .doUpdateSet(({ ref }) => ({
-            hash: ref('excluded.hash'),
-            timestamp: ref('excluded.timestamp'),
-            value: ref('excluded.value'),
+            hash: ref("excluded.hash"),
+            timestamp: ref("excluded.timestamp"),
+            value: ref("excluded.value"),
             updatedAt: now,
           }))
           .where(({ or, cmpr, ref }) =>
             // Only update if a value has actually changed
             or([
-              cmpr('excluded.hash', '!=', ref('userData.hash')),
-              cmpr('excluded.timestamp', '!=', ref('userData.timestamp')),
-              cmpr('excluded.value', '!=', ref('userData.value')),
-              cmpr('excluded.updatedAt', '!=', ref('userData.updatedAt')),
-            ])
-          )
+              cmpr("excluded.hash", "!=", ref("userData.hash")),
+              cmpr("excluded.timestamp", "!=", ref("userData.timestamp")),
+              cmpr("excluded.value", "!=", ref("userData.value")),
+              cmpr("excluded.updatedAt", "!=", ref("userData.updatedAt")),
+            ]),
+          ),
       )
       .execute();
 
@@ -618,7 +618,7 @@ export class HubReplicator {
 
   private async onLinkAdd(messages: LinkAddMessage[], isInitialCreation: Record<string, boolean>) {
     await this.db
-      .insertInto('links')
+      .insertInto("links")
       .values(
         messages.map((message) => ({
           timestamp: farcasterTimeToDate(message.data.timestamp),
@@ -627,7 +627,7 @@ export class HubReplicator {
           type: message.data.linkBody.type,
           fid: message.data.fid,
           displayTimestamp: farcasterTimeToDate(message.data.linkBody.displayTimestamp),
-        }))
+        })),
       )
       .execute();
 
@@ -641,11 +641,11 @@ export class HubReplicator {
   private async onLinkRemove(messages: LinkRemoveMessage[]) {
     for (const message of messages) {
       await this.db
-        .updateTable('links')
-        .where('fid', '=', message.data.fid)
+        .updateTable("links")
+        .where("fid", "=", message.data.fid)
         // type assertion due to a problem with the type definitions. This field is infact required and present in all valid messages
-        .where('targetFid', '=', message.data.linkBody.targetFid!)
-        .where('type', '=', message.data.linkBody.type)
+        .where("targetFid", "=", message.data.linkBody.targetFid!)
+        .where("type", "=", message.data.linkBody.type)
         .set({ deletedAt: farcasterTimeToDate(message.data.timestamp) })
         .execute();
 

--- a/packages/hub-nodejs/examples/replicate-data-postgres/hubSubscriber.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/hubSubscriber.ts
@@ -1,7 +1,7 @@
-import { ClientReadableStream, HubEvent, HubEventType, HubRpcClient } from '@farcaster/hub-nodejs';
-import { Result, ok, err } from 'neverthrow';
-import { Logger } from 'pino';
-import { TypedEmitter } from 'tiny-typed-emitter';
+import { ClientReadableStream, HubEvent, HubEventType, HubRpcClient } from "@farcaster/hub-nodejs";
+import { Result, ok, err } from "neverthrow";
+import { Logger } from "pino";
+import { TypedEmitter } from "tiny-typed-emitter";
 
 interface HubEvents {
   event: (hubEvent: HubEvent) => void;
@@ -67,7 +67,7 @@ export class HubSubscriber extends TypedEmitter<HubEvents> {
         this.stream = stream;
         this.stopped = false;
 
-        stream.on('close', async () => {
+        stream.on("close", async () => {
           this.log.info(`HubSubscriber stream closed`);
           this.stopped = true;
           this.stream = null;
@@ -89,7 +89,7 @@ export class HubSubscriber extends TypedEmitter<HubEvents> {
       for await (const event of stream) {
         const fnLog = this.log.child({ eventId: event.id, eventType: event.type });
         fnLog.debug(`Processing event ${event.id} (${event.type})`);
-        this.emit('event', event);
+        this.emit("event", event);
       }
     } catch (e: any) {
       this.log.info(`Hub event stream processing halted ${e.message}`);

--- a/packages/hub-nodejs/examples/replicate-data-postgres/index.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/index.ts
@@ -1,6 +1,6 @@
-import { HubReplicator } from './hubReplicator';
-import { getDbClient, migrateToLatest } from './db';
-import { log } from './log';
+import { HubReplicator } from "./hubReplicator";
+import { getDbClient, migrateToLatest } from "./db";
+import { log } from "./log";
 
 /**
  * Populate the following constants with your own values.
@@ -8,9 +8,9 @@ import { log } from './log';
  * If you're running this from the examples directory, make sure you follow the
  * README.
  */
-const HUB_HOST = process.env['HUB_HOST'] || 'nemes.farcaster.xyz:2283';
-const HUB_SSL = (process.env['HUB_SSL'] || 'true') === 'true';
-const POSTGRES_URL = process.env['POSTGRES_URL'] || 'postgres://app:password@localhost:6541/hub';
+const HUB_HOST = process.env["HUB_HOST"] || "nemes.farcaster.xyz:2283";
+const HUB_SSL = (process.env["HUB_SSL"] || "true") === "true";
+const POSTGRES_URL = process.env["POSTGRES_URL"] || "postgres://app:password@localhost:6541/hub";
 
 const db = getDbClient(POSTGRES_URL);
 
@@ -27,11 +27,11 @@ const shutdown = async () => {
   }
 };
 
-process.on('exit', (code) => {
+process.on("exit", (code) => {
   log.info(`Exiting process with status code ${code}`);
 });
 
-for (const signal of ['SIGTERM', 'SIGINT']) {
+for (const signal of ["SIGTERM", "SIGINT"]) {
   process.once(signal, (signalName: string) => {
     log.info(`Process received ${signalName}`);
     process.exitCode =

--- a/packages/hub-nodejs/examples/replicate-data-postgres/log.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/log.ts
@@ -1,8 +1,8 @@
-import { pino } from 'pino';
+import { pino } from "pino";
 
 export const log = pino({
   transport: {
-    target: 'pino-pretty',
+    target: "pino-pretty",
     options: {
       colorize: true,
     },

--- a/packages/hub-nodejs/examples/replicate-data-postgres/migrations/001_initial_migration.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/migrations/001_initial_migration.ts
@@ -1,203 +1,203 @@
-import { Kysely, sql } from 'kysely';
+import { Kysely, sql } from "kysely";
 
 export const up = async (db: Kysely<any>) => {
   await db.schema
-    .createTable('hubSubscriptions')
-    .addColumn('host', 'text', (col) => col.notNull().primaryKey())
-    .addColumn('last_event_id', 'bigint')
+    .createTable("hubSubscriptions")
+    .addColumn("host", "text", (col) => col.notNull().primaryKey())
+    .addColumn("last_event_id", "bigint")
     .execute();
 
   await db.schema
-    .createTable('messages')
-    .addColumn('id', 'bigint', (col) => col.generatedAlwaysAsIdentity().primaryKey())
-    .addColumn('createdAt', 'timestamp', (col) => col.notNull().defaultTo(sql`current_timestamp`))
-    .addColumn('updatedAt', 'timestamp', (col) => col.notNull().defaultTo(sql`current_timestamp`))
-    .addColumn('deletedAt', 'timestamp')
-    .addColumn('prunedAt', 'timestamp')
-    .addColumn('revokedAt', 'timestamp')
-    .addColumn('timestamp', 'timestamp', (col) => col.notNull())
-    .addColumn('messageType', sql`smallint`, (col) => col.notNull())
-    .addColumn('fid', 'bigint', (col) => col.notNull())
-    .addColumn('hash', sql`bytea`, (col) => col.notNull())
-    .addColumn('hashScheme', sql`smallint`, (col) => col.notNull())
-    .addColumn('signature', sql`bytea`, (col) => col.notNull())
-    .addColumn('signatureScheme', sql`smallint`, (col) => col.notNull())
-    .addColumn('signer', sql`bytea`, (col) => col.notNull())
-    .addColumn('raw', sql`bytea`, (col) => col.notNull())
-    .addUniqueConstraint('messages_hash_unique', ['hash'])
+    .createTable("messages")
+    .addColumn("id", "bigint", (col) => col.generatedAlwaysAsIdentity().primaryKey())
+    .addColumn("createdAt", "timestamp", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("updatedAt", "timestamp", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("deletedAt", "timestamp")
+    .addColumn("prunedAt", "timestamp")
+    .addColumn("revokedAt", "timestamp")
+    .addColumn("timestamp", "timestamp", (col) => col.notNull())
+    .addColumn("messageType", sql`smallint`, (col) => col.notNull())
+    .addColumn("fid", "bigint", (col) => col.notNull())
+    .addColumn("hash", sql`bytea`, (col) => col.notNull())
+    .addColumn("hashScheme", sql`smallint`, (col) => col.notNull())
+    .addColumn("signature", sql`bytea`, (col) => col.notNull())
+    .addColumn("signatureScheme", sql`smallint`, (col) => col.notNull())
+    .addColumn("signer", sql`bytea`, (col) => col.notNull())
+    .addColumn("raw", sql`bytea`, (col) => col.notNull())
+    .addUniqueConstraint("messages_hash_unique", ["hash"])
     .execute();
 
-  await db.schema.createIndex('messages_timestamp_index').on('messages').columns(['timestamp']).execute();
+  await db.schema.createIndex("messages_timestamp_index").on("messages").columns(["timestamp"]).execute();
 
   await db.schema
-    .createTable('casts')
-    .addColumn('id', 'bigint', (col) => col.generatedAlwaysAsIdentity().primaryKey())
-    .addColumn('createdAt', 'timestamp', (col) => col.notNull().defaultTo(sql`current_timestamp`))
-    .addColumn('updatedAt', 'timestamp', (col) => col.notNull().defaultTo(sql`current_timestamp`))
-    .addColumn('deletedAt', 'timestamp')
-    .addColumn('timestamp', 'timestamp', (col) => col.notNull())
-    .addColumn('fid', 'bigint', (col) => col.notNull())
-    .addColumn('hash', sql`bytea`, (col) => col.notNull())
-    .addColumn('parentHash', sql`bytea`)
-    .addColumn('parentFid', 'bigint')
-    .addColumn('parentUrl', 'text')
-    .addColumn('text', 'text', (col) => col.notNull())
-    .addColumn('embeds', sql`text[]`, (col) => col.notNull().defaultTo(sql`'{}'`))
-    .addColumn('mentions', sql`bigint[]`, (col) => col.notNull().defaultTo(sql`'{}'`))
-    .addColumn('mentionsPositions', sql`smallint[]`, (col) => col.notNull().defaultTo(sql`'{}'`))
-    .addUniqueConstraint('casts_hash_unique', ['hash'])
-    .addForeignKeyConstraint('casts_hash_foreign', ['hash'], 'messages', ['hash'])
+    .createTable("casts")
+    .addColumn("id", "bigint", (col) => col.generatedAlwaysAsIdentity().primaryKey())
+    .addColumn("createdAt", "timestamp", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("updatedAt", "timestamp", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("deletedAt", "timestamp")
+    .addColumn("timestamp", "timestamp", (col) => col.notNull())
+    .addColumn("fid", "bigint", (col) => col.notNull())
+    .addColumn("hash", sql`bytea`, (col) => col.notNull())
+    .addColumn("parentHash", sql`bytea`)
+    .addColumn("parentFid", "bigint")
+    .addColumn("parentUrl", "text")
+    .addColumn("text", "text", (col) => col.notNull())
+    .addColumn("embeds", sql`text[]`, (col) => col.notNull().defaultTo(sql`'{}'`))
+    .addColumn("mentions", sql`bigint[]`, (col) => col.notNull().defaultTo(sql`'{}'`))
+    .addColumn("mentionsPositions", sql`smallint[]`, (col) => col.notNull().defaultTo(sql`'{}'`))
+    .addUniqueConstraint("casts_hash_unique", ["hash"])
+    .addForeignKeyConstraint("casts_hash_foreign", ["hash"], "messages", ["hash"])
     .execute();
 
-  await db.schema.createIndex('casts_fid_timestamp_index').on('casts').columns(['fid', 'timestamp']).execute();
-  await db.schema.createIndex('casts_timestamp_index').on('casts').columns(['timestamp']).execute();
+  await db.schema.createIndex("casts_fid_timestamp_index").on("casts").columns(["fid", "timestamp"]).execute();
+  await db.schema.createIndex("casts_timestamp_index").on("casts").columns(["timestamp"]).execute();
   await db.schema
-    .createIndex('casts_parent_hash_parent_fid_index')
-    .on('casts')
-    .columns(['parentHash', 'parentFid'])
-    .where('parentHash', 'is not', null)
-    .where('parentFid', 'is not', null)
+    .createIndex("casts_parent_hash_parent_fid_index")
+    .on("casts")
+    .columns(["parentHash", "parentFid"])
+    .where("parentHash", "is not", null)
+    .where("parentFid", "is not", null)
     .execute();
   await db.schema
-    .createIndex('casts_parent_url_index')
-    .on('casts')
-    .columns(['parentUrl'])
-    .where('parentUrl', 'is not', null)
-    .execute();
-
-  await db.schema
-    .createTable('reactions')
-    .addColumn('id', 'bigint', (col) => col.generatedAlwaysAsIdentity().primaryKey())
-    .addColumn('createdAt', 'timestamp', (col) => col.notNull().defaultTo(sql`current_timestamp`))
-    .addColumn('updatedAt', 'timestamp', (col) => col.notNull().defaultTo(sql`current_timestamp`))
-    .addColumn('deletedAt', 'timestamp')
-    .addColumn('timestamp', 'timestamp', (col) => col.notNull())
-    .addColumn('reactionType', sql`smallint`, (col) => col.notNull())
-    .addColumn('fid', 'bigint', (col) => col.notNull())
-    .addColumn('hash', sql`bytea`, (col) => col.notNull())
-    .addColumn('targetHash', sql`bytea`)
-    .addColumn('targetFid', 'bigint')
-    .addColumn('targetUrl', 'text')
-    .addUniqueConstraint('reactions_hash_unique', ['hash'])
-    .addForeignKeyConstraint('reactions_hash_foreign', ['hash'], 'messages', ['hash'])
-    .execute();
-
-  await db.schema.createIndex('reactions_fid_timestamp_index').on('reactions').columns(['fid', 'timestamp']).execute();
-  await db.schema
-    .createIndex('reactions_target_hash_target_fid_index')
-    .on('reactions')
-    .columns(['targetHash', 'targetFid'])
-    .where('targetHash', 'is not', null)
-    .where('targetFid', 'is not', null)
-    .execute();
-  await db.schema
-    .createIndex('reactions_target_url_index')
-    .on('reactions')
-    .columns(['targetUrl'])
-    .where('targetUrl', 'is not', null)
+    .createIndex("casts_parent_url_index")
+    .on("casts")
+    .columns(["parentUrl"])
+    .where("parentUrl", "is not", null)
     .execute();
 
   await db.schema
-    .createTable('signers')
-    .addColumn('id', 'bigint', (col) => col.generatedAlwaysAsIdentity().primaryKey())
-    .addColumn('createdAt', 'timestamp', (col) => col.notNull().defaultTo(sql`current_timestamp`))
-    .addColumn('updatedAt', 'timestamp', (col) => col.notNull().defaultTo(sql`current_timestamp`))
-    .addColumn('deletedAt', 'timestamp')
-    .addColumn('timestamp', 'timestamp', (col) => col.notNull())
-    .addColumn('fid', 'bigint', (col) => col.notNull())
-    .addColumn('hash', sql`bytea`, (col) => col.notNull())
-    .addColumn('custodyAddress', sql`bytea`, (col) => col.notNull())
-    .addColumn('signer', sql`bytea`, (col) => col.notNull())
-    .addColumn('name', 'text')
-    .addUniqueConstraint('signers_hash_unique', ['hash'])
-    .addForeignKeyConstraint('signers_hash_foreign', ['hash'], 'messages', ['hash'])
+    .createTable("reactions")
+    .addColumn("id", "bigint", (col) => col.generatedAlwaysAsIdentity().primaryKey())
+    .addColumn("createdAt", "timestamp", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("updatedAt", "timestamp", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("deletedAt", "timestamp")
+    .addColumn("timestamp", "timestamp", (col) => col.notNull())
+    .addColumn("reactionType", sql`smallint`, (col) => col.notNull())
+    .addColumn("fid", "bigint", (col) => col.notNull())
+    .addColumn("hash", sql`bytea`, (col) => col.notNull())
+    .addColumn("targetHash", sql`bytea`)
+    .addColumn("targetFid", "bigint")
+    .addColumn("targetUrl", "text")
+    .addUniqueConstraint("reactions_hash_unique", ["hash"])
+    .addForeignKeyConstraint("reactions_hash_foreign", ["hash"], "messages", ["hash"])
     .execute();
 
-  await db.schema.createIndex('signers_fid_timestamp_index').on('signers').columns(['fid', 'timestamp']).execute();
-
+  await db.schema.createIndex("reactions_fid_timestamp_index").on("reactions").columns(["fid", "timestamp"]).execute();
   await db.schema
-    .createTable('verifications')
-    .addColumn('id', 'bigint', (col) => col.generatedAlwaysAsIdentity().primaryKey())
-    .addColumn('createdAt', 'timestamp', (col) => col.notNull().defaultTo(sql`current_timestamp`))
-    .addColumn('updatedAt', 'timestamp', (col) => col.notNull().defaultTo(sql`current_timestamp`))
-    .addColumn('deletedAt', 'timestamp')
-    .addColumn('timestamp', 'timestamp', (col) => col.notNull())
-    .addColumn('fid', 'bigint', (col) => col.notNull())
-    .addColumn('hash', sql`bytea`, (col) => col.notNull())
-    .addColumn('claim', 'jsonb', (col) => col.notNull())
-    .addUniqueConstraint('verifications_hash_unique', ['hash'])
-    .addForeignKeyConstraint('verifications_hash_foreign', ['hash'], 'messages', ['hash'])
+    .createIndex("reactions_target_hash_target_fid_index")
+    .on("reactions")
+    .columns(["targetHash", "targetFid"])
+    .where("targetHash", "is not", null)
+    .where("targetFid", "is not", null)
+    .execute();
+  await db.schema
+    .createIndex("reactions_target_url_index")
+    .on("reactions")
+    .columns(["targetUrl"])
+    .where("targetUrl", "is not", null)
     .execute();
 
   await db.schema
-    .createIndex('verifications_claim_address_index')
-    .on('verifications')
+    .createTable("signers")
+    .addColumn("id", "bigint", (col) => col.generatedAlwaysAsIdentity().primaryKey())
+    .addColumn("createdAt", "timestamp", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("updatedAt", "timestamp", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("deletedAt", "timestamp")
+    .addColumn("timestamp", "timestamp", (col) => col.notNull())
+    .addColumn("fid", "bigint", (col) => col.notNull())
+    .addColumn("hash", sql`bytea`, (col) => col.notNull())
+    .addColumn("custodyAddress", sql`bytea`, (col) => col.notNull())
+    .addColumn("signer", sql`bytea`, (col) => col.notNull())
+    .addColumn("name", "text")
+    .addUniqueConstraint("signers_hash_unique", ["hash"])
+    .addForeignKeyConstraint("signers_hash_foreign", ["hash"], "messages", ["hash"])
+    .execute();
+
+  await db.schema.createIndex("signers_fid_timestamp_index").on("signers").columns(["fid", "timestamp"]).execute();
+
+  await db.schema
+    .createTable("verifications")
+    .addColumn("id", "bigint", (col) => col.generatedAlwaysAsIdentity().primaryKey())
+    .addColumn("createdAt", "timestamp", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("updatedAt", "timestamp", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("deletedAt", "timestamp")
+    .addColumn("timestamp", "timestamp", (col) => col.notNull())
+    .addColumn("fid", "bigint", (col) => col.notNull())
+    .addColumn("hash", sql`bytea`, (col) => col.notNull())
+    .addColumn("claim", "jsonb", (col) => col.notNull())
+    .addUniqueConstraint("verifications_hash_unique", ["hash"])
+    .addForeignKeyConstraint("verifications_hash_foreign", ["hash"], "messages", ["hash"])
+    .execute();
+
+  await db.schema
+    .createIndex("verifications_claim_address_index")
+    .on("verifications")
     .expression(sql`(claim ->> 'address'::text)`)
     .execute();
 
   await db.schema
-    .createIndex('verifications_fid_timestamp_index')
-    .on('verifications')
-    .columns(['fid', 'timestamp'])
+    .createIndex("verifications_fid_timestamp_index")
+    .on("verifications")
+    .columns(["fid", "timestamp"])
     .execute();
 
   await db.schema
-    .createTable('userData')
-    .addColumn('id', 'bigint', (col) => col.generatedAlwaysAsIdentity().primaryKey())
-    .addColumn('createdAt', 'timestamp', (col) => col.notNull().defaultTo(sql`current_timestamp`))
-    .addColumn('updatedAt', 'timestamp', (col) => col.notNull().defaultTo(sql`current_timestamp`))
-    .addColumn('deletedAt', 'timestamp')
-    .addColumn('timestamp', 'timestamp', (col) => col.notNull())
-    .addColumn('fid', 'bigint', (col) => col.notNull())
-    .addColumn('hash', sql`bytea`, (col) => col.notNull())
-    .addColumn('type', sql`smallint`, (col) => col.notNull())
-    .addColumn('value', 'text', (col) => col.notNull())
-    .addUniqueConstraint('user_data_hash_unique', ['hash'])
-    .addUniqueConstraint('user_data_fid_type_unique', ['fid', 'type'])
-    .addForeignKeyConstraint('user_data_hash_foreign', ['hash'], 'messages', ['hash'])
+    .createTable("userData")
+    .addColumn("id", "bigint", (col) => col.generatedAlwaysAsIdentity().primaryKey())
+    .addColumn("createdAt", "timestamp", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("updatedAt", "timestamp", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("deletedAt", "timestamp")
+    .addColumn("timestamp", "timestamp", (col) => col.notNull())
+    .addColumn("fid", "bigint", (col) => col.notNull())
+    .addColumn("hash", sql`bytea`, (col) => col.notNull())
+    .addColumn("type", sql`smallint`, (col) => col.notNull())
+    .addColumn("value", "text", (col) => col.notNull())
+    .addUniqueConstraint("user_data_hash_unique", ["hash"])
+    .addUniqueConstraint("user_data_fid_type_unique", ["fid", "type"])
+    .addForeignKeyConstraint("user_data_hash_foreign", ["hash"], "messages", ["hash"])
     .execute();
 
-  await db.schema.createIndex('user_data_fid_index').on('user_data').columns(['fid']).execute();
+  await db.schema.createIndex("user_data_fid_index").on("user_data").columns(["fid"]).execute();
 
   await db.schema
-    .createTable('fids')
-    .addColumn('fid', 'bigint', (col) => col.primaryKey())
-    .addColumn('createdAt', 'timestamp', (col) => col.notNull().defaultTo(sql`current_timestamp`))
-    .addColumn('updatedAt', 'timestamp', (col) => col.notNull().defaultTo(sql`current_timestamp`))
-    .addColumn('custodyAddress', sql`bytea`, (col) => col.notNull())
-    .execute();
-
-  await db.schema
-    .createTable('fnames')
-    .addColumn('fname', 'text', (col) => col.primaryKey())
-    .addColumn('createdAt', 'timestamp', (col) => col.notNull().defaultTo(sql`current_timestamp`))
-    .addColumn('updatedAt', 'timestamp', (col) => col.notNull().defaultTo(sql`current_timestamp`))
-    .addColumn('custodyAddress', sql`bytea`, (col) => col.notNull())
-    .addColumn('expiresAt', 'timestamp', (col) => col.notNull())
+    .createTable("fids")
+    .addColumn("fid", "bigint", (col) => col.primaryKey())
+    .addColumn("createdAt", "timestamp", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("updatedAt", "timestamp", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("custodyAddress", sql`bytea`, (col) => col.notNull())
     .execute();
 
   await db.schema
-    .createTable('links')
-    .addColumn('id', 'bigint', (col) => col.generatedAlwaysAsIdentity().primaryKey())
-    .addColumn('fid', 'bigint')
-    .addColumn('targetFid', 'bigint')
-    .addColumn('timestamp', 'timestamp', (col) => col.notNull())
-    .addColumn('createdAt', 'timestamp', (col) => col.notNull().defaultTo(sql`current_timestamp`))
-    .addColumn('updatedAt', 'timestamp', (col) => col.notNull().defaultTo(sql`current_timestamp`))
-    .addColumn('deletedAt', 'timestamp')
-    .addColumn('type', 'text')
-    .addColumn('displayTimestamp', 'timestamp')
+    .createTable("fnames")
+    .addColumn("fname", "text", (col) => col.primaryKey())
+    .addColumn("createdAt", "timestamp", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("updatedAt", "timestamp", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("custodyAddress", sql`bytea`, (col) => col.notNull())
+    .addColumn("expiresAt", "timestamp", (col) => col.notNull())
+    .execute();
+
+  await db.schema
+    .createTable("links")
+    .addColumn("id", "bigint", (col) => col.generatedAlwaysAsIdentity().primaryKey())
+    .addColumn("fid", "bigint")
+    .addColumn("targetFid", "bigint")
+    .addColumn("timestamp", "timestamp", (col) => col.notNull())
+    .addColumn("createdAt", "timestamp", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("updatedAt", "timestamp", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("deletedAt", "timestamp")
+    .addColumn("type", "text")
+    .addColumn("displayTimestamp", "timestamp")
     .execute();
 };
 
 export const down = async (db: Kysely<any>) => {
-  await db.schema.dropTable('links').ifExists().execute();
-  await db.schema.dropTable('fnames').ifExists().execute();
-  await db.schema.dropTable('fids').ifExists().execute();
-  await db.schema.dropTable('casts').ifExists().execute();
-  await db.schema.dropTable('reactions').ifExists().execute();
-  await db.schema.dropTable('signers').ifExists().execute();
-  await db.schema.dropTable('verifications').ifExists().execute();
-  await db.schema.dropTable('userData').ifExists().execute();
-  await db.schema.dropTable('messages').ifExists().execute();
+  await db.schema.dropTable("links").ifExists().execute();
+  await db.schema.dropTable("fnames").ifExists().execute();
+  await db.schema.dropTable("fids").ifExists().execute();
+  await db.schema.dropTable("casts").ifExists().execute();
+  await db.schema.dropTable("reactions").ifExists().execute();
+  await db.schema.dropTable("signers").ifExists().execute();
+  await db.schema.dropTable("verifications").ifExists().execute();
+  await db.schema.dropTable("userData").ifExists().execute();
+  await db.schema.dropTable("messages").ifExists().execute();
 };

--- a/packages/hub-nodejs/examples/replicate-data-postgres/util.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/util.ts
@@ -1,6 +1,6 @@
 /* eslint-disable prefer-arrow-functions/prefer-arrow-functions */
 
-import { fromFarcasterTime } from '@farcaster/hub-nodejs';
+import { fromFarcasterTime } from "@farcaster/hub-nodejs";
 
 export function farcasterTimeToDate(time: undefined): undefined;
 export function farcasterTimeToDate(time: null): null;
@@ -20,5 +20,5 @@ export function bytesToHex(bytes: Uint8Array): string;
 export function bytesToHex(bytes: Uint8Array | null | undefined): string | null | undefined {
   if (bytes === undefined) return undefined;
   if (bytes === null) return null;
-  return '0x' + Buffer.from(bytes).toString('hex');
+  return "0x" + Buffer.from(bytes).toString("hex");
 }

--- a/packages/hub-nodejs/examples/write-data/index.ts
+++ b/packages/hub-nodejs/examples/write-data/index.ts
@@ -6,9 +6,9 @@ import {
   makeUserDataAdd,
   NobleEd25519Signer,
   UserDataType,
-} from '@farcaster/hub-nodejs';
-import * as ed from '@noble/ed25519';
-import { Wallet } from 'ethers';
+} from "@farcaster/hub-nodejs";
+import * as ed from "@noble/ed25519";
+import { Wallet } from "ethers";
 
 /* eslint no-console: 0 */
 
@@ -17,13 +17,13 @@ import { Wallet } from 'ethers';
  */
 
 // Recovery phrase of the custody address
-const MNEMONIC = 'ordinary long coach bounce thank quit become youth belt pretty diet caught attract melt bargain';
+const MNEMONIC = "ordinary long coach bounce thank quit become youth belt pretty diet caught attract melt bargain";
 
 // Fid owned by the custody address
 const FID = 2;
 
 // Testnet Configuration
-const HUB_URL = 'testnet1.farcaster.xyz:2283'; // URL + Port of the Hub
+const HUB_URL = "testnet1.farcaster.xyz:2283"; // URL + Port of the Hub
 const NETWORK = FarcasterNetwork.TESTNET; // Network of the Hub
 
 // Mainnet Configuration
@@ -87,7 +87,7 @@ const NETWORK = FarcasterNetwork.TESTNET; // Network of the Hub
     return;
   }
 
-  console.log('SignerAdd was published successfully!');
+  console.log("SignerAdd was published successfully!");
 
   /**
    *
@@ -100,7 +100,7 @@ const NETWORK = FarcasterNetwork.TESTNET; // Network of the Hub
   // Set a profile picture
   const userDataPfpBody = {
     type: UserDataType.PFP,
-    value: 'https://i.imgur.com/yed5Zfk.gif',
+    value: "https://i.imgur.com/yed5Zfk.gif",
   };
 
   const userDataAddMakeResult = await makeUserDataAdd(userDataPfpBody, dataOptions, ed25519Signer);
@@ -117,7 +117,7 @@ const NETWORK = FarcasterNetwork.TESTNET; // Network of the Hub
     return;
   }
 
-  console.log('UserDataAdd was published successfully!');
+  console.log("UserDataAdd was published successfully!");
 
   client.close();
 })();

--- a/packages/hub-web/examples/chron-feed/index.ts
+++ b/packages/hub-web/examples/chron-feed/index.ts
@@ -9,19 +9,19 @@ import {
   isCastAddMessage,
   isUserDataAddMessage,
   UserDataType,
-} from '@farcaster/hub-web';
-import TimeAgo from 'javascript-time-ago';
-import en from 'javascript-time-ago/locale/en';
-import { err, ok, Result } from 'neverthrow';
+} from "@farcaster/hub-web";
+import TimeAgo from "javascript-time-ago";
+import en from "javascript-time-ago/locale/en";
+import { err, ok, Result } from "neverthrow";
 
 TimeAgo.addDefaultLocale(en);
-const timeAgo = new TimeAgo('en-US');
+const timeAgo = new TimeAgo("en-US");
 
 /**
  * Populate the following constants with your own values
  */
 
-const HUB_URL = 'nemes.farcaster.xyz:2283'; // URL of the Hub
+const HUB_URL = "nemes.farcaster.xyz:2283"; // URL of the Hub
 const FIDS = [2, 3]; // User IDs to fetch casts for
 
 /**
@@ -47,7 +47,7 @@ const getFnameFromFid = async (fid: number, client: HubRpcClient): HubAsyncResul
     if (isUserDataAddMessage(message)) {
       return message.data.userDataBody.value;
     } else {
-      return '';
+      return "";
     }
   });
 };
@@ -81,7 +81,7 @@ const castToString = async (cast: CastAddMessage, nameMapping: Map<number, strin
   const bytes = encoder.encode(text);
 
   const decoder = new TextDecoder();
-  let textWithMentions = '';
+  let textWithMentions = "";
   let indexBytes = 0;
   for (let i = 0; i < mentions.length; i++) {
     textWithMentions += decoder.decode(bytes.slice(indexBytes, mentionsPositions[i]));
@@ -92,7 +92,7 @@ const castToString = async (cast: CastAddMessage, nameMapping: Map<number, strin
   textWithMentions += decoder.decode(bytes.slice(indexBytes));
 
   // Remove newlines from the message text
-  const textNoLineBreaks = textWithMentions.replace(/(\r\n|\n|\r)/gm, ' ');
+  const textNoLineBreaks = textWithMentions.replace(/(\r\n|\n|\r)/gm, " ");
 
   return `${fname}: ${textNoLineBreaks}\n${dateString}\n`;
 };
@@ -119,7 +119,7 @@ const castToString = async (cast: CastAddMessage, nameMapping: Map<number, strin
         const fname = uData.data.userDataBody.value;
         fidToFname.set(fid, fname);
       }
-    })
+    }),
   );
 
   // 2. Fetch primary casts for each fid and print them
@@ -127,7 +127,7 @@ const castToString = async (cast: CastAddMessage, nameMapping: Map<number, strin
   const castsResult = Result.combine(await Promise.all(castResultPromises));
 
   if (castsResult.isErr()) {
-    console.error('Fetching fnames failed:' + castsResult.error);
+    console.error("Fetching fnames failed:" + castsResult.error);
     return;
   }
 


### PR DESCRIPTION
## Motivation

As part of the migration from eslint/prettier to rome-tools, this PR applies rome's default formatting to files. The goal is to break the migration PR into smaller, manageable chunks.

## Change Summary

Apply rome's formatter to the `examples` folder in `packages`

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating import statements and string formatting in the codebase. 

### Detailed summary
- Updated import statements to use double quotes instead of single quotes.
- Updated string formatting from single quotes to double quotes in various places.

> The following files were skipped due to too many changes: `packages/hub-nodejs/examples/chron-feed/index.ts`, `packages/hub-nodejs/examples/make-cast/index.ts`, `packages/hub-nodejs/examples/replicate-data-postgres/migrations/001_initial_migration.ts`, `packages/hub-nodejs/examples/replicate-data-postgres/hubReplicator.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->