### PR TITLE
chore: Automate Docker Hub publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish
+on:
+  push:
+    tags:
+      - '@farcaster/hubble@*'
+
+concurrency: package-tags
+
+jobs:
+  publish-docker-image:
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # Log in so we can push the image layers + tags to Docker Hub
+      - uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.FARCASTERXYZ_DOCKER_HUB_USER }}
+          password: ${{ secrets.FARCASTERXYZ_DOCKER_HUB_TOKEN }}
+
+      - uses: depot/setup-action@v1
+
+      - run: ./scripts/publish-image.sh
+        shell: bash
+        env:
+          DEPOT_TOKEN: ${{ secrets.DEPOT_TOKEN }}
+          DEPOT_PROJECT_ID: ${{ secrets.DEPOT_PROJECT_ID }}

--- a/scripts/publish-image.sh
+++ b/scripts/publish-image.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Builds and publishes image to Docker Hub.
+# This is intended to be run by our GitHub Actions workflow.
+#
+# MUST be run from the root of the repository so the Docker build context is correct.
+#
+# You must `docker login ...` first so that we have the necessary permissions to
+# push the image layers + tags to Docker Hub.
+
+HUBBLE_VERSION=$(node -e "console.log(require('./apps/hubble/package.json').version);")
+
+echo "Publishing $HUBBLE_VERSION"
+
+depot build -f Dockerfile.hubble \
+  --platform "linux/amd64,linux/arm64" \
+  --push \
+  -t farcasterxyz/hubble:${HUBBLE_VERSION} \
+  -t farcasterxyz/hubble:latest \
+  .


### PR DESCRIPTION
## Motivation

Set up automation so that when we push the `@farcaster/hubble@X.Y.Z` tag we will automatically kick off a Docker build and push the resulting image layers + tag to Docker Hub.

## Change Summary

Adds a GitHub Actions workflow + corresponding script. The necessary secrets are already added.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a workflow and script to publish a Docker image to Docker Hub. 

### Detailed summary
- Added a workflow file `.github/workflows/publish.yml` to trigger the publishing process on push and tag events.
- The workflow runs on Ubuntu latest and has a timeout of 20 minutes.
- The workflow includes steps to checkout the code, login to Docker Hub, set up the environment, and run the publish script.
- Added a script `scripts/publish-image.sh` to build and publish the Docker image.
- The script retrieves the version from `./apps/hubble/package.json` and uses it to tag the image.
- The script uses the `depot` command to build and push the image to Docker Hub with tags for the version and "latest".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->