### PR TITLE
chore: hard fail if cannot connect to eth RPC provider

### DIFF
--- a/.changeset/flat-trainers-hide.md
+++ b/.changeset/flat-trainers-hide.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+Updated EthEventProviders to hard fail unable to connect to eth RPC provider

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -340,7 +340,10 @@ app
     }
 
     const hub = hubResult.value;
-    const startResult = await ResultAsync.fromPromise(hub.start(), (e) => new Error(`Failed to start hub: ${e}`));
+    const startResult = await ResultAsync.fromPromise(
+      hub.start(),
+      (e) => new Error("Failed to start hub", { cause: e }),
+    );
     if (startResult.isErr()) {
       logger.fatal(startResult.error);
       logger.fatal({ reason: "Hub Startup failed" }, "shutting down hub");

--- a/apps/hubble/src/eth/ethEventsProvider.test.ts
+++ b/apps/hubble/src/eth/ethEventsProvider.test.ts
@@ -5,8 +5,9 @@ import {
   IdRegistryEventType,
   hexStringToBytes,
   NameRegistryEventType,
+  HubError,
 } from "@farcaster/hub-nodejs";
-import { parseEther, toHex } from "viem";
+import { createPublicClient, http, parseEther, toHex } from "viem";
 import { IdRegistry, NameRegistry } from "./abis.js";
 import { EthEventsProvider } from "./ethEventsProvider.js";
 import { getIdRegistryEvent } from "../storage/db/idRegistryEvent.js";
@@ -23,6 +24,7 @@ import {
 } from "../test/utils.js";
 import { accounts } from "../test/constants.js";
 import { sleep } from "../utils/crypto.js";
+import { goerli } from "viem/chains";
 
 const db = jestRocksDB("protobufs.ethEventsProvider.test");
 const engine = new Engine(db, FarcasterNetwork.TESTNET);
@@ -48,190 +50,208 @@ afterAll(async () => {
   await engine.stop();
 });
 
-describe("process events", () => {
-  beforeEach(async () => {
-    const { contractAddress: idAddr } = await deployIdRegistry();
-    if (!idAddr) throw new Error("Failed to deploy NameRegistry contract");
-    idRegistryAddress = idAddr;
+describe("EthEventsProvider", () => {
+  describe("start", () => {
+    test("throws if cannot connect to eth RPC provider", async () => {
+      ethEventsProvider = new EthEventsProvider(
+        hub,
+        createPublicClient({ chain: goerli, transport: http("bad-url") }),
+        idRegistryAddress,
+        nameRegistryAddress,
+        1,
+        10000,
+        false,
+      );
 
-    const { contractAddress: nameAddr } = await deployNameRegistry();
-    if (!nameAddr) throw new Error("Failed to deploy NameRegistry contract");
-    nameRegistryAddress = nameAddr;
-
-    ethEventsProvider = new EthEventsProvider(
-      hub,
-      publicClient,
-      idRegistryAddress,
-      nameRegistryAddress,
-      1,
-      10000,
-      false,
-    );
-
-    await ethEventsProvider.start();
+      await expect(ethEventsProvider.start()).rejects.toThrowError(HubError);
+    });
   });
 
-  afterEach(async () => {
-    await ethEventsProvider.stop();
-  });
+  describe("process events", () => {
+    beforeEach(async () => {
+      const { contractAddress: idAddr } = await deployIdRegistry();
+      if (!idAddr) throw new Error("Failed to deploy NameRegistry contract");
+      idRegistryAddress = idAddr;
 
-  const waitForBlock = async (blockNumber: number) => {
-    while (ethEventsProvider.getLatestBlockNumber() <= blockNumber) {
-      // Wait for all async promises to resolve
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    }
-  };
+      const { contractAddress: nameAddr } = await deployNameRegistry();
+      if (!nameAddr) throw new Error("Failed to deploy NameRegistry contract");
+      nameRegistryAddress = nameAddr;
 
-  test("handles new blocks", async () => {
-    await testClient.mine({ blocks: 1 });
-    const latestBlockNumber = await publicClient.getBlockNumber();
-    await waitForBlock(Number(latestBlockNumber));
-    expect(ethEventsProvider.getLatestBlockNumber()).toBeGreaterThanOrEqual(latestBlockNumber);
-  });
+      ethEventsProvider = new EthEventsProvider(
+        hub,
+        publicClient,
+        idRegistryAddress,
+        nameRegistryAddress,
+        1,
+        10000,
+        false,
+      );
 
-  test("processes IdRegistry events", async () => {
-    const address1 = generateEthAddressHex();
-    const address2 = generateEthAddressHex();
-    const changeTrustedCallerSim = await publicClient.simulateContract({
-      address: idRegistryAddress,
-      abi: IdRegistry.abi,
-      functionName: "changeTrustedCaller",
-      account: accounts[0].address,
-      args: [accounts[0].address as `0x${string}`],
-    });
-    const changeTrustedCallerHash = await walletClientWithAccount.writeContract(changeTrustedCallerSim.request);
-    await publicClient.waitForTransactionReceipt({ hash: changeTrustedCallerHash });
-
-    const registerSim = await publicClient.simulateContract({
-      address: idRegistryAddress,
-      abi: IdRegistry.abi,
-      functionName: "trustedRegister",
-      account: accounts[0].address,
-      args: [address1 as `0x${string}`, address2 as `0x${string}`, ""],
+      await ethEventsProvider.start();
     });
 
-    const registerHash = await walletClientWithAccount.writeContract(registerSim.request);
-    const registerTrx = await publicClient.waitForTransactionReceipt({ hash: registerHash });
-    await sleep(1000); // allow time for the register event to be polled for
-
-    // The event is not immediately available, since it has to wait for confirmations
-    await expect(getIdRegistryEvent(db, 1)).rejects.toThrow();
-    await testClient.mine({ blocks: 7 });
-
-    // Wait for the register block to be confirmed
-    await waitForBlock(Number(registerTrx.blockNumber) + EthEventsProvider.numConfirmations);
-    const idRegistryEvent = await getIdRegistryEvent(db, 1);
-    expect(idRegistryEvent.fid).toEqual(1);
-
-    await testClient.setBalance({
-      address: address1,
-      value: parseEther("1"),
-    });
-    await testClient.impersonateAccount({
-      address: address1,
-    });
-    const transferSim = await publicClient.simulateContract({
-      address: idRegistryAddress,
-      abi: IdRegistry.abi,
-      functionName: "transfer",
-      account: address1,
-      args: [address2 as `0x${string}`],
-    });
-    const transferHash = await walletClientWithAccount.writeContract(transferSim.request);
-    const transferTrx = await publicClient.waitForTransactionReceipt({ hash: transferHash });
-    await sleep(1000); // allow time for the register event to be polled for
-
-    // Wait for the transfer block to be confirmed
-    await testClient.mine({ blocks: 7 });
-    await waitForBlock(Number(transferTrx.blockNumber) + EthEventsProvider.numConfirmations);
-
-    const postTransferIdRegistryEvent = await getIdRegistryEvent(db, 1);
-    expect(postTransferIdRegistryEvent.fid).toEqual(1);
-    expect(postTransferIdRegistryEvent.type).toEqual(IdRegistryEventType.TRANSFER);
-    expect(postTransferIdRegistryEvent.to).toEqual(hexStringToBytes(address2)._unsafeUnwrap());
-  });
-
-  test("processes NameRegistry events", async () => {
-    const address1 = generateEthAddressHex();
-    const address2 = generateEthAddressHex();
-    const changeTrustedCallerSim = await publicClient.simulateContract({
-      address: idRegistryAddress,
-      abi: IdRegistry.abi,
-      functionName: "changeTrustedCaller",
-      account: accounts[0].address,
-      args: [accounts[0].address as `0x${string}`],
-    });
-    const changeTrustedCallerHash = await walletClientWithAccount.writeContract(changeTrustedCallerSim.request);
-    await publicClient.waitForTransactionReceipt({ hash: changeTrustedCallerHash });
-
-    const registerSim = await publicClient.simulateContract({
-      address: idRegistryAddress,
-      abi: IdRegistry.abi,
-      functionName: "trustedRegister",
-      account: accounts[0].address,
-      args: [address1 as `0x${string}`, address2 as `0x${string}`, ""],
-    });
-    const registerHash = await walletClientWithAccount.writeContract(registerSim.request);
-    const registerTrx = await publicClient.waitForTransactionReceipt({ hash: registerHash });
-    await sleep(1000); // allow time for the register event to be polled for
-
-    // The event is not immediately available, since it has to wait for confirmations
-    await expect(getIdRegistryEvent(db, 1)).rejects.toThrow();
-    await testClient.mine({ blocks: 7 });
-
-    // Wait for the register block to be confirmed
-    await waitForBlock(Number(registerTrx.blockNumber) + EthEventsProvider.numConfirmations);
-    const idRegistryEvent = await getIdRegistryEvent(db, 1);
-    expect(idRegistryEvent.fid).toEqual(1);
-
-    await testClient.setBalance({
-      address: address1,
-      value: parseEther("10"),
-    });
-    await testClient.impersonateAccount({
-      address: address1,
+    afterEach(async () => {
+      await ethEventsProvider.stop();
     });
 
-    const commit = await publicClient.readContract({
-      address: nameRegistryAddress,
-      abi: NameRegistry.abi,
-      functionName: "generateCommit",
-      args: [toHex(fname, { size: 16 }), address1, toHex("secret", { size: 32 }), address2],
-    });
-    const makeCommitSim = await publicClient.simulateContract({
-      address: nameRegistryAddress,
-      abi: NameRegistry.abi,
-      functionName: "makeCommit",
-      account: address1,
-      args: [commit],
-    });
-    const makeCommitHash = await walletClientWithAccount.writeContract(makeCommitSim.request);
-    await publicClient.waitForTransactionReceipt({ hash: makeCommitHash });
+    const waitForBlock = async (blockNumber: number) => {
+      while (ethEventsProvider.getLatestBlockNumber() <= blockNumber) {
+        // Wait for all async promises to resolve
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+    };
 
-    await testClient.increaseTime({
-      seconds: 120,
+    test("handles new blocks", async () => {
+      await testClient.mine({ blocks: 1 });
+      const latestBlockNumber = await publicClient.getBlockNumber();
+      await waitForBlock(Number(latestBlockNumber));
+      expect(ethEventsProvider.getLatestBlockNumber()).toBeGreaterThanOrEqual(latestBlockNumber);
     });
-    await testClient.mine({ blocks: 1 });
-    const fnameRegisterSim = await publicClient.simulateContract({
-      address: nameRegistryAddress,
-      abi: NameRegistry.abi,
-      functionName: "register",
-      account: address1,
-      value: parseEther("1"),
-      args: [toHex(fname, { size: 16 }), address1, toHex("secret", { size: 32 }), address2],
+
+    test("processes IdRegistry events", async () => {
+      const address1 = generateEthAddressHex();
+      const address2 = generateEthAddressHex();
+      const changeTrustedCallerSim = await publicClient.simulateContract({
+        address: idRegistryAddress,
+        abi: IdRegistry.abi,
+        functionName: "changeTrustedCaller",
+        account: accounts[0].address,
+        args: [accounts[0].address as `0x${string}`],
+      });
+      const changeTrustedCallerHash = await walletClientWithAccount.writeContract(changeTrustedCallerSim.request);
+      await publicClient.waitForTransactionReceipt({ hash: changeTrustedCallerHash });
+
+      const registerSim = await publicClient.simulateContract({
+        address: idRegistryAddress,
+        abi: IdRegistry.abi,
+        functionName: "trustedRegister",
+        account: accounts[0].address,
+        args: [address1 as `0x${string}`, address2 as `0x${string}`, ""],
+      });
+
+      const registerHash = await walletClientWithAccount.writeContract(registerSim.request);
+      const registerTrx = await publicClient.waitForTransactionReceipt({ hash: registerHash });
+      await sleep(1000); // allow time for the register event to be polled for
+
+      // The event is not immediately available, since it has to wait for confirmations
+      await expect(getIdRegistryEvent(db, 1)).rejects.toThrow();
+      await testClient.mine({ blocks: 7 });
+
+      // Wait for the register block to be confirmed
+      await waitForBlock(Number(registerTrx.blockNumber) + EthEventsProvider.numConfirmations);
+      const idRegistryEvent = await getIdRegistryEvent(db, 1);
+      expect(idRegistryEvent.fid).toEqual(1);
+
+      await testClient.setBalance({
+        address: address1,
+        value: parseEther("1"),
+      });
+      await testClient.impersonateAccount({
+        address: address1,
+      });
+      const transferSim = await publicClient.simulateContract({
+        address: idRegistryAddress,
+        abi: IdRegistry.abi,
+        functionName: "transfer",
+        account: address1,
+        args: [address2 as `0x${string}`],
+      });
+      const transferHash = await walletClientWithAccount.writeContract(transferSim.request);
+      const transferTrx = await publicClient.waitForTransactionReceipt({ hash: transferHash });
+      await sleep(1000); // allow time for the register event to be polled for
+
+      // Wait for the transfer block to be confirmed
+      await testClient.mine({ blocks: 7 });
+      await waitForBlock(Number(transferTrx.blockNumber) + EthEventsProvider.numConfirmations);
+
+      const postTransferIdRegistryEvent = await getIdRegistryEvent(db, 1);
+      expect(postTransferIdRegistryEvent.fid).toEqual(1);
+      expect(postTransferIdRegistryEvent.type).toEqual(IdRegistryEventType.TRANSFER);
+      expect(postTransferIdRegistryEvent.to).toEqual(hexStringToBytes(address2)._unsafeUnwrap());
     });
-    const fnameRegisterHash = await walletClientWithAccount.writeContract(fnameRegisterSim.request);
-    const fnameRegisterTrx = await publicClient.waitForTransactionReceipt({ hash: fnameRegisterHash });
-    await sleep(1000); // allow time for the register event to be polled for
 
-    // Wait for the transfer block to be confirmed
-    await expect(getNameRegistryEvent(db, fname)).rejects.toThrow();
-    await testClient.mine({ blocks: 7 });
-    await waitForBlock(Number(fnameRegisterTrx.blockNumber) + EthEventsProvider.numConfirmations);
+    test("processes NameRegistry events", async () => {
+      const address1 = generateEthAddressHex();
+      const address2 = generateEthAddressHex();
+      const changeTrustedCallerSim = await publicClient.simulateContract({
+        address: idRegistryAddress,
+        abi: IdRegistry.abi,
+        functionName: "changeTrustedCaller",
+        account: accounts[0].address,
+        args: [accounts[0].address as `0x${string}`],
+      });
+      const changeTrustedCallerHash = await walletClientWithAccount.writeContract(changeTrustedCallerSim.request);
+      await publicClient.waitForTransactionReceipt({ hash: changeTrustedCallerHash });
 
-    const nameRegistryEvent = await getNameRegistryEvent(db, fname);
-    expect(nameRegistryEvent.fname).toEqual(fname);
-    expect(nameRegistryEvent.type).toEqual(NameRegistryEventType.TRANSFER);
-    expect(nameRegistryEvent.to).toEqual(hexStringToBytes(address1)._unsafeUnwrap());
+      const registerSim = await publicClient.simulateContract({
+        address: idRegistryAddress,
+        abi: IdRegistry.abi,
+        functionName: "trustedRegister",
+        account: accounts[0].address,
+        args: [address1 as `0x${string}`, address2 as `0x${string}`, ""],
+      });
+      const registerHash = await walletClientWithAccount.writeContract(registerSim.request);
+      const registerTrx = await publicClient.waitForTransactionReceipt({ hash: registerHash });
+      await sleep(1000); // allow time for the register event to be polled for
+
+      // The event is not immediately available, since it has to wait for confirmations
+      await expect(getIdRegistryEvent(db, 1)).rejects.toThrow();
+      await testClient.mine({ blocks: 7 });
+
+      // Wait for the register block to be confirmed
+      await waitForBlock(Number(registerTrx.blockNumber) + EthEventsProvider.numConfirmations);
+      const idRegistryEvent = await getIdRegistryEvent(db, 1);
+      expect(idRegistryEvent.fid).toEqual(1);
+
+      await testClient.setBalance({
+        address: address1,
+        value: parseEther("10"),
+      });
+      await testClient.impersonateAccount({
+        address: address1,
+      });
+
+      const commit = await publicClient.readContract({
+        address: nameRegistryAddress,
+        abi: NameRegistry.abi,
+        functionName: "generateCommit",
+        args: [toHex(fname, { size: 16 }), address1, toHex("secret", { size: 32 }), address2],
+      });
+      const makeCommitSim = await publicClient.simulateContract({
+        address: nameRegistryAddress,
+        abi: NameRegistry.abi,
+        functionName: "makeCommit",
+        account: address1,
+        args: [commit],
+      });
+      const makeCommitHash = await walletClientWithAccount.writeContract(makeCommitSim.request);
+      await publicClient.waitForTransactionReceipt({ hash: makeCommitHash });
+
+      await testClient.increaseTime({
+        seconds: 120,
+      });
+      await testClient.mine({ blocks: 1 });
+      const fnameRegisterSim = await publicClient.simulateContract({
+        address: nameRegistryAddress,
+        abi: NameRegistry.abi,
+        functionName: "register",
+        account: address1,
+        value: parseEther("1"),
+        args: [toHex(fname, { size: 16 }), address1, toHex("secret", { size: 32 }), address2],
+      });
+      const fnameRegisterHash = await walletClientWithAccount.writeContract(fnameRegisterSim.request);
+      const fnameRegisterTrx = await publicClient.waitForTransactionReceipt({ hash: fnameRegisterHash });
+      await sleep(1000); // allow time for the register event to be polled for
+
+      // Wait for the transfer block to be confirmed
+      await expect(getNameRegistryEvent(db, fname)).rejects.toThrow();
+      await testClient.mine({ blocks: 7 });
+      await waitForBlock(Number(fnameRegisterTrx.blockNumber) + EthEventsProvider.numConfirmations);
+
+      const nameRegistryEvent = await getNameRegistryEvent(db, fname);
+      expect(nameRegistryEvent.fname).toEqual(fname);
+      expect(nameRegistryEvent.type).toEqual(NameRegistryEventType.TRANSFER);
+      expect(nameRegistryEvent.to).toEqual(hexStringToBytes(address1)._unsafeUnwrap());
+    });
   });
 });

--- a/apps/hubble/src/eth/ethEventsProvider.ts
+++ b/apps/hubble/src/eth/ethEventsProvider.ts
@@ -171,7 +171,7 @@ export class EthEventsProvider {
   ): EthEventsProvider {
     const publicClient = createPublicClient({
       chain: goerli,
-      transport: http(ethRpcUrl, { retryCount: 10 }),
+      transport: http(ethRpcUrl, { retryCount: 5 }),
     });
 
     const provider = new EthEventsProvider(
@@ -242,11 +242,12 @@ export class EthEventsProvider {
   private async connectAndSyncHistoricalEvents() {
     const latestBlockResult = await ResultAsync.fromPromise(this._publicClient.getBlockNumber(), (err) => err);
     if (latestBlockResult.isErr()) {
-      log.error(
-        { err: latestBlockResult.error },
-        "failed to connect to ethereum node. Check your eth RPC URL (e.g. --eth-rpc-url)",
-      );
-      return;
+      logger.fatal(latestBlockResult.error);
+      logger.fatal("Failed to connect to ethereum node. Check your eth RPC URL (e.g. --eth-rpc-url)");
+      throw new HubError("unknown", {
+        message: "Failed to connect to ethereum node.",
+        cause: latestBlockResult.error as Error,
+      });
     }
 
     const latestBlock = Number(latestBlockResult.value);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Updated `EthEventProviders` to hard fail when unable to connect to the Ethereum RPC provider.
- Modified the `cli.ts` file to use `ResultAsync.fromPromise` with an error object that includes the original error as the cause.
- Updated the `ethEventsProvider.ts` file to use a retry count of 5 instead of 10 when creating the `http` transport.
- Modified the `ethEventsProvider.ts` file to throw a `HubError` with the original error as the cause when unable to connect to the Ethereum node.
- Updated the `ethEventsProvider.test.ts` file to import `HubError` from `@farcaster/hub-nodejs`.
- Updated the `ethEventsProvider.test.ts` file to import `goerli` from `viem/chains`.

> The following files were skipped due to too many changes: `apps/hubble/src/eth/ethEventsProvider.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->