### PR TITLE
feat: add eth events to sync trie

### DIFF
--- a/apps/hubble/src/network/p2p/gossipNode.test.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.test.ts
@@ -19,6 +19,7 @@ import SyncEngine from "../sync/syncEngine.js";
 import { PeerId } from "@libp2p/interface-peer-id";
 import { sleep } from "../../utils/crypto.js";
 import { createEd25519PeerId } from "@libp2p/peer-id-factory";
+import { RootPrefix } from "storage/db/types.js";
 
 const TEST_TIMEOUT_SHORT = 10 * 1000;
 const db = jestRocksDB("network.p2p.gossipNode.test");
@@ -166,7 +167,17 @@ describe("GossipNode", () => {
       const hub = new MockHub(db, undefined, mockGossipNode);
 
       const syncEngine = new SyncEngine(hub, db);
-      server = new Server(hub, hub.engine, syncEngine, mockGossipNode);
+      const ethSyncEngine = new SyncEngine(
+        hub,
+        db,
+        undefined,
+        undefined,
+        false,
+        RootPrefix.SyncEthEventsMerkleTrieNode,
+        [RootPrefix.IdRegistryEvent, RootPrefix.NameRegistryEvent, RootPrefix.FNameUserNameProof],
+        ["mergeIdRegistryEvent", "mergeNameRegistryEvent", "mergeUsernameProofEvent"],
+      );
+      server = new Server(hub, hub.engine, syncEngine, ethSyncEngine, mockGossipNode);
       const port = await server.start();
       client = getInsecureHubRpcClient(`127.0.0.1:${port}`);
 

--- a/apps/hubble/src/network/p2p/gossipNode.test.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.test.ts
@@ -19,7 +19,7 @@ import SyncEngine from "../sync/syncEngine.js";
 import { PeerId } from "@libp2p/interface-peer-id";
 import { sleep } from "../../utils/crypto.js";
 import { createEd25519PeerId } from "@libp2p/peer-id-factory";
-import { RootPrefix } from "storage/db/types.js";
+import { RootPrefix } from "../../storage/db/types.js";
 
 const TEST_TIMEOUT_SHORT = 10 * 1000;
 const db = jestRocksDB("network.p2p.gossipNode.test");

--- a/apps/hubble/src/network/sync/trieNode.test.ts
+++ b/apps/hubble/src/network/sync/trieNode.test.ts
@@ -3,6 +3,7 @@ import { TIMESTAMP_LENGTH } from "./syncId.js";
 import { EMPTY_HASH, TrieNode } from "./trieNode.js";
 import { NetworkFactories } from "../utils/factories.js";
 import { jestRocksDB } from "../../storage/db/jestUtils.js";
+import { RootPrefix } from "storage/db/types.js";
 
 // Safety: fs inputs are always safe in tests
 
@@ -28,7 +29,7 @@ describe("TrieNode", () => {
 
   describe("insert", () => {
     test("succeeds inserting a single item", async () => {
-      const root = new TrieNode();
+      const root = new TrieNode(RootPrefix.User);
       const id = await NetworkFactories.SyncId.create();
 
       expect(root.items).toEqual(0);
@@ -41,7 +42,7 @@ describe("TrieNode", () => {
     });
 
     test("inserting the same item twice is idempotent", async () => {
-      const root = new TrieNode();
+      const root = new TrieNode(RootPrefix.User);
       const id = await NetworkFactories.SyncId.create();
 
       await root.insert(id.syncId(), db, new Map());
@@ -54,7 +55,7 @@ describe("TrieNode", () => {
     });
 
     test("value is always undefined for non-leaf nodes", async () => {
-      const trie = new TrieNode();
+      const trie = new TrieNode(RootPrefix.User);
       const syncId = await NetworkFactories.SyncId.create();
 
       await trie.insert(syncId.syncId(), db, new Map());
@@ -63,7 +64,7 @@ describe("TrieNode", () => {
     });
 
     test("insert compacts hashstring component of syncid to single node for efficiency", async () => {
-      const root = new TrieNode();
+      const root = new TrieNode(RootPrefix.User);
       const id = await NetworkFactories.SyncId.create();
 
       await root.insert(id.syncId(), db, new Map());
@@ -96,7 +97,7 @@ describe("TrieNode", () => {
       // The node at which the trie splits should be the first character that differs between the two hashes
       const firstDiffPos = hash1.findIndex((c, i) => c !== hash2[i]);
 
-      const root = new TrieNode();
+      const root = new TrieNode(RootPrefix.User);
 
       await root.insert(id1.syncId(), db, new Map());
       await root.insert(id2.syncId(), db, new Map());
@@ -120,7 +121,7 @@ describe("TrieNode", () => {
 
   describe("delete", () => {
     test("deleting a single item removes the node", async () => {
-      const root = new TrieNode();
+      const root = new TrieNode(RootPrefix.User);
       const id = await NetworkFactories.SyncId.create();
 
       await root.insert(id.syncId(), db, new Map());
@@ -132,7 +133,7 @@ describe("TrieNode", () => {
     });
 
     test("deleting a single item from a node with multiple items removes the item", async () => {
-      const root = new TrieNode();
+      const root = new TrieNode(RootPrefix.User);
       const id1 = await NetworkFactories.SyncId.create(undefined, { transient: { date: sharedDate } });
       const id2 = await NetworkFactories.SyncId.create(undefined, { transient: { date: sharedDate } });
 
@@ -155,7 +156,7 @@ describe("TrieNode", () => {
         transient: { date: sharedDate, hash: sharedPrefixHashB },
       });
 
-      const root = new TrieNode();
+      const root = new TrieNode(RootPrefix.User);
       await root.insert(id1.syncId(), db, new Map());
       const previousRootHash = root.hash;
       const leafNode = traverse(root);
@@ -177,7 +178,7 @@ describe("TrieNode", () => {
         `${"0".padStart(TIMESTAMP_LENGTH * 2, "0")}05d220`,
       ].map((id) => hexStringToBytes(id)._unsafeUnwrap());
 
-      const root = new TrieNode();
+      const root = new TrieNode(RootPrefix.User);
 
       for (let i = 0; i < ids.length; i++) {
         // Safety: i is controlled by the loop and cannot be used to inject
@@ -197,7 +198,7 @@ describe("TrieNode", () => {
       const ids = ["0030662167axxxx", "0030662167bcdxxxx", "0035059000xxxx"].map((id) =>
         utf8StringToBytes(id)._unsafeUnwrap(),
       );
-      const root = new TrieNode();
+      const root = new TrieNode(RootPrefix.User);
 
       for (let i = 0; i < ids.length; i++) {
         // Safety: i is controlled by the loop and cannot be used to inject
@@ -220,7 +221,7 @@ describe("TrieNode", () => {
 
   describe("get", () => {
     test("getting a single item returns the value", async () => {
-      const root = new TrieNode();
+      const root = new TrieNode(RootPrefix.User);
       const id = await NetworkFactories.SyncId.create();
 
       await root.insert(id.syncId(), db, new Map());
@@ -230,7 +231,7 @@ describe("TrieNode", () => {
     });
 
     test("getting an item after deleting it returns undefined", async () => {
-      const root = new TrieNode();
+      const root = new TrieNode(RootPrefix.User);
       const id = await NetworkFactories.SyncId.create();
 
       await root.insert(id.syncId(), db, new Map());
@@ -249,7 +250,7 @@ describe("TrieNode", () => {
         transient: { date: sharedDate, hash: sharedPrefixHashB },
       });
 
-      const root = new TrieNode();
+      const root = new TrieNode(RootPrefix.User);
       await root.insert(id1.syncId(), db, new Map());
 
       // id2 shares the same prefix, but doesn't exist, so it should return undefined

--- a/apps/hubble/src/network/sync/trieNode.test.ts
+++ b/apps/hubble/src/network/sync/trieNode.test.ts
@@ -3,7 +3,7 @@ import { TIMESTAMP_LENGTH } from "./syncId.js";
 import { EMPTY_HASH, TrieNode } from "./trieNode.js";
 import { NetworkFactories } from "../utils/factories.js";
 import { jestRocksDB } from "../../storage/db/jestUtils.js";
-import { RootPrefix } from "storage/db/types.js";
+import { RootPrefix } from "../../storage/db/types.js";
 
 // Safety: fs inputs are always safe in tests
 

--- a/apps/hubble/src/rpc/test/rpcAuth.test.ts
+++ b/apps/hubble/src/rpc/test/rpcAuth.test.ts
@@ -46,7 +46,7 @@ afterAll(async () => {
 
 describe("auth tests", () => {
   test("fails with invalid password", async () => {
-    const authServer = new Server(hub, engine, new SyncEngine(hub, db), undefined, "admin:password");
+    const authServer = new Server(hub, engine, new SyncEngine(hub, db), undefined, undefined, "admin:password");
     const port = await authServer.start();
     const authClient = getInsecureHubRpcClient(`127.0.0.1:${port}`);
 
@@ -89,7 +89,7 @@ describe("auth tests", () => {
   });
 
   test("all submit methods require auth", async () => {
-    const authServer = new Server(hub, engine, new SyncEngine(hub, db), undefined, "admin:password");
+    const authServer = new Server(hub, engine, new SyncEngine(hub, db), undefined, undefined, "admin:password");
     const port = await authServer.start();
     const authClient = getInsecureHubRpcClient(`127.0.0.1:${port}`);
 

--- a/apps/hubble/src/rpc/test/syncService.test.ts
+++ b/apps/hubble/src/rpc/test/syncService.test.ts
@@ -15,6 +15,7 @@ import { MockHub } from "../../test/mocks.js";
 import Server from "../server.js";
 import SyncEngine from "../../network/sync/syncEngine.js";
 import { GossipNode } from "../../network/p2p/gossipNode.js";
+import { RootPrefix } from "storage/db/types.js";
 
 const db = jestRocksDB("protobufs.rpc.syncService.test");
 const network = FarcasterNetwork.TESTNET;
@@ -28,7 +29,22 @@ let server: Server;
 let client: HubRpcClient;
 
 beforeAll(async () => {
-  server = new Server(hub, engine, new SyncEngine(hub, db), mockGossipNode);
+  server = new Server(
+    hub,
+    engine,
+    new SyncEngine(hub, db),
+    new SyncEngine(
+      hub,
+      db,
+      undefined,
+      undefined,
+      false,
+      RootPrefix.SyncEthEventsMerkleTrieNode,
+      [RootPrefix.IdRegistryEvent, RootPrefix.NameRegistryEvent, RootPrefix.FNameUserNameProof],
+      ["mergeIdRegistryEvent", "mergeNameRegistryEvent", "mergeUsernameProofEvent"],
+    ),
+    mockGossipNode,
+  );
   const port = await server.start();
   client = getInsecureHubRpcClient(`127.0.0.1:${port}`);
 });

--- a/apps/hubble/src/rpc/test/syncService.test.ts
+++ b/apps/hubble/src/rpc/test/syncService.test.ts
@@ -15,7 +15,7 @@ import { MockHub } from "../../test/mocks.js";
 import Server from "../server.js";
 import SyncEngine from "../../network/sync/syncEngine.js";
 import { GossipNode } from "../../network/p2p/gossipNode.js";
-import { RootPrefix } from "storage/db/types.js";
+import { RootPrefix } from "../../storage/db/types.js";
 
 const db = jestRocksDB("protobufs.rpc.syncService.test");
 const network = FarcasterNetwork.TESTNET;

--- a/apps/hubble/src/storage/db/message.ts
+++ b/apps/hubble/src/storage/db/message.ts
@@ -1,4 +1,4 @@
-import { bytesIncrement, CastId, HubError, HubResult, Message, MessageType } from "@farcaster/hub-nodejs";
+import { bytesIncrement, CastId, EthEvent, HubError, HubResult, Message, MessageType } from "@farcaster/hub-nodejs";
 import { err, ok, ResultAsync } from "neverthrow";
 import RocksDB, { Iterator, Transaction } from "./rocksdb.js";
 import { FID_BYTES, RootPrefix, TRUE_VALUE, UserMessagePostfix, UserMessagePostfixMax, UserPostfix } from "./types.js";
@@ -129,6 +129,11 @@ export const deleteMessage = (db: RocksDB, message: Message): Promise<void> => {
 export const getManyMessages = async <T extends Message>(db: RocksDB, primaryKeys: Buffer[]): Promise<T[]> => {
   const buffers = await db.getMany(primaryKeys);
   return buffers.map((buffer) => Message.decode(new Uint8Array(buffer)) as T);
+};
+
+export const getManyEvents = async <T extends EthEvent>(db: RocksDB, primaryKeys: Buffer[]): Promise<T[]> => {
+  const buffers = await db.getMany(primaryKeys);
+  return buffers.map((buffer) => EthEvent.decode(new Uint8Array(buffer)) as T);
 };
 
 export const getManyMessagesByFid = async <T extends Message>(

--- a/apps/hubble/src/storage/db/types.ts
+++ b/apps/hubble/src/storage/db/types.ts
@@ -65,6 +65,8 @@ export enum RootPrefix {
   RentRegistryEventsByExpiry = 21,
   /* Used to store storage admin registry events */
   StorageAdminRegistryEvent = 22,
+  /* Sync Eth Events Merkle Trie Node */
+  SyncEthEventsMerkleTrieNode = 23,
 }
 
 /**

--- a/apps/hubble/src/storage/stores/storeEventHandler.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.ts
@@ -17,7 +17,6 @@ import {
   MergeUsernameProofHubEvent,
   PruneMessageHubEvent,
   RevokeMessageHubEvent,
-  MessageType,
 } from "@farcaster/hub-nodejs";
 import AsyncLock from "async-lock";
 import { err, ok, ResultAsync } from "neverthrow";

--- a/packages/core/src/protobufs/generated/gossip.ts
+++ b/packages/core/src/protobufs/generated/gossip.ts
@@ -3,6 +3,8 @@ import Long from "long";
 import _m0 from "protobufjs/minimal";
 import { IdRegistryEvent } from "./id_registry_event";
 import { FarcasterNetwork, farcasterNetworkFromJSON, farcasterNetworkToJSON, Message } from "./message";
+import { NameRegistryEvent } from "./name_registry_event";
+import { UserNameProof } from "./username_proof";
 
 export enum GossipVersion {
   V1 = 0,
@@ -72,6 +74,8 @@ export interface GossipMessage {
   idRegistryEvent?: IdRegistryEvent | undefined;
   contactInfoContent?: ContactInfoContent | undefined;
   networkLatencyMessage?: NetworkLatencyMessage | undefined;
+  nameRegistryEvent?: NameRegistryEvent | undefined;
+  userNameProof?: UserNameProof | undefined;
   topics: string[];
   peerId: Uint8Array;
   version: GossipVersion;
@@ -588,6 +592,8 @@ function createBaseGossipMessage(): GossipMessage {
     idRegistryEvent: undefined,
     contactInfoContent: undefined,
     networkLatencyMessage: undefined,
+    nameRegistryEvent: undefined,
+    userNameProof: undefined,
     topics: [],
     peerId: new Uint8Array(),
     version: 0,
@@ -607,6 +613,12 @@ export const GossipMessage = {
     }
     if (message.networkLatencyMessage !== undefined) {
       NetworkLatencyMessage.encode(message.networkLatencyMessage, writer.uint32(58).fork()).ldelim();
+    }
+    if (message.nameRegistryEvent !== undefined) {
+      NameRegistryEvent.encode(message.nameRegistryEvent, writer.uint32(66).fork()).ldelim();
+    }
+    if (message.userNameProof !== undefined) {
+      UserNameProof.encode(message.userNameProof, writer.uint32(74).fork()).ldelim();
     }
     for (const v of message.topics) {
       writer.uint32(34).string(v!);
@@ -655,6 +667,20 @@ export const GossipMessage = {
 
           message.networkLatencyMessage = NetworkLatencyMessage.decode(reader, reader.uint32());
           continue;
+        case 8:
+          if (tag != 66) {
+            break;
+          }
+
+          message.nameRegistryEvent = NameRegistryEvent.decode(reader, reader.uint32());
+          continue;
+        case 9:
+          if (tag != 74) {
+            break;
+          }
+
+          message.userNameProof = UserNameProof.decode(reader, reader.uint32());
+          continue;
         case 4:
           if (tag != 34) {
             break;
@@ -695,6 +721,10 @@ export const GossipMessage = {
       networkLatencyMessage: isSet(object.networkLatencyMessage)
         ? NetworkLatencyMessage.fromJSON(object.networkLatencyMessage)
         : undefined,
+      nameRegistryEvent: isSet(object.nameRegistryEvent)
+        ? NameRegistryEvent.fromJSON(object.nameRegistryEvent)
+        : undefined,
+      userNameProof: isSet(object.userNameProof) ? UserNameProof.fromJSON(object.userNameProof) : undefined,
       topics: Array.isArray(object?.topics) ? object.topics.map((e: any) => String(e)) : [],
       peerId: isSet(object.peerId) ? bytesFromBase64(object.peerId) : new Uint8Array(),
       version: isSet(object.version) ? gossipVersionFromJSON(object.version) : 0,
@@ -712,6 +742,11 @@ export const GossipMessage = {
     message.networkLatencyMessage !== undefined && (obj.networkLatencyMessage = message.networkLatencyMessage
       ? NetworkLatencyMessage.toJSON(message.networkLatencyMessage)
       : undefined);
+    message.nameRegistryEvent !== undefined && (obj.nameRegistryEvent = message.nameRegistryEvent
+      ? NameRegistryEvent.toJSON(message.nameRegistryEvent)
+      : undefined);
+    message.userNameProof !== undefined &&
+      (obj.userNameProof = message.userNameProof ? UserNameProof.toJSON(message.userNameProof) : undefined);
     if (message.topics) {
       obj.topics = message.topics.map((e) => e);
     } else {
@@ -742,6 +777,12 @@ export const GossipMessage = {
       (object.networkLatencyMessage !== undefined && object.networkLatencyMessage !== null)
         ? NetworkLatencyMessage.fromPartial(object.networkLatencyMessage)
         : undefined;
+    message.nameRegistryEvent = (object.nameRegistryEvent !== undefined && object.nameRegistryEvent !== null)
+      ? NameRegistryEvent.fromPartial(object.nameRegistryEvent)
+      : undefined;
+    message.userNameProof = (object.userNameProof !== undefined && object.userNameProof !== null)
+      ? UserNameProof.fromPartial(object.userNameProof)
+      : undefined;
     message.topics = object.topics?.map((e) => e) || [];
     message.peerId = object.peerId ?? new Uint8Array();
     message.version = object.version ?? 0;

--- a/packages/hub-nodejs/src/generated/rpc.ts
+++ b/packages/hub-nodejs/src/generated/rpc.ts
@@ -20,6 +20,7 @@ import { NameRegistryEvent } from "./name_registry_event";
 import {
   CastsByParentRequest,
   Empty,
+  EthEventsResponse,
   EventRequest,
   FidRequest,
   FidsRequest,
@@ -404,6 +405,15 @@ export const HubServiceService = {
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
+  getAllEthEventsBySyncIds: {
+    path: "/HubService/GetAllEthEventsBySyncIds",
+    requestStream: false,
+    responseStream: false,
+    requestSerialize: (value: SyncIds) => Buffer.from(SyncIds.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => SyncIds.decode(value),
+    responseSerialize: (value: EthEventsResponse) => Buffer.from(EthEventsResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer) => EthEventsResponse.decode(value),
+  },
   getSyncMetadataByPrefix: {
     path: "/HubService/GetSyncMetadataByPrefix",
     requestStream: false,
@@ -476,6 +486,7 @@ export interface HubServiceServer extends UntypedServiceImplementation {
   getSyncStatus: handleUnaryCall<SyncStatusRequest, SyncStatusResponse>;
   getAllSyncIdsByPrefix: handleUnaryCall<TrieNodePrefix, SyncIds>;
   getAllMessagesBySyncIds: handleUnaryCall<SyncIds, MessagesResponse>;
+  getAllEthEventsBySyncIds: handleUnaryCall<SyncIds, EthEventsResponse>;
   getSyncMetadataByPrefix: handleUnaryCall<TrieNodePrefix, TrieNodeMetadataResponse>;
   getSyncSnapshotByPrefix: handleUnaryCall<TrieNodePrefix, TrieNodeSnapshotResponse>;
 }
@@ -1023,6 +1034,21 @@ export interface HubServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
+  ): ClientUnaryCall;
+  getAllEthEventsBySyncIds(
+    request: SyncIds,
+    callback: (error: ServiceError | null, response: EthEventsResponse) => void,
+  ): ClientUnaryCall;
+  getAllEthEventsBySyncIds(
+    request: SyncIds,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: EthEventsResponse) => void,
+  ): ClientUnaryCall;
+  getAllEthEventsBySyncIds(
+    request: SyncIds,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: EthEventsResponse) => void,
   ): ClientUnaryCall;
   getSyncMetadataByPrefix(
     request: TrieNodePrefix,

--- a/packages/hub-web/src/generated/rpc.ts
+++ b/packages/hub-web/src/generated/rpc.ts
@@ -10,6 +10,7 @@ import { NameRegistryEvent } from "./name_registry_event";
 import {
   CastsByParentRequest,
   Empty,
+  EthEventsResponse,
   EventRequest,
   FidRequest,
   FidsRequest,
@@ -112,6 +113,7 @@ export interface HubService {
   getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpc.Metadata): Promise<SyncStatusResponse>;
   getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpc.Metadata): Promise<SyncIds>;
   getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getAllEthEventsBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpc.Metadata): Promise<EthEventsResponse>;
   getSyncMetadataByPrefix(
     request: DeepPartial<TrieNodePrefix>,
     metadata?: grpc.Metadata,
@@ -164,6 +166,7 @@ export class HubServiceClientImpl implements HubService {
     this.getSyncStatus = this.getSyncStatus.bind(this);
     this.getAllSyncIdsByPrefix = this.getAllSyncIdsByPrefix.bind(this);
     this.getAllMessagesBySyncIds = this.getAllMessagesBySyncIds.bind(this);
+    this.getAllEthEventsBySyncIds = this.getAllEthEventsBySyncIds.bind(this);
     this.getSyncMetadataByPrefix = this.getSyncMetadataByPrefix.bind(this);
     this.getSyncSnapshotByPrefix = this.getSyncSnapshotByPrefix.bind(this);
   }
@@ -340,6 +343,10 @@ export class HubServiceClientImpl implements HubService {
 
   getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllMessagesBySyncIdsDesc, SyncIds.fromPartial(request), metadata);
+  }
+
+  getAllEthEventsBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpc.Metadata): Promise<EthEventsResponse> {
+    return this.rpc.unary(HubServiceGetAllEthEventsBySyncIdsDesc, SyncIds.fromPartial(request), metadata);
   }
 
   getSyncMetadataByPrefix(
@@ -1200,6 +1207,29 @@ export const HubServiceGetAllMessagesBySyncIdsDesc: UnaryMethodDefinitionish = {
   responseType: {
     deserializeBinary(data: Uint8Array) {
       const value = MessagesResponse.decode(data);
+      return {
+        ...value,
+        toObject() {
+          return value;
+        },
+      };
+    },
+  } as any,
+};
+
+export const HubServiceGetAllEthEventsBySyncIdsDesc: UnaryMethodDefinitionish = {
+  methodName: "GetAllEthEventsBySyncIds",
+  service: HubServiceDesc,
+  requestStream: false,
+  responseStream: false,
+  requestType: {
+    serializeBinary() {
+      return SyncIds.encode(this).finish();
+    },
+  } as any,
+  responseType: {
+    deserializeBinary(data: Uint8Array) {
+      const value = EthEventsResponse.decode(data);
       return {
         ...value,
         toObject() {

--- a/protobufs/schemas/gossip.proto
+++ b/protobufs/schemas/gossip.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 import "message.proto";
 import "id_registry_event.proto";
+import "name_registry_event.proto";
+import "username_proof.proto";
 
 enum GossipVersion {
   GOSSIP_VERSION_V1 = 0;
@@ -50,6 +52,8 @@ message GossipMessage {
     IdRegistryEvent id_registry_event = 2;
     ContactInfoContent contact_info_content = 3;
     NetworkLatencyMessage network_latency_message = 7;
+    NameRegistryEvent name_registry_event = 8;
+    UserNameProof user_name_proof = 9;
   }
   repeated string topics = 4;
   bytes peer_id = 5;

--- a/protobufs/schemas/request_response.proto
+++ b/protobufs/schemas/request_response.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 
 import "message.proto";
+import "id_registry_event.proto";
+import "name_registry_event.proto";
 import "storage_event.proto";
 import "hub_event.proto";
 import "username_proof.proto";
@@ -37,11 +39,13 @@ message DbStats {
 
 message SyncStatusRequest {
   optional string peerId = 1;
+  optional bytes sync_trie_root_prefix = 2;
 }
 
 message SyncStatusResponse {
   bool is_syncing = 1;
   repeated SyncStatus sync_status = 2;
+  optional bytes sync_trie_root_prefix = 3;
 }
 
 message SyncStatus {
@@ -53,6 +57,7 @@ message SyncStatus {
   uint64 theirMessages = 6;
   uint64 ourMessages = 7;
   int64 lastBadSync = 8;
+  optional bytes sync_trie_root_prefix = 9;
 }
 
 message TrieNodeMetadataResponse {
@@ -60,6 +65,7 @@ message TrieNodeMetadataResponse {
   uint64 num_messages = 2;
   string hash = 3;
   repeated TrieNodeMetadataResponse children = 4;
+  optional bytes sync_trie_root_prefix = 5;
 }
 
 message TrieNodeSnapshotResponse {
@@ -67,10 +73,12 @@ message TrieNodeSnapshotResponse {
   repeated string excluded_hashes = 2;
   uint64 num_messages = 3;
   string root_hash = 4;
+  optional bytes sync_trie_root_prefix = 5;
 }
 
 message TrieNodePrefix {
   bytes prefix = 1;
+  optional bytes sync_trie_root_prefix = 2;
 }
 
 message SyncIds {
@@ -98,6 +106,19 @@ message FidsResponse {
 message MessagesResponse {
   repeated Message messages = 1;
   optional bytes next_page_token = 2;
+}
+
+message EthEventsResponse {
+  repeated EthEvent eth_events = 1;
+  optional bytes next_page_token = 2;
+}
+
+message EthEvent {
+  oneof eth_event {
+    IdRegistryEvent id_registry_event = 1;
+    NameRegistryEvent name_registry_event = 2;
+    UserNameProof user_name_proof = 3;
+  }
 }
 
 message CastsByParentRequest {

--- a/protobufs/schemas/rpc.proto
+++ b/protobufs/schemas/rpc.proto
@@ -67,6 +67,7 @@ service HubService {
   rpc GetSyncStatus(SyncStatusRequest) returns (SyncStatusResponse);
   rpc GetAllSyncIdsByPrefix(TrieNodePrefix) returns (SyncIds);
   rpc GetAllMessagesBySyncIds(SyncIds) returns (MessagesResponse);
+  rpc GetAllEthEventsBySyncIds(SyncIds) returns (EthEventsResponse);
   rpc GetSyncMetadataByPrefix(TrieNodePrefix) returns (TrieNodeMetadataResponse);
   rpc GetSyncSnapshotByPrefix(TrieNodePrefix) returns (TrieNodeSnapshotResponse);
 }


### PR DESCRIPTION
## Motivation

Synchronizing eth events has had some slight issues due to dropped events. We can leverage our sync processes to let hubs catch up. See https://github.com/farcasterxyz/hub-monorepo/issues/1045

## Change Summary

This creates a secondary sync trie/engine, which follows eth events. A similar one will need to exist for L2 events, but cannot be the same in case reorgs (despite rarity) happen.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding support for retrieving Ethereum events by sync IDs. 

### Detailed summary
- Added `GetAllEthEventsBySyncIds` RPC method to retrieve Ethereum events by sync IDs.
- Modified various files to support the new RPC method and handle Ethereum events.

> The following files were skipped due to too many changes: `packages/hub-web/src/generated/rpc.ts`, `apps/hubble/src/network/sync/merkleTrie.ts`, `apps/hubble/src/network/sync/trieNode.ts`, `apps/hubble/src/rpc/server.ts`, `packages/core/src/protobufs/generated/gossip.ts`, `apps/hubble/src/network/sync/trieNode.test.ts`, `apps/hubble/src/hubble.ts`, `apps/hubble/src/network/sync/syncEngine.ts`, `packages/hub-web/src/generated/request_response.ts`, `packages/hub-nodejs/src/generated/request_response.ts`, `packages/core/src/protobufs/generated/request_response.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->