### PR TITLE
chore: remove obsolete ethers dependency from hub-nodejs

### DIFF
--- a/.changeset/blue-spoons-double.md
+++ b/.changeset/blue-spoons-double.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hub-nodejs": patch
+---
+
+Remove ethers dependency

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -17,7 +17,6 @@
     "@farcaster/core": "0.10.1",
     "@grpc/grpc-js": "^1.8.8",
     "@noble/hashes": "^1.3.0",
-    "ethers": "~6.2.1",
     "neverthrow": "^6.0.0"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2843,11 +2843,6 @@ aes-js@3.0.0:
   resolved "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
   integrity sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==
 
-aes-js@4.0.0-beta.3:
-  version "4.0.0-beta.3"
-  resolved "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.3.tgz#da2253f0ff03a0b3a9e445c8cbdf78e7fda7d48c"
-  integrity sha512-/xJX0/VTPcbc5xQE2VUP91y1xN8q/rDfhEzLm+vLc3hYvb5+qHCnpJRuFcrKn63zumK/sCwYYzhG8HP78JYSTA==
-
 aes-js@4.0.0-beta.5:
   version "4.0.0-beta.5"
   resolved "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz#8d2452c52adedebc3a3e28465d858c11ca315873"
@@ -4223,18 +4218,6 @@ ethers@^6.6.1:
     "@noble/secp256k1" "1.7.1"
     "@types/node" "18.15.13"
     aes-js "4.0.0-beta.5"
-    tslib "2.4.0"
-    ws "8.5.0"
-
-ethers@~6.2.1:
-  version "6.2.1"
-  resolved "https://registry.npmjs.org/ethers/-/ethers-6.2.1.tgz#3ba2c4ff02e6131828bd8b6bfa0885d112bd43b4"
-  integrity sha512-bwDC1A6a0NlokpjzYGnKSVo68eBNsTRdzN0nHgmpTsvowEuRDHorhMiFg/tx/7WMl2bGESfABsfH0MPZUp+EJQ==
-  dependencies:
-    "@adraffy/ens-normalize" "1.9.0"
-    "@noble/hashes" "1.1.2"
-    "@noble/secp256k1" "1.7.1"
-    aes-js "4.0.0-beta.3"
     tslib "2.4.0"
     ws "8.5.0"
 


### PR DESCRIPTION
## Motivation

We no longer use ethers in hub-nodejs, so removing the obsolete dependency

## Change Summary

Remove ethers from package.json

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

N/A

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Remove ethers dependency from `hub-nodejs` package

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->