### PR TITLE
perf: Tune sync params

### DIFF
--- a/.changeset/happy-terms-occur.md
+++ b/.changeset/happy-terms-occur.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+perf: Tune sync parameters and add mergeMessages profile

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -298,11 +298,14 @@ export class Hub implements HubInterface {
           if (profile) {
             profileLog.info({ wallTimeMs: profile.getSyncDuration() });
 
-            for (const [method, p] of profile.getRpcMethodProfiles()) {
+            for (const [method, p] of profile.getAllMethodProfiles()) {
               profileLog.info({ method, p });
             }
 
             // Also write to console for easy copy/paste
+            console.log("\nTotal Time\n");
+            console.log(prettyPrintTable(profile.durationToPrettyPrintObject()));
+
             console.log("\nLatencies (ms)\n");
             console.log(prettyPrintTable(profile.latenciesToPrettyPrintObject()));
 
@@ -864,7 +867,7 @@ export class Hub implements HubInterface {
 
     mergeResult.match(
       (eventId) => {
-        logMessage.info(
+        logMessage.debug(
           `submitMessage success ${eventId}: fid ${message.data?.fid} merged ${messageTypeToName(
             message.data?.type,
           )} ${bytesToHexString(message.hash)._unsafeUnwrap()}`,


### PR DESCRIPTION
## Motivation

We should tune the sync params so that the network latency balances the merge latency (So the merge queue isn't waiting for messages / We aren't fetching messages that are backed up in the merge queue)

## Change Summary

- Add profiling for the merge queue
- Fetch 128 messages per batch
- Upto 16 leaf nodes at a time

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context
This improves full sync time by ~70% (210 min -> 124 min) by making sure the queues are not waiting for each other.

Here's a profile for a full sync (Incremental sync also has similar numbers)
```
Total Time

          | Duration (s)
------------------------
Wall Time |         7471

Latencies (ms)

                 Method | Count | Min |  Max |   Avg  | Median
--------------------------------------------------------------
getSyncMetadataByPrefix | 93.0K |  49 |  751 | 101.47 |     79
  getAllSyncIdsByPrefix | 83.7K |  49 | 1.1K | 188.85 |    114
getAllMessagesBySyncIds | 83.7K |  48 | 1.2K | 206.68 |    300
          mergeMessages | 83.7K |   3 | 8.4K |   1.4K |   1.1K

Data Fetched (bytes)

                 Method | Count | Objects |  Total | Min |   Max |    Avg | Median
----------------------------------------------------------------------------------
getSyncMetadataByPrefix | 93.0K |   93.0K |  57.4M |  78 | 11.9K | 617.45 |    655
  getAllSyncIdsByPrefix | 83.7K |    2.5M | 178.7M |  78 |  9.2K |   2.1K |    790
getAllMessagesBySyncIds | 83.7K |    2.5M | 961.9M | 333 | 56.7K |  11.5K |   4.2K
          mergeMessages | 83.7K |    2.5M |      0 |   0 |     0 |      0 |      0

```