### PR TITLE
chore: prepare for rome migration

### DIFF
--- a/apps/hubble/src/allowedPeers.mainnet.ts
+++ b/apps/hubble/src/allowedPeers.mainnet.ts
@@ -1,61 +1,61 @@
 // List of peers that are allowed to connect to the mainnet
 export const MAINNET_ALLOWED_PEERS = [
-  '12D3KooWRnSZUxjVJjbSHhVKpXtvibMarSfLSKDBeMpfVaNm1Joo', // hoyt.farcaster.xyz
-  '12D3KooWJECuSHn5edaorpufE9ceAoqR5zcAuD4ThoyDzVaz77GV', // lamia.farcaster.xyz
-  '12D3KooWMQrf6unpGJfLBmTGy3eKTo4cGcXktWRbgMnfbZLXqBbn', // nemes.farcaster.xyz
-  '12D3KooWN9ztVoHYi26NwTDDLNjgBozz479br3pwBuy3oLQVQmhz', // @cassie
-  '12D3KooWHiyvASqvhGn9kqsLBemPTAF6UYEaFGaLUpPxnM54KFbG', // @deodad
-  '12D3KooWKXAG1Z212HHrwYaW5NnwBxoXkk3Sr7USzRxMzS9pieZi', // @paden
-  '12D3KooWFbnaXtbD5fwbMGq2JRjPaj7C6EpZRgaxC8jdtcX7FJbZ', // @v
-  '12D3KooWNr294AH1fviDQxRmQ4K79iFSGoRCWzGspVxPprJUKN47', // @adityapk
-  '12D3KooWKwUpms7tgUoVsjQ2uV9g93hS2UiMRUfR8f4xjMtsk1Kq', // @pfh
-  '12D3KooWATZKmurjSqWHfcLBgD4oYbNYiAHZ5VPq8W2kNid5TEuL', // @df
-  '12D3KooWMnmYq2BDGKJ76w5pFyz2c1ZsK8pMvu6wxyg747j3p679', // @eddy
-  '12D3KooWFoPsstYWVH3a4uFpmxksF6nDEsgYizHnPpd9Atw9DRbH', // @gavi
-  '12D3KooWKYqmj1bQJChn4hCAhsneg9sRKRd6Zzp3DkVMUL2pjyAB', // @16
-  '12D3KooWReH654LePzAE4shSw6wuWqP3i9jSN2jBNswWJu2kiPQ5', // @vern
-  '12D3KooWRxgeFVLTAxeVgj4QHPzuT6HaV3Hj93LNZQeRi7gAwUVk', // @stout
-  '12D3KooWSii9GJheDmFRBzii43fpzvb3WkmPn62QSoJ8MjvGKMxr', // @mp
-  '12D3KooWQ76P8kBUvjNx2Q8EpYDL1BsqXdqZmAkHzTxE1uruuwRd', // @brianjckim
-  '12D3KooWRrFF356RALgsPwQQpg68reJL2y94VwKZFogUkM9der1V', // @lndnnft
-  '12D3KooWPNDmUeNiGdCdoHp8iAf8Uay3c2C9n5QVygd3J1hfv65w', // @sanjay
-  '12D3KooWFZwTP5bUZbQViTk79i2DZujHBBjPpAZyDwyrkPb79eAL', // @molo
-  '12D3KooWHK4EXZ33nVFLSCLRuFNUK74v72eZEcRKoHTPbX9Nove7', // @neynar
-  '12D3KooWDMXc4uVXr8zWGujaRuzhDnTBBHkTsJ58WimB8QU4cgos', // @nj
-  '12D3KooWCZBZAirRXA2cecgud2zC7T5iN4hwr9nf7VAn9d8u9px2', // @rss3
-  '12D3KooWJwBPFDdCkxWqVE6tCWPs4sDx2t4Pgy2cCewqKzLTRHgr', // @cryptobenkei
-  '12D3KooWErFRoVgMHwShjDUjVGBFUGRfyCC1dHSix4HoEsxjmMvA', // @les
-  '12D3KooWEr4WoKduAQg8VJSgwcNsqptbdkSQLw1ceEr8oSBQurJX', // @yanisme
-  '12D3KooWMZK4VeMX3ZARugTuGexXFHNiGHgNFq6XE2vzi88fMgwC', // @event
-  '12D3KooWEs1QcvJcoVv3ihHqqa3yxh4gijegrjyyVkvso2qayUdj', // @colin / @paragraph
-  '12D3KooWBhm9XdafZiBWPncDVcvMhcmV3kLFLnBiS83CjY833sWN', // @pjc (fc.bus.events)
-  '12D3KooWFHsw17MsY9eSbYLhkemUYcAwAjPPA7D6g3wTuhnLgAbT', // @sds
-  '12D3KooWKEuT74vxNfhGJh5XGUURaenDj1qokjA811Wv78tFo5WV', // @blanker
-  '12D3KooWCeDDcnpiwRMTGJjxsMayYuUuhRY71QxHxsLtx1ZP2Eq8', // @myz1237
-  '12D3KooWMcDyq1KwcEgSjLixYLEPUZPYwDVFpWcyr8sp9nXCx6Dv', // Jam.so Hub 1
-  '12D3KooWBP4DbXcJrjpwTAsWbLfEXAcWKLQhZoP9HpXrWbbNiogC', // Jam.so Hub 2
-  '12D3KooWNXZSmpCLKBtkS9QyzEqG3qTZARLtKUkShxkTWV2EqsaK', // Jam.so Hub 3
-  '12D3KooWSJj9pDSX5sEFoZum1fsdHuCJnoxwgHKhCg5rrLU7Gepe', // @pfista
-  '12D3KooWDXSemEhSAidFCZT1HyRhTHayunCokg68VSuwStf8UEU5', // @98967eth
-  '12D3KooWHcViME8KUZXo1wStoRF2jmg4edWidexGy5utVyoxNNnn', // @parthkohli
-  '12D3KooWJtEEh7Bcx9T2oKUpcMb9K8xuMFFk5BQNNdJ63Rsx853C', // Jam.so Hub 4
-  '12D3KooWH3FAGri9Ki4j7xBBjghav9nRTyu8jVVBsRh55odGxraM', // @kencodes
-  '12D3KooWQ8fFUMipLC4Fm6DLN9vWQLX5XBbiewM1N5Vt6QxsPVxn', // @thezluf
-  '12D3KooWPsSJu7jPS2UcroV4R1Ed1VJKVBxBkuNs4haDTEUnYBvm', // @sheldon
-  '12D3KooWR5qBN6GraBd4DzAJVaGzVk9TZgUYFusoPhxt5suPFtqH', // @silent
-  '12D3KooWRDvjugV5fhkTA2BBmrLXmKyBXLe4V7YJyMXyLQGj1PAM', // @rysiman
-  '12D3KooWNLshuXk4x2gacFTMEJjMGGFxPjpHg5KcV88KoqJP7dDR', // @bhgomes
-  '12D3KooWS39hrt41rMuD5ZfPFMxUVycxVwz7w15CxZVhxP4AZDGr', // @rozhnovskiyigor
-  '12D3KooWHXZkdEYWb5RCajv7YbffasjYNSEP1U68DMR1JeZ4QiXH', // @fedecastelli
-  '12D3KooWCPdo8CNq3pu7oyJQYFzV6d4GbHUH8HTUbtHM6jpv6buy', // @cameron
-  '12D3KooWHguasQqxAK9px8i5NDMFSG7VYhHRt4C7d2brpjakh5Sk', // @mboyle
-  '12D3KooWDfxjnmTTk2nb89dBZZrCQ7g71BoJELKnVpUQUTt4YcL4', // @razzle
-  '12D3KooWEoXRpLMjiRo9KxVHqg8Ng5gJxkJdd9uDotSNfYy8jFNv', // @pseudobun
-  '12D3KooWPcrf4XYUQrxsLniTJR4u4roQJre2T6ev14JeJcAFzZZv', // airstack.xyz
-  '12D3KooWLCAqhHempm8C8ZCLMMnK4pBPAyjS3HM2BMBopsC2HZDS', // airstack.xyz
-  '12D3KooWCDxDVkirzdV6Ze8zgDq2i1X3tQLGgwTGRxwuYeHD6XDE', // @wrdwccz
-  '12D3KooWHkYUwM3PeRqdYniuxAGXWhPYx6EzPhDY39J3cyNciQhE', // @naratech-eng
-  '12D3KooWGU1ebBRwdTBrfb2jQniip7FsWfr22PJhZQwwAf4d8jgX', // Gvozdaryova43654.telegram
+  "12D3KooWRnSZUxjVJjbSHhVKpXtvibMarSfLSKDBeMpfVaNm1Joo", // hoyt.farcaster.xyz
+  "12D3KooWJECuSHn5edaorpufE9ceAoqR5zcAuD4ThoyDzVaz77GV", // lamia.farcaster.xyz
+  "12D3KooWMQrf6unpGJfLBmTGy3eKTo4cGcXktWRbgMnfbZLXqBbn", // nemes.farcaster.xyz
+  "12D3KooWN9ztVoHYi26NwTDDLNjgBozz479br3pwBuy3oLQVQmhz", // @cassie
+  "12D3KooWHiyvASqvhGn9kqsLBemPTAF6UYEaFGaLUpPxnM54KFbG", // @deodad
+  "12D3KooWKXAG1Z212HHrwYaW5NnwBxoXkk3Sr7USzRxMzS9pieZi", // @paden
+  "12D3KooWFbnaXtbD5fwbMGq2JRjPaj7C6EpZRgaxC8jdtcX7FJbZ", // @v
+  "12D3KooWNr294AH1fviDQxRmQ4K79iFSGoRCWzGspVxPprJUKN47", // @adityapk
+  "12D3KooWKwUpms7tgUoVsjQ2uV9g93hS2UiMRUfR8f4xjMtsk1Kq", // @pfh
+  "12D3KooWATZKmurjSqWHfcLBgD4oYbNYiAHZ5VPq8W2kNid5TEuL", // @df
+  "12D3KooWMnmYq2BDGKJ76w5pFyz2c1ZsK8pMvu6wxyg747j3p679", // @eddy
+  "12D3KooWFoPsstYWVH3a4uFpmxksF6nDEsgYizHnPpd9Atw9DRbH", // @gavi
+  "12D3KooWKYqmj1bQJChn4hCAhsneg9sRKRd6Zzp3DkVMUL2pjyAB", // @16
+  "12D3KooWReH654LePzAE4shSw6wuWqP3i9jSN2jBNswWJu2kiPQ5", // @vern
+  "12D3KooWRxgeFVLTAxeVgj4QHPzuT6HaV3Hj93LNZQeRi7gAwUVk", // @stout
+  "12D3KooWSii9GJheDmFRBzii43fpzvb3WkmPn62QSoJ8MjvGKMxr", // @mp
+  "12D3KooWQ76P8kBUvjNx2Q8EpYDL1BsqXdqZmAkHzTxE1uruuwRd", // @brianjckim
+  "12D3KooWRrFF356RALgsPwQQpg68reJL2y94VwKZFogUkM9der1V", // @lndnnft
+  "12D3KooWPNDmUeNiGdCdoHp8iAf8Uay3c2C9n5QVygd3J1hfv65w", // @sanjay
+  "12D3KooWFZwTP5bUZbQViTk79i2DZujHBBjPpAZyDwyrkPb79eAL", // @molo
+  "12D3KooWHK4EXZ33nVFLSCLRuFNUK74v72eZEcRKoHTPbX9Nove7", // @neynar
+  "12D3KooWDMXc4uVXr8zWGujaRuzhDnTBBHkTsJ58WimB8QU4cgos", // @nj
+  "12D3KooWCZBZAirRXA2cecgud2zC7T5iN4hwr9nf7VAn9d8u9px2", // @rss3
+  "12D3KooWJwBPFDdCkxWqVE6tCWPs4sDx2t4Pgy2cCewqKzLTRHgr", // @cryptobenkei
+  "12D3KooWErFRoVgMHwShjDUjVGBFUGRfyCC1dHSix4HoEsxjmMvA", // @les
+  "12D3KooWEr4WoKduAQg8VJSgwcNsqptbdkSQLw1ceEr8oSBQurJX", // @yanisme
+  "12D3KooWMZK4VeMX3ZARugTuGexXFHNiGHgNFq6XE2vzi88fMgwC", // @event
+  "12D3KooWEs1QcvJcoVv3ihHqqa3yxh4gijegrjyyVkvso2qayUdj", // @colin / @paragraph
+  "12D3KooWBhm9XdafZiBWPncDVcvMhcmV3kLFLnBiS83CjY833sWN", // @pjc (fc.bus.events)
+  "12D3KooWFHsw17MsY9eSbYLhkemUYcAwAjPPA7D6g3wTuhnLgAbT", // @sds
+  "12D3KooWKEuT74vxNfhGJh5XGUURaenDj1qokjA811Wv78tFo5WV", // @blanker
+  "12D3KooWCeDDcnpiwRMTGJjxsMayYuUuhRY71QxHxsLtx1ZP2Eq8", // @myz1237
+  "12D3KooWMcDyq1KwcEgSjLixYLEPUZPYwDVFpWcyr8sp9nXCx6Dv", // Jam.so Hub 1
+  "12D3KooWBP4DbXcJrjpwTAsWbLfEXAcWKLQhZoP9HpXrWbbNiogC", // Jam.so Hub 2
+  "12D3KooWNXZSmpCLKBtkS9QyzEqG3qTZARLtKUkShxkTWV2EqsaK", // Jam.so Hub 3
+  "12D3KooWSJj9pDSX5sEFoZum1fsdHuCJnoxwgHKhCg5rrLU7Gepe", // @pfista
+  "12D3KooWDXSemEhSAidFCZT1HyRhTHayunCokg68VSuwStf8UEU5", // @98967eth
+  "12D3KooWHcViME8KUZXo1wStoRF2jmg4edWidexGy5utVyoxNNnn", // @parthkohli
+  "12D3KooWJtEEh7Bcx9T2oKUpcMb9K8xuMFFk5BQNNdJ63Rsx853C", // Jam.so Hub 4
+  "12D3KooWH3FAGri9Ki4j7xBBjghav9nRTyu8jVVBsRh55odGxraM", // @kencodes
+  "12D3KooWQ8fFUMipLC4Fm6DLN9vWQLX5XBbiewM1N5Vt6QxsPVxn", // @thezluf
+  "12D3KooWPsSJu7jPS2UcroV4R1Ed1VJKVBxBkuNs4haDTEUnYBvm", // @sheldon
+  "12D3KooWR5qBN6GraBd4DzAJVaGzVk9TZgUYFusoPhxt5suPFtqH", // @silent
+  "12D3KooWRDvjugV5fhkTA2BBmrLXmKyBXLe4V7YJyMXyLQGj1PAM", // @rysiman
+  "12D3KooWNLshuXk4x2gacFTMEJjMGGFxPjpHg5KcV88KoqJP7dDR", // @bhgomes
+  "12D3KooWS39hrt41rMuD5ZfPFMxUVycxVwz7w15CxZVhxP4AZDGr", // @rozhnovskiyigor
+  "12D3KooWHXZkdEYWb5RCajv7YbffasjYNSEP1U68DMR1JeZ4QiXH", // @fedecastelli
+  "12D3KooWCPdo8CNq3pu7oyJQYFzV6d4GbHUH8HTUbtHM6jpv6buy", // @cameron
+  "12D3KooWHguasQqxAK9px8i5NDMFSG7VYhHRt4C7d2brpjakh5Sk", // @mboyle
+  "12D3KooWDfxjnmTTk2nb89dBZZrCQ7g71BoJELKnVpUQUTt4YcL4", // @razzle
+  "12D3KooWEoXRpLMjiRo9KxVHqg8Ng5gJxkJdd9uDotSNfYy8jFNv", // @pseudobun
+  "12D3KooWPcrf4XYUQrxsLniTJR4u4roQJre2T6ev14JeJcAFzZZv", // airstack.xyz
+  "12D3KooWLCAqhHempm8C8ZCLMMnK4pBPAyjS3HM2BMBopsC2HZDS", // airstack.xyz
+  "12D3KooWCDxDVkirzdV6Ze8zgDq2i1X3tQLGgwTGRxwuYeHD6XDE", // @wrdwccz
+  "12D3KooWHkYUwM3PeRqdYniuxAGXWhPYx6EzPhDY39J3cyNciQhE", // @naratech-eng
+  "12D3KooWGU1ebBRwdTBrfb2jQniip7FsWfr22PJhZQwwAf4d8jgX", // Gvozdaryova43654.telegram
   /*
    * Add a new entry by adding your peerId and a comment with your farcaster username. To ensure a
    * fast merge, add your name randomly in the middle of the list, since adding at the end creates

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -165,6 +165,7 @@ app
     }, PROCESS_SHUTDOWN_FILE_CHECK_INTERVAL_MS);
 
     // try to load the config file
+    // rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
     let hubConfig: any = DefaultConfig;
     if (cliOptions.config) {
       if (!cliOptions.config.endsWith(".js")) {
@@ -393,7 +394,7 @@ const writePeerId = async (peerId: PeerId, filepath: string) => {
       await mkdir(directory, { recursive: true });
     }
     await writeFile(filepath, proto, "binary");
-    /* eslint-enable security/detect-non-literal-fs-filename */
+    // rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
   } catch (err: any) {
     throw new Error(err);
   }
