### PR TITLE
feat: limit logs to 7gb when run with docker compose

### DIFF
--- a/apps/hubble/docker-compose.yml
+++ b/apps/hubble/docker-compose.yml
@@ -15,4 +15,4 @@ services:
       driver: "json-file"
       options:
         max-size: "1g"
-        max-file: "7"
+        max-file: "2"

--- a/apps/hubble/docker-compose.yml
+++ b/apps/hubble/docker-compose.yml
@@ -11,3 +11,8 @@ services:
     volumes:
       - ./.hub:/home/node/app/apps/hubble/.hub
       - ./.rocks:/home/node/app/apps/hubble/.rocks
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1g"
+        max-file: "7"


### PR DESCRIPTION
Docker Compose will store an indefinite amount of logs. Long running hubs will eventually run out of disk space.

This will limit logs to 7 1gb size files when run via docker compose.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding logging options to the `docker-compose.yml` file for the `hubble` app.

### Detailed summary
- Removed the `./.hub` and `./.rocks` volume mappings.
- Added logging options for the `hubble` app:
  - Set the logging driver to "json-file".
  - Added options for maximum log file size (`max-size`) and maximum number of log files (`max-file`).

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->