### PR TITLE
fix: Prevent connecting to peers not in allowed peer list

### DIFF
--- a/.changeset/angry-lizards-hammer.md
+++ b/.changeset/angry-lizards-hammer.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+Prevent connecting to peers not in allowed peer list

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -946,6 +946,12 @@ export class Hub implements HubInterface {
   }
 
   async isValidPeer(ourPeerId: PeerId, message: ContactInfoContent) {
+    const peerId = ourPeerId.toString();
+    if (MAINNET_ALLOWED_PEERS?.length && !MAINNET_ALLOWED_PEERS.includes(peerId)) {
+      log.warn(`Peer ${ourPeerId.toString()} is not in the allowed peers list`);
+      return false;
+    }
+
     const theirVersion = message.hubVersion;
     const theirNetwork = message.network;
 


### PR DESCRIPTION
## Motivation

We needed to add some additional logic to ensure we didn't connect to peers not in the allowlist. This will ensure we don't waste cycles with these peers.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on preventing connections to peers that are not in the allowed peer list. 

### Detailed summary
- Added a check to validate if the peer is in the allowed peer list before connecting.
- Logged a warning message if the peer is not in the allowed peers list.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->