### PR TITLE
chore: Include bad_request.prunable in list of INVALID_ARGUMENT errors

### DIFF
--- a/.changeset/fast-olives-promise.md
+++ b/.changeset/fast-olives-promise.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+Include bad_request.prunable in list of INVALID_ARGUMENT errors

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -117,7 +117,8 @@ export const toServiceError = (err: HubError): ServiceError => {
     err.errCode === "bad_request.validation_failure" ||
     err.errCode === "bad_request.invalid_param" ||
     err.errCode === "bad_request.conflict" ||
-    err.errCode === "bad_request.duplicate"
+    err.errCode === "bad_request.duplicate" ||
+    err.errCode === "bad_request.prunable"
   ) {
     grpcCode = status.INVALID_ARGUMENT;
   } else if (err.errCode === "not_found") {


### PR DESCRIPTION
## Motivation

Ensure that this error doesn't get categorized as unknown.

## Change Summary

Include `bad_request.prunable` in the set of INVALID_ARGUMENT errors.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
Include `bad_request.prunable` in the list of `INVALID_ARGUMENT` errors.

### Detailed summary:
- Added `bad_request.prunable` to the list of `INVALID_ARGUMENT` errors in `err.errCode` check in `server.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->