@@ -410,7 +411,7 @@ const createIdCommand = new Command("create")
     for (let i = 0; i < options.count; i++) {
       const peerId = await createEd25519PeerId();
 
-      if (i == 0) {
+      if (i === 0) {
         // Create a copy of the first peerId as the default one to use
         await writePeerId(peerId, resolve(`${options.output}/${DEFAULT_PEER_ID_FILENAME}`));
       }

--- a/apps/hubble/src/console/console.ts
+++ b/apps/hubble/src/console/console.ts
@@ -22,6 +22,7 @@ export interface ConsoleCommandInterface {
   commandName(): string;
   shortHelp(): string;
   help(): string;
+  // rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
   object(): any;
 }
 
@@ -38,7 +39,7 @@ export const startConsole = async (addressString: string, useInsecure: boolean) 
     });
 
   replServer.output.write("\nWelcome to the Hub console. Type '.help' for a list of commands.\n");
-  replServer.output.write('Connecting to hub at "' + addressString + '"\n');
+  replServer.output.write(`Connecting to hub at "${addressString}"\n`);
 
   replServer.setupHistory(path.join(process.cwd(), ".hub_history"), (err) => {
     if (err) {
@@ -70,7 +71,7 @@ export const startConsole = async (addressString: string, useInsecure: boolean) 
     action() {
       this.clearBufferedCommand();
 
-      this.output.write(`Available commands:\n`);
+      this.output.write("Available commands:\n");
       commands.forEach((command) => {
         this.output.write(`\t${command.commandName()} - ${command.shortHelp()}\n`);
       });
@@ -93,13 +94,13 @@ export const startConsole = async (addressString: string, useInsecure: boolean) 
   });
 
   if (info.isErr()) {
-    replServer.output.write('Could not connect to hub at "' + addressString + '"\n');
+    replServer.output.write(`Could not connect to hub at "${addressString}"\n`);
     // eslint-disable-next-line no-console
     console.log(info.error);
     process.exit(1);
   }
 
-  replServer.output.write("Connected Info: " + JSON.stringify(info.value) + "\n");
+  replServer.output.write(`Connected Info: ${JSON.stringify(info.value)}\n`);
 
   replServer.displayPrompt();
 };

--- a/apps/hubble/src/console/rpcClientCommand.ts
+++ b/apps/hubble/src/console/rpcClientCommand.ts
@@ -10,7 +10,7 @@ export class RpcClientCommand implements ConsoleCommandInterface {
     return "Use the RPC client connected to the Hub";
   }
   help(): string {
-    return `Usage: rpcClient.<rpc>(<args>)`;
+    return "Usage: rpcClient.<rpc>(<args>)";
   }
   object(): HubRpcClient {
     return this.rpcClient;

--- a/apps/hubble/src/eth/fnameRegistryEventsProvider.ts
+++ b/apps/hubble/src/eth/fnameRegistryEventsProvider.ts
@@ -78,7 +78,7 @@ export class FNameRegistryEventsProvider {
       this.lastTransferId = result.value.lastFnameProof;
     }
     if (this.resyncEvents) {
-      log.error(`Resyncing fname events from the beginning`);
+      log.error("Resyncing fname events from the beginning");
       this.lastTransferId = 0;
     }
     const rawAddress = await this.client.getSigner();
@@ -136,7 +136,7 @@ export class FNameRegistryEventsProvider {
 
   private async mergeTransfers(transfers: FNameTransfer[]) {
     if (this.serverSignerAddress.length === 0) {
-      log.warn(`No signer address, unable to merge name proofs`);
+      log.warn("No signer address, unable to merge name proofs");
       return;
     }
 

--- a/apps/hubble/src/eth/watchContractEvent.ts
+++ b/apps/hubble/src/eth/watchContractEvent.ts
@@ -42,12 +42,12 @@ export class WatchContractEvent<
       },
     });
 
-    this._log.info(`Started watching contract events`);
+    this._log.info("Started watching contract events");
   }
 
   public stop() {
     if (this._unwatch) this._unwatch();
-    this._log.info(`Stopped watching contract events`);
+    this._log.info("Stopped watching contract events");
   }
 
   public restart() {

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -365,8 +365,7 @@ export class Hub implements HubInterface {
     if (dbNetworkResult.isOk() && dbNetworkResult.value && dbNetworkResult.value !== this.options.network) {
       throw new HubError(
         "unavailable",
-        `network mismatch: DB is ${dbNetworkResult.value}, but Hub is started with ${this.options.network}. ` +
-          `Please reset the DB with the "dbreset" command if this is intentional.`,
+        `network mismatch: DB is ${dbNetworkResult.value}, but Hub is started with ${this.options.network}. Please reset the DB with the "dbreset" command if this is intentional.`,
       );
     }
 
@@ -559,7 +558,7 @@ export class Hub implements HubInterface {
         // will eventually re-fetch and merge this message in anyway.
         log.warn(
           { syncTrieQ: this.syncEngine.syncTrieQSize, syncMergeQ: this.syncEngine.syncMergeQSize },
-          `Sync queue is full, dropping gossip message`,
+          "Sync queue is full, dropping gossip message",
         );
         return err(new HubError("unavailable", "Sync queue is full"));
       }
@@ -699,7 +698,7 @@ export class Hub implements HubInterface {
     // sorts addresses by Public IPs first
     const addr = peerInfo.addresses.sort((a, b) => publicAddressesFirst(a, b))[0];
     if (addr === undefined) {
-      log.info({ function: "getRPCClientForPeer", peer }, `peer found but no address is available to request sync`);
+      log.info({ function: "getRPCClientForPeer", peer }, "peer found but no address is available to request sync");
 
       return;
     }

--- a/apps/hubble/src/network/p2p/connectionFilter.test.ts
+++ b/apps/hubble/src/network/p2p/connectionFilter.test.ts
@@ -18,7 +18,7 @@ describe("connectionFilter tests", () => {
     expect(multiaddr(allowedMultiAddrStr)).toBeDefined();
     filteredMultiAddrStr = `/ip4/127.0.0.1/tcp/64455/p2p/${blockedPeerId.toString()}`;
     expect(multiaddr(filteredMultiAddrStr)).toBeDefined();
-    localMultiAddrStr = `/ip4/127.0.0.1/tcp/64456/`;
+    localMultiAddrStr = "/ip4/127.0.0.1/tcp/64456/";
   });
 
   test("denies all connections by default", async () => {

--- a/apps/hubble/src/network/p2p/connectionFilter.ts
+++ b/apps/hubble/src/network/p2p/connectionFilter.ts
@@ -27,7 +27,7 @@ export class ConnectionFilter implements ConnectionGater {
   denyDialPeer = async (peerId: PeerId): Promise<boolean> => {
     const deny = this.shouldDeny(peerId.toString());
     if (deny) {
-      log.info({ peerId, filter: "denyDialPeer" }, `denied a connection`);
+      log.info({ peerId, filter: "denyDialPeer" }, "denied a connection");
     }
     return deny;
   };
@@ -35,7 +35,7 @@ export class ConnectionFilter implements ConnectionGater {
   denyDialMultiaddr = async (peerId: PeerId, _multiaddr: Multiaddr): Promise<boolean> => {
     const deny = this.shouldDeny(peerId.toString());
     if (deny) {
-      log.info({ peerId, filter: "denyDialMultiaddr" }, `denied a connection`);
+      log.info({ peerId, filter: "denyDialMultiaddr" }, "denied a connection");
     }
     return deny;
   };
@@ -48,7 +48,7 @@ export class ConnectionFilter implements ConnectionGater {
   denyOutboundConnection = async (peerId: PeerId, _maConn: MultiaddrConnection): Promise<boolean> => {
     const deny = this.shouldDeny(peerId.toString());
     if (deny) {
-      log.info({ peerId, filter: "denyOutboundConnection" }, `denied a connection`);
+      log.info({ peerId, filter: "denyOutboundConnection" }, "denied a connection");
     }
     return deny;
   };
@@ -56,7 +56,7 @@ export class ConnectionFilter implements ConnectionGater {
   denyInboundEncryptedConnection = async (peerId: PeerId, _maConn: MultiaddrConnection): Promise<boolean> => {
     const deny = this.shouldDeny(peerId.toString());
     if (deny) {
-      log.info({ peerId, filter: "denyInboundEncryptedConnection" }, `denied a connection`);
+      log.info({ peerId, filter: "denyInboundEncryptedConnection" }, "denied a connection");
     }
     return deny;
   };
@@ -64,7 +64,7 @@ export class ConnectionFilter implements ConnectionGater {
   denyOutboundEncryptedConnection = async (peerId: PeerId, _maConn: MultiaddrConnection): Promise<boolean> => {
     const deny = this.shouldDeny(peerId.toString());
     if (deny) {
-      log.info({ peerId, filter: "denyOutboundEncryptedConnection" }, `denied a connection`);
+      log.info({ peerId, filter: "denyOutboundEncryptedConnection" }, "denied a connection");
     }
     return deny;
   };
@@ -72,7 +72,7 @@ export class ConnectionFilter implements ConnectionGater {
   denyInboundUpgradedConnection = async (peerId: PeerId, _maConn: MultiaddrConnection): Promise<boolean> => {
     const deny = this.shouldDeny(peerId.toString());
     if (deny) {
-      log.info({ peerId, filter: "denyInboundUpgradedConnection" }, `denied a connection`);
+      log.info({ peerId, filter: "denyInboundUpgradedConnection" }, "denied a connection");
     }
     return deny;
   };
@@ -80,7 +80,7 @@ export class ConnectionFilter implements ConnectionGater {
   denyOutboundUpgradedConnection = async (peerId: PeerId, _maConn: MultiaddrConnection): Promise<boolean> => {
     const deny = this.shouldDeny(peerId.toString());
     if (deny) {
-      log.info({ peerId, filter: "denyOutboundUpgradedConnection" }, `denied a connection`);
+      log.info({ peerId, filter: "denyOutboundUpgradedConnection" }, "denied a connection");
     }
     return deny;
   };

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -1,6 +1,6 @@
-import { gossipsub, GossipSub } from '@chainsafe/libp2p-gossipsub';
-import { Message as GossipSubMessage, PublishResult } from '@libp2p/interface-pubsub';
-import { noise } from '@chainsafe/libp2p-noise';
+import { gossipsub, GossipSub } from "@chainsafe/libp2p-gossipsub";
+import { Message as GossipSubMessage, PublishResult } from "@libp2p/interface-pubsub";
+import { noise } from "@chainsafe/libp2p-noise";
 import {
   ContactInfoContent,
   FarcasterNetwork,
@@ -10,29 +10,29 @@ import {
   HubError,
   HubResult,
   Message,
-} from '@farcaster/hub-nodejs';
-import { Connection } from '@libp2p/interface-connection';
-import { PeerId } from '@libp2p/interface-peer-id';
-import { peerIdFromBytes } from '@libp2p/peer-id';
-import { mplex } from '@libp2p/mplex';
-import { pubsubPeerDiscovery } from '@libp2p/pubsub-peer-discovery';
-import { tcp } from '@libp2p/tcp';
-import { Multiaddr } from '@multiformats/multiaddr';
-import { createLibp2p, Libp2p } from 'libp2p';
-import { err, ok, Result, ResultAsync } from 'neverthrow';
-import { TypedEmitter } from 'tiny-typed-emitter';
-import { ConnectionFilter } from './connectionFilter.js';
-import { logger } from '../../utils/logger.js';
-import { addressInfoFromParts, checkNodeAddrs, ipMultiAddrStrFromAddressInfo } from '../../utils/p2p.js';
-import { PeriodicPeerCheckScheduler } from './periodicPeerCheck.js';
-import { GOSSIP_PROTOCOL_VERSION, msgIdFnStrictSign } from './protocol.js';
+} from "@farcaster/hub-nodejs";
+import { Connection } from "@libp2p/interface-connection";
+import { PeerId } from "@libp2p/interface-peer-id";
+import { peerIdFromBytes } from "@libp2p/peer-id";
+import { mplex } from "@libp2p/mplex";
+import { pubsubPeerDiscovery } from "@libp2p/pubsub-peer-discovery";
+import { tcp } from "@libp2p/tcp";
+import { Multiaddr } from "@multiformats/multiaddr";
+import { createLibp2p, Libp2p } from "libp2p";
+import { err, ok, Result, ResultAsync } from "neverthrow";
+import { TypedEmitter } from "tiny-typed-emitter";
+import { ConnectionFilter } from "./connectionFilter.js";
+import { logger } from "../../utils/logger.js";
+import { addressInfoFromParts, checkNodeAddrs, ipMultiAddrStrFromAddressInfo } from "../../utils/p2p.js";
+import { PeriodicPeerCheckScheduler } from "./periodicPeerCheck.js";
+import { GOSSIP_PROTOCOL_VERSION, msgIdFnStrictSign } from "./protocol.js";
 
-const MultiaddrLocalHost = '/ip4/127.0.0.1';
+const MultiaddrLocalHost = "/ip4/127.0.0.1";
 
 /** The maximum number of pending merge messages before we drop new incoming gossip or sync messages. */
 export const MAX_MESSAGE_QUEUE_SIZE = 100_000;
 
-const log = logger.child({ component: 'Node' });
+const log = logger.child({ component: "Node" });
 
 /** Events emitted by a Farcaster Gossip Node */
 interface NodeEvents {
@@ -92,14 +92,14 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
 
   async addPeerToAddressBook(peerId: PeerId, multiaddr: Multiaddr) {
     if (!this.addressBook) {
-      log.error({}, 'address book missing for gossipNode');
+      log.error({}, "address book missing for gossipNode");
     } else {
       const addResult = await ResultAsync.fromPromise(
         this.addressBook.add(peerId, [multiaddr]),
-        (error) => new HubError('unavailable', error as Error)
+        (error) => new HubError("unavailable", error as Error),
       );
       if (addResult.isErr()) {
-        log.error({ error: addResult.error, peerId }, 'failed to add contact info to address book');
+        log.error({ error: addResult.error, peerId }, "failed to add contact info to address book");
       }
     }
   }
@@ -109,15 +109,15 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
     if (this._node) {
       const hangupResult = await ResultAsync.fromPromise(
         this._node.hangUp(peerId),
-        (error) => new HubError('unavailable', error as Error)
+        (error) => new HubError("unavailable", error as Error),
       );
       if (hangupResult.isErr()) {
-        log.error({ error: hangupResult.error, peerId }, 'failed to hang up peer');
+        log.error({ error: hangupResult.error, peerId }, "failed to hang up peer");
       }
     }
 
     if (!this.addressBook) {
-      log.error({}, 'address book missing for gossipNode');
+      log.error({}, "address book missing for gossipNode");
     } else {
       return this.addressBook.delete(peerId);
     }
@@ -159,7 +159,7 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
     await this._node.start();
     log.info(
       { identity: this.identity, addresses: this._node.getMultiaddrs().map((a) => a.toString()) },
-      'Starting libp2p'
+      "Starting libp2p",
     );
 
     // Wait for a few seconds for everything to initialize before connecting to bootstrap nodes
@@ -180,7 +180,7 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
     await this._node?.stop();
     this._periodicPeerCheckJob?.stop();
 
-    log.info({ identity: this.identity }, 'Stopped libp2p...');
+    log.info({ identity: this.identity }, "Stopped libp2p...");
   }
 
   get identity() {
@@ -215,13 +215,13 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
     const encodedMessage = GossipNode.encodeMessage(message);
 
     log.debug({ identity: this.identity }, `Publishing message to topics: ${topics}`);
-    if (this.gossip == undefined) {
-      return [err(new HubError('unavailable', new Error('GossipSub not initialized')))];
+    if (this.gossip === undefined) {
+      return [err(new HubError("unavailable", new Error("GossipSub not initialized")))];
     }
     const gossip = this.gossip;
 
     if (encodedMessage.isErr()) {
-      log.error(encodedMessage.error, 'Failed to publish message.');
+      log.error(encodedMessage.error, "Failed to publish message.");
       return [err(encodedMessage.error)];
     } else {
       const results = await Promise.all(
@@ -229,14 +229,15 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
           try {
             const publishResult = await gossip.publish(topic, encodedMessage.value);
             return ok(publishResult);
+            // rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
           } catch (error: any) {
-            log.error(error, 'Failed to publish message');
-            return err(new HubError('bad_request.duplicate', error));
+            log.error(error, "Failed to publish message");
+            return err(new HubError("bad_request.duplicate", error));
           }
-        })
+        }),
       );
 
-      log.debug({ identity: this.identity, results }, 'Published to gossip peers');
+      log.debug({ identity: this.identity, results }, "Published to gossip peers");
       return results;
     }
   }
@@ -245,17 +246,17 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
   async connect(peerNode: GossipNode): Promise<HubResult<void>> {
     const multiaddrs = peerNode.multiaddrs;
     if (!multiaddrs) {
-      return err(new HubError('unavailable', { message: 'no peer id' }));
+      return err(new HubError("unavailable", { message: "no peer id" }));
     }
 
     for (const addr of multiaddrs) {
       const result = await this.connectAddress(addr);
       // Short-circuit and return if we connect to at least one address
       if (result.isOk()) return ok(undefined);
-      log.error(result.error, 'Failed to connect to addr');
+      log.error(result.error, "Failed to connect to addr");
     }
 
-    return err(new HubError('unavailable', { message: 'cannot connect to any peer' }));
+    return err(new HubError("unavailable", { message: "cannot connect to any peer" }));
   }
 
   /** Connect to a peer Gossip Node using a specific address */
@@ -268,23 +269,24 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
         log.info({ identity: this.identity, address }, `Connected to peer at address: ${address}`);
         return ok(undefined);
       }
+      // rome-ignore lint/suspicious/noExplicitAny: error catching
     } catch (error: any) {
       log.error(error, `Failed to connect to peer at address: ${address}`);
-      return err(new HubError('unavailable', error));
+      return err(new HubError("unavailable", error));
     }
-    return err(new HubError('unavailable', { message: `cannot connect to peer: ${address}` }));
+    return err(new HubError("unavailable", { message: `cannot connect to peer: ${address}` }));
   }
 
   registerListeners() {
-    this._node?.addEventListener('peer:connect', (event) => {
-      log.info({ peer: event.detail.remotePeer }, `P2P Connection established`);
-      this.emit('peerConnect', event.detail);
+    this._node?.addEventListener("peer:connect", (event) => {
+      log.info({ peer: event.detail.remotePeer }, "P2P Connection established");
+      this.emit("peerConnect", event.detail);
     });
-    this._node?.addEventListener('peer:disconnect', (event) => {
-      log.info({ peer: event.detail.remotePeer }, `P2P Connection disconnected`);
-      this.emit('peerDisconnect', event.detail);
+    this._node?.addEventListener("peer:disconnect", (event) => {
+      log.info({ peer: event.detail.remotePeer }, "P2P Connection disconnected");
+      this.emit("peerDisconnect", event.detail);
     });
-    this.gossip?.addEventListener('gossipsub:message', (event) => {
+    this.gossip?.addEventListener("gossipsub:message", (event) => {
       log.debug({
         identity: this.identity,
         gossipMessageId: event.detail.msgId,
@@ -294,33 +296,34 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
 
       // ignore messages not in our topic lists (e.g. GossipSub peer discovery messages)
       if (this.gossipTopics().includes(event.detail.msg.topic)) {
-        this.emit('message', event.detail.msg.topic, GossipNode.decodeMessage(event.detail.msg.data));
+        this.emit("message", event.detail.msg.topic, GossipNode.decodeMessage(event.detail.msg.data));
       }
     });
   }
 
   registerDebugListeners() {
-    this._node?.addEventListener('peer:discovery', (event) => {
+    this._node?.addEventListener("peer:discovery", (event) => {
       log.info({ identity: this.identity }, `Found peer: ${event.detail.multiaddrs}  }`);
     });
-    this._node?.addEventListener('peer:connect', (event) => {
+    this._node?.addEventListener("peer:connect", (event) => {
       log.info({ identity: this.identity }, `Connection established to: ${event.detail.remotePeer.toString()}`);
     });
-    this._node?.addEventListener('peer:disconnect', (event) => {
+    this._node?.addEventListener("peer:disconnect", (event) => {
       log.info({ identity: this.identity }, `Disconnected from: ${event.detail.remotePeer.toString()} `);
     });
-    this.gossip?.addEventListener('message', (event) => {
+    this.gossip?.addEventListener("message", (event) => {
       log.info(
-        { identity: this.identity, from: (event.detail as any)['from'] },
-        `Received message for topic: ${event.detail.topic}`
+        // rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
+        { identity: this.identity, from: (event.detail as any)["from"] },
+        `Received message for topic: ${event.detail.topic}`,
       );
     });
-    this.gossip?.addEventListener('subscription-change', (event) => {
+    this.gossip?.addEventListener("subscription-change", (event) => {
       log.info(
         { identity: this.identity },
         `Subscription change: ${event.detail.subscriptions.map((value) => {
           value.topic;
-        })}`
+        })}`,
       );
     });
   }
@@ -350,13 +353,14 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
     try {
       const gossipMessage = GossipMessage.decode(Uint8Array.from(message));
       const supportedVersions = [GOSSIP_PROTOCOL_VERSION, GossipVersion.V1];
-      if (gossipMessage.topics.length == 0 || supportedVersions.findIndex((v) => v == gossipMessage.version) == -1) {
-        return err(new HubError('bad_request.parse_failure', 'invalid message'));
+      if (gossipMessage.topics.length === 0 || supportedVersions.findIndex((v) => v === gossipMessage.version) === -1) {
+        return err(new HubError("bad_request.parse_failure", "invalid message"));
       }
       peerIdFromBytes(gossipMessage.peerId);
       return ok(GossipMessage.decode(Uint8Array.from(message)));
+      // rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
     } catch (error: any) {
-      return err(new HubError('bad_request.parse_failure', error));
+      return err(new HubError("bad_request.parse_failure", error));
     }
   }
 
@@ -366,13 +370,13 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
 
   /* Attempts to dial all the addresses in the bootstrap list */
   public async bootstrap(bootstrapAddrs: Multiaddr[]): Promise<HubResult<void>> {
-    if (bootstrapAddrs.length == 0) return ok(undefined);
+    if (bootstrapAddrs.length === 0) return ok(undefined);
     const results = await Promise.all(bootstrapAddrs.map((addr) => this.connectAddress(addr)));
 
     const finalResults = Result.combineWithAllErrors(results) as Result<void[], HubError[]>;
-    if (finalResults.isErr() && finalResults.error.length == bootstrapAddrs.length) {
+    if (finalResults.isErr() && finalResults.error.length === bootstrapAddrs.length) {
       // only fail if all connections failed
-      return err(new HubError('unavailable', 'could not connect to any bootstrap nodes'));
+      return err(new HubError("unavailable", "could not connect to any bootstrap nodes"));
     }
 
     return ok(undefined);
@@ -389,10 +393,10 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
     if (message.topic.includes(this.primaryTopic())) {
       // check if message is a Farcaster Protocol Message
       const protocolMessage = GossipNode.decodeMessage(message.data);
-      if (protocolMessage.isOk() && protocolMessage.value.version == GossipVersion.V1_1) {
-        if (protocolMessage.value.message != undefined)
+      if (protocolMessage.isOk() && protocolMessage.value.version === GossipVersion.V1_1) {
+        if (protocolMessage.value.message !== undefined)
           return protocolMessage._unsafeUnwrap().message?.hash as Uint8Array;
-        if (protocolMessage.value.idRegistryEvent != undefined)
+        if (protocolMessage.value.idRegistryEvent !== undefined)
           return protocolMessage.value.idRegistryEvent?.transactionHash as Uint8Array;
       }
     }
@@ -409,7 +413,7 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
     let announceMultiAddrStrList: string[] = [];
     if (options.announceIp && options.gossipPort) {
       const announceMultiAddr = addressInfoFromParts(options.announceIp, options.gossipPort).map((addressInfo) =>
-        ipMultiAddrStrFromAddressInfo(addressInfo)
+        ipMultiAddrStrFromAddressInfo(addressInfo),
       );
       if (announceMultiAddr.isOk() && announceMultiAddr.value.isOk()) {
         // If we have a valid announce IP, use it
@@ -419,19 +423,19 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
     }
 
     const checkResult = checkNodeAddrs(listenIPMultiAddr, listenMultiAddrStr);
-    if (checkResult.isErr()) return err(new HubError('unavailable', checkResult.error));
+    if (checkResult.isErr()) return err(new HubError("unavailable", checkResult.error));
 
     const gossip = gossipsub({
       emitSelf: false,
       allowPublishToZeroPeers: true,
-      globalSignaturePolicy: 'StrictSign',
+      globalSignaturePolicy: "StrictSign",
       msgIdFn: this.getMessageId.bind(this),
     });
 
     if (options.allowedPeerIdStrs) {
       log.info(
-        { identity: this.identity, function: 'createNode', allowedPeerIds: options.allowedPeerIdStrs },
-        `!!! PEER-ID RESTRICTIONS ENABLED !!!`
+        { identity: this.identity, function: "createNode", allowedPeerIds: options.allowedPeerIdStrs },
+        "!!! PEER-ID RESTRICTIONS ENABLED !!!",
       );
     }
     const connectionGater = new ConnectionFilter(options.allowedPeerIdStrs);
@@ -451,7 +455,7 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
         pubsub: gossip,
         peerDiscovery: [pubsubPeerDiscovery({ topics: [peerDiscoveryTopic] })],
       }),
-      (e) => new HubError('unavailable', { message: 'failed to create libp2p node', cause: e as Error })
+      (e) => new HubError("unavailable", { message: "failed to create libp2p node", cause: e as Error }),
     );
   }
 }

--- a/apps/hubble/src/network/sync/mock.ts
+++ b/apps/hubble/src/network/sync/mock.ts
@@ -10,8 +10,11 @@ export class MockRpcClient {
   engine: Engine;
   syncEngine: SyncEngine;
 
+  // rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
   getSyncMetadataByPrefixCalls: Array<any> = [];
+  // rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
   getAllSyncIdsByPrefixCalls: Array<any> = [];
+  // rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
   getAllMessagesBySyncIdsCalls: Array<any> = [];
   getAllMessagesBySyncIdsReturns = 0;
 

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -28,8 +28,8 @@ import { deployIdRegistry, deployNameRegistry, publicClient } from "../../test/u
 
 const TEST_TIMEOUT_LONG = 60 * 1000;
 
-const testDb1 = jestRocksDB(`engine1.peersyncEngine.test`);
-const testDb2 = jestRocksDB(`engine2.peersyncEngine.test`);
+const testDb1 = jestRocksDB("engine1.peersyncEngine.test");
+const testDb2 = jestRocksDB("engine2.peersyncEngine.test");
 
 const network = FarcasterNetwork.TESTNET;
 

--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -23,8 +23,8 @@ import { NetworkFactories } from "../../network/utils/factories.js";
 import { HubInterface } from "../../hubble.js";
 import { MockHub } from "../../test/mocks.js";
 
-const testDb = jestRocksDB(`engine.syncEngine.test`);
-const testDb2 = jestRocksDB(`engine2.syncEngine.test`);
+const testDb = jestRocksDB("engine.syncEngine.test");
+const testDb2 = jestRocksDB("engine2.syncEngine.test");
 
 const network = FarcasterNetwork.TESTNET;
 const fid = Factories.Fid.build();

--- a/apps/hubble/src/network/sync/syncEnginePerf.test.ts
+++ b/apps/hubble/src/network/sync/syncEnginePerf.test.ts
@@ -15,8 +15,8 @@ import { MockRpcClient } from "./mock.js";
 import { EMPTY_HASH } from "./trieNode.js";
 import { getFarcasterTime } from "@farcaster/core";
 
-const testDb = jestRocksDB(`engine.syncEnginePerf.test`);
-const testDb2 = jestRocksDB(`engine2.syncEnginePerf.test`);
+const testDb = jestRocksDB("engine.syncEnginePerf.test");
+const testDb2 = jestRocksDB("engine2.syncEnginePerf.test");
 
 const network = FarcasterNetwork.TESTNET;
 const fid = Factories.Fid.build();

--- a/apps/hubble/src/network/sync/trieNode.test.ts
+++ b/apps/hubble/src/network/sync/trieNode.test.ts
@@ -176,9 +176,9 @@ describe("TrieNode", () => {
 
     test("deleting item only compacts the branch of the trie with the deleted item", async () => {
       const ids = [
-        "0".padStart(TIMESTAMP_LENGTH * 2, "0") + "010680",
-        "0".padStart(TIMESTAMP_LENGTH * 2, "0") + "010a10",
-        "0".padStart(TIMESTAMP_LENGTH * 2, "0") + "05d220",
+        `${"0".padStart(TIMESTAMP_LENGTH * 2, "0")}010680`,
+        `${"0".padStart(TIMESTAMP_LENGTH * 2, "0")}010a10`,
+        `${"0".padStart(TIMESTAMP_LENGTH * 2, "0")}05d220`,
       ].map((id) => hexStringToBytes(id)._unsafeUnwrap());
 
       const root = new TrieNode();

--- a/apps/hubble/src/rocksdb.d.ts
+++ b/apps/hubble/src/rocksdb.d.ts
@@ -55,8 +55,7 @@ declare module '@farcaster/rocksdb' {
   declare namespace RocksDB {
     type Bytes = string | Buffer;
     type ErrorSizeCallback = (err: Error | undefined, size: number) => void;
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface OpenOptions extends AbstractOpenOptions {}
+    type OpenOptions = AbstractOpenOptions;
 
     interface GetOptions extends AbstractGetOptions {
       fillCache?: boolean | undefined;

--- a/apps/hubble/src/rpc/bufferedStreamWriter.ts
+++ b/apps/hubble/src/rpc/bufferedStreamWriter.ts
@@ -14,6 +14,7 @@ export const STREAM_MESSAGE_BUFFER_SIZE = 1000;
 export class BufferedStreamWriter {
   private streamIsBackedUp = false;
   private stream: ServerWritableStream<SubscribeRequest, HubEvent>;
+  // rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
   private dataWaitingForDrain: any[] = [];
 
   constructor(stream: ServerWritableStream<SubscribeRequest, HubEvent>) {
@@ -26,6 +27,7 @@ export class BufferedStreamWriter {
    * ok(false) if the message was buffered because the stream is full
    * err if the stream can't be written to any more and will be closed.
    */
+  // rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
   public writeToStream(message: any): HubResult<boolean> {
     if (this.streamIsBackedUp) {
       this.dataWaitingForDrain.push(message);

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -244,7 +244,7 @@ export default class Server {
     return new Promise((resolve, reject) => {
       if (force) {
         this.grpcServer.forceShutdown();
-        log.info({ component: "gRPC Server" }, `Force shutdown succeeded`);
+        log.info({ component: "gRPC Server" }, "Force shutdown succeeded");
         resolve();
       } else {
         this.grpcServer.tryShutdown((err) => {
@@ -252,7 +252,7 @@ export default class Server {
             log.error({ component: "gRPC Server" }, `Shutdown failed: ${err}`);
             reject(err);
           } else {
-            log.info({ component: "gRPC Server" }, `Shutdown succeeded`);
+            log.info({ component: "gRPC Server" }, "Shutdown succeeded");
             resolve();
           }
         });
@@ -360,6 +360,7 @@ export default class Server {
               log.warn({ num: corruptedMessages.length }, "Found corrupted messages, rebuilding some syncIDs");
               // Don't wait for this to finish, just return the messages we have.
               this.syncEngine?.rebuildSyncIds(request.syncIds);
+              // rome-ignore lint/style/noParameterAssign: legacy migration
               messages = messages.filter((message) => message.data !== undefined && message.hash.length > 0);
             }
 

--- a/apps/hubble/src/rpc/test/eventService.test.ts
+++ b/apps/hubble/src/rpc/test/eventService.test.ts
@@ -55,6 +55,7 @@ let usernameProof: UserNameProof;
 let signerAdd: SignerAddMessage;
 let castAdd: CastAddMessage;
 let reactionAdd: ReactionAddMessage;
+// rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
 let events: [HubEventType, any][];
 let stream: ClientReadableStream<HubEvent>;
 
@@ -82,6 +83,7 @@ beforeAll(async () => {
 });
 
 const setupSubscription = async (
+  // rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
   events: [HubEventType, any][],
   options: { eventTypes?: HubEventType[]; fromId?: number } = {},
 ): Promise<ClientReadableStream<HubEvent>> => {
@@ -93,16 +95,22 @@ const setupSubscription = async (
 
   stream.on("data", (event: HubEvent) => {
     if (isMergeMessageHubEvent(event)) {
+      // rome-ignore lint/style/noNonNullAssertion: legacy eslint migration
       events.push([event.type, Message.toJSON(event.mergeMessageBody.message!)]);
     } else if (isPruneMessageHubEvent(event)) {
+      // rome-ignore lint/style/noNonNullAssertion: legacy eslint migration
       events.push([event.type, Message.toJSON(event.pruneMessageBody.message!)]);
     } else if (isRevokeMessageHubEvent(event)) {
+      // rome-ignore lint/style/noNonNullAssertion: legacy eslint migration
       events.push([event.type, Message.toJSON(event.revokeMessageBody.message!)]);
     } else if (isMergeIdRegistryEventHubEvent(event)) {
+      // rome-ignore lint/style/noNonNullAssertion: legacy eslint migration
       events.push([event.type, IdRegistryEvent.toJSON(event.mergeIdRegistryEventBody.idRegistryEvent!)]);
     } else if (isMergeNameRegistryEventHubEvent(event)) {
+      // rome-ignore lint/style/noNonNullAssertion: legacy eslint migration
       events.push([event.type, NameRegistryEvent.toJSON(event.mergeNameRegistryEventBody.nameRegistryEvent!)]);
     } else if (isMergeUsernameProofHubEvent(event)) {
+      // rome-ignore lint/style/noNonNullAssertion: legacy eslint migration
       events.push([event.type, UserNameProof.toJSON(event.mergeUsernameProofBody.usernameProof!)]);
     }
   });

--- a/apps/hubble/src/rpc/test/rpcAuth.test.ts
+++ b/apps/hubble/src/rpc/test/rpcAuth.test.ts
@@ -60,7 +60,7 @@ describe("auth tests", () => {
 
     // Wrong password
     const metadata = new Metadata();
-    metadata.set("authorization", `Basic ${Buffer.from(`admin:wrongpassword`).toString("base64")}`);
+    metadata.set("authorization", `Basic ${Buffer.from("admin:wrongpassword").toString("base64")}`);
     const result2 = await authClient.submitMessage(signerAdd, metadata);
     expect(result2._unsafeUnwrapErr()).toEqual(
       new HubError("unauthorized", "gRPC authentication failed: Invalid password for user: admin"),
@@ -68,7 +68,7 @@ describe("auth tests", () => {
 
     // Wrong username
     const metadata2 = new Metadata();
-    metadata2.set("authorization", `Basic ${Buffer.from(`wronguser:password`).toString("base64")}`);
+    metadata2.set("authorization", `Basic ${Buffer.from("wronguser:password").toString("base64")}`);
     const result3 = await authClient.submitMessage(signerAdd, metadata2);
     expect(result3._unsafeUnwrapErr()).toEqual(
       new HubError("unauthorized", "gRPC authentication failed: Invalid username: wronguser"),
@@ -76,7 +76,7 @@ describe("auth tests", () => {
 
     // Right password
     const metadata3 = new Metadata();
-    metadata3.set("authorization", `Basic ${Buffer.from(`admin:password`).toString("base64")}`);
+    metadata3.set("authorization", `Basic ${Buffer.from("admin:password").toString("base64")}`);
     const result4 = await authClient.submitMessage(signerAdd, metadata3);
     expect(result4.isOk()).toBeTruthy();
 
@@ -103,7 +103,7 @@ describe("auth tests", () => {
 
     // Works with auth
     const metadata = new Metadata();
-    metadata.set("authorization", `Basic ${Buffer.from(`admin:password`).toString("base64")}`);
+    metadata.set("authorization", `Basic ${Buffer.from("admin:password").toString("base64")}`);
 
     const result2 = await authClient.submitMessage(signerAdd, metadata);
     expect(result2.isOk()).toBeTruthy();

--- a/apps/hubble/src/storage/db/nameRegistryEvent.ts
+++ b/apps/hubble/src/storage/db/nameRegistryEvent.ts
@@ -58,39 +58,40 @@ export const putNameRegistryEventTransaction = (txn: Transaction, event: NameReg
   const eventBuffer = Buffer.from(NameRegistryEvent.encode(event).finish());
 
   const primaryKey = makeNameRegistryEventPrimaryKey(event.fname);
-  txn = txn.put(primaryKey, eventBuffer);
+  let putTxn = txn.put(primaryKey, eventBuffer);
 
   if (event.expiry) {
     const byExpiryKey = makeNameRegistryEventByExpiryKey(event.expiry, event.fname);
-    txn = txn.put(byExpiryKey, eventBuffer);
+    putTxn = putTxn.put(byExpiryKey, eventBuffer);
   }
 
-  return txn;
+  return putTxn;
 };
 
 export const putUserNameProofTransaction = (txn: Transaction, usernameProof: UserNameProof): Transaction => {
   const proofBuffer = Buffer.from(UserNameProof.encode(usernameProof).finish());
 
   const primaryKey = makeUserNameProofPrimaryKey(usernameProof.name);
-  txn = txn.put(primaryKey, proofBuffer);
+  const putTxn = txn.put(primaryKey, proofBuffer);
 
-  return txn;
+  return putTxn;
 };
 
 export const deleteUserNameProofTransaction = (txn: Transaction, usernameProof: UserNameProof): Transaction => {
   const primaryKey = makeUserNameProofPrimaryKey(usernameProof.name);
-  txn = txn.del(primaryKey);
+  const deleteTxn = txn.del(primaryKey);
 
-  return txn;
+  return deleteTxn;
 };
 
 export const deleteNameRegistryEventTransaction = (txn: Transaction, event: NameRegistryEvent): Transaction => {
+  let deleteTxn = txn;
   if (event.expiry) {
     const byExpiryKey = makeNameRegistryEventByExpiryKey(event.expiry, event.fname);
-    txn = txn.del(byExpiryKey);
+    deleteTxn = deleteTxn.del(byExpiryKey);
   }
 
   const primaryKey = makeNameRegistryEventPrimaryKey(event.fname);
 
-  return txn.del(primaryKey);
+  return deleteTxn.del(primaryKey);
 };

--- a/apps/hubble/src/storage/db/rocksdb.ts
+++ b/apps/hubble/src/storage/db/rocksdb.ts
@@ -37,6 +37,7 @@ export class Iterator {
   async *[Symbol.asyncIterator]() {
     try {
       let kv: [Buffer | undefined, Buffer | undefined] | undefined;
+      // rome-ignore lint/suspicious/noAssignInExpressions: legacy eslint migration, to fix
       while ((kv = await this.next())) {
         yield kv;
       }

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -177,7 +177,7 @@ class Engine {
       return err(validatedMessage.error);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    // rome-ignore lint/style/noNonNullAssertion: legacy migration
     const setPostfix = typeToSetPostfix(message.data!.type);
 
     switch (setPostfix) {

--- a/apps/hubble/src/storage/engine/seed.ts
+++ b/apps/hubble/src/storage/engine/seed.ts
@@ -9,6 +9,7 @@ export const seedSigner = async (
   ethSigner?: Eip712Signer,
 ): Promise<Eip712Signer> => {
   if (!ethSigner) {
+    // rome-ignore lint/style/noParameterAssign: legacy migration
     ethSigner = Factories.Eip712Signer.build();
     const ethSignerKey = (await ethSigner.getSignerKey())._unsafeUnwrap();
 

--- a/apps/hubble/src/storage/jobs/revokeMessagesBySignerJob.ts
+++ b/apps/hubble/src/storage/jobs/revokeMessagesBySignerJob.ts
@@ -119,9 +119,7 @@ export class RevokeMessagesBySignerJobQueue extends TypedEmitter<JobQueueEvents>
 
   async enqueueJob(payload: RevokeMessagesBySignerJobPayload, doAt?: number): HubAsyncResult<Buffer> {
     // If doAt timestamp is missing, use current timestamp
-    if (!doAt) {
-      doAt = Date.now();
-    }
+    const doAtTimestamp = doAt ? doAt : Date.now();
 
     const payloadBytes = RevokeMessagesBySignerJobPayload.encode(payload).finish();
 
@@ -129,7 +127,7 @@ export class RevokeMessagesBySignerJobQueue extends TypedEmitter<JobQueueEvents>
     const hash = blake3(Uint8Array.from(payloadBytes), { dkLen: 4 });
 
     // Create job key
-    const key = RevokeMessagesBySignerJobQueue.makeJobKey(doAt, hash);
+    const key = RevokeMessagesBySignerJobQueue.makeJobKey(doAtTimestamp, hash);
     if (key.isErr()) {
       return err(key.error);
     }
@@ -168,7 +166,7 @@ export class RevokeMessagesBySignerJobQueue extends TypedEmitter<JobQueueEvents>
       (err) =>
         new HubError("bad_request.parse_failure", {
           cause: err as Error,
-          message: `Failed to parse RevokeMessagesBySignerJobPayload`,
+          message: "Failed to parse RevokeMessagesBySignerJobPayload",
         }),
     )();
 

--- a/apps/hubble/src/storage/jobs/updateNameRegistryEventExpiryJob.ts
+++ b/apps/hubble/src/storage/jobs/updateNameRegistryEventExpiryJob.ts
@@ -179,9 +179,7 @@ export class UpdateNameRegistryEventExpiryJobQueue extends TypedEmitter<JobQueue
 
   async enqueueJob(payload: UpdateNameRegistryEventExpiryJobPayload, doAt?: number): HubAsyncResult<Buffer> {
     // If doAt timestamp is missing, use current timestamp
-    if (!doAt) {
-      doAt = Date.now();
-    }
+    const doAtTimestamp = doAt ? doAt : Date.now();
 
     const payloadBytes = UpdateNameRegistryEventExpiryJobPayload.encode(payload).finish();
 
@@ -189,7 +187,7 @@ export class UpdateNameRegistryEventExpiryJobQueue extends TypedEmitter<JobQueue
     const hash = blake3(Uint8Array.from(payloadBytes), { dkLen: 4 });
 
     // Create job key
-    const key = UpdateNameRegistryEventExpiryJobQueue.makeJobKey(doAt, hash);
+    const key = UpdateNameRegistryEventExpiryJobQueue.makeJobKey(doAtTimestamp, hash);
     if (key.isErr()) {
       return err(key.error);
     }
@@ -228,7 +226,7 @@ export class UpdateNameRegistryEventExpiryJobQueue extends TypedEmitter<JobQueue
       (err) =>
         new HubError("bad_request.parse_failure", {
           cause: err as Error,
-          message: `Failed to parse UpdateNameRegistryEventExpiryJobPayload`,
+          message: "Failed to parse UpdateNameRegistryEventExpiryJobPayload",
         }),
     )();
 

--- a/apps/hubble/src/storage/stores/castStore.ts
+++ b/apps/hubble/src/storage/stores/castStore.ts
@@ -149,11 +149,13 @@ class CastStore extends Store<CastAddMessage, CastRemoveMessage> {
     // Puts the message key into the ByParent index
     const parent = message.data.castAddBody.parentCastId ?? message.data.castAddBody.parentUrl;
     if (parent) {
+      // rome-ignore lint/style/noParameterAssign: legacy migration
       txn = txn.put(makeCastsByParentKey(parent, message.data.fid, tsHash.value), TRUE_VALUE);
     }
 
     // Puts the message key into the ByMentions index
     for (const mentionFid of message.data.castAddBody.mentions) {
+      // rome-ignore lint/style/noParameterAssign: legacy migration
       txn = txn.put(makeCastsByMentionKey(mentionFid, message.data.fid, tsHash.value), TRUE_VALUE);
     }
 
@@ -169,12 +171,14 @@ class CastStore extends Store<CastAddMessage, CastRemoveMessage> {
 
     // Delete the message key from the ByMentions index
     for (const mentionFid of message.data.castAddBody.mentions) {
+      // rome-ignore lint/style/noParameterAssign: legacy migration
       txn = txn.del(makeCastsByMentionKey(mentionFid, message.data.fid, tsHash.value));
     }
 
     // Delete the message key from the ByParent index
     const parent = message.data.castAddBody.parentCastId ?? message.data.castAddBody.parentUrl;
     if (parent) {
+      // rome-ignore lint/style/noParameterAssign: legacy migration
       txn = txn.del(makeCastsByParentKey(parent, message.data.fid, tsHash.value));
     }
 

--- a/apps/hubble/src/storage/stores/linkStore.ts
+++ b/apps/hubble/src/storage/stores/linkStore.ts
@@ -41,7 +41,7 @@ const makeLinkAddsKey = (fid: number, type?: string, target?: number): Buffer =>
     throw new HubError("bad_request.validation_failure", "targetId provided without type");
   }
 
-  if (type && (Buffer.from(type).length > 8 || type.length == 0)) {
+  if (type && (Buffer.from(type).length > 8 || type.length === 0)) {
     throw new HubError("bad_request.validation_failure", "type must be 1-8 bytes");
   }
 
@@ -67,7 +67,7 @@ const makeLinkRemovesKey = (fid: number, type?: string, target?: number): Buffer
     throw new HubError("bad_request.validation_failure", "targetId provided without type");
   }
 
-  if (type && (Buffer.from(type).length > 8 || type.length == 0)) {
+  if (type && (Buffer.from(type).length > 8 || type.length === 0)) {
     throw new HubError("bad_request.validation_failure", "type must be 1-8 bytes");
   }
 
@@ -168,6 +168,7 @@ class LinkStore extends Store<LinkAddMessage, LinkRemoveMessage> {
 
     // Puts message key into the byTarget index
     const byTargetKey = makeLinksByTargetKey(message.data.linkBody.targetFid, message.data.fid, tsHash.value);
+    // rome-ignore lint/style/noParameterAssign: legacy eslint migration
     txn = txn.put(byTargetKey, Buffer.from(message.data.linkBody.type));
 
     return ok(undefined);
@@ -186,6 +187,7 @@ class LinkStore extends Store<LinkAddMessage, LinkRemoveMessage> {
 
     // Delete the message key from byTarget index
     const byTargetKey = makeLinksByTargetKey(message.data.linkBody.targetFid, message.data.fid, tsHash.value);
+    // rome-ignore lint/style/noParameterAssign: legacy eslint migration
     txn = txn.del(byTargetKey);
 
     return ok(undefined);
@@ -272,7 +274,7 @@ class LinkStore extends Store<LinkAddMessage, LinkRemoveMessage> {
 
       lastPageToken = Uint8Array.from((key as Buffer).subarray(prefix.length));
 
-      if (type === undefined || (value !== undefined && value.equals(Buffer.from(type)))) {
+      if (type === undefined || value?.equals(Buffer.from(type))) {
         // Calculates the positions in the key where the fid and tsHash begin
         const tsHashOffset = prefix.length;
         const fidOffset = tsHashOffset + TSHASH_LENGTH;

--- a/apps/hubble/src/storage/stores/reactionStore.ts
+++ b/apps/hubble/src/storage/stores/reactionStore.ts
@@ -177,6 +177,7 @@ class ReactionStore extends Store<ReactionAddMessage, ReactionRemoveMessage> {
 
     // Puts message key into the byTarget index
     const byTargetKey = makeReactionsByTargetKey(target, message.data.fid, tsHash.value);
+    // rome-ignore lint/style/noParameterAssign: legacy eslint migration
     txn = txn.put(byTargetKey, Buffer.from([message.data.reactionBody.type]));
 
     return ok(undefined);
@@ -197,6 +198,7 @@ class ReactionStore extends Store<ReactionAddMessage, ReactionRemoveMessage> {
 
     // Delete the message key from byTarget index
     const byTargetKey = makeReactionsByTargetKey(target, message.data.fid, tsHash.value);
+    // rome-ignore lint/style/noParameterAssign: legacy eslint migration
     txn = txn.del(byTargetKey);
 
     return ok(undefined);
@@ -287,7 +289,7 @@ class ReactionStore extends Store<ReactionAddMessage, ReactionRemoveMessage> {
 
       lastPageToken = Uint8Array.from((key as Buffer).subarray(prefix.length));
 
-      if (type === undefined || (value !== undefined && value.equals(Buffer.from([type])))) {
+      if (type === undefined || value?.equals(Buffer.from([type]))) {
         // Calculates the positions in the key where the fid and tsHash begin
         const tsHashOffset = prefix.length;
         const fidOffset = tsHashOffset + TSHASH_LENGTH;

--- a/apps/hubble/src/storage/stores/storeEventHandler.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.ts
@@ -109,7 +109,7 @@ const makeEventId = (timestamp: number, seq: number): number => {
   let binarySeq = seq.toString(2);
   if (binarySeq.length) {
     while (binarySeq.length < SEQUENCE_BITS) {
-      binarySeq = "0" + binarySeq;
+      binarySeq = `0${binarySeq}`;
     }
   }
 
@@ -284,6 +284,7 @@ class StoreEventHandler extends TypedEmitter<StoreEvents> {
         }
         const event = HubEvent.create({ ...eventArgs, id: eventId.value });
         // TODO: validate event
+        // rome-ignore lint/style/noParameterAssign: legacy eslint migration
         txn = putEventTransaction(txn, event);
 
         await this._db.commit(txn);

--- a/apps/hubble/src/test/bench/merkleTrie.ts
+++ b/apps/hubble/src/test/bench/merkleTrie.ts
@@ -80,6 +80,7 @@ export const benchMerkleTrie = async ({
   while (i < syncIds.length) {
     let start = performance.now();
     for (let j = 0; j < cycle; j++) {
+      // rome-ignore lint/style/noNonNullAssertion: legacy migration
       await trie.insert(syncIds[(i + j) % syncIds.length]!);
     }
     const insertDuration = performance.now() - start;
@@ -88,6 +89,7 @@ export const benchMerkleTrie = async ({
 
     start = performance.now();
     for (let j = 0; j < cycle; j++) {
+      // rome-ignore lint/style/noNonNullAssertion: legacy migration
       await trie.getSnapshot(syncIds[(i - 1) % syncIds.length]!.syncId().slice(0, 10));
     }
     const snapshotDuration = performance.now() - start;

--- a/apps/hubble/src/test/bench/syncEngine.ts
+++ b/apps/hubble/src/test/bench/syncEngine.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable security/detect-object-injection */
-import { Writable } from 'node:stream';
+import { Writable } from "node:stream";
 
-import Chance from 'chance';
+import Chance from "chance";
 
 import {
   CastAddBody,
@@ -12,15 +12,15 @@ import {
   Message,
   MessageData,
   MessageType,
-} from '@farcaster/hub-nodejs';
-import { MockRpcClient } from '../../network/sync/mock.js';
-import SyncEngine from '../../network/sync/syncEngine.js';
-import { SyncId } from '../../network/sync/syncId.js';
-import RocksDB from '../../storage/db/rocksdb.js';
-import { blake3Truncate160, sleepWhile } from '../../utils/crypto.js';
-import { avgRecords } from './helpers.js';
-import { yieldToEventLoop } from './utils.js';
-import { MockHub } from '../mocks.js';
+} from "@farcaster/hub-nodejs";
+import { MockRpcClient } from "../../network/sync/mock.js";
+import SyncEngine from "../../network/sync/syncEngine.js";
+import { SyncId } from "../../network/sync/syncId.js";
+import RocksDB from "../../storage/db/rocksdb.js";
+import { blake3Truncate160, sleepWhile } from "../../utils/crypto.js";
+import { avgRecords } from "./helpers.js";
+import { yieldToEventLoop } from "./utils.js";
+import { MockHub } from "../mocks.js";
 
 const INITIAL_MESSAGES_COUNT = 10_000;
 const FID_COUNT = 10_000;
@@ -34,13 +34,14 @@ const makeSyncEninge = async (id: number) => {
   await db.clear();
   const hub = new MockHub(db);
   const syncEngine = new SyncEngine(hub, db);
-  (syncEngine as any)['_id'] = id;
+  // rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
+  (syncEngine as any)["_id"] = id;
   return syncEngine;
 };
 
 const makeMessage = (fid: number, messageId: number, timestamp: number) => {
   const hash = Buffer.from(blake3Truncate160(Buffer.from(messageId.toString())));
-  hash.fill(' ', 10);
+  hash.fill(" ", 10);
   hash.write(messageId.toString(), 10);
   return Message.create({
     data: MessageData.create({
@@ -49,7 +50,7 @@ const makeMessage = (fid: number, messageId: number, timestamp: number) => {
       timestamp,
       network: FarcasterNetwork.DEVNET,
       castAddBody: CastAddBody.create({
-        text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam pharetra dolor leo, vitae tincidunt justo scelerisque vel. Praesent ac leo at nibh rutrum aliquet. Fusce rhoncus ligula a ipsum porta, nec.',
+        text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam pharetra dolor leo, vitae tincidunt justo scelerisque vel. Praesent ac leo at nibh rutrum aliquet. Fusce rhoncus ligula a ipsum porta, nec.",
       }),
     }),
     hash,
@@ -76,6 +77,7 @@ export const estimateEntropy = async () => {
   let sum = 0;
   for (let i = estimateEntropySkip; i < messages.length; i++) {
     let pm = 0;
+    // rome-ignore lint/style/noNonNullAssertion: <explanation>
     const syncId = new SyncId(messages[i]!);
     for (let j = 0; j < peers.length; j++) {
       const exists = await peers[j]?.trie.exists(syncId);
@@ -86,7 +88,7 @@ export const estimateEntropy = async () => {
     pm /= peers.length;
 
     // Skip unnecessary check in next round
-    if (pm == 1 && i == estimateEntropySkip) {
+    if (pm === 1 && i === estimateEntropySkip) {
       estimateEntropySkip++;
     }
 
@@ -171,9 +173,10 @@ export const benchSyncEngine = async ({
 
   // Stub the timestamp
   global.Date.now = () =>
+    // rome-ignore lint/style/noNonNullAssertion: legacy eslint migration
     (messages[messages.length - 1]!.data!.timestamp + chance.integer({ min: 1, max: 60 })) * 1000 + FARCASTER_EPOCH;
 
-  writer.write([0, '', '', '', '', '']);
+  writer.write([0, "", "", "", "", ""]);
 
   try {
     // Rounds
@@ -207,6 +210,7 @@ export const benchSyncEngine = async ({
         // Pick a random peer to sync
         const stats = new Array(peers.length).fill({});
         for (let i = 0; i < peers.length; i++) {
+          // rome-ignore lint/style/noNonNullAssertion: <explanation>
           const ourSyncEngine = peers[i]!;
           let theirSyncEngine;
           do {
@@ -215,12 +219,14 @@ export const benchSyncEngine = async ({
 
           const otherSnapshot = (await theirSyncEngine.getSnapshot())._unsafeUnwrap();
           if ((await ourSyncEngine.syncStatus(i.toString(), otherSnapshot))._unsafeUnwrap().shouldSync) {
+            // rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
             const rpcClient = new MockRpcClient((theirSyncEngine as any).engine, theirSyncEngine);
             await ourSyncEngine.performSync(i.toString(), otherSnapshot, rpcClient as unknown as HubRpcClient);
 
             const nodeMetadata = await ourSyncEngine.getTrieNodeMetadata(new Uint8Array());
             stats[i] = {
               synced: 1,
+              // rome-ignore lint/style/noNonNullAssertion: legacy eslint migration
               staled: messages.length > nodeMetadata!.numMessages,
               ...rpcClient.stats(),
             };
@@ -233,10 +239,10 @@ export const benchSyncEngine = async ({
 
         cycleStats[c] = {
           dropped: (peers.length * roundSize - realDelivered) / peers.length, // Average drop per peer
-          synced: avg['synced'] ?? 0,
-          getSyncMetadataByPrefixCalls: avg['getSyncMetadataByPrefixCalls'] ?? 0,
-          getAllSyncIdsByPrefixCalls: avg['getAllSyncIdsByPrefixCalls'] ?? 0,
-          getAllMessagesBySyncIdsReturns: avg['getAllMessagesBySyncIdsReturns'] ?? 0,
+          synced: avg["synced"] ?? 0,
+          getSyncMetadataByPrefixCalls: avg["getSyncMetadataByPrefixCalls"] ?? 0,
+          getAllSyncIdsByPrefixCalls: avg["getAllSyncIdsByPrefixCalls"] ?? 0,
+          getAllMessagesBySyncIdsReturns: avg["getAllMessagesBySyncIdsReturns"] ?? 0,
           entropy,
         };
       }
@@ -245,20 +251,21 @@ export const benchSyncEngine = async ({
 
       writer.write([
         round,
-        avg['dropped'] ?? 0,
-        avg['synced'] ?? 0,
-        avg['getSyncMetadataByPrefixCalls'] ?? 0,
-        avg['getAllSyncIdsByPrefixCalls'] ?? 0,
-        avg['getAllMessagesBySyncIdsReturns'] ?? 0,
-        avg['entropy'],
+        avg["dropped"] ?? 0,
+        avg["synced"] ?? 0,
+        avg["getSyncMetadataByPrefixCalls"] ?? 0,
+        avg["getAllSyncIdsByPrefixCalls"] ?? 0,
+        avg["getAllMessagesBySyncIdsReturns"] ?? 0,
+        avg["entropy"],
       ]);
 
       await yieldToEventLoop();
     }
   } finally {
     // Clean up RocksDb
-    process.stderr.write('Cleaning up\n');
+    process.stderr.write("Cleaning up\n");
     peers.forEach((syncEngine) => {
+      // rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
       const db = (syncEngine.trie as any)._db;
       db.destroy();
     });

--- a/apps/hubble/src/test/bench/utils.ts
+++ b/apps/hubble/src/test/bench/utils.ts
@@ -26,6 +26,7 @@ export const yieldToEventLoop = (): Promise<void> => {
 
 export const waitForPromise = (promise: Promise<unknown>) => {
   let finished = false;
+  // rome-ignore lint/suspicious/noAssignInExpressions: legacy eslint migration
   promise.finally(() => (finished = true));
 
   const pollToFinish = () => {

--- a/apps/hubble/src/test/e2e/gossipNetwork.test.ts
+++ b/apps/hubble/src/test/e2e/gossipNetwork.test.ts
@@ -40,7 +40,7 @@ describe("gossip network tests", () => {
         const result = await n.connect(nodes[0] as GossipNode);
         expect(result.isOk()).toBeTruthy();
       }
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      // rome-ignore lint/style/noNonNullAssertion: legacy migration
       const primaryTopic = nodes[0]!.primaryTopic();
       // Subscribe each node to the test topic
       nodes.forEach((n) => n.gossip?.subscribe(primaryTopic));

--- a/apps/hubble/src/test/utils.ts
+++ b/apps/hubble/src/test/utils.ts
@@ -19,12 +19,15 @@ export const anvilChain = {
 } as const satisfies Chain;
 
 const provider = {
+  // rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
   on: (message: string, listener: (...args: any[]) => null) => {
     if (message === "accountsChanged") {
+      // rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
       listener([accounts[0].address] as any);
     }
   },
   removeListener: () => null,
+  // rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
   request: async ({ method, params }: any) => {
     if (method === "eth_requestAccounts") {
       return [accounts[0].address];

--- a/apps/hubble/src/utils/p2p.ts
+++ b/apps/hubble/src/utils/p2p.ts
@@ -26,7 +26,7 @@ export const checkNodeAddrs = (listenIPAddr: string, listenCombinedAddr: string)
 
 /** Builds an AddressInfo from a NodeAddress */
 export const addressInfoFromNodeAddress = (nodeAddress: NodeAddress): HubResult<AddressInfo> => {
-  if (nodeAddress.family != 4 && nodeAddress.family != 6)
+  if (nodeAddress.family !== 4 && nodeAddress.family !== 6)
     return err(new HubError("bad_request", `invalid nodeAddress family: ${nodeAddress.family}`));
 
   return ok({
@@ -55,7 +55,7 @@ export const addressInfoFromParts = (address: string, port: number): HubResult<A
  * Does not preserve port or transport information
  */
 export const ipMultiAddrStrFromAddressInfo = (addressInfo: AddressInfo): HubResult<string> => {
-  if (addressInfo.family != "IPv6" && addressInfo.family != "IPv4")
+  if (addressInfo.family !== "IPv6" && addressInfo.family !== "IPv4")
     return err(new HubError("bad_request", `invalid AddressInfo family: ${addressInfo.family}`));
 
   const family = addressInfo.family === "IPv6" ? "ip6" : "ip4";
@@ -95,7 +95,7 @@ export const addressInfoFromGossip = (addressInfo: GossipAddressInfo): HubResult
 
 /* Converts ipFamily number to string */
 export const ipFamilyToString = (family: number): string => {
-  return family == 4 ? "IPv4" : "IPv6";
+  return family === 4 ? "IPv4" : "IPv6";
 };
 
 /* Converts AddressInfo to address string  */
@@ -116,19 +116,20 @@ export const getPublicIp = async (): HubAsyncResult<string> => {
   return new Promise((resolve, reject) => {
     const now = new Date().getTime();
     const since = now - lastIpFetch.timestamp;
-    if (since <= 10 * 60 * 1000 && lastIpFetch.ip != "") {
-      logger.debug({ component: "utils/p2p", ip: lastIpFetch.ip }, `Cached public IP`);
+    if (since <= 10 * 60 * 1000 && lastIpFetch.ip !== "") {
+      logger.debug({ component: "utils/p2p", ip: lastIpFetch.ip }, "Cached public IP");
       resolve(ok(lastIpFetch.ip));
       return;
     }
     try {
       get({ host: "api64.ipify.org", port: 80, path: "/" }, (resp) => {
         resp.on("data", (ip: Buffer) => {
-          logger.info({ component: "utils/p2p", ip: ip.toString() }, `Fetched public IP`);
+          logger.info({ component: "utils/p2p", ip: ip.toString() }, "Fetched public IP");
           lastIpFetch = { timestamp: now, ip: ip.toString() };
           resolve(ok(ip.toString()));
         });
       });
+      // rome-ignore lint/suspicious/noExplicitAny: error catching
     } catch (err: any) {
       reject(new HubError("unavailable.network_failure", err));
     }
@@ -168,7 +169,7 @@ const checkCombinedAddr = (combinedAddr: string): HubResult<void> => {
   )();
 
   return optionsResult.andThen((options) => {
-    if (options.transport != "tcp") return err(new HubError("bad_request", "multiaddr transport must be tcp"));
+    if (options.transport !== "tcp") return err(new HubError("bad_request", "multiaddr transport must be tcp"));
     return ok(undefined);
   });
 };

--- a/apps/hubble/src/utils/versions.test.ts
+++ b/apps/hubble/src/utils/versions.test.ts
@@ -20,6 +20,7 @@ describe("versions tests", () => {
     test("returns ok if version is greater than min version", () => {
       const minVersion = getMinFarcasterVersion();
       const higherVersion = semver.inc(minVersion._unsafeUnwrap(), "patch");
+      // rome-ignore lint/style/noNonNullAssertion: legacy migration
       const result = ensureAboveMinFarcasterVersion(higherVersion!);
       expect(result).toEqual(ok(undefined));
     });
@@ -46,6 +47,7 @@ describe("versions tests", () => {
       const current = FARCASTER_VERSIONS_SCHEDULE.find((value) => value.version === FARCASTER_VERSION);
       expect(current).toBeTruthy();
       const seven_days_in_ms = 7 * 24 * 60 * 60 * 1000;
+      // rome-ignore lint/style/noNonNullAssertion: legacy migration
       expect(current!.expiresAt - Date.now()).toBeGreaterThan(seven_days_in_ms);
     });
   });
@@ -55,6 +57,7 @@ describe("versions tests", () => {
       const current = FARCASTER_VERSIONS_SCHEDULE.find((value) => value.version === FARCASTER_VERSION);
       expect(current).toBeTruthy();
       setReferenceDateForTest(0);
+      // rome-ignore lint/style/noNonNullAssertion: legacy migration
       const result = ensureAboveTargetFarcasterVersion(current!.version);
       expect(result.isErr()).toBeTruthy();
       expect(result._unsafeUnwrapErr().message).toEqual("target version has not expired");
@@ -64,6 +67,7 @@ describe("versions tests", () => {
       const current = FARCASTER_VERSIONS_SCHEDULE.find((value) => value.version === FARCASTER_VERSION);
       expect(current).toBeTruthy();
       setReferenceDateForTest(100000000000000000000000);
+      // rome-ignore lint/style/noNonNullAssertion: legacy migration
       const result = ensureAboveTargetFarcasterVersion(current!.version);
       expect(result).toEqual(ok(undefined));
     });

--- a/packages/core/src/bytes.ts
+++ b/packages/core/src/bytes.ts
@@ -92,7 +92,7 @@ export const bigIntToBytes = (value: bigint): HubResult<Uint8Array> => {
   let hexValue = value.toString(16);
 
   // Prefix odd-length hex values with a 0 since hexStringToBytes requires even-length hex values
-  hexValue = hexValue.length % 2 == 0 ? hexValue : "0" + hexValue;
+  hexValue = hexValue.length % 2 === 0 ? hexValue : `0${hexValue}`;
 
   return hexStringToBytes(hexValue);
 };

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -6,6 +6,7 @@ interface HubErrorOpts {
   presentable: boolean;
 }
 
+// rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
 export const isHubError = (e: any): e is HubError => {
   return typeof e.errCode !== "undefined";
 };
@@ -30,17 +31,21 @@ export class HubError extends Error {
    * @param context - a message, another Error, or a HubErrorOpts
    */
   constructor(errCode: HubErrorCode, context: Partial<HubErrorOpts> | string | Error) {
+    let parsedContext: string | Error | Partial<HubErrorOpts>;
+
     if (typeof context === "string") {
-      context = { message: context };
+      parsedContext = { message: context };
     } else if (context instanceof Error) {
-      context = { cause: context, message: context.message };
+      parsedContext = { cause: context, message: context.message };
+    } else {
+      parsedContext = context;
     }
 
-    if (!context.message) {
-      context.message = context.cause?.message || "";
+    if (!parsedContext.message) {
+      parsedContext.message = parsedContext.cause?.message || "";
     }
 
-    super(context.message, { cause: context.cause });
+    super(parsedContext.message, { cause: parsedContext.cause });
 
     this.name = "HubError";
     this.errCode = errCode;

--- a/packages/core/src/validations.test.ts
+++ b/packages/core/src/validations.test.ts
@@ -246,7 +246,7 @@ describe("validateCastAddBody", () => {
       });
 
       test("with an embed url string over 256 bytes", () => {
-        body = Factories.CastAddBody.build({ embeds: [], embedsDeprecated: [faker.random.alphaNumeric(254) + "🤓"] });
+        body = Factories.CastAddBody.build({ embeds: [], embedsDeprecated: [`${faker.random.alphaNumeric(254)}🤓`] });
         hubErrorMessage = "url > 256 bytes";
       });
     });
@@ -278,7 +278,7 @@ describe("validateCastAddBody", () => {
     });
 
     test("when text is longer than 320 bytes", () => {
-      const text = faker.random.alphaNumeric(318) + "🤓";
+      const text = `${faker.random.alphaNumeric(318)}🤓`;
       expect(text.length).toEqual(320);
       body = Factories.CastAddBody.build({ text });
       hubErrorMessage = "text > 320 bytes";
@@ -307,7 +307,7 @@ describe("validateCastAddBody", () => {
 
     test("with an embed url string over 256 bytes", () => {
       body = Factories.CastAddBody.build({
-        embeds: [{ url: faker.random.alphaNumeric(254) + "🤓" }],
+        embeds: [{ url: `${faker.random.alphaNumeric(254)}🤓` }],
       });
       hubErrorMessage = "url > 256 bytes";
     });
@@ -680,7 +680,7 @@ describe("validateSignerAddBody", () => {
     test("with name > 32 bytes", () => {
       let name = "";
       for (let i = 0; i < 10; i++) {
-        name = name + "🔥";
+        name = `${name}🔥`;
       }
       body = Factories.SignerAddBody.build({ name });
     });

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -184,6 +184,7 @@ export const validateMessageData = async <T extends protobufs.MessageData>(data:
   }
 
   // 5. Validate body
+  // rome-ignore lint/suspicious/noExplicitAny: legacy from eslint migration
   let bodyResult: HubResult<any>;
   if (validType.value === protobufs.MessageType.CAST_ADD && !!data.castAddBody) {
     // Allow usage of embedsDeprecated if timestamp is before cut-off
@@ -385,6 +386,7 @@ export const validateCastAddBody = (
     }
     if (i > 0) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      // rome-ignore lint/style/noNonNullAssertion: not sure why we do this, legacy when migrating from eslint.
       const prevPosition = body.mentionsPositions[i - 1]!;
       if (position < prevPosition) {
         return err(

--- a/packages/hub-nodejs/examples/chron-feed/index.ts
+++ b/packages/hub-nodejs/examples/chron-feed/index.ts
@@ -86,6 +86,7 @@ const castToString = async (cast: CastAddMessage, nameMapping: Map<number, strin
   for (let i = 0; i < mentions.length; i++) {
     textWithMentions += decoder.decode(bytes.slice(indexBytes, mentionsPositions[i]));
     const result = await getFnameFromFid(mentions[i], client);
+    // rome-ignore lint/suspicious/noAssignInExpressions: legacy eslint migration
     result.map((fname) => (textWithMentions += fname));
     indexBytes = mentionsPositions[i];
   }

--- a/packages/hub-nodejs/examples/replicate-data-postgres/db.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/db.ts
@@ -143,7 +143,9 @@ export const getDbClient = (connectionString: string) => {
           bigint: {
             to: 20,
             from: 20,
+            // rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
             parse: (x: any) => Number(x),
+            // rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
             serialize: (x: any) => x.toString(),
           },
         },
@@ -154,6 +156,7 @@ export const getDbClient = (connectionString: string) => {
   });
 };
 
+// rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
 export const migrateToLatest = async (db: Kysely<any>, log: Logger): Promise<Result<void, unknown>> => {
   const migrator = new Migrator({
     db,

--- a/packages/hub-nodejs/examples/replicate-data-postgres/hubReplicator.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/hubReplicator.ts
@@ -623,6 +623,7 @@ export class HubReplicator {
         messages.map((message) => ({
           timestamp: farcasterTimeToDate(message.data.timestamp),
           // type assertion due to a problem with the type definitions. This field is infact required and present in all valid messages
+          // rome-ignore lint/style/noNonNullAssertion: legacy eslint migration
           targetFid: message.data.linkBody.targetFid!,
           type: message.data.linkBody.type,
           fid: message.data.fid,
@@ -644,6 +645,7 @@ export class HubReplicator {
         .updateTable("links")
         .where("fid", "=", message.data.fid)
         // type assertion due to a problem with the type definitions. This field is infact required and present in all valid messages
+        // rome-ignore lint/style/noNonNullAssertion: legacy eslint migration
         .where("targetFid", "=", message.data.linkBody.targetFid!)
         .where("type", "=", message.data.linkBody.type)
         .set({ deletedAt: farcasterTimeToDate(message.data.timestamp) })

--- a/packages/hub-nodejs/examples/replicate-data-postgres/hubSubscriber.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/hubSubscriber.ts
@@ -23,7 +23,7 @@ export class HubSubscriber extends TypedEmitter<HubEvents> {
   public stop() {
     this.stream?.cancel();
     this.stopped = true;
-    this.log.info(`Stopped HubSubscriber`);
+    this.log.info("Stopped HubSubscriber");
   }
 
   public destroy() {
@@ -40,14 +40,14 @@ export class HubSubscriber extends TypedEmitter<HubEvents> {
   }
 
   public async start(fromId?: number) {
-    this.log.info(`Starting HubSubscriber`);
+    this.log.info("Starting HubSubscriber");
 
     const hubClientReady = await this._waitForReadyHubClient();
     if (hubClientReady.isErr()) {
       this.log.error(`Failed to connect to hub: ${hubClientReady.error}`);
       return err(hubClientReady.error);
     }
-    this.log.info(`Connected to hub`);
+    this.log.info("Connected to hub");
 
     const subscribeParams: { eventTypes: HubEventType[]; fromId?: number } = {
       eventTypes: [
@@ -63,12 +63,12 @@ export class HubSubscriber extends TypedEmitter<HubEvents> {
     const subscribeRequest = await this.hubClient.subscribe(subscribeParams);
     return subscribeRequest
       .andThen((stream) => {
-        this.log.info(`Subscribed to hub events`);
+        this.log.info("Subscribed to hub events");
         this.stream = stream;
         this.stopped = false;
 
         stream.on("close", async () => {
-          this.log.info(`HubSubscriber stream closed`);
+          this.log.info("HubSubscriber stream closed");
           this.stopped = true;
           this.stream = null;
         });
@@ -84,13 +84,14 @@ export class HubSubscriber extends TypedEmitter<HubEvents> {
   }
 
   private async processStream(stream: ClientReadableStream<HubEvent>) {
-    this.log.debug(`Started hub event stream processing`);
+    this.log.debug("Started hub event stream processing");
     try {
       for await (const event of stream) {
         const fnLog = this.log.child({ eventId: event.id, eventType: event.type });
         fnLog.debug(`Processing event ${event.id} (${event.type})`);
         this.emit("event", event);
       }
+      // rome-ignore lint/suspicious/noExplicitAny: error catching
     } catch (e: any) {
       this.log.info(`Hub event stream processing halted ${e.message}`);
     }

--- a/packages/hub-nodejs/examples/replicate-data-postgres/migrations/001_initial_migration.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/migrations/001_initial_migration.ts
@@ -1,5 +1,6 @@
 import { Kysely, sql } from "kysely";
 
+// rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
 export const up = async (db: Kysely<any>) => {
   await db.schema
     .createTable("hubSubscriptions")
@@ -190,6 +191,7 @@ export const up = async (db: Kysely<any>) => {
     .execute();
 };
 
+// rome-ignore lint/suspicious/noExplicitAny: legacy eslint migration
 export const down = async (db: Kysely<any>) => {
   await db.schema.dropTable("links").ifExists().execute();
   await db.schema.dropTable("fnames").ifExists().execute();

--- a/packages/hub-nodejs/examples/replicate-data-postgres/util.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/util.ts
@@ -20,5 +20,5 @@ export function bytesToHex(bytes: Uint8Array): string;
 export function bytesToHex(bytes: Uint8Array | null | undefined): string | null | undefined {
   if (bytes === undefined) return undefined;
   if (bytes === null) return null;
-  return "0x" + Buffer.from(bytes).toString("hex");
+  return `0x${Buffer.from(bytes).toString("hex")}`;
 }

--- a/packages/hub-nodejs/src/client.ts
+++ b/packages/hub-nodejs/src/client.ts
@@ -1,17 +1,16 @@
-import { AdminServiceClient, HubServiceClient } from './generated/rpc';
-import * as grpc from '@grpc/grpc-js';
-import { Metadata } from '@grpc/grpc-js';
-import type { CallOptions, Client, ClientReadableStream, ClientUnaryCall, ServiceError } from '@grpc/grpc-js';
-import { err, ok } from 'neverthrow';
-import { HubError, HubErrorCode, HubResult } from '@farcaster/core';
+import { AdminServiceClient, HubServiceClient } from "./generated/rpc";
+import * as grpc from "@grpc/grpc-js";
+import { Metadata } from "@grpc/grpc-js";
+import type { CallOptions, Client, ClientReadableStream, ClientUnaryCall, ServiceError } from "@grpc/grpc-js";
+import { err, ok } from "neverthrow";
+import { HubError, HubErrorCode, HubResult } from "@farcaster/core";
 
 const fromServiceError = (err: ServiceError): HubError => {
   let context = err.details;
-  if (err.code === 14 && err.details === 'No connection established') {
-    context =
-      'Connection failed: please check that the hub’s address, ports and authentication config are correct. ' + context;
+  if (err.code === 14 && err.details === "No connection established") {
+    context = `Connection failed: please check that the hub’s address, ports and authentication config are correct. ${context}`;
   }
-  return new HubError(err.metadata.get('errCode')[0] as HubErrorCode, context);
+  return new HubError(err.metadata.get("errCode")[0] as HubErrorCode, context);
 };
 
 // grpc-js generates a Client stub that uses callbacks for async calls. Callbacks are
@@ -24,25 +23,25 @@ type OriginalUnaryCall<T, U> = (
   request: T,
   metadata: Metadata,
   options: Partial<CallOptions>,
-  callback: (err: ServiceError | null, res?: U) => void
+  callback: (err: ServiceError | null, res?: U) => void,
 ) => ClientUnaryCall;
 
 type OriginalStream<T, U> = (
   request: T,
   metadata?: Metadata,
-  options?: Partial<CallOptions>
+  options?: Partial<CallOptions>,
 ) => ClientReadableStream<U>;
 
 type PromisifiedUnaryCall<T, U> = (
   request: T,
   metadata?: Metadata,
-  options?: Partial<CallOptions>
+  options?: Partial<CallOptions>,
 ) => Promise<HubResult<U>>;
 
 type PromisifiedStream<T, U> = (
   request: T,
   metadata?: Metadata,
-  options?: Partial<CallOptions>
+  options?: Partial<CallOptions>,
 ) => Promise<HubResult<ClientReadableStream<U>>>;
 
 type PromisifiedClient<C> = { $: C; close: () => void } & {
@@ -58,13 +57,14 @@ const promisifyClient = <C extends Client>(client: C) => {
     get: (target, descriptor) => {
       const key = descriptor as keyof PromisifiedClient<C>;
 
-      if (key === '$') return target;
+      if (key === "$") return target;
 
-      if (key === 'close') return () => target.close;
+      if (key === "close") return () => target.close;
 
       // eslint-disable-next-line security/detect-object-injection
       const func = target[key];
-      if (typeof func === 'function' && (func as any).responseStream === false) {
+      // rome-ignore lint/suspicious/noExplicitAny: any is needed here because of the grpc-js types
+      if (typeof func === "function" && (func as any).responseStream === false) {
         return (...args: unknown[]) =>
           new Promise((resolve, _reject) =>
             func.call(
@@ -73,17 +73,18 @@ const promisifyClient = <C extends Client>(client: C) => {
                 ...args,
                 (e: unknown, res: unknown) =>
                   e ? resolve(err(fromServiceError(e as ServiceError))) : resolve(ok(res)),
-              ]
-            )
+              ],
+            ),
           );
       }
 
-      if (typeof func === 'function' && (func as any).responseStream === true) {
+      // rome-ignore lint/suspicious/noExplicitAny: any is needed here because of the grpc-js types
+      if (typeof func === "function" && (func as any).responseStream === true) {
         return (...args: unknown[]) => {
           return new Promise((resolve) => {
             const stream = func.call(target, ...args);
 
-            stream.on('error', (e: unknown) => {
+            stream.on("error", (e: unknown) => {
               return e; // TODO: improve stream error handling
             });
 
@@ -115,7 +116,7 @@ export const getAdminRpcClient = async (address: string): Promise<AdminRpcClient
 
 export const getAuthMetadata = (username: string, password: string): Metadata => {
   const metadata = new Metadata();
-  metadata.set('authorization', `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`);
+  metadata.set("authorization", `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`);
   return metadata;
 };
 

--- a/packages/hub-web/examples/chron-feed/index.ts
+++ b/packages/hub-web/examples/chron-feed/index.ts
@@ -86,6 +86,7 @@ const castToString = async (cast: CastAddMessage, nameMapping: Map<number, strin
   for (let i = 0; i < mentions.length; i++) {
     textWithMentions += decoder.decode(bytes.slice(indexBytes, mentionsPositions[i]));
     const result = await getFnameFromFid(mentions[i], client);
+    // rome-ignore lint/suspicious/noAssignInExpressions: legacy eslint migration
     result.map((fname) => (textWithMentions += fname));
     indexBytes = mentionsPositions[i];
   }
@@ -127,7 +128,7 @@ const castToString = async (cast: CastAddMessage, nameMapping: Map<number, strin
   const castsResult = Result.combine(await Promise.all(castResultPromises));
 
   if (castsResult.isErr()) {
-    console.error("Fetching fnames failed:" + castsResult.error);
+    console.error(`Fetching fnames failed:${castsResult.error}`);
     return;
   }
 

--- a/packages/hub-web/src/client.ts
+++ b/packages/hub-web/src/client.ts
@@ -36,8 +36,7 @@ const fromServiceError = (err: GrpcWebError): HubError => {
 
   // due to envoy, the error for no connection is Response closed without headers
   if (err.code === 2 && context === "Response closed without headers") {
-    context =
-      "Connection failed: please check that the hub’s address, ports and authentication config are correct. " + context;
+    context = `Connection failed: please check that the hub’s address, ports and authentication config are correct. ${context}`;
     return new HubError("unavailable" as HubErrorCode, context);
   }
 
@@ -75,6 +74,7 @@ const wrapClient = <C extends object>(client: C) => {
         return (...args: unknown[]) => {
           const result = func.call(target, ...args);
           if (result instanceof Promise) {
+            // rome-ignore lint/suspicious/noExplicitAny: legacy from eslint migration
             return (result as Promise<any>).then(
               (res) => ok(res),
               (e) => err(fromServiceError(e as GrpcWebError)),


### PR DESCRIPTION
## Motivation

As part of the migration from eslint/prettier to rome-tools, this PR applies rome's default formatting to files. The goal is to break the migration PR into smaller, manageable chunks.

## Change Summary

Apply rome's linter and formatter to all src files in apps and packages

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on addressing linting issues and making code improvements. 

### Detailed summary:
- Fixed linting issues in multiple files
- Improved code readability by using template literals instead of string concatenation
- Addressed legacy eslint migration comments

> The following files were skipped due to too many changes: `packages/hub-web/src/client.ts`, `packages/hub-nodejs/examples/replicate-data-postgres/hubReplicator.ts`, `apps/hubble/src/cli.ts`, `apps/hubble/src/rpc/server.ts`, `apps/hubble/src/storage/jobs/revokeMessagesBySignerJob.ts`, `packages/core/src/errors.ts`, `apps/hubble/src/storage/jobs/updateNameRegistryEventExpiryJob.ts`, `apps/hubble/src/storage/stores/reactionStore.ts`, `apps/hubble/src/storage/stores/castStore.ts`, `apps/hubble/src/hubble.ts`, `packages/core/src/validations.test.ts`, `apps/hubble/src/console/console.ts`, `apps/hubble/src/storage/db/nameRegistryEvent.ts`, `apps/hubble/src/utils/versions.test.ts`, `apps/hubble/src/rpc/test/rpcAuth.test.ts`, `apps/hubble/src/rpc/test/eventService.test.ts`, `apps/hubble/src/storage/stores/linkStore.ts`, `packages/hub-nodejs/examples/replicate-data-postgres/hubSubscriber.ts`, `apps/hubble/src/utils/p2p.ts`, `apps/hubble/src/network/p2p/connectionFilter.ts`, `packages/hub-nodejs/src/client.ts`, `apps/hubble/src/network/sync/syncEngine.ts`, `apps/hubble/src/test/bench/syncEngine.ts`, `apps/hubble/src/allowedPeers.mainnet.ts`, `apps/hubble/src/storage/stores/store.ts`, `apps/hubble/src/network/p2p/gossipNode.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->