### PR TITLE
fix: Move validateOrRevokeMessages and storageCache iterators to be managed

### DIFF
--- a/.changeset/large-items-rescue.md
+++ b/.changeset/large-items-rescue.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Move validatorOrRevokeMessage and storageCache iterators to be managed

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -771,19 +771,21 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     let numFids = 0;
     let numFnames = 0;
 
-    for await (const [,] of this._db.iteratorByPrefix(Buffer.from([RootPrefix.IdRegistryEvent]), {
-      keys: false,
-      values: false,
-    })) {
-      numFids += 1;
-    }
+    await this._db.forEachIteratorByPrefix(
+      Buffer.from([RootPrefix.IdRegistryEvent]),
+      () => {
+        numFids += 1;
+      },
+      { keys: false, values: false },
+    );
 
-    for await (const [,] of this._db.iteratorByPrefix(Buffer.from([RootPrefix.NameRegistryEvent]), {
-      keys: false,
-      values: false,
-    })) {
-      numFnames += 1;
-    }
+    await this._db.forEachIteratorByPrefix(
+      Buffer.from([RootPrefix.NameRegistryEvent]),
+      () => {
+        numFnames += 1;
+      },
+      { keys: false, values: false },
+    );
 
     return {
       numMessages: await this._trie.items(),

--- a/apps/hubble/src/storage/db/message.ts
+++ b/apps/hubble/src/storage/db/message.ts
@@ -258,11 +258,11 @@ export const getAllMessagesBySigner = async <T extends Message>(
   // Loop through all keys that start with the given prefix
   await db.forEachIteratorByPrefix(
     prefix,
-    (key, _value) => {
+    (key) => {
       // Get the tsHash for the message using its position in the key relative to the prefix
       // If the prefix did not include type, add an extra byte to the tsHash offset
       const tsHashOffset = prefix.length + (type ? 0 : 1);
-      const tsHash = new Uint8Array((key as Buffer).slice(tsHashOffset));
+      const tsHash = new Uint8Array(key as Buffer).slice(tsHashOffset);
 
       // Get the type for the message, either from the predefined type variable or by looking at the byte
       // prior to the tsHash in the key
@@ -280,16 +280,6 @@ export const getAllMessagesBySigner = async <T extends Message>(
 
   // Look up many messages using the array of primaryKeys
   return getManyMessages(db, primaryKeys);
-};
-
-export const getMessagesPruneIterator = (db: RocksDB, fid: number, setPostfix: UserMessagePostfix): Iterator => {
-  const prefix = makeMessagePrimaryKey(fid, setPostfix);
-  return db.iteratorByPrefix(prefix, { keys: false, valueAsBuffer: true });
-};
-
-export const getNextMessageFromIterator = async (iterator: Iterator): Promise<Message> => {
-  const [, value] = await iterator.next();
-  return Message.decode(new Uint8Array(value as Buffer));
 };
 
 export const putMessageTransaction = (txn: Transaction, message: Message): Transaction => {

--- a/apps/hubble/src/storage/db/rocksdb.ts
+++ b/apps/hubble/src/storage/db/rocksdb.ts
@@ -110,16 +110,18 @@ class RocksDB {
         if (!entry.iterator.isOpen) {
           return [];
         } else {
-          if (now - entry.openTimestamp >= MAX_DB_ITERATOR_OPEN_MILLISECONDS) {
+          const timeout = entry.timeoutMs ?? MAX_DB_ITERATOR_OPEN_MILLISECONDS;
+          const openFor = now - entry.openTimestamp;
+          if (openFor >= timeout) {
             log.warn(
               {
                 options: entry.options,
-                openSecs: now - entry.openTimestamp,
+                openForMs: openFor,
                 stackTrace: entry.stackTrace,
                 id: entry.id,
                 timeoutMs: entry.timeoutMs,
               },
-              `RocksDB iterator open for more than ${MAX_DB_ITERATOR_OPEN_MILLISECONDS} ms`,
+              "RocksDB iterator open for longer than timeout",
             );
           }
           return [entry];

--- a/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
@@ -83,7 +83,7 @@ export class ValidateOrRevokeMessagesJobScheduler {
         }
       },
       {},
-      1 * 60 * 60 * 1000, // 1 hour
+      3 * 60 * 60 * 1000, // 3 hours
     );
 
     log.info({ timeTakenMs: Date.now() - start }, "finished ValidateOrRevokeMessagesJob");

--- a/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
@@ -41,46 +41,52 @@ export class ValidateOrRevokeMessagesJobScheduler {
   async doJobs(): HubAsyncResult<void> {
     log.info({}, "starting ValidateOrRevokeMessagesJob");
 
+    const start = Date.now();
+
     const allUserPrefix = Buffer.from([RootPrefix.User]);
+    await this._db.forEachIteratorByPrefix(
+      allUserPrefix,
+      async (key, value) => {
+        if ((key as Buffer).length !== 1 + FID_BYTES + 1 + TSHASH_LENGTH) {
+          // Not a message key, so we can skip it.
+          return; // continue
+        }
 
-    for await (const [key, value] of this._db.iteratorByPrefix(allUserPrefix)) {
-      if ((key as Buffer).length !== 1 + FID_BYTES + 1 + TSHASH_LENGTH) {
-        // Not a message key, so we can skip it.
-        continue;
-      }
+        // Get the UserMessagePostfix from the key, which is the 1 + 32 bytes from the start
+        const postfix = (key as Buffer).readUint8(1 + FID_BYTES);
+        if (postfix > UserMessagePostfixMax) {
+          // Not a message key, so we can skip it.
+          return; // continue
+        }
 
-      // Get the UserMessagePostfix from the key, which is the 1 + 32 bytes from the start
-      const postfix = (key as Buffer).readUint8(1 + FID_BYTES);
-      if (postfix > UserMessagePostfixMax) {
-        // Not a message key, so we can skip it.
-        continue;
-      }
+        const message = Result.fromThrowable(
+          () => Message.decode(new Uint8Array(value as Buffer)),
+          (e) => e as HubError,
+        )();
 
-      const message = Result.fromThrowable(
-        () => Message.decode(new Uint8Array(value as Buffer)),
-        (e) => e as HubError,
-      )();
+        if (message.isOk()) {
+          const result = await this._engine.validateOrRevokeMessage(message.value);
+          result.match(
+            (result) => {
+              if (result !== undefined) {
+                log.info(
+                  `revoked message ${bytesToHexString(message.value.hash)._unsafeUnwrap()} from fid ${
+                    message.value.data?.fid
+                  }`,
+                );
+              }
+            },
+            (e) => {
+              log.error({ errCode: e.errCode }, `error validating and revoking message: ${e.message}`);
+            },
+          );
+        }
+      },
+      {},
+      1 * 60 * 60 * 1000, // 1 hour
+    );
 
-      if (message.isOk()) {
-        const result = await this._engine.validateOrRevokeMessage(message.value);
-        result.match(
-          (result) => {
-            if (result !== undefined) {
-              log.info(
-                `revoked message ${bytesToHexString(message.value.hash)._unsafeUnwrap()} from fid ${
-                  message.value.data?.fid
-                }`,
-              );
-            }
-          },
-          (e) => {
-            log.error({ errCode: e.errCode }, `error validating and revoking message: ${e.message}`);
-          },
-        );
-      }
-    }
-
-    log.info({}, "finished ValidateOrRevokeMessagesJob");
+    log.info({ timeTakenMs: Date.now() - start }, "finished ValidateOrRevokeMessagesJob");
 
     return ok(undefined);
   }

--- a/apps/hubble/src/storage/stores/store.ts
+++ b/apps/hubble/src/storage/stores/store.ts
@@ -277,8 +277,8 @@ export abstract class Store<TAdd extends Message, TRemove extends Message> {
 
         const count = await this._eventHandler.getCacheMessageCount(fid, this._postfix);
         if (count.isErr()) {
-          logger.error({ err: count.error, fid }, "failed to get message count for pruning");
-          return false; // Ignore invalid messages and continue
+          logger.error({ err: count.error, fid, postfix: this._postfix }, "failed to get message count for pruning");
+          return true; // Can't continue pruning
         }
 
         if (


### PR DESCRIPTION
## Motivation

Move validateOrRevokeMessages and storageCache iterators to be managed so they don't leak 

## Change Summary

- move iterators to be managed
- Add perf info to job's logs

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the performance and reliability of the storage cache in the Hubble app. 

### Detailed summary
- Moved iterator operations to `forEachIteratorByPrefix` for better memory management.
- Added a flag to prevent running multiple instances of the prune messages job.
- Added logging and time measurements for job execution.
- Refactored message retrieval and storage in the database.
- Improved error handling and logging in the validate and revoke messages job.
- Optimized usage tracking and synchronization in the storage cache.

> The following files were skipped due to too many changes: `apps/hubble/src/storage/stores/storageCache.ts`, `apps/hubble/src/storage/db/rocksdb.ts`, `apps/hubble/src/storage/stores/store.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->