### PR TITLE
fix: Correct allowed peer IDs behavior

### DIFF
--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -210,6 +210,7 @@ export class Hub implements HubInterface {
   private contactTimer?: NodeJS.Timer;
   private rocksDB: RocksDB;
   private syncEngine: SyncEngine;
+  private allowedPeerIds: string[] = [];
 
   private pruneMessagesJobScheduler: PruneMessagesJobScheduler;
   private periodSyncJobScheduler: PeriodicSyncJobScheduler;
@@ -295,6 +296,13 @@ export class Hub implements HubInterface {
         this.rocksDB,
         this.ethRegistryProvider,
       );
+    }
+
+    this.allowedPeerIds = this.options.allowedPeers || [];
+    if (this.options.network === FarcasterNetwork.MAINNET) {
+      // Mainnet is right now resitrcited to a few peers
+      // Append and de-dup the allowed peers
+      this.allowedPeerIds = [...new Set([...(this.allowedPeerIds ?? []), ...MAINNET_ALLOWED_PEERS])];
     }
   }
 
@@ -404,19 +412,12 @@ export class Hub implements HubInterface {
       this.updateNameRegistryEventExpiryJobWorker.start();
     }
 
-    let allowedPeerIdStrs = this.options.allowedPeers;
-    if (this.options.network === FarcasterNetwork.MAINNET) {
-      // Mainnet is right now resitrcited to a few peers
-      // Append and de-dup the allowed peers
-      allowedPeerIdStrs = [...new Set([...(allowedPeerIdStrs ?? []), ...MAINNET_ALLOWED_PEERS])];
-    }
-
     await this.gossipNode.start(this.options.bootstrapAddrs ?? [], {
       peerId: this.options.peerId,
       ipMultiAddr: this.options.ipMultiAddr,
       announceIp: this.options.announceIp,
       gossipPort: this.options.gossipPort,
-      allowedPeerIdStrs,
+      allowedPeerIdStrs: this.allowedPeerIds,
     });
 
     this.registerEventHandlers();
@@ -947,7 +948,7 @@ export class Hub implements HubInterface {
 
   async isValidPeer(ourPeerId: PeerId, message: ContactInfoContent) {
     const peerId = ourPeerId.toString();
-    if (MAINNET_ALLOWED_PEERS?.length && !MAINNET_ALLOWED_PEERS.includes(peerId)) {
+    if (this.allowedPeerIds?.length && !this.allowedPeerIds.includes(peerId)) {
       log.warn(`Peer ${ourPeerId.toString()} is not in the allowed peers list`);
       return false;
     }


### PR DESCRIPTION
## Motivation

This was broken by d5d65bdc.

## Change Summary

Fix it.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on allowing only certain peers for the Mainnet network. 

### Detailed summary
- Added `allowedPeerIds` property to the `Hub` class.
- Initialized `allowedPeerIds` as an empty array.
- If the network is Mainnet, append and de-duplicate the allowed peers to `allowedPeerIds`.
- Updated the `allowedPeerIdStrs` parameter in the `start` method of `gossipNode` with `allowedPeerIds`.
- Updated the `isValidPeer` method to check if the peer is in the `allowedPeerIds` list.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->