### PR TITLE
Dedupgossip

### DIFF
--- a/.changeset/sweet-chefs-glow.md
+++ b/.changeset/sweet-chefs-glow.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Dedup recently gossip'd messages

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -563,6 +563,10 @@ export class Hub implements HubInterface {
         return err(new HubError("unavailable", "Sync queue is full"));
       }
 
+      if (this.gossipNode.checkDupMessage(message)) {
+        return err(new HubError("bad_request.duplicate", "message was recently merged"));
+      }
+
       // Merge the message
       const result = await this.submitMessage(message, "gossip");
       return result.map(() => undefined);

--- a/apps/hubble/src/network/p2p/gossipNode.test.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.test.ts
@@ -156,6 +156,17 @@ describe("GossipNode", () => {
       castAdd = await Factories.CastAddMessage.create({ data: { fid, network } }, { transient: { signer } });
     });
 
+    test("blocks dup", async () => {
+      const node = new GossipNode();
+
+      const isDup = node.checkDupMessage(signerAdd);
+      expect(isDup).toBeFalsy();
+
+      // Now adding it again will make it a dup
+      const isDup2 = node.checkDupMessage(signerAdd);
+      expect(isDup2).toBeTruthy();
+    });
+
     test("gossip messages only from rpc", async () => {
       let numMessagesGossiped = 0;
       const mockGossipNode = {


### PR DESCRIPTION
## Motivation

Prevent duplicates when merging gossip'd messages. Fixes #885 

## Change Summary

- Create a cache of recently gossip'd messages
- Prevent merging messages that were recently merged

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)
