### PR TITLE
chore: add peer id for wijuwiju to allowed peers

### DIFF
--- a/apps/hubble/src/allowedPeers.mainnet.ts
+++ b/apps/hubble/src/allowedPeers.mainnet.ts
@@ -9,6 +9,7 @@ export const MAINNET_ALLOWED_PEERS = [
   "12D3KooWHiyvASqvhGn9kqsLBemPTAF6UYEaFGaLUpPxnM54KFbG", // @deodad
   // "12D3KooWKXAG1Z212HHrwYaW5NnwBxoXkk3Sr7USzRxMzS9pieZi", // @paden (Add back once version updated to 1.3.3 or newer)
   "12D3KooWFbnaXtbD5fwbMGq2JRjPaj7C6EpZRgaxC8jdtcX7FJbZ", // @v
+  "12D3KooWHL4wFVz2gysrYLJvSmnLP7A3vKT2bxUyUPbSKPhfpUz2", // @wijuwiju
   "12D3KooWDYihZomibY21nh3hLRWBF6ExLLQ8xaBRaFBVwATHDsuG", // @woj
   "12D3KooWNr294AH1fviDQxRmQ4K79iFSGoRCWzGspVxPprJUKN47", // @adityapk
   "12D3KooWKwUpms7tgUoVsjQ2uV9g93hS2UiMRUfR8f4xjMtsk1Kq", // @pfh


### PR DESCRIPTION
## Motivation

add peer id for wijuwiju to allowed peers

## Change Summary

add peer id for wijuwiju to allowed peers

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the list of allowed peers in the `allowedPeers.mainnet.ts` file. 

### Detailed summary
- Added a new peer address for `@wijuwiju`
- Removed a peer address for `@paden` temporarily until version 1.3.3 or newer
- Updated the peer addresses for `@v`, `@woj`, `@adityapk`, and `@pfh`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->