### PR TITLE
Add rocksDB storage profiling

### DIFF
--- a/.changeset/twenty-chairs-switch.md
+++ b/.changeset/twenty-chairs-switch.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+Add a "yarn profile storage" command that prints the usage of the RocksDB database

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -25,6 +25,7 @@
     "identity": "node build/cli.js identity",
     "dbreset": "node build/cli.js dbreset",
     "console": "node build/cli.js console",
+    "profile": "node build/cli.js profile",
     "status": "node build/cli.js status",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:ci": "ENVIRONMENT=test NODE_OPTIONS=--experimental-vm-modules jest --ci --forceExit --coverage"

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -482,7 +482,7 @@ const storageProfileCommand = new Command("storage")
     if (!rocksDBName) throw new Error("No RocksDB name provided.");
     const dbResult = await ResultAsync.fromPromise(rocksDB.open(), (e) => e as Error);
     if (dbResult.isErr()) {
-      logger.warn({ rocksDBName }, "Failed to open RocksDB, falling back to rm");
+      logger.warn({ rocksDBName }, "Failed to open RocksDB. The Hub needs to be stopped to run this command.");
     } else {
       await profileStorageUsed(rocksDB);
     }

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -21,6 +21,7 @@ import RocksDB, { DB_DIRECTORY } from "./storage/db/rocksdb.js";
 import { parseNetwork } from "./utils/command.js";
 import { sleep } from "./utils/crypto.js";
 import { Config as DefaultConfig } from "./defaultConfig.js";
+import { profileStorageUsed } from "./profile.js";
 
 /** A CLI to accept options from the user and start the Hub */
 
@@ -468,6 +469,29 @@ app
   .description("Create or verify a peerID")
   .addCommand(createIdCommand)
   .addCommand(verifyIdCommand);
+
+const storageProfileCommand = new Command("storage")
+  .description("Profile the storage layout of the hub, accounting for all the storage")
+  .option("--db-name <name>", "The name of the RocksDB instance")
+  .option("-c, --config <filepath>", "Path to a config file with options")
+  .action(async (cliOptions) => {
+    const hubConfig = cliOptions.config ? (await import(resolve(cliOptions.config))).Config : DefaultConfig;
+    const rocksDBName = cliOptions.dbName ?? hubConfig.dbName ?? "";
+    const rocksDB = new RocksDB(rocksDBName);
+
+    if (!rocksDBName) throw new Error("No RocksDB name provided.");
+    const dbResult = await ResultAsync.fromPromise(rocksDB.open(), (e) => e as Error);
+    if (dbResult.isErr()) {
+      logger.warn({ rocksDBName }, "Failed to open RocksDB, falling back to rm");
+    } else {
+      await profileStorageUsed(rocksDB);
+    }
+
+    await rocksDB.close();
+    exit(0);
+  });
+
+app.command("profile").description("Profile various resources used by the hub").addCommand(storageProfileCommand);
 
 app
   .command("status")

