### PR TITLE
chore(hubble) add vercel analytics to www

### DIFF
--- a/apps/hubble/www/docs/.vitepress/config.ts
+++ b/apps/hubble/www/docs/.vitepress/config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "vitepress";
 export default defineConfig({
   title: "Hubble",
   description: "Documentation for Hubble",
+  head: [["script", { src: "/_vercel/insights/script.js", defer: "true" }]],
   themeConfig: {
     nav: [{ text: "Home", link: "/" }],
     search: {


### PR DESCRIPTION
## Motivation

Add analytics to track usage of pages in hubble's www documentation so we know which pages are most useful. 

## Change Summary

Add vercel analytics script to hubble website

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Added a script tag in the `head` section of the `config.ts` file in the `apps/hubble/www/docs/.vitepress` directory.
- The added script tag has the `src` attribute set to `"/_vercel/insights/script.js"` and the `defer` attribute set to `"true"`.
- This change adds a script to the Hubble documentation that will be executed after the page has finished parsing.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->