### PR TITLE
perf: Get exact diff nodes during incremental sync

### DIFF
--- a/.changeset/tiny-chicken-marry.md
+++ b/.changeset/tiny-chicken-marry.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+perf: Improve incremental sync performance

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -689,23 +689,23 @@ export class Hub implements HubInterface {
       await this.gossipNode.addPeerToAddressBook(peerId, multiaddrValue);
     }
 
-    log.info({ identity: this.identity, peer: peerId, message }, "received a Contact Info for sync");
+    log.debug({ identity: this.identity, peer: peerId, message }, "received peer ContactInfo");
 
     // Check if we already have this client
     const peerInfo = this.syncEngine.getContactInfoForPeerId(peerId.toString());
     if (peerInfo) {
-      log.info({ peerInfo }, "Already have this peer, skipping sync");
+      log.debug({ peerInfo }, "Already have this peer, skipping sync");
       return;
     } else {
       // If it is a new client, we do a sync against it
-      log.info({ peerInfo }, "New Peer Contact Info, syncing");
+      log.info({ peerInfo, connectedPeers: this.syncEngine.getPeerCount() }, "New Peer ContactInfo");
       this.syncEngine.addContactInfoForPeerId(peerId, message);
       const syncResult = await ResultAsync.fromPromise(
         this.syncEngine.diffSyncIfRequired(this, peerId.toString()),
         (e) => e,
       );
       if (syncResult.isErr()) {
-        log.error({ error: syncResult.error, peerId }, "failed to sync with new peer");
+        log.error({ error: syncResult.error, peerId }, "Failed to sync with new peer");
       }
     }
   }
@@ -867,11 +867,19 @@ export class Hub implements HubInterface {
 
     mergeResult.match(
       (eventId) => {
-        logMessage.debug(
-          `submitMessage success ${eventId}: fid ${message.data?.fid} merged ${messageTypeToName(
-            message.data?.type,
-          )} ${bytesToHexString(message.hash)._unsafeUnwrap()}`,
-        );
+        const logData = {
+          eventId,
+          fid: message.data?.fid,
+          type: messageTypeToName(message.data?.type),
+          hash: bytesToHexString(message.hash)._unsafeUnwrap(),
+        };
+        const msg = "submitMessage success";
+
+        if (source === "sync") {
+          log.debug(logData, msg);
+        } else {
+          log.info(logData, msg);
+        }
       },
       (e) => {
         logMessage.warn({ errCode: e.errCode }, `submitMessage error: ${e.message}`);

--- a/apps/hubble/src/network/sync/merkleTrie.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.ts
@@ -327,7 +327,11 @@ class MerkleTrie {
     // Fn that does the actual unloading
     const doUnload = async () => {
       this._callsSinceLastUnload = 0;
-      logger.info("Unloading trie from memory");
+
+      if (this._pendingDbUpdates.size === 0) {
+        // Trie has no pending DB updates, skipping unload
+        return;
+      }
 
       const txn = this._db.transaction();
 
@@ -341,7 +345,7 @@ class MerkleTrie {
       }
 
       await this._db.commit(txn);
-      logger.info({ numDbUpdates: this._pendingDbUpdates.size }, "Trie committed pending DB updates");
+      logger.info({ numDbUpdates: this._pendingDbUpdates.size, force }, "Trie committed pending DB updates");
 
       this._pendingDbUpdates.clear();
       this._root.unloadChildren();

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -547,7 +547,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
                 fid: msg.data?.fid,
                 err: result.error.message,
                 signer: bytesToHexString(msg.signer)._unsafeUnwrap(),
-                retryResult,
+                retryResult: retryResult.isOk() ? "ok" : "err",
               },
               "Unknown signer, fetched all signers from peer",
             );


### PR DESCRIPTION
## Motivation

Improve performance of incremental sync

## Change Summary

- During incremental sync, we were accidentally fetching messages that we already had
- Make sure we get the exact node/message that is missing instead of getting everything from a leaf. 
- Remove some duplicate logging

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

Stats:
Time drops from 17s -> 9s, and data fetched drops from 11kb / call -> 0.3kb / call
```
Fast Divergence Measurement
With optimization (9s 0.3kb / call)
Total Time

          | Duration (s)
------------------------
Wall Time |            9

Latencies (ms)

                 Method | Count | Min | Max |  Avg  | Median
------------------------------------------------------------
getSyncMetadataByPrefix |   371 |  41 |  75 | 44.50 |     42
  getAllSyncIdsByPrefix |    79 |  41 |  59 | 46.04 |     45
getAllMessagesBySyncIds |    22 |  43 |  65 | 56.32 |     63
          mergeMessages |    22 |   7 | 132 | 79.50 |    102

Data Fetched (bytes)

                 Method | Count | Objects |  Total | Min |  Max |    Avg | Median
---------------------------------------------------------------------------------
getSyncMetadataByPrefix |   371 |     371 | 175.6K |  78 |  800 | 473.40 |    787
  getAllSyncIdsByPrefix |    79 |     111 |   8.8K |  80 |  369 | 111.56 |     82
getAllMessagesBySyncIds |    22 |      54 |  20.8K | 346 | 1.9K | 947.50 |    348
          mergeMessages |    22 |      54 |      0 |   0 |    0 |      0 |      0

Without optimisation (17s, 11kb / call)

Total Time

          | Duration (s)
------------------------
Wall Time |           17

Latencies (ms)

                 Method | Count | Min | Max |   Avg  | Median
-------------------------------------------------------------
getSyncMetadataByPrefix |   344 |  43 | 375 |  88.85 |     53
  getAllSyncIdsByPrefix |    61 |  44 | 100 |  62.20 |     44
getAllMessagesBySyncIds |    44 |  98 | 101 |  99.50 |     99
          mergeMessages |    44 | 215 | 282 | 246.75 |    257

Data Fetched (bytes)

                 Method | Count | Objects |  Total |  Min |   Max |    Avg | Median
-----------------------------------------------------------------------------------
getSyncMetadataByPrefix |   344 |     344 | 168.6K |   78 |   800 | 490.20 |    764
  getAllSyncIdsByPrefix |    61 |     156 |  11.8K |   80 |  2.3K | 193.61 |     81
getAllMessagesBySyncIds |    44 |      54 |  37.1K | 6.7K | 11.6K |   9.3K |  11.6K
          mergeMessages |    44 |      54 |      0 |    0 |     0 |      0 |      0
```

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Improved incremental sync performance in the `MerkleTrie` class by skipping unload if there are no pending DB updates.
- Added a test case to ensure that only the exact missing message is fetched during syncing.
- Updated log levels and messages for better clarity and debugging.
- Added a method to retrieve the number of connected peers in the `SyncEngine` class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->