### PR TITLE
Update allowedPeers.mainnet.ts

### DIFF
--- a/apps/hubble/src/allowedPeers.mainnet.ts
+++ b/apps/hubble/src/allowedPeers.mainnet.ts
@@ -20,6 +20,11 @@ export const MAINNET_ALLOWED_PEERS = [
   "12D3KooWSii9GJheDmFRBzii43fpzvb3WkmPn62QSoJ8MjvGKMxr", // @mp
   "12D3KooWQ76P8kBUvjNx2Q8EpYDL1BsqXdqZmAkHzTxE1uruuwRd", // @brianjckim
   "12D3KooWRrFF356RALgsPwQQpg68reJL2y94VwKZFogUkM9der1V", // @lndnnft
+  "12D3KooWAr5LEwhSU1vNsgBQhkrLxZUKspag2CrwH5AYWu451Auj", // @withportals Shared Hub 1 (@lndnnft)
+  "12D3KooWAPgyKfRPYXfJvUa2YmW1ZnFCs4Sx1m9WmEKxNn8mEXkJ", // @withportals Shared Hub 2 (@lndnnft)
+  "12D3KooWCx2XRmiMoQKFRALhbet21ezvgChbJ9PtVSFatYfUpUhX", // @withportals Dedicated Hub 1 (@lndnnft)
+  "12D3KooWATFp6YuGXGZrCMcm9JWCsnZxeYSJZ7ExzENFn3S4MExG", // @withportals Dedicated Hub 2 (@lndnnft)
+  "12D3KooWKxHRB3K9JSpRba9hPd2e1zzmdgPH35qcf7yKMjFBcBuE", // @withportals Dedicated Hub 3 (@lndnnft)
   "12D3KooWPNDmUeNiGdCdoHp8iAf8Uay3c2C9n5QVygd3J1hfv65w", // @sanjay
   "12D3KooWFZwTP5bUZbQViTk79i2DZujHBBjPpAZyDwyrkPb79eAL", // @molo
   "12D3KooWHK4EXZ33nVFLSCLRuFNUK74v72eZEcRKoHTPbX9Nove7", // @neynar


### PR DESCRIPTION
## Motivation

I am currently building out a developer platform for Farcaster, called Portals. We plan to offer access to shared, and dedicated hubs. Since permissionless peering is not released yet, the goal here is to pre-add / sync 3 dedicated hubs to offer, and then have 2 hubs we offer shared access to.

## Change Summary

Just updates the allows peers list for mainnet.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds new peers to the allowedPeers.mainnet.ts file in the hubble app.

### Detailed summary
- Added a new shared hub with address `12D3KooWAr5LEwhSU1vNsgBQhkrLxZUKspag2CrwH5AYWu451Auj` for user `@withportals`
- Added a new shared hub with address `12D3KooWAPgyKfRPYXfJvUa2YmW1ZnFCs4Sx1m9WmEKxNn8mEXkJ` for user `@withportals`
- Added a new dedicated hub with address `12D3KooWCx2XRmiMoQKFRALhbet21ezvgChbJ9PtVSFatYfUpUhX` for user `@withportals`
- Added a new dedicated hub with address `12D3KooWATFp6YuGXGZrCMcm9JWCsnZxeYSJZ7ExzENFn3S4MExG` for user `@withportals`
- Added a new dedicated hub with address `12D3KooWKxHRB3K9JSpRba9hPd2e1zzmdgPH35qcf7yKMjFBcBuE` for user `@withportals`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->