### PR TITLE
fix: Improve open iterator logging

### DIFF
--- a/.changeset/stupid-rice-laugh.md
+++ b/.changeset/stupid-rice-laugh.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Improve logging for open iterators and add hub events timeout

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -952,6 +952,22 @@ export default class Server {
             return;
           }
 
+          // We'll set a timeout of 1 hour, after which we'll stop writing to the stream
+          // This is to prevent a situation where we're writing to the stream, but the client
+          // is not reading it.
+          const timeout = setTimeout(async () => {
+            logger.warn(
+              { timeout: 1 * 60 * 60 * 1000, peer: stream.getPeer() },
+              "HubEvents subscribe: timeout, stopping stream",
+            );
+
+            // If the iterator throws, it is already closed, so it doesn't matter.
+            await ResultAsync.fromPromise(eventsIterator.value.end(), (e) => e as Error);
+
+            const error = new HubError("unavailable.network_failure", `stream timeout for peer: ${stream.getPeer()}`);
+            stream.destroy(error);
+          }, 1 * 60 * 60 * 1000);
+
           // Track our RSS usage, to detect a situation where we're writing a lot of data to the stream,
           // but the client is not reading it. If we detect this, we'll stop writing to the stream.
           // Right now, we don't act on it, but we'll log it for now. We could potentially
@@ -989,7 +1005,7 @@ export default class Server {
                   // We'll destroy the stream.
                   const error = new HubError(
                     "unavailable.network_failure",
-                    `stream memory usage too for peer: ${stream.getPeer()}`,
+                    `stream memory usage too much for peer: ${stream.getPeer()}`,
                   );
                   logger.error({ errCode: error.errCode }, error.message);
                   stream.destroy(error);
@@ -1002,6 +1018,9 @@ export default class Server {
               }
             }
           }
+
+          // If we reach here, the iterator has ended, so we'll clear the timeout
+          clearTimeout(timeout);
         }
 
         // if no type filters are provided, subscribe to all event types and start streaming events

--- a/apps/hubble/src/storage/db/rocksdb.ts
+++ b/apps/hubble/src/storage/db/rocksdb.ts
@@ -117,8 +117,7 @@ class RocksDB {
                 stackTrace: entry.stackTrace,
                 id: entry.id,
               },
-              `RocksDB iterator open
-                for more than ${MAX_DB_ITERATOR_OPEN_MILLISECONDS} ms`,
+              `RocksDB iterator open for more than ${MAX_DB_ITERATOR_OPEN_MILLISECONDS} ms`,
             );
           }
           return [entry];

--- a/apps/hubble/src/storage/db/rocksdb.ts
+++ b/apps/hubble/src/storage/db/rocksdb.ts
@@ -92,9 +92,12 @@ class RocksDB {
    */
   private _openIterators: Set<{
     iterator: Iterator;
+    id: number;
     openTimestamp: number;
     options: AbstractRocksDB.IteratorOptions | undefined;
+    stackTrace: string;
   }>;
+  private _openIteratorId = 0;
   private _iteratorCheckTimer?: NodeJS.Timer;
 
   constructor(name?: string) {
@@ -108,7 +111,12 @@ class RocksDB {
         } else {
           if (now - entry.openTimestamp >= MAX_DB_ITERATOR_OPEN_MILLISECONDS) {
             log.warn(
-              entry.options,
+              {
+                options: entry.options,
+                openSecs: now - entry.openTimestamp,
+                stackTrace: entry.stackTrace,
+                id: entry.id,
+              },
               `RocksDB iterator open
                 for more than ${MAX_DB_ITERATOR_OPEN_MILLISECONDS} ms`,
             );
@@ -226,8 +234,16 @@ class RocksDB {
   }
 
   iterator(options?: AbstractRocksDB.IteratorOptions): Iterator {
+    const stackTrace = new Error().stack || "<no stacktrace>";
+
     const iterator = new Iterator(this._db.iterator({ ...options, valueAsBuffer: true, keyAsBuffer: true }));
-    this._openIterators.add({ iterator: iterator, openTimestamp: Date.now(), options: options });
+    this._openIterators.add({
+      id: this._openIteratorId++,
+      iterator: iterator,
+      openTimestamp: Date.now(),
+      options: options,
+      stackTrace,
+    });
     return iterator;
   }
 


### PR DESCRIPTION
## Motivation

Improve logging for iterators so we know exactly where the iterators are open

## Change Summary

- Fix issue where hubevents that too long didn't close the iterator
- Improve iterator logging with id, stacktrace
- Don't overlap multiple DB compactions

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Improve logging for open iterators and add a timeout for hub events stream.

### Detailed summary:
- Added a new private property `_isCompacting` to track if the database is currently being compacted.
- Modified the `compactDbIfRequired` method to check if the database is already being compacted before initiating a compaction.
- Added logging statements for starting and completing database compaction.
- Added a new private property `_openIteratorId` to assign unique IDs to open iterators.
- Modified the `iterator` method to store the stack trace and ID of each open iterator in the `_openIterators` set.
- Added a new timeout for the hub events stream to prevent situations where the client is not reading the stream.
- Added logging statements for stream timeout and stream memory usage.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->