### PR TITLE
fix: Adjust chunk size to 1000

### DIFF
--- a/.changeset/slow-roses-dream.md
+++ b/.changeset/slow-roses-dream.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+Adjust chunk size to 1000 from 10000

--- a/apps/hubble/src/eth/ethEventsProvider.ts
+++ b/apps/hubble/src/eth/ethEventsProvider.ts
@@ -27,7 +27,7 @@ export class GoerliEthConstants {
   public static IdRegistryAddress = "0xda107a1caf36d198b12c16c7b6a1d1c795978c42" as const;
   public static NameRegistryAddress = "0xe3be01d99baa8db9905b33a3ca391238234b79d1" as const;
   public static FirstBlock = 7648795;
-  public static ChunkSize = 10000;
+  public static ChunkSize = 1000;
 }
 
 type NameRegistryRenewEvent = Omit<NameRegistryEvent, "to" | "from">;

--- a/apps/hubble/src/eth/l2EventsProvider.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.ts
@@ -24,7 +24,7 @@ const log = logger.child({
 export class OPGoerliEthConstants {
   public static StorageRegistryAddress = "0xa89cC9427335da6E8138517419FCB3c9c37d1604" as const;
   public static FirstBlock = 11183461;
-  public static ChunkSize = 10000;
+  public static ChunkSize = 1000;
   public static chainId = BigInt(420); // OP Goerli
 }
 


### PR DESCRIPTION
## Motivation

ID Events are starting to arrive more often, resulting in 10000 block chunks having enough events to sometimes hit lock contention. Reducing this has minimal impact on fresh hub sync time while avoiding lock contention.

## Change Summary

Adjusted chunk size to 1000 from 10000.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
