### PR TITLE
chore: release hubble v1.4.1 and new package versions

### DIFF
--- a/.changeset/blue-spoons-double.md
+++ b/.changeset/blue-spoons-double.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
----
-
-Remove ethers dependency

--- a/.changeset/four-beds-prove.md
+++ b/.changeset/four-beds-prove.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: throw error if unable to fetch fname server signature

--- a/.changeset/hot-numbers-help.md
+++ b/.changeset/hot-numbers-help.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-Reduce number of confirmations for ETH blocks from 6 to 3

--- a/.changeset/many-games-exist.md
+++ b/.changeset/many-games-exist.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-Add support for direct peering

--- a/.changeset/modern-spies-study.md
+++ b/.changeset/modern-spies-study.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Add managed iterator that will close the iterator under all conditions

--- a/.changeset/selfish-cougars-bathe.md
+++ b/.changeset/selfish-cougars-bathe.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: only revoke the username if the nameproof matches

--- a/.changeset/shiny-rivers-hang.md
+++ b/.changeset/shiny-rivers-hang.md
@@ -1,8 +1,0 @@
----
-'@farcaster/hub-nodejs': minor
-'@farcaster/hub-web': minor
-'@farcaster/core': minor
-'@farcaster/hubble': minor
----
-
-Adds support for storage events

--- a/.changeset/slow-roses-dream.md
+++ b/.changeset/slow-roses-dream.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-Adjust chunk size to 1000 from 10000

--- a/.changeset/tasty-countries-jump.md
+++ b/.changeset/tasty-countries-jump.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": minor
----
-
-feat: support fallback RPC providers

--- a/.changeset/tiny-chicken-marry.md
+++ b/.changeset/tiny-chicken-marry.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-perf: Improve incremental sync performance

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @farcaster/hubble
 
+## 1.4.1
+
+### Minor Changes
+
+- 2391c3a5: Adds support for storage events
+- 15d43931: feat: support fallback RPC providers
+- 3dfc29de: fix: throw error if unable to fetch fname server signature
+- 71558f87: Reduce number of confirmations for ETH blocks from 6 to 3
+- 8d0d87dc: Add support for direct peering
+- f179dd6a: fix: Add managed iterator that will close the iterator under all conditions
+- 6042e957: fix: only revoke the username if the nameproof matches
+- 728a557a: Adjust chunk size to 1000 from 10000
+- a0dbfbd8: perf: Improve incremental sync performance
+- Updated dependencies [57235761]
+- Updated dependencies [2391c3a5]
+  - @farcaster/hub-nodejs@0.9.0
+
 ## 1.4.0
 
 ### Minor Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -54,7 +54,7 @@
     "@chainsafe/libp2p-gossipsub": "6.1.0",
     "@chainsafe/libp2p-noise": "^11.0.0 ",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.8.4",
+    "@farcaster/hub-nodejs": "^0.9.0",
     "@farcaster/rocksdb": "^5.5.0",
     "@grpc/grpc-js": "~1.8.8",
     "@libp2p/interface-connection": "^3.0.2",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/core
 
+## 0.11.0
+
+### Minor Changes
+
+- 2391c3a5: Adds support for storage events
+
 ## 0.10.2
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @farcaster/hub-nodejs
 
+## 0.9.0
+
+### Minor Changes
+
+- 2391c3a5: Adds support for storage events
+
+### Patch Changes
+
+- 57235761: Remove ethers dependency
+- Updated dependencies [2391c3a5]
+  - @farcaster/core@0.11.0
+
 ## 0.8.4
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@farcaster/core": "0.10.2",
+    "@farcaster/core": "0.11.0",
     "@grpc/grpc-js": "^1.8.8",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"

--- a/packages/hub-web/CHANGELOG.md
+++ b/packages/hub-web/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @farcaster/hub-web
 
+## 0.5.0
+
+### Minor Changes
+
+- 2391c3a5: Adds support for storage events
+
+### Patch Changes
+
+- Updated dependencies [2391c3a5]
+  - @farcaster/core@0.11.0
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-web",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -29,7 +29,7 @@
     "ts-proto": "^1.146.0"
   },
   "dependencies": {
-    "@farcaster/core": "^0.10.2",
+    "@farcaster/core": "^0.11.0",
     "@improbable-eng/grpc-web": "^0.15.0",
     "rxjs": "^7.8.0"
   }


### PR DESCRIPTION
## Motivation

Release new versions of apps and packages. 

## Change Summary

Releases: 

- @farcaster/hubble v1.4.1
- @farcaster/core v0.11.0
- @farcaster/hub-nodejs v0.9.0
- @farcaster/hub-web v0.5.0

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the versions of various packages and adding support for storage events. 

### Detailed summary
- Updated `@farcaster/core` package version to `0.11.0`
- Updated `@farcaster/hub-web` package version to `0.5.0`
- Updated `@farcaster/hub-nodejs` package version to `0.9.0`
- Added support for storage events in `@farcaster/core`, `@farcaster/hub-web`, and `@farcaster/hub-nodejs`
- Removed `ethers` dependency in `@farcaster/hub-nodejs`
- Made other minor changes and performance improvements

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->