### PR TITLE
feat: support fallback RPC providers

### DIFF
--- a/.changeset/tasty-countries-jump.md
+++ b/.changeset/tasty-countries-jump.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": minor
+---
+
+feat: support fallback RPC providers

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -52,9 +52,10 @@ app.name("hub").description("Farcaster Hub").version(APP_VERSION);
 app
   .command("start")
   .description("Start a Hub")
-  .option("-e, --eth-rpc-url <url>", "RPC URL of a Goerli Ethereum Node")
-  .option("-l, --l2-rpc-url <url>", "RPC URL of a Goerli Optimism Node")
-  .option("-m, --eth-mainnet-rpc-url <url>", "RPC URL of a mainnet Ethereum Node")
+  .option("-e, --eth-rpc-url <url>", "RPC URL of a Goerli Ethereum Node (or comma separated list of URLs)")
+  .option("-l, --l2-rpc-url <url>", "RPC URL of a Goerli Optimism Node (or comma separated list of URLs)")
+  .option("-m, --eth-mainnet-rpc-url <url>", "RPC URL of a mainnet Ethereum Node (or comma separated list of URLs)")
+  .option("--rank-rpcs", "Rank the RPCs by latency/stability and use the fastest one (default: disabled)")
   .option("-c, --config <filepath>", "Path to a config file with options")
   .option("--fir-address <address>", "The address of the Farcaster ID Registry contract")
   .option("--fnr-address <address>", "The address of the Farcaster Name Registry contract")
@@ -315,6 +316,7 @@ app
       ethMainnetRpcUrl: cliOptions.ethMainnetRpcUrl ?? hubConfig.ethMainnetRpcUrl,
       fnameServerUrl: cliOptions.fnameServerUrl ?? hubConfig.fnameServerUrl ?? DEFAULT_FNAME_SERVER_URL,
       l2RpcUrl: cliOptions.l2RpcUrl ?? hubConfig.l2RpcUrl,
+      rankRpcs: cliOptions.rankRpcs ?? hubConfig.rankRpcs ?? false,
       idRegistryAddress: cliOptions.firAddress ?? hubConfig.firAddress,
       nameRegistryAddress: cliOptions.fnrAddress ?? hubConfig.fnrAddress,
       firstBlock: cliOptions.firstBlock ?? hubConfig.firstBlock,

--- a/apps/hubble/src/eth/ethEventsProvider.test.ts
+++ b/apps/hubble/src/eth/ethEventsProvider.test.ts
@@ -7,7 +7,7 @@ import {
   NameRegistryEventType,
   HubError,
 } from "@farcaster/hub-nodejs";
-import { createPublicClient, http, parseEther, toHex } from "viem";
+import { Transport, createPublicClient, http, parseEther, toHex } from "viem";
 import { IdRegistry, NameRegistry } from "./abis.js";
 import { EthEventsProvider } from "./ethEventsProvider.js";
 import { getIdRegistryEvent } from "../storage/db/idRegistryEvent.js";
@@ -64,6 +64,44 @@ describe("EthEventsProvider", () => {
       );
 
       await expect(ethEventsProvider.start()).rejects.toThrowError(HubError);
+    });
+  });
+
+  describe("build", () => {
+    test("handles single RPC URL", () => {
+      const ethEventsProvider = EthEventsProvider.build(
+        hub,
+        "http://some-url",
+        false,
+        idRegistryAddress,
+        nameRegistryAddress,
+        1,
+        10000,
+        false,
+      );
+
+      const transports = (ethEventsProvider["_publicClient"].transport as unknown as { transports: Transport[] })
+        .transports;
+
+      expect(transports.length).toBe(1);
+    });
+
+    test("handles multiple RPC URLs", () => {
+      const ethEventsProvider = EthEventsProvider.build(
+        hub,
+        "http://some-url,http://some-other-url",
+        false,
+        idRegistryAddress,
+        nameRegistryAddress,
+        1,
+        10000,
+        false,
+      );
+
+      const transports = (ethEventsProvider["_publicClient"].transport as unknown as { transports: Transport[] })
+        .transports;
+
+      expect(transports.length).toBe(2);
     });
   });
 

