### PR TITLE
docs: add documentation requirement and instructions to pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ _Choose all relevant options below by adding an `x` now or at any time before su
 - [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
 - [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
 - [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
-- [ ] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
+- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
 - [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)
 
 ## Additional Context

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,9 @@ All changes that involve features or bugfixes should be accompanied by tests, an
 
 ### 3.2 Writing Docs
 
-All changes should have supporting documentation that makes reviewing and understanding the code easy. You should:
+If your PR has changes to gRPC or protobuf files, you must update the [public documentation website](./apps/hubble/www/). See the [Protobuf README](./protobufs/README.md) for instructions on how to auto-gen the documentation.
+
+All PR's should have supporting documentation that makes reviewing and understanding the code easy. You should:
 
 - Update high-level changes in the [contract docs](docs/docs.md).
 - Always use TSDoc style comments for functions, variables, constants, events and params.


### PR DESCRIPTION
## Motivation

Encourage developers to add documentation for changes.

## Change Summary

- Updated CONTRIBUTING.md with documentation guidelines for external facing changes
- Added documentation checklist item to PR review template

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the PR template and contributing guidelines. 

### Detailed summary
- Added a checkbox for including documentation in the PR
- Removed the checkbox for changing the protocol
- Updated the guidelines for writing documentation
- Added instructions for updating documentation for gRPC and protobuf files
- Updated the guidelines for updating contract docs and using TSDoc style comments

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->