### PR TITLE
chore: Rename UserDataType.FNAME to USERNAME

### DIFF
--- a/.changeset/violet-radios-beam.md
+++ b/.changeset/violet-radios-beam.md
@@ -1,0 +1,8 @@
+---
+"@farcaster/hub-nodejs": patch
+"@farcaster/hub-web": patch
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+rename UserDataType.FNAME to UserDataType.USERNAME

--- a/apps/hubble/src/rpc/test/userDataService.test.ts
+++ b/apps/hubble/src/rpc/test/userDataService.test.ts
@@ -89,7 +89,7 @@ beforeAll(async () => {
       data: {
         fid,
         userDataBody: {
-          type: UserDataType.FNAME,
+          type: UserDataType.USERNAME,
           value: bytesToUtf8String(fname)._unsafeUnwrap(),
         },
         timestamp: pfpAdd.data.timestamp + 2,
@@ -122,7 +122,7 @@ beforeAll(async () => {
       data: {
         fid,
         userDataBody: {
-          type: UserDataType.FNAME,
+          type: UserDataType.USERNAME,
           value: bytesToUtf8String(ensNameProof.data.usernameProofBody.name)._unsafeUnwrap(),
         },
         timestamp: addFname.data.timestamp + 2,
@@ -152,7 +152,7 @@ describe("getUserData", () => {
     await engine.mergeUserNameProof(fnameProof);
 
     expect(await engine.mergeMessage(addFname)).toBeInstanceOf(Ok);
-    const fnameData = await client.getUserData(UserDataRequest.create({ fid, userDataType: UserDataType.FNAME }));
+    const fnameData = await client.getUserData(UserDataRequest.create({ fid, userDataType: UserDataType.USERNAME }));
     expect(Message.toJSON(fnameData._unsafeUnwrap())).toEqual(Message.toJSON(addFname));
 
     const usernameProof = await client.getUsernameProof(UsernameProofRequest.create({ name: fnameProof.name }));
@@ -165,14 +165,14 @@ describe("getUserData", () => {
     );
 
     expect(await engine.mergeMessage(addEnsName)).toBeInstanceOf(Ok);
-    const ensNameData = await client.getUserData(UserDataRequest.create({ fid, userDataType: UserDataType.FNAME }));
+    const ensNameData = await client.getUserData(UserDataRequest.create({ fid, userDataType: UserDataType.USERNAME }));
     expect(Message.toJSON(ensNameData._unsafeUnwrap())).toEqual(Message.toJSON(addEnsName));
   });
 
   test("fails when user data is missing", async () => {
     const pfp = await client.getUserData(UserDataRequest.create({ fid, userDataType: UserDataType.PFP }));
     expect(pfp._unsafeUnwrapErr().errCode).toEqual("not_found");
-    const fname = await client.getUserData(UserDataRequest.create({ fid, userDataType: UserDataType.FNAME }));
+    const fname = await client.getUserData(UserDataRequest.create({ fid, userDataType: UserDataType.USERNAME }));
     expect(fname._unsafeUnwrapErr().errCode).toEqual("not_found");
   });
 

--- a/apps/hubble/src/storage/engine/index.test.ts
+++ b/apps/hubble/src/storage/engine/index.test.ts
@@ -250,7 +250,7 @@ describe("mergeMessage", () => {
               data: {
                 fid,
                 network,
-                userDataBody: { type: UserDataType.FNAME, value: nameString },
+                userDataBody: { type: UserDataType.USERNAME, value: nameString },
               },
             },
             { transient: { signer } },
@@ -595,7 +595,7 @@ describe("mergeMessage", () => {
             data: {
               fid,
               userDataBody: {
-                type: UserDataType.FNAME,
+                type: UserDataType.USERNAME,
                 value: "test.eth",
               },
             },
@@ -607,7 +607,7 @@ describe("mergeMessage", () => {
             data: {
               fid,
               userDataBody: {
-                type: UserDataType.FNAME,
+                type: UserDataType.USERNAME,
                 value: "test123.eth",
               },
             },
@@ -619,12 +619,12 @@ describe("mergeMessage", () => {
       test("succeeds setting name when name is owned by custody address", async () => {
         const result = await engine.mergeMessage(userDataAdd);
         expect(result.isOk()).toBeTruthy();
-        expect((await engine.getUserData(fid, UserDataType.FNAME))._unsafeUnwrap()).toMatchObject(userDataAdd);
+        expect((await engine.getUserData(fid, UserDataType.USERNAME))._unsafeUnwrap()).toMatchObject(userDataAdd);
       });
       test("succeeds setting name when name is owned by verified address", async () => {
         const result = await engine.mergeMessage(userDataAdd2);
         expect(result.isOk()).toBeTruthy();
-        expect((await engine.getUserData(fid, UserDataType.FNAME))._unsafeUnwrap()).toMatchObject(userDataAdd2);
+        expect((await engine.getUserData(fid, UserDataType.USERNAME))._unsafeUnwrap()).toMatchObject(userDataAdd2);
       });
       test("fails when custody address no longer owns the ens", async () => {
         jest.spyOn(publicClient, "getEnsAddress").mockImplementation(() => {
@@ -665,7 +665,7 @@ describe("mergeMessage", () => {
       test("revokes the user data add when the username proof is revoked", async () => {
         const result = await engine.mergeMessage(userDataAdd);
         expect(result.isOk()).toBeTruthy();
-        expect((await engine.getUserData(fid, UserDataType.FNAME))._unsafeUnwrap()).toMatchObject(userDataAdd);
+        expect((await engine.getUserData(fid, UserDataType.USERNAME))._unsafeUnwrap()).toMatchObject(userDataAdd);
 
         jest.spyOn(publicClient, "getEnsAddress").mockImplementation(() => {
           return Promise.resolve(randomEthAddress);
@@ -673,7 +673,7 @@ describe("mergeMessage", () => {
         const revokeResult = await engine.validateOrRevokeMessage(test1Message);
         expect(revokeResult.isOk()).toBeTruthy();
 
-        expect((await engine.getUserData(fid, UserDataType.FNAME))._unsafeUnwrap()).toMatchObject(userDataAdd);
+        expect((await engine.getUserData(fid, UserDataType.USERNAME))._unsafeUnwrap()).toMatchObject(userDataAdd);
       });
     });
 
@@ -907,7 +907,7 @@ describe("with listeners and workers", () => {
       const fnameAdd = await Factories.UserDataAddMessage.create(
         {
           data: {
-            userDataBody: { type: UserDataType.FNAME, value: bytesToUtf8String(fname)._unsafeUnwrap() },
+            userDataBody: { type: UserDataType.USERNAME, value: bytesToUtf8String(fname)._unsafeUnwrap() },
             fid,
           },
         },
@@ -936,7 +936,7 @@ describe("with listeners and workers", () => {
       const fnameAdd = await Factories.UserDataAddMessage.create(
         {
           data: {
-            userDataBody: { type: UserDataType.FNAME, value: bytesToUtf8String(fname)._unsafeUnwrap() },
+            userDataBody: { type: UserDataType.USERNAME, value: bytesToUtf8String(fname)._unsafeUnwrap() },
             fid,
           },
         },

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -822,7 +822,7 @@ class Engine {
     }
 
     // 5. For fname add UserDataAdd messages, check that the user actually owns the fname
-    if (isUserDataAddMessage(message) && message.data.userDataBody.type === UserDataType.FNAME) {
+    if (isUserDataAddMessage(message) && message.data.userDataBody.type === UserDataType.USERNAME) {
       // For fname messages, check if the user actually owns the fname.
       const nameBytes = utf8StringToBytes(message.data.userDataBody.value);
       if (nameBytes.isErr()) {
@@ -951,7 +951,7 @@ class Engine {
 
       // Revoke UserDataAdd fname messages
       const fnameAdd = await ResultAsync.fromPromise(
-        this._userDataStore.getUserDataAdd(idRegistryEvent.fid, UserDataType.FNAME),
+        this._userDataStore.getUserDataAdd(idRegistryEvent.fid, UserDataType.USERNAME),
         () => undefined,
       );
       if (fnameAdd.isOk()) {
@@ -986,21 +986,21 @@ class Engine {
     if (deletedUsernameProof && deletedUsernameProof.owner.length > 0) {
       const fid = deletedUsernameProof.fid;
 
-      // Check if this fid assigned the fname with a UserDataAdd message
-      const fnameAdd = await ResultAsync.fromPromise(
-        this._userDataStore.getUserDataAdd(fid, UserDataType.FNAME),
+      // Check if this fid assigned the name with a UserDataAdd message
+      const usernameAdd = await ResultAsync.fromPromise(
+        this._userDataStore.getUserDataAdd(fid, UserDataType.USERNAME),
         () => undefined,
       );
-      if (fnameAdd.isOk()) {
-        const revokeResult = await this._userDataStore.revoke(fnameAdd.value);
-        const fnameAddHex = bytesToHexString(fnameAdd.value.hash);
+      if (usernameAdd.isOk()) {
+        const revokeResult = await this._userDataStore.revoke(usernameAdd.value);
+        const usernameAddHex = bytesToHexString(usernameAdd.value.hash);
         revokeResult.match(
           () =>
-            log.info(`revoked message ${fnameAddHex._unsafeUnwrap()} for fid ${fid} due to name proof invalidation`),
+            log.info(`revoked message ${usernameAddHex._unsafeUnwrap()} for fid ${fid} due to name proof invalidation`),
           (e) =>
             log.error(
               { errCode: e.errCode },
-              `failed to revoke message ${fnameAddHex._unsafeUnwrap()} for fid ${fid} due to name proof invalidation: ${
+              `failed to revoke message ${usernameAddHex._unsafeUnwrap()} for fid ${fid} due to name proof invalidation: ${
                 e.message
               }`,
             ),

--- a/apps/hubble/src/storage/stores/userDataStore.test.ts
+++ b/apps/hubble/src/storage/stores/userDataStore.test.ts
@@ -41,7 +41,7 @@ beforeEach(async () => {
 describe("getUserDataAdd", () => {
   test("fails if missing", async () => {
     await expect(set.getUserDataAdd(fid, UserDataType.PFP)).rejects.toThrow(HubError);
-    await expect(set.getUserDataAdd(fid, UserDataType.FNAME)).rejects.toThrow(HubError);
+    await expect(set.getUserDataAdd(fid, UserDataType.USERNAME)).rejects.toThrow(HubError);
   });
 
   test("fails if the wrong fid or datatype is provided", async () => {

--- a/packages/core/src/factories.ts
+++ b/packages/core/src/factories.ts
@@ -131,7 +131,7 @@ const UserDataTypeFactory = Factory.define<protobufs.UserDataType>(() => {
   return faker.helpers.arrayElement([
     protobufs.UserDataType.BIO,
     protobufs.UserDataType.DISPLAY,
-    protobufs.UserDataType.FNAME,
+    protobufs.UserDataType.USERNAME,
     protobufs.UserDataType.PFP,
     protobufs.UserDataType.URL,
   ]);

--- a/packages/core/src/protobufs/generated/message.ts
+++ b/packages/core/src/protobufs/generated/message.ts
@@ -236,8 +236,8 @@ export enum UserDataType {
   BIO = 3,
   /** URL - URL of the user */
   URL = 5,
-  /** FNAME - Preferred Farcaster Name for the user */
-  FNAME = 6,
+  /** USERNAME - Preferred Name for the user */
+  USERNAME = 6,
 }
 
 export function userDataTypeFromJSON(object: any): UserDataType {
@@ -258,8 +258,8 @@ export function userDataTypeFromJSON(object: any): UserDataType {
     case "USER_DATA_TYPE_URL":
       return UserDataType.URL;
     case 6:
-    case "USER_DATA_TYPE_FNAME":
-      return UserDataType.FNAME;
+    case "USER_DATA_TYPE_USERNAME":
+      return UserDataType.USERNAME;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }
@@ -277,8 +277,8 @@ export function userDataTypeToJSON(object: UserDataType): string {
       return "USER_DATA_TYPE_BIO";
     case UserDataType.URL:
       return "USER_DATA_TYPE_URL";
-    case UserDataType.FNAME:
-      return "USER_DATA_TYPE_FNAME";
+    case UserDataType.USERNAME:
+      return "USER_DATA_TYPE_USERNAME";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }

--- a/packages/core/src/validations.test.ts
+++ b/packages/core/src/validations.test.ts
@@ -796,7 +796,7 @@ describe("validateUserDataAddBody", () => {
   });
 
   test("succeeds for ens names", async () => {
-    const body = Factories.UserDataBody.build({ type: UserDataType.FNAME, value: "averylongensname.eth" });
+    const body = Factories.UserDataBody.build({ type: UserDataType.USERNAME, value: "averylongensname.eth" });
     expect(validations.validateUserDataAddBody(body)).toEqual(ok(body));
   });
 

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -619,7 +619,7 @@ export const validateUserDataAddBody = (body: protobufs.UserDataBody): HubResult
         return err(new HubError("bad_request.validation_failure", "url value > 256"));
       }
       break;
-    case protobufs.UserDataType.FNAME: {
+    case protobufs.UserDataType.USERNAME: {
       // Users are allowed to set fname = '' to remove their fname, otherwise we need a valid fname to add
       if (value !== "") {
         const validatedFname = validateFname(value);

--- a/packages/hub-nodejs/docs/Messages.md
+++ b/packages/hub-nodejs/docs/Messages.md
@@ -172,14 +172,14 @@ The type of the Reaction contained in the message.
 
 The UserData property being changed by the message.
 
-| Name                   | Number | Description                           |
-| ---------------------- | ------ | ------------------------------------- |
-| USER_DATA_TYPE_NONE    | 0      | Invalid default value                 |
-| USER_DATA_TYPE_PFP     | 1      | Profile Picture for the user          |
-| USER_DATA_TYPE_DISPLAY | 2      | Display Name for the user             |
-| USER_DATA_TYPE_BIO     | 3      | Bio for the user                      |
-| USER_DATA_TYPE_URL     | 5      | URL of the user                       |
-| USER_DATA_TYPE_FNAME   | 6      | Preferred Farcaster Name for the user |
+| Name                    | Number | Description                           |
+|-------------------------| ------ | ------------------------------------- |
+| USER_DATA_TYPE_NONE     | 0      | Invalid default value                 |
+| USER_DATA_TYPE_PFP      | 1      | Profile Picture for the user          |
+| USER_DATA_TYPE_DISPLAY  | 2      | Display Name for the user             |
+| USER_DATA_TYPE_BIO      | 3      | Bio for the user                      |
+| USER_DATA_TYPE_URL      | 5      | URL of the user                       |
+| USER_DATA_TYPE_USERNAME | 6      | Preferred Name for the user |
 
 ## Miscellaneous Types
 

--- a/packages/hub-nodejs/examples/chron-feed/index.ts
+++ b/packages/hub-nodejs/examples/chron-feed/index.ts
@@ -40,7 +40,7 @@ const getPrimaryCastsByFid = async (fid: number, client: HubRpcClient): HubAsync
 };
 
 const getFnameFromFid = async (fid: number, client: HubRpcClient): HubAsyncResult<string> => {
-  const result = await client.getUserData({ fid: fid, userDataType: UserDataType.FNAME });
+  const result = await client.getUserData({ fid: fid, userDataType: UserDataType.USERNAME });
   return result.map((message) => {
     if (isUserDataAddMessage(message)) {
       return message.data.userDataBody.value;
@@ -103,7 +103,7 @@ const castToString = async (cast: CastAddMessage, nameMapping: Map<number, strin
   // 1. Create a mapping of fids to fnames, which we'll need later to display messages
   const fidToFname = new Map<number, string>();
 
-  const fnameResultPromises = FIDS.map((fid) => client.getUserData({ fid, userDataType: UserDataType.FNAME }));
+  const fnameResultPromises = FIDS.map((fid) => client.getUserData({ fid, userDataType: UserDataType.USERNAME }));
   const fnameResults = Result.combine(await Promise.all(fnameResultPromises));
 
   if (fnameResults.isErr()) {

--- a/packages/hub-nodejs/src/generated/message.ts
+++ b/packages/hub-nodejs/src/generated/message.ts
@@ -236,8 +236,8 @@ export enum UserDataType {
   BIO = 3,
   /** URL - URL of the user */
   URL = 5,
-  /** FNAME - Preferred Farcaster Name for the user */
-  FNAME = 6,
+  /** USERNAME - Preferred Name for the user */
+  USERNAME = 6,
 }
 
 export function userDataTypeFromJSON(object: any): UserDataType {
@@ -258,8 +258,8 @@ export function userDataTypeFromJSON(object: any): UserDataType {
     case "USER_DATA_TYPE_URL":
       return UserDataType.URL;
     case 6:
-    case "USER_DATA_TYPE_FNAME":
-      return UserDataType.FNAME;
+    case "USER_DATA_TYPE_USERNAME":
+      return UserDataType.USERNAME;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }
@@ -277,8 +277,8 @@ export function userDataTypeToJSON(object: UserDataType): string {
       return "USER_DATA_TYPE_BIO";
     case UserDataType.URL:
       return "USER_DATA_TYPE_URL";
-    case UserDataType.FNAME:
-      return "USER_DATA_TYPE_FNAME";
+    case UserDataType.USERNAME:
+      return "USER_DATA_TYPE_USERNAME";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }

--- a/packages/hub-web/examples/chron-feed/index.ts
+++ b/packages/hub-web/examples/chron-feed/index.ts
@@ -40,7 +40,7 @@ const getPrimaryCastsByFid = async (fid: number, client: HubRpcClient): HubAsync
 };
 
 const getFnameFromFid = async (fid: number, client: HubRpcClient): HubAsyncResult<string> => {
-  const result = await client.getUserData({ fid: fid, userDataType: UserDataType.FNAME });
+  const result = await client.getUserData({ fid: fid, userDataType: UserDataType.USERNAME });
   return result.map((message) => {
     if (isUserDataAddMessage(message)) {
       return message.data.userDataBody.value;
@@ -103,7 +103,7 @@ const castToString = async (cast: CastAddMessage, nameMapping: Map<number, strin
   // 1. Create a mapping of fids to fnames, which we'll need later to display messages
   const fidToFname = new Map<number, string>();
 
-  const fnameResultPromises = FIDS.map((fid) => client.getUserData({ fid, userDataType: UserDataType.FNAME }));
+  const fnameResultPromises = FIDS.map((fid) => client.getUserData({ fid, userDataType: UserDataType.USERNAME }));
   const fnameResults = Result.combine(await Promise.all(fnameResultPromises));
 
   if (fnameResults.isErr()) {

--- a/packages/hub-web/src/generated/message.ts
+++ b/packages/hub-web/src/generated/message.ts
@@ -236,8 +236,8 @@ export enum UserDataType {
   BIO = 3,
   /** URL - URL of the user */
   URL = 5,
-  /** FNAME - Preferred Farcaster Name for the user */
-  FNAME = 6,
+  /** USERNAME - Preferred Name for the user */
+  USERNAME = 6,
 }
 
 export function userDataTypeFromJSON(object: any): UserDataType {
@@ -258,8 +258,8 @@ export function userDataTypeFromJSON(object: any): UserDataType {
     case "USER_DATA_TYPE_URL":
       return UserDataType.URL;
     case 6:
-    case "USER_DATA_TYPE_FNAME":
-      return UserDataType.FNAME;
+    case "USER_DATA_TYPE_USERNAME":
+      return UserDataType.USERNAME;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }
@@ -277,8 +277,8 @@ export function userDataTypeToJSON(object: UserDataType): string {
       return "USER_DATA_TYPE_BIO";
     case UserDataType.URL:
       return "USER_DATA_TYPE_URL";
-    case UserDataType.FNAME:
-      return "USER_DATA_TYPE_FNAME";
+    case UserDataType.USERNAME:
+      return "USER_DATA_TYPE_USERNAME";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }

--- a/protobufs/docs/message.md
+++ b/protobufs/docs/message.md
@@ -117,14 +117,14 @@ Adds metadata about a user
 
 Type of UserData
 
-| Name                   | Number | Description                           |
-| ---------------------- | ------ | ------------------------------------- |
-| USER_DATA_TYPE_NONE    | 0      | Invalid default value                 |
-| USER_DATA_TYPE_PFP     | 1      | Profile Picture for the user          |
-| USER_DATA_TYPE_DISPLAY | 2      | Display Name for the user             |
-| USER_DATA_TYPE_BIO     | 3      | Bio for the user                      |
-| USER_DATA_TYPE_URL     | 5      | URL of the user                       |
-| USER_DATA_TYPE_FNAME   | 6      | Preferred Farcaster Name for the user |
+| Name                    | Number | Description                           |
+|-------------------------| ------ | ------------------------------------- |
+| USER_DATA_TYPE_NONE     | 0      | Invalid default value                 |
+| USER_DATA_TYPE_PFP      | 1      | Profile Picture for the user          |
+| USER_DATA_TYPE_DISPLAY  | 2      | Display Name for the user             |
+| USER_DATA_TYPE_BIO      | 3      | Bio for the user                      |
+| USER_DATA_TYPE_URL      | 5      | URL of the user                       |
+| USER_DATA_TYPE_USERNAME | 6      | Preferred Farcaster Name for the user |
 
 ## 4. Cast
 

--- a/protobufs/schemas/message.proto
+++ b/protobufs/schemas/message.proto
@@ -99,7 +99,7 @@ enum UserDataType {
   USER_DATA_TYPE_DISPLAY = 2; // Display Name for the user
   USER_DATA_TYPE_BIO = 3; // Bio for the user
   USER_DATA_TYPE_URL = 5; // URL of the user
-  USER_DATA_TYPE_FNAME = 6; // Preferred Farcaster Name for the user
+  USER_DATA_TYPE_USERNAME = 6; // Preferred Name for the user
 }
 
 message Embed {


### PR DESCRIPTION
## Motivation

Names can be both fnames and ens names, so rename to USERNAME for clarity

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming the `FNAME` user data type to `USERNAME`. 

### Detailed summary
- Renamed `UserDataType.FNAME` to `UserDataType.USERNAME` in multiple files and tests.
- Updated protobuf definitions and generated code to reflect the change.

> The following files were skipped due to too many changes: `apps/hubble/src/rpc/test/userDataService.test.ts`, `apps/hubble/src/storage/engine/index.ts`, `apps/hubble/src/storage/engine/index.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->