### PR TITLE
fix: Add managed Iterators

### DIFF
--- a/.changeset/modern-spies-study.md
+++ b/.changeset/modern-spies-study.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Add managed iterator that will close the iterator under all conditions

--- a/apps/hubble/src/profile.ts
+++ b/apps/hubble/src/profile.ts
@@ -294,44 +294,48 @@ export async function profileStorageUsed(rocksDB: RocksDB) {
   const valueStats = Array.from({ length: 7 }, (_v, i: number) => new ValueStats(UserPostfix[i]?.toString()));
 
   // Iterate over all the keys in the DB
-  await rocksDB.forEachIterator((key, value) => {
-    allKeys.count++;
-    allKeys.keyBytes += key?.length || 0;
-    allKeys.valueBytes += value?.length || 0;
+  await rocksDB.forEachIterator(
+    (key, value) => {
+      allKeys.count++;
+      allKeys.keyBytes += key?.length || 0;
+      allKeys.valueBytes += value?.length || 0;
 
-    if (key && key.length > 0) {
-      const prefix = key[0] as number;
+      if (key && key.length > 0) {
+        const prefix = key[0] as number;
 
-      if (prefix > 0 && prefix < prefixKeys.length) {
-        (prefixKeys[prefix] as KeysProfile).count++;
-        (prefixKeys[prefix] as KeysProfile).keyBytes += key?.length || 0;
-        (prefixKeys[prefix] as KeysProfile).valueBytes += value?.length || 0;
+        if (prefix > 0 && prefix < prefixKeys.length) {
+          (prefixKeys[prefix] as KeysProfile).count++;
+          (prefixKeys[prefix] as KeysProfile).keyBytes += key?.length || 0;
+          (prefixKeys[prefix] as KeysProfile).valueBytes += value?.length || 0;
 
-        // Further categorize user data into user postfixes
-        if (prefix === RootPrefix.User) {
-          const postfix = key[1 + 4] as number;
+          // Further categorize user data into user postfixes
+          if (prefix === RootPrefix.User) {
+            const postfix = key[1 + 4] as number;
 
-          if (postfix > 0 && postfix < userPostfixKeys.length) {
-            (userPostfixKeys[postfix] as KeysProfile).count++;
-            (userPostfixKeys[postfix] as KeysProfile).keyBytes += key?.length || 0;
-            (userPostfixKeys[postfix] as KeysProfile).valueBytes += value?.length || 0;
+            if (postfix > 0 && postfix < userPostfixKeys.length) {
+              (userPostfixKeys[postfix] as KeysProfile).count++;
+              (userPostfixKeys[postfix] as KeysProfile).keyBytes += key?.length || 0;
+              (userPostfixKeys[postfix] as KeysProfile).valueBytes += value?.length || 0;
 
-            if (postfix <= UserPostfix.UserDataMessage) {
-              (valueStats[postfix] as ValueStats).addValue(value?.length || 0);
+              if (postfix <= UserPostfix.UserDataMessage) {
+                (valueStats[postfix] as ValueStats).addValue(value?.length || 0);
+              }
+            } else {
+              logger.error(`Invalid postfix ${postfix} for key ${key.toString("hex")}`);
             }
-          } else {
-            logger.error(`Invalid postfix ${postfix} for key ${key.toString("hex")}`);
           }
+        } else {
+          logger.error(`Invalid prefix ${prefix} for key ${key.toString("hex")}`);
         }
-      } else {
-        logger.error(`Invalid prefix ${prefix} for key ${key.toString("hex")}`);
       }
-    }
 
-    if (allKeys.count % 1_000_000 === 0) {
-      logger.info(`Read ${formatNumber(allKeys.count)} keys`);
-    }
-  });
+      if (allKeys.count % 1_000_000 === 0) {
+        logger.info(`Read ${formatNumber(allKeys.count)} keys`);
+      }
+    },
+    {},
+    1 * 60 * 60 * 1000, // 1 hour timeout
+  );
 
   logger.info(`RocksDB contains ${allKeys.toString()}`);
 

--- a/apps/hubble/src/storage/db/message.ts
+++ b/apps/hubble/src/storage/db/message.ts
@@ -152,10 +152,12 @@ export const getAllMessagesByFid = async (db: RocksDB, fid: number): Promise<Mes
     gte: userPrefix,
     lt: maxPrefix,
   };
-  const messages = [];
-  for await (const [, buffer] of db.iterator(iteratorOptions)) {
+
+  const messages: Message[] = [];
+  await db.forEachIterator((_key, buffer) => {
     messages.push(Message.decode(new Uint8Array(buffer as Buffer)));
-  }
+  }, iteratorOptions);
+
   return messages;
 };
 

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -184,6 +184,10 @@ class Engine {
     log.info("engine stopped");
   }
 
+  getDb(): RocksDB {
+    return this._db;
+  }
+
   async mergeMessages(messages: Message[]): Promise<Array<HubResult<number>>> {
     return Promise.all(messages.map((message) => this.mergeMessage(message)));
   }

--- a/apps/hubble/src/storage/stores/storageEventStore.test.ts
+++ b/apps/hubble/src/storage/stores/storageEventStore.test.ts
@@ -10,7 +10,7 @@ import { jestRocksDB } from "../db/jestUtils.js";
 import StorageEventStore from "./storageEventStore.js";
 import StoreEventHandler from "./storeEventHandler.js";
 
-const db = jestRocksDB("protobufs.signerStore.test");
+const db = jestRocksDB("protobufs.storageEventStore.test");
 const eventHandler = new StoreEventHandler(db);
 const set = new StorageEventStore(db, eventHandler);
 // const signer = Factories.Ed25519Signer.build();


### PR DESCRIPTION
## Motivation

We use "raw" iterators in our code base that can sometimes not be closed, which causes memory leaks and DB size bloats. 
This change adds the managed iterator, which will ensure that the  iterators close under all circumstances

## Change Summary
- Add managed iterator + test
- Move some of the iterators to use managed iterators

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context
All uses of iterators have not moved over yet, but I moved some of the fishy looking ones. I'll move the rest in a new PR


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a managed iterator to the `RocksDB` class that will close the iterator under all conditions. 

### Detailed summary
- Added a `forEachIterator` method to `RocksDB` that implements a callback and handles various conditions such as returning a value, throwing an error, or timing out.
- Updated code in multiple files to use the new `forEachIterator` method.
- Added tests for the new functionality.

> The following files were skipped due to too many changes: `apps/hubble/src/storage/db/rocksdb.test.ts`, `apps/hubble/src/rpc/server.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->