--- a/apps/hubble/src/eth/l2EventsProvider.test.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.test.ts
@@ -13,7 +13,7 @@ import {
   getRentRegistryEventsIterator,
   getStorageAdminRegistryEventsIterator,
 } from "../storage/db/storageRegistryEvent.js";
-import { toBytes } from "viem";
+import { Transport, toBytes } from "viem";
 
 const db = jestRocksDB("protobufs.l2EventsProvider.test");
 const engine = new Engine(db, FarcasterNetwork.TESTNET);
@@ -30,6 +30,42 @@ beforeAll(() => {
 
 afterAll(async () => {
   await engine.stop();
+});
+
+describe("build", () => {
+  test("handles single RPC URL", () => {
+    const l2EventsProvider = L2EventsProvider.build(
+      hub,
+      "http://some-url",
+      false,
+      storageRegistryAddress,
+      1,
+      10000,
+      false,
+    );
+
+    const transports = (l2EventsProvider["_publicClient"].transport as unknown as { transports: Transport[] })
+      .transports;
+
+    expect(transports.length).toBe(1);
+  });
+
+  test("handles multiple RPC URLs", () => {
+    const l2EventsProvider = L2EventsProvider.build(
+      hub,
+      "http://some-url,http://some-other-url",
+      false,
+      storageRegistryAddress,
+      1,
+      10000,
+      false,
+    );
+
+    const transports = (l2EventsProvider["_publicClient"].transport as unknown as { transports: Transport[] })
+      .transports;
+
+    expect(transports.length).toBe(2);
+  });
 });
 
 describe("process events", () => {

--- a/apps/hubble/src/eth/l2EventsProvider.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.ts
@@ -13,7 +13,7 @@ import { StorageRegistry } from "./abis.js";
 import { HubInterface } from "../hubble.js";
 import { logger } from "../utils/logger.js";
 import { optimismGoerli } from "viem/chains";
-import { createPublicClient, http, Log, PublicClient } from "viem";
+import { createPublicClient, fallback, http, Log, PublicClient } from "viem";
 import { WatchContractEvent } from "./watchContractEvent.js";
 import { WatchBlockNumber } from "./watchBlockNumber.js";
 
@@ -179,14 +179,18 @@ export class L2EventsProvider {
   public static build(
     hub: HubInterface,
     l2RpcUrl: string,
+    rankRpcs: boolean,
     storageRegistryAddress: `0x${string}`,
     firstBlock: number,
     chunkSize: number,
     resyncEvents: boolean,
   ): L2EventsProvider {
+    const l2RpcUrls = l2RpcUrl.split(",");
+    const transports = l2RpcUrls.map((url) => http(url, { retryCount: 10 }));
+
     const publicClient = createPublicClient({
       chain: optimismGoerli,
-      transport: http(l2RpcUrl, { retryCount: 10 }),
+      transport: fallback(transports, { rank: rankRpcs }),
     });
 
     const provider = new L2EventsProvider(


### PR DESCRIPTION
CLI now supports comma separated RPC URLs to fall back on (--eth-rpc-url, --eth-mainnet-rpc-url, --l2-rpc-url)

## Motivation

"This ensures that if a backend has become out-of-sync, or if it has been compromised that its responses are dropped in favor of responses that match the majority." #742.

## Change Summary

Implements backwards-compatible fallback URLs using viem's `fallback` transport, as suggested by #742.
Makes use of existing --eth-rpc-url, --eth-mainnet-rpc-url, --l2-rpc-url arguments, but splits by ',' to support multiple URLs to fall back on if others are not responding.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

Ranking can also be enabled. This would periodically make additional calls to each RPC URL every 10 seconds to determine its ranking based on [latency and stability](https://viem.sh/docs/clients/transports/fallback.html#transport-ranking). Perhaps this configuration could be exposed to the user via CLI?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding support for fallback RPC providers in the Hubble application. 

### Detailed summary
- Added `fallback` function to the `viem` library to handle fallback RPC providers.
- Modified `L2EventsProvider` and `EthEventsProvider` classes to support multiple RPC URLs.
- Updated the `Hub` class to use the `rankRpcs` option and fallback transports for RPC providers.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->