### PR TITLE
feat: Allow log level to be configured via environment variable

### DIFF
--- a/.changeset/plenty-trainers-raise.md
+++ b/.changeset/plenty-trainers-raise.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+Allow log level to be configured via environment variable

--- a/apps/hubble/src/utils/logger.ts
+++ b/apps/hubble/src/utils/logger.ts
@@ -44,6 +44,8 @@ const defaultOptions: pino.LoggerOptions = {};
 if (process.env["NODE_ENV"] === "test" || process.env["CI"]) {
   // defaultOptions.level = 'debug';
   defaultOptions.level = "silent";
+} else if (process.env["LOG_LEVEL"]) {
+  defaultOptions.level = process.env["LOG_LEVEL"];
 }
 
 export const logger = pino.pino(defaultOptions);


### PR DESCRIPTION
## Motivation

This is useful in allowing operators to reduce verbosity of logs if they so choose.

## Change Summary

Add check for `LOG_LEVEL` environment variable.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)
