### PR TITLE
feat: Add hash to links table in postgres replicator

### DIFF
--- a/packages/hub-nodejs/examples/replicate-data-postgres/db.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/db.ts
@@ -119,6 +119,7 @@ export interface Database {
   };
 
   links: {
+    hash: Uint8Array;
     id: GeneratedAlways<string>;
     fid: number;
     targetFid: number | null;

--- a/packages/hub-nodejs/examples/replicate-data-postgres/hubReplicator.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/hubReplicator.ts
@@ -621,6 +621,7 @@ export class HubReplicator {
       .insertInto("links")
       .values(
         messages.map((message) => ({
+          hash: message.hash,
           timestamp: farcasterTimeToDate(message.data.timestamp),
           // type assertion due to a problem with the type definitions. This field is infact required and present in all valid messages
           // rome-ignore lint/style/noNonNullAssertion: legacy code, avoid using ignore for new code

--- a/packages/hub-nodejs/examples/replicate-data-postgres/migrations/002_add_hash_to_links.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/migrations/002_add_hash_to_links.ts
@@ -1,0 +1,12 @@
+import { Kysely, sql } from 'kysely';
+
+export const up = async (db: Kysely<any>) => {
+  await db.schema
+    .alterTable('links')
+    .addColumn('hash', sql`bytea`, (col) => col.notNull())
+    .execute();
+};
+
+export const down = async (db: Kysely<any>) => {
+  await db.schema.alterTable('links').dropColumn('hash').execute();
+};

--- a/packages/hub-nodejs/examples/replicate-data-postgres/migrations/002_add_hash_to_links.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/migrations/002_add_hash_to_links.ts
@@ -1,13 +1,13 @@
-import { Kysely, sql } from 'kysely';
-import { Database } from '../db';
+import { Kysely, sql } from "kysely";
+import { Database } from "../db";
 
 export const up = async (db: Kysely<Database>) => {
   await db.schema
-    .alterTable('links')
-    .addColumn('hash', sql`bytea`, (col) => col.notNull())
+    .alterTable("links")
+    .addColumn("hash", sql`bytea`, (col) => col.notNull())
     .execute();
 };
 
 export const down = async (db: Kysely<Database>) => {
-  await db.schema.alterTable('links').dropColumn('hash').execute();
+  await db.schema.alterTable("links").dropColumn("hash").execute();
 };

--- a/packages/hub-nodejs/examples/replicate-data-postgres/migrations/002_add_hash_to_links.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/migrations/002_add_hash_to_links.ts
@@ -1,12 +1,13 @@
 import { Kysely, sql } from 'kysely';
+import { Database } from '../db';
 
-export const up = async (db: Kysely<any>) => {
+export const up = async (db: Kysely<Database>) => {
   await db.schema
     .alterTable('links')
     .addColumn('hash', sql`bytea`, (col) => col.notNull())
     .execute();
 };
 
-export const down = async (db: Kysely<any>) => {
+export const down = async (db: Kysely<Database>) => {
   await db.schema.alterTable('links').dropColumn('hash').execute();
 };


### PR DESCRIPTION
## Motivation

Right now every table has a `hash` column, so this is just making the `links` table consistent

## Change Summary

Added property, added migration

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)
