### PR TITLE
chore: hard fail on missing rpc urls

### DIFF
--- a/.changeset/dull-onions-sniff.md
+++ b/.changeset/dull-onions-sniff.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": minor
+---
+
+chore: Hard fail on missing RPC urls.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run Hubble
         shell: bash
-        run: docker run --name hub --detach -p2282:2282 -p2283:2283 farcasterxyz/hubble:test sh -c 'node build/cli.js identity create && node build/cli.js start --rpc-port 2283 --ip 0.0.0.0 --gossip-port 2282 --eth-rpc-url "https://eth-goerli.g.alchemy.com/v2/IvjMoCKt1hT66f9OJoL_dMXypnvQYUdd" --network 3 --allowed-peers none'
+        run: docker run --name hub --detach -p2282:2282 -p2283:2283 farcasterxyz/hubble:test sh -c 'node build/cli.js identity create && node build/cli.js start --rpc-port 2283 --ip 0.0.0.0 --gossip-port 2282 --eth-rpc-url "https://eth-goerli.g.alchemy.com/v2/IvjMoCKt1hT66f9OJoL_dMXypnvQYUdd" --eth-mainnet-rpc-url "https://eth-mainnet.g.alchemy.com/v2/8cz__IXnQ5FK_GNYDlfooLzYhBAW7ta0" --network 3 --allowed-peers none'
 
       - name: Download grpcurl
         shell: bash

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -254,11 +254,13 @@ export class Hub implements HubInterface {
         options.resyncEthEvents ?? false,
       );
     } else {
-      log.warn("No ETH RPC URL provided, not syncing with ETH contract events");
+      log.warn("No ETH RPC URL provided, unable to sync ETH contract events");
+      throw new HubError("bad_request.invalid_param", "Invalid eth testnet rpc url");
     }
 
     if (!options.ethMainnetRpcUrl || options.ethMainnetRpcUrl === "") {
       log.warn("No ETH mainnet RPC URL provided, unable to validate ens names");
+      throw new HubError("bad_request.invalid_param", "Invalid eth mainnet rpc url");
     }
 
     if (options.fnameServerUrl && options.fnameServerUrl !== "") {
@@ -268,7 +270,8 @@ export class Hub implements HubInterface {
         options.resyncNameEvents ?? false,
       );
     } else {
-      log.warn("No FName Registry URL provided, not syncing with fname events");
+      log.warn("No FName Registry URL provided, unable to sync fname events");
+      throw new HubError("bad_request.invalid_param", "Invalid fname server url");
     }
 
     const eventHandler = new StoreEventHandler(this.rocksDB, {

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -258,7 +258,7 @@ export class Hub implements HubInterface {
       throw new HubError("bad_request.invalid_param", "Invalid eth testnet rpc url");
     }
 
-    if (!options.ethMainnetRpcUrl || options.ethMainnetRpcUrl === "") {
+    if (!options.ethMainnetRpcUrl) {
       log.warn("No ETH mainnet RPC URL provided, unable to validate ens names");
       throw new HubError("bad_request.invalid_param", "Invalid eth mainnet rpc url");
     }


### PR DESCRIPTION
## Motivation

Hubs cannot converge properly if they are missing eth RPC urls, so make it a hard requirement to start.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on improving error handling and providing more informative error messages in the Hubble application.

### Detailed summary:
- Added error handling for missing RPC URLs and threw specific error messages.
- Updated log messages to provide more information about missing RPC URLs.
- Threw specific error messages for invalid RPC URLs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->