### PR TITLE
fix: fix testnet defaulting to no allowed peers

### DIFF
--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -247,7 +247,7 @@ export class Hub implements HubInterface {
   private contactTimer?: NodeJS.Timer;
   private rocksDB: RocksDB;
   private syncEngine: SyncEngine;
-  private allowedPeerIds: string[] = [];
+  private allowedPeerIds: string[] | undefined;
 
   private pruneMessagesJobScheduler: PruneMessagesJobScheduler;
   private periodSyncJobScheduler: PeriodicSyncJobScheduler;
@@ -417,7 +417,7 @@ export class Hub implements HubInterface {
     //   );
     // }
 
-    this.allowedPeerIds = this.options.allowedPeers || [];
+    this.allowedPeerIds = this.options.allowedPeers;
     if (this.options.network === FarcasterNetwork.MAINNET) {
       // Mainnet is right now resitrcited to a few peers
       // Append and de-dup the allowed peers


### PR DESCRIPTION
## Motivation

The default allowed peer list was empty, this means no peers are allowed. Change it to undefined to allow all peers by default.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Changed the type of `allowedPeerIds` property from `string[]` to `string[] | undefined`.
- Removed the assignment of an empty array to `allowedPeerIds` property and assigned the value of `options.allowedPeers` directly.

This PR focuses on modifying the `allowedPeerIds` property in the `Hub` class. It changes the type of `allowedPeerIds` from `string[]` to `string[] | undefined` and modifies the assignment of its value from an empty array to the value of `options.allowedPeers`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->