### PR TITLE
perf: Don't await leaf nodes during sync

### DIFF
--- a/.changeset/perfect-baboons-visit.md
+++ b/.changeset/perfect-baboons-visit.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+perf: Fetch upto 4 leaf nodes at a time during sync

--- a/apps/hubble/src/network/sync/trieNode.ts
+++ b/apps/hubble/src/network/sync/trieNode.ts
@@ -8,7 +8,7 @@ import { blake3Truncate160, BLAKE3TRUNCATE160_EMPTY_HASH } from "../../utils/cry
 import { NodeMetadata } from "./merkleTrie.js";
 
 export const EMPTY_HASH = BLAKE3TRUNCATE160_EMPTY_HASH.toString("hex");
-export const MAX_VALUES_RETURNED_PER_CALL = 1000;
+export const MAX_VALUES_RETURNED_PER_CALL = 1024;
 
 /**
  * A snapshot of the trie at a particular timestamp which can be used to determine if two
@@ -299,9 +299,8 @@ class TrieNode {
   }
 
   public async getNodeMetadata(prefix: Uint8Array, db: RocksDB): Promise<NodeMetadata> {
-    const children = this.children || new Map();
     const result = new Map<number, NodeMetadata>();
-    for (const [char] of children) {
+    for (const [char] of this.children) {
       const child = await this._getOrLoadChild(prefix, char, db);
       const newPrefix = Buffer.concat([prefix, Buffer.from([char])]);
       result.set(char, {
@@ -328,7 +327,7 @@ class TrieNode {
       values.push(...(await child.getAllValues(Buffer.concat([prefix, Buffer.from([char])]), db)));
 
       // Prevent this from growing indefinitely, since it could potentially load the whole trie.
-      // Limit to 1000 values.
+      // Limit to 1024 values.
       if (values.length > MAX_VALUES_RETURNED_PER_CALL) {
         break;
       }


### PR DESCRIPTION
## Motivation

Sync was designed to be parallel, but we were not using the parallelism properly. 

## Change Summary

- We were unnecessarily awaiting every leaf node during sync. This is not needed, as we can merge the leaf nodes async, and move on to the next nodes.
- Use up to 4 threads to fetch leaf nodes during sync

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context
Improves sync speed by 2x (From 408 minutes down to 210 minutes)!

Sync stats
```
Latencies (ms)

                 Method | Count | Min |  Max |   Avg  | Median
--------------------------------------------------------------
getSyncMetadataByPrefix | 40.9K |  42 | 2.1K | 128.88 |    438
  getAllSyncIdsByPrefix | 36.8K |  42 | 2.0K |  97.40 |     43
getAllMessagesBySyncIds | 36.8K |  42 | 1.9K |  79.07 |     44

Data Fetched (bytes)

                 Method | Count | Objects |  Total | Min |    Max |    Avg | Median
-----------------------------------------------------------------------------------
getSyncMetadataByPrefix | 40.9K |   40.9K |  29.4M |  78 |    828 | 719.87 |    437
  getAllSyncIdsByPrefix | 36.8K |    2.5M | 177.8M |  79 |  18.4K |   4.8K |     81
getAllMessagesBySyncIds | 36.8K |    2.5M | 959.3M | 339 | 111.1K |  26.1K |    345
```


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on improving the performance of the sync process in the `hubble` app by fetching up to 4 leaf nodes at a time.

### Detailed summary:
- Increased the value of `MAX_VALUES_RETURNED_PER_CALL` from 1000 to 1024.
- Added a new constant `SYNC_PARALLELISM` with a value of 4 to fetch up to 4 leaf nodes in parallel during sync.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->