### PR TITLE
chore: Decrease block confirmations from 6 to 3 for L1 ETH events

### DIFF
--- a/.changeset/hot-numbers-help.md
+++ b/.changeset/hot-numbers-help.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+Reduce number of confirmations for ETH blocks from 6 to 3

--- a/apps/hubble/src/eth/ethEventsProvider.ts
+++ b/apps/hubble/src/eth/ethEventsProvider.ts
@@ -62,10 +62,11 @@ export class EthEventsProvider {
   private _isHistoricalSyncDone = false;
 
   // Number of blocks to wait before processing an event. This is hardcoded to
-  // 6 for now, because that's the threshold beyond which blocks are unlikely
-  // to reorg anymore. 6 blocks represents ~72 seconds on Goerli, so the delay
-  // is not too long.
-  static numConfirmations = 6;
+  // 3 for now, since we're on testnet and we want to recognize user
+  // registration events as quickly as possible without introducing too much
+  // risk due to block reorganization.
+  // Once we move registration to an L2 this will be less of a concern.
+  static numConfirmations = 3;
 
   // Events are only processed after 6 blocks have been confirmed; poll less
   // frequently while ensuring events are available the moment they are


### PR DESCRIPTION
## Motivation

For now, since we're on testnet we want to ensure user registrations are recognized relatively quickly so that onboarding doesn't take too long.

Once we move to user registration happening on an L2, this will be less of a concern.

## Change Summary

Reduce the number of confirmations from 6 to 3.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on reducing the number of confirmations for ETH blocks from 6 to 3. 

### Detailed summary
- `ethEventsProvider.ts`: Changed the value of `numConfirmations` from 6 to 3.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->