### PR TITLE
fix: Throw error if unable to fetch fname server signature

### DIFF
--- a/.changeset/four-beds-prove.md
+++ b/.changeset/four-beds-prove.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: throw error if unable to fetch fname server signature

--- a/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
+++ b/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
@@ -208,4 +208,9 @@ describe("fnameRegistryEventsProvider", () => {
       expect(await getUserNameProof(db, utf8ToBytes("farcaster"))).toBeTruthy();
     });
   });
+
+  test("throws for invalid signer", async () => {
+    mockFnameRegistryClient.setSignerAddress("0x");
+    await expect(provider.start()).rejects.toThrowError("Failed to parse server address");
+  });
 });


### PR DESCRIPTION
## Motivation

We're seeing some logs around failing to verify fname server signatures, add logging to track it down.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Fixed a bug where an error was not being thrown if the server address could not be fetched.
- Added a check to throw an error if the signer address is invalid.
- Added a `shouldStop` flag to stop the provider.
- Added logging and error handling for failed username proof verification.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->