### PR TITLE
feat: support direct peering

### DIFF
--- a/.changeset/many-games-exist.md
+++ b/.changeset/many-games-exist.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+Add support for direct peering

--- a/apps/hubble/src/defaultConfig.ts
+++ b/apps/hubble/src/defaultConfig.ts
@@ -57,4 +57,6 @@ export const Config = {
   adminServerEnabled: false,
   /** The admin server bind host */
   adminServerHost: "127.0.0.1",
+  /** A list of addresses the node directly peers with, provided in MultiAddr format */
+  directPeers: [],
 };

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -75,6 +75,7 @@ import { prettyPrintTable } from "./profile.js";
 import packageJson from "./package.json" assert { type: "json" };
 import { createPublicClient, http } from "viem";
 import { mainnet } from "viem/chains";
+import { AddrInfo } from "@chainsafe/libp2p-gossipsub/types";
 
 export type HubSubmitSource = "gossip" | "rpc" | "eth-provider" | "l2-provider" | "sync" | "fname-registry";
 
@@ -221,6 +222,9 @@ export interface HubOptions {
 
   /** Periodically send network latency ping messages to the gossip network and log metrics */
   gossipMetricsEnabled?: boolean;
+
+  /** A list of addresses the node directly peers with, provided in MultiAddr format */
+  directPeers?: AddrInfo[];
 }
 
 /** @returns A randomized string of the format `rocksdb.tmp.*` used for the DB Name */
@@ -531,6 +535,7 @@ export class Hub implements HubInterface {
       announceIp: this.options.announceIp,
       gossipPort: this.options.gossipPort,
       allowedPeerIdStrs: this.allowedPeerIds,
+      directPeers: this.options.directPeers,
     });
 
     this.registerEventHandlers();

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -29,6 +29,7 @@ import { PeriodicPeerCheckScheduler } from "./periodicPeerCheck.js";
 import { GOSSIP_PROTOCOL_VERSION, msgIdFnStrictSign } from "./protocol.js";
 import { GossipMetricsRecorder } from "./gossipMetricsRecorder.js";
 import RocksDB from "storage/db/rocksdb.js";
+import { AddrInfo } from "@chainsafe/libp2p-gossipsub/types";
 
 const MultiaddrLocalHost = "/ip4/127.0.0.1";
 
@@ -57,8 +58,10 @@ interface NodeOptions {
   announceIp?: string | undefined;
   /** A port used to listen for gossip messages. A random value is selected if not specified */
   gossipPort?: number | undefined;
-  /** A list of PeedIds that are allowed to connect to this node */
+  /** A list of PeerIds that are allowed to connect to this node */
   allowedPeerIdStrs?: string[] | undefined;
+  /** A list of addresses the node directly peers with, provided in MultiAddr format */
+  directPeers?: AddrInfo[] | undefined;
 }
 
 /**
@@ -463,6 +466,7 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
       allowPublishToZeroPeers: true,
       globalSignaturePolicy: "StrictSign",
       msgIdFn: this.getMessageId.bind(this),
+      directPeers: options.directPeers || [],
     });
 
     if (options.allowedPeerIdStrs) {


### PR DESCRIPTION
## Motivation

Direct peering is useful in certain situations. The gossipsub option should be exposed as hub options.

## Change Summary

Adds directPeers as a configurable option either by cli or json config. CLI use:

```--direct-peers /ip4/45.58.32.111/tcp/2282/p2p/12D3KooWN9ztVoHYi26NwTDDLNjgBozz479br3pwBuy3oLQVQmhz```

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
