### PR TITLE
fix: Only revoke the username if the name proof matches

### DIFF
--- a/.changeset/selfish-cougars-bathe.md
+++ b/.changeset/selfish-cougars-bathe.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: only revoke the username if the nameproof matches

--- a/apps/hubble/src/storage/engine/index.test.ts
+++ b/apps/hubble/src/storage/engine/index.test.ts
@@ -903,7 +903,13 @@ describe("with listeners and workers", () => {
         fid,
         owner: custodyEvent.to,
       });
+      const anotherNameProof = Factories.UserNameProof.build({
+        name: Factories.Fname.build(),
+        fid,
+        owner: custodyEvent.to,
+      });
       await expect(liveEngine.mergeUserNameProof(nameProof)).resolves.toBeInstanceOf(Ok);
+      await expect(liveEngine.mergeUserNameProof(anotherNameProof)).resolves.toBeInstanceOf(Ok);
       const fnameAdd = await Factories.UserDataAddMessage.create(
         {
           data: {
@@ -920,6 +926,18 @@ describe("with listeners and workers", () => {
         owner: Factories.EthAddress.build(),
         timestamp: nameProof.timestamp + 1,
       });
+      const anotherNameTransfer = Factories.UserNameProof.build({
+        name: anotherNameProof.name,
+        fid,
+        owner: Factories.EthAddress.build(),
+        timestamp: anotherNameProof.timestamp + 1,
+      });
+      await expect(liveEngine.mergeUserNameProof(anotherNameTransfer)).resolves.toBeInstanceOf(Ok);
+      expect(revokedMessages).toEqual([]);
+      await sleep(200); // Wait for engine to revoke messages
+      // Does not revoke name because current username has not been transferred yet
+      expect(revokedMessages).toEqual([]);
+
       await expect(liveEngine.mergeUserNameProof(nameTransfer)).resolves.toBeInstanceOf(Ok);
       expect(revokedMessages).toEqual([]);
       await sleep(200); // Wait for engine to revoke messages

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -1034,6 +1034,20 @@ class Engine {
         () => undefined,
       );
       if (usernameAdd.isOk()) {
+        const nameBytes = utf8StringToBytes(usernameAdd.value.data.userDataBody.value);
+        if (!nameBytes.isOk()) {
+          log.error(
+            `failed to convert username add message ${bytesToHexString(
+              usernameAdd.value.hash,
+            )} for fid ${fid} to utf8 string`,
+          );
+          return err(nameBytes.error);
+        }
+        if (bytesCompare(nameBytes.value, deletedUsernameProof.name) !== 0) {
+          log.debug(`deleted name proof for ${fid} does not match current user name, skipping revoke`);
+          return ok(undefined);
+        }
+
         const revokeResult = await this._userDataStore.revoke(usernameAdd.value);
         const usernameAddHex = bytesToHexString(usernameAdd.value.hash);
         revokeResult.match(


### PR DESCRIPTION
## Motivation

Currently we always revoke the username as long as the name proof for the fid matches, but with ens usernames we need to also make sure that the current username matches the revoked proof.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a bug related to revoking usernames. 

### Detailed summary
- Only revokes the username if the nameproof matches
- Converts username add message to UTF-8 string before comparing with deleted name proof
- Skips revoke if deleted name proof does not match current user name
- Adds tests for merging username proof and transferring username

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->