### PR TITLE
fix: Add overheads to storage profile

### DIFF
--- a/apps/hubble/src/profile.ts
+++ b/apps/hubble/src/profile.ts
@@ -337,6 +337,7 @@ export async function profileStorageUsed(rocksDB: RocksDB) {
 
   logger.info(`RocksDB contains ${allKeys.toString()}`);
 
+  console.log("\nBy Prefix:\n");
   console.log(prettyPrintTable(KeysProfileToPrettyPrintObject(prefixKeys)));
 
   console.log("\nBy Data Type:\n");


### PR DESCRIPTION
## Motivation

Improve storage profile by adding overheads and actual message sizes

## Change Summary

Improve storage profile by adding overheads and actual message sizes

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the profiling functionality in the Hubble app. It introduces a new class for calculating value statistics and updates the prettyPrintTable function to display value sizes. 

### Detailed summary
- Added a new class `ValueStats` for calculating value statistics
- Updated the `prettyPrintTable` function to display value sizes in the table
- Added a new section in the console output for value sizes
- Improved the overall profiling functionality in the Hubble app

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->