--- a/apps/hubble/src/profile.ts
+++ b/apps/hubble/src/profile.ts
@@ -124,13 +124,17 @@ function prefixProfileToDataType(keysProfile: KeysProfile[], userPostfixKeys: Ke
 
     let index = 0;
 
-    if (kp.label.includes("User")) {
+    if (i === RootPrefix.User) {
       index = 0;
-    } else if (kp.label.includes("By")) {
+    } else if (
+      (i >= RootPrefix.CastsByParent && i <= RootPrefix.ReactionsByTarget) ||
+      i === RootPrefix.IdRegistryEventByCustodyAddress ||
+      i === RootPrefix.NameRegistryEventsByExpiry
+    ) {
       index = 1;
-    } else if (kp.label.includes("Trie")) {
+    } else if (i === RootPrefix.SyncMerkleTrieNode) {
       index = 2;
-    } else if (kp.label.includes("HubEvents")) {
+    } else if (i === RootPrefix.HubEvents) {
       index = 3;
     } else {
       index = 4;

--- a/apps/hubble/src/profile.ts
+++ b/apps/hubble/src/profile.ts
@@ -1,0 +1,214 @@
+import { RootPrefix, UserPostfix } from "./storage/db/types.js";
+import { logger } from "./utils/logger.js";
+import RocksDB from "./storage/db/rocksdb.js";
+
+// rome-ignore lint/suspicious/noExplicitAny: Generic check for enums needs 'any'
+function getMaxValue(enumType: any): number {
+  let maxValue = 0;
+
+  for (const key in enumType) {
+    if (enumType[key] > maxValue) {
+      maxValue = enumType[key];
+    }
+  }
+  return maxValue;
+}
+
+// Pretty print a number with K/M/B/T suffixes
+function formatNumber(num?: number): string {
+  if (num === undefined) return "";
+
+  if (Math.abs(num) >= 1.0e12) return `${(Math.abs(num) / 1.0e12).toFixed(1)}T`;
+  else if (Math.abs(num) >= 1.0e9) return `${(Math.abs(num) / 1.0e9).toFixed(1)}B`;
+  else if (Math.abs(num) >= 1.0e6) return `${(Math.abs(num) / 1.0e6).toFixed(1)}M`;
+  else if (Math.abs(num) >= 1.0e3) return `${(Math.abs(num) / 1.0e3).toFixed(1)}K`;
+  else return num.toString();
+}
+
+// Pretty print a percentage
+function formatPercentage(num?: number): string {
+  if (num === undefined) return "";
+
+  return `${(num * 100).toFixed(2)}%`;
+}
+
+// A class to track usage of key/value bytes in the DB
+class KeysProfile {
+  count: number;
+  keyBytes: number;
+  valueBytes: number;
+
+  label: string;
+
+  constructor(label = "") {
+    this.count = 0;
+    this.keyBytes = 0;
+    this.valueBytes = 0;
+
+    this.label = label;
+  }
+
+  toString() {
+    return `count=${formatNumber(this.count)}, keyBytes=${formatNumber(this.keyBytes)}, valueBytes=${formatNumber(
+      this.valueBytes,
+    )}`;
+  }
+}
+
+// Return a string that can printed to console of a table with the data
+function prettyPrintTable(data: (string | number)[][]): string {
+  // First, calculate the maximum width of each column
+  const columnWidths =
+    data[0]?.map((_, columnIndex) => Math.max(...data.map((row) => row[columnIndex]?.toString().length || 0))) || [];
+
+  // Then, create a string representation of each row, padding each cell as necessary
+  let rows = data.map((row) => row.map((cell, i) => cell.toString().padStart(columnWidths[i] || 0)).join(" | "));
+
+  const totalWidth = rows[0]?.length || 0;
+
+  // Finally, join all the rows together with line breaks
+  rows = [rows[0] as string, "-".repeat(totalWidth), ...rows.slice(1)];
+  return rows.join("\n");
+}
+
+// Format the keys profiles into a printable table
+function toPrettyPrintObject(keysProfile: KeysProfile[]): string[][] {
+  const data = [];
+  // First, write the headers to the first row
+  data.push(["Prefix", "Count", "Key Bytes", "Value Bytes", "Total Bytes %"]);
+
+  // First, calculate the total bytes
+  let totalBytes = 0;
+  for (let i = 0; i < keysProfile.length; i++) {
+    totalBytes += keysProfile[i]?.valueBytes || 0;
+    totalBytes += keysProfile[i]?.keyBytes || 0;
+  }
+
+  // Then, for each prefix, write a row with the prefix and the count, key bytes, and value bytes
+  // for that prefix
+  for (let i = 0; i < keysProfile.length; i++) {
+    if ((keysProfile[i]?.count || 0) > 0) {
+      const label = keysProfile[i]?.label || "";
+      data.push([
+        label,
+        formatNumber(keysProfile[i]?.count),
+        formatNumber(keysProfile[i]?.keyBytes),
+        formatNumber(keysProfile[i]?.valueBytes),
+        formatPercentage(((keysProfile[i]?.valueBytes || 0) + (keysProfile[i]?.keyBytes || 0)) / totalBytes),
+      ]);
+    }
+  }
+
+  return data;
+}
+
+/**
+ * Given an array of KeysProfile objects of the RootPrefixes, categorize each prefix into :
+ * 1. User Data
+ * 2. Indexes
+ * 3. Sync Trie data
+ * 4. Hub Events
+ * 5. Others
+ */
+function prefixProfileToDataType(keysProfile: KeysProfile[]): KeysProfile[] {
+  const dataTypePrefixes = [
+    new KeysProfile("User Data"),
+    new KeysProfile("Indexes"),
+    new KeysProfile("Sync Trie Data"),
+    new KeysProfile("Hub Events"),
+    new KeysProfile("Others"),
+  ];
+
+  for (let i = 0; i < keysProfile.length; i++) {
+    const kp = keysProfile[i] as KeysProfile;
+
+    if (kp.label.includes("User")) {
+      (dataTypePrefixes[0] as KeysProfile).count += kp.count;
+      (dataTypePrefixes[0] as KeysProfile).keyBytes += kp.keyBytes;
+      (dataTypePrefixes[0] as KeysProfile).valueBytes += kp.valueBytes;
+    } else if (kp.label.includes("By")) {
+      (dataTypePrefixes[1] as KeysProfile).count += kp.count;
+      (dataTypePrefixes[1] as KeysProfile).keyBytes += kp.keyBytes;
+      (dataTypePrefixes[1] as KeysProfile).valueBytes += kp.valueBytes;
+    } else if (kp.label.includes("Trie")) {
+      (dataTypePrefixes[2] as KeysProfile).count += kp.count;
+      (dataTypePrefixes[2] as KeysProfile).keyBytes += kp.keyBytes;
+      (dataTypePrefixes[2] as KeysProfile).valueBytes += kp.valueBytes;
+    } else if (kp.label.includes("HubEvents")) {
+      (dataTypePrefixes[3] as KeysProfile).count += kp.count;
+      (dataTypePrefixes[3] as KeysProfile).keyBytes += kp.keyBytes;
+      (dataTypePrefixes[3] as KeysProfile).valueBytes += kp.valueBytes;
+    } else {
+      (dataTypePrefixes[4] as KeysProfile).count += kp.count;
+      (dataTypePrefixes[4] as KeysProfile).keyBytes += kp.keyBytes;
+      (dataTypePrefixes[4] as KeysProfile).valueBytes += kp.valueBytes;
+    }
+  }
+
+  return dataTypePrefixes;
+}
+
+// Main function to print the usage profile of the DB
+export async function profileStorageUsed(rocksDB: RocksDB) {
+  // Iterate over all the keys in the DB
+  const iterator = rocksDB.iterator();
+
+  const allKeys = new KeysProfile("All Keys");
+  const prefixKeys = Array.from(
+    { length: getMaxValue(RootPrefix) + 1 },
+    (_v, i: number) => new KeysProfile(RootPrefix[i]?.toString()),
+  );
+
+  const userPostfixKeys = Array.from(
+    { length: getMaxValue(UserPostfix) + 1 },
+    (_v, i: number) => new KeysProfile(UserPostfix[i]?.toString()),
+  );
+
+  for await (const [key, value] of iterator) {
+    allKeys.count++;
+    allKeys.keyBytes += key?.length || 0;
+    allKeys.valueBytes += value?.length || 0;
+
+    if (key && key.length > 0) {
+      const prefix = key[0] as number;
+
+      if (prefix > 0 && prefix < prefixKeys.length) {
+        (prefixKeys[prefix] as KeysProfile).count++;
+        (prefixKeys[prefix] as KeysProfile).keyBytes += key?.length || 0;
+        (prefixKeys[prefix] as KeysProfile).valueBytes += value?.length || 0;
+
+        // Further categorize user data into user postfixes
+        if (prefix === RootPrefix.User) {
+          const postfix = key[1 + 4] as number;
+
+          if (postfix > 0 && postfix < userPostfixKeys.length) {
+            (userPostfixKeys[postfix] as KeysProfile).count++;
+            (userPostfixKeys[postfix] as KeysProfile).keyBytes += key?.length || 0;
+            (userPostfixKeys[postfix] as KeysProfile).valueBytes += value?.length || 0;
+          } else {
+            logger.error(`Invalid postfix ${postfix} for key ${key.toString("hex")}`);
+          }
+        }
+      } else {
+        logger.error(`Invalid prefix ${prefix} for key ${key.toString("hex")}`);
+      }
+    }
+
+    if (allKeys.count % 1_000_000 === 0) {
+      logger.info(`Read ${formatNumber(allKeys.count)} keys`);
+    }
+  }
+
+  logger.info(`RocksDB contains ${allKeys.toString()}`);
+
+  console.log(prettyPrintTable(toPrettyPrintObject(prefixKeys)));
+
+  console.log("\nBy Data Type:\n");
+  console.log(prettyPrintTable(toPrettyPrintObject(prefixProfileToDataType(prefixKeys))));
+
+  console.log("\nBy User Data type:\n");
+  console.log(prettyPrintTable(toPrettyPrintObject(userPostfixKeys)));
+
+  console.log("\nTotals:\n");
+  console.log(prettyPrintTable(toPrettyPrintObject([allKeys])));
+}


### PR DESCRIPTION
## Motivation

Add a `yarn profile storage` command to print out stats about how the rocksDB is being used

## Change Summary

- Add new `yarn profile storage` command. 
- Needs to run when hub is stopped

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context
From a fully synced mainnet node:

```
                         Prefix |  Count | Key Bytes | Value Bytes | Total Bytes %
----------------------------------------------------------------------------------
                           User |   7.3M |    281.9M |      534.2M |        46.49%
                  CastsByParent | 499.9K |     26.5M |      499.9K |         1.54%
                 CastsByMention |  69.5K |      2.3M |       69.5K |         0.13%
                  LinksByTarget |   1.0M |     34.3M |        6.2M |         2.31%
              ReactionsByTarget | 523.3K |     27.7M |      523.3K |         1.61%
                IdRegistryEvent |  15.6K |     78.2K |        1.6M |         0.10%
              NameRegistryEvent |  15.6K |    126.6K |        2.1M |         0.13%
IdRegistryEventByCustodyAddress |  15.7K |    328.6K |        1.6M |         0.11%
                       HubState |      1 |         1 |           8 |         0.00%
             SyncMerkleTrieNode |   5.0M |     60.5M |      226.2M |        16.33%
     NameRegistryEventsByExpiry |  15.6K |    189.2K |        2.1M |         0.13%
               HubCleanShutdown |      1 |         1 |           1 |         0.00%
                      HubEvents |   2.5M |     22.4M |      522.2M |        31.02%
                        Network |      1 |         1 |           4 |         0.00%
                  UserNameProof |  15.6K |    126.5K |        1.7M |         0.10%
```
By Data Type:
```
        Prefix | Count | Key Bytes | Value Bytes | Total Bytes %
----------------------------------------------------------------
     User Data |  2.4M |     73.0M |      475.9M |        31.22%
       Indexes |  7.0M |    301.0M |       71.8M |        21.20%
Sync Trie Data |  5.0M |     60.6M |      226.5M |        16.33%
    Hub Events |  2.5M |     22.4M |      522.9M |        31.02%
        Others | 31.3K |    205.0K |        3.7M |         0.22%
```
By User Postfix:
```
             Prefix |  Count | Key Bytes | Value Bytes | Total Bytes %
----------------------------------------------------------------------
        CastMessage | 764.4K |     22.9M |      208.0M |        28.30%
        LinkMessage |   1.1M |     31.9M |      162.7M |        23.84%
    ReactionMessage | 530.2K |     15.9M |       90.6M |        13.05%
VerificationMessage |   5.3K |    158.8K |        1.4M |         0.19%
      SignerMessage |  15.6K |    468.2K |        2.7M |         0.38%
    UserDataMessage |  46.1K |      1.4M |        8.2M |         1.18%
           BySigner |   2.4M |    152.6M |        2.4M |        19.00%
           CastAdds | 732.4K |     19.0M |       17.6M |         4.49%
        CastRemoves |  31.9K |    830.5K |      766.6K |         0.20%
           LinkAdds |   1.0M |     18.7M |       25.0M |         5.35%
        LinkRemoves |  24.1K |    433.4K |      577.8K |         0.12%
       ReactionAdds | 523.3K |     16.2M |       12.6M |         3.53%
    ReactionRemoves |   6.9K |    212.7K |      164.6K |         0.05%
   VerificationAdds |   5.1K |    132.5K |      122.3K |         0.03%
VerificationRemoves |    197 |      5.1K |        4.7K |         0.00%
         SignerAdds |  15.1K |    574.8K |      363.0K |         0.11%
      SignerRemoves |    479 |     18.2K |       11.5K |         0.00%
       UserDataAdds |  46.1K |    322.9K |        1.1M |         0.18%
```
Totals:
```
  Prefix | Count | Key Bytes | Value Bytes | Total Bytes %
----------------------------------------------------------
All Keys | 16.9M |    456.5M |        1.3B |       100.00%
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new command "yarn profile storage" to the Hubble app that profiles the storage layout of the RocksDB database. 

### Detailed summary
- Adds a new command "yarn profile storage" to the Hubble app
- Profiles the storage layout of the RocksDB database
- Prints usage of the RocksDB database, including count, key bytes, and value bytes for each prefix
- Categorizes the usage into different data types and user data types
- Prints a table with the profiled data

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->