### PR TITLE
feat: validateOrRevoke fid-by-fid

### DIFF
--- a/.changeset/little-comics-exist.md
+++ b/.changeset/little-comics-exist.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: Do the validateOrRevokeMessages job fid-by-fid

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -948,6 +948,7 @@ export class Hub implements HubInterface {
           fid: message.data?.fid,
           type: messageTypeToName(message.data?.type),
           hash: bytesToHexString(message.hash)._unsafeUnwrap(),
+          source,
         };
         const msg = "submitMessage success";
 

--- a/apps/hubble/src/profile.ts
+++ b/apps/hubble/src/profile.ts
@@ -1,4 +1,4 @@
-import { RootPrefix, UserPostfix } from "./storage/db/types.js";
+import { RootPrefix, UserMessagePostfixMax, UserPostfix } from "./storage/db/types.js";
 import { logger } from "./utils/logger.js";
 import RocksDB from "./storage/db/rocksdb.js";
 
@@ -261,7 +261,7 @@ function prefixProfileToDataType(keysProfile: KeysProfile[], userPostfixKeys: Ke
   for (let i = 0; i < userPostfixKeys.length; i++) {
     const kp = userPostfixKeys[i] as KeysProfile;
 
-    if (i >= 86) {
+    if (i > UserMessagePostfixMax) {
       // This is index data, so remove it from the UserData
       (dataTypePrefixes[0] as KeysProfile).count -= kp.count;
       (dataTypePrefixes[0] as KeysProfile).keyBytes -= kp.keyBytes;

--- a/apps/hubble/src/storage/db/rocksdb.ts
+++ b/apps/hubble/src/storage/db/rocksdb.ts
@@ -332,6 +332,7 @@ class RocksDB {
     const iterator = this.iterator(options, timeoutMs);
     const timeoutId = setTimeout(async () => {
       await iterator.end();
+      log.warn(options, "forEachIterator timed out. Was force closed");
     }, timeoutMs);
 
     let returnValue: T | undefined | void;
@@ -357,7 +358,7 @@ class RocksDB {
     } catch (e) {
       if (e instanceof Error && e.message === "cannot call next() after end()") {
         // The iterator timed out
-        log.warn({ options, timeout: timeoutMs }, "forEachIterator: iterator timed out");
+        log.warn(options, "forEachIterator: iterator timed out");
       } else {
         await iterator.end();
         caughtError = e;

--- a/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
@@ -1,10 +1,11 @@
 import { bytesToHexString, HubAsyncResult, HubError, Message } from "@farcaster/hub-nodejs";
-import { ok, Result } from "neverthrow";
+import { err, ok, Result } from "neverthrow";
 import cron from "node-cron";
 import { logger } from "../../utils/logger.js";
-import { FID_BYTES, RootPrefix, TSHASH_LENGTH, UserMessagePostfixMax } from "../db/types.js";
+import { FID_BYTES, TSHASH_LENGTH, UserMessagePostfixMax } from "../db/types.js";
 import RocksDB from "../db/rocksdb.js";
 import Engine from "../engine/index.js";
+import { makeUserKey } from "../db/message.js";
 
 export const DEFAULT_VALIDATE_AND_REVOKE_MESSAGES_CRON = "0 1 * * *"; // Every day at 01:00 UTC
 
@@ -18,6 +19,7 @@ export class ValidateOrRevokeMessagesJobScheduler {
   private _db: RocksDB;
   private _engine: Engine;
   private _cronTask?: cron.ScheduledTask;
+  private _running = false;
 
   constructor(db: RocksDB, engine: Engine) {
     this._db = db;
@@ -26,6 +28,9 @@ export class ValidateOrRevokeMessagesJobScheduler {
 
   start(cronSchedule?: string) {
     this._cronTask = cron.schedule(cronSchedule ?? DEFAULT_VALIDATE_AND_REVOKE_MESSAGES_CRON, () => this.doJobs());
+
+    // TEMP: run once on startup
+    setTimeout(async () => await this.doJobs(), 20 * 1000);
   }
 
   stop() {
@@ -39,13 +44,63 @@ export class ValidateOrRevokeMessagesJobScheduler {
   }
 
   async doJobs(): HubAsyncResult<void> {
+    if (this._running) {
+      log.info({}, "ValidateOrRevokeMessagesJob already running, skipping");
+      return ok(undefined);
+    }
+
     log.info({}, "starting ValidateOrRevokeMessagesJob");
+    this._running = true;
 
     const start = Date.now();
 
-    const allUserPrefix = Buffer.from([RootPrefix.User]);
+    const allFids = [];
+    let finished = false;
+    let pageToken: Uint8Array | undefined;
+    do {
+      const fidsPage = await this._engine.getFids({ pageToken, pageSize: 100 });
+      if (fidsPage.isErr()) {
+        return err(fidsPage.error);
+      }
+      const { fids, nextPageToken } = fidsPage.value;
+      if (!nextPageToken) {
+        finished = true;
+      } else {
+        pageToken = nextPageToken;
+      }
+      allFids.push(...fids);
+    } while (!finished);
+
+    let totalMessagesChecked = 0;
+
+    const numFids = allFids.length;
+    const scheduledTimePerFidMs = (6 * 60 * 60 * 1000) / numFids; // 6 hours for all FIDs
+
+    for (let i = 0; i < numFids; i++) {
+      const fid = allFids[i] as number;
+      const numChecked = await this.doJobForFid(fid);
+      totalMessagesChecked += numChecked.unwrapOr(0);
+
+      // If we are running ahead of schedule, sleep for a bit to let the other jobs catch up.
+      if (Date.now() - start < (i + 1) * scheduledTimePerFidMs) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+    }
+
+    log.info(
+      { timeTakenMs: Date.now() - start, numFids, totalMessagesChecked },
+      "finished ValidateOrRevokeMessagesJob",
+    );
+    this._running = false;
+    return ok(undefined);
+  }
+
+  async doJobForFid(fid: number): HubAsyncResult<number> {
+    const prefix = makeUserKey(fid);
+    let count = 0;
+
     await this._db.forEachIteratorByPrefix(
-      allUserPrefix,
+      prefix,
       async (key, value) => {
         if ((key as Buffer).length !== 1 + FID_BYTES + 1 + TSHASH_LENGTH) {
           // Not a message key, so we can skip it.
@@ -66,14 +121,11 @@ export class ValidateOrRevokeMessagesJobScheduler {
 
         if (message.isOk()) {
           const result = await this._engine.validateOrRevokeMessage(message.value);
+          count += 1;
           result.match(
             (result) => {
               if (result !== undefined) {
-                log.info(
-                  `revoked message ${bytesToHexString(message.value.hash)._unsafeUnwrap()} from fid ${
-                    message.value.data?.fid
-                  }`,
-                );
+                log.info({ fid, hash: bytesToHexString(message.value.hash)._unsafeUnwrap() }, "revoked message");
               }
             },
             (e) => {
@@ -83,11 +135,9 @@ export class ValidateOrRevokeMessagesJobScheduler {
         }
       },
       {},
-      3 * 60 * 60 * 1000, // 3 hours
+      15 * 60 * 1000, // 15 minutes
     );
 
-    log.info({ timeTakenMs: Date.now() - start }, "finished ValidateOrRevokeMessagesJob");
-
-    return ok(undefined);
+    return ok(count);
   }
 }

--- a/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
@@ -28,9 +28,6 @@ export class ValidateOrRevokeMessagesJobScheduler {
 
   start(cronSchedule?: string) {
     this._cronTask = cron.schedule(cronSchedule ?? DEFAULT_VALIDATE_AND_REVOKE_MESSAGES_CRON, () => this.doJobs());
-
-    // TEMP: run once on startup
-    setTimeout(async () => await this.doJobs(), 20 * 1000);
   }
 
   stop() {

--- a/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
@@ -80,7 +80,7 @@ export class ValidateOrRevokeMessagesJobScheduler {
 
       // If we are running ahead of schedule, sleep for a bit to let the other jobs catch up.
       if (Date.now() - start < (i + 1) * scheduledTimePerFidMs) {
-        await new Promise((resolve) => setTimeout(resolve, 100));
+        await new Promise((resolve) => setTimeout(resolve, scheduledTimePerFidMs));
       }
     }
 
@@ -132,7 +132,7 @@ export class ValidateOrRevokeMessagesJobScheduler {
         }
       },
       {},
-      15 * 60 * 1000, // 15 minutes
+      5 * 60 * 1000, // 5 minutes
     );
 
     return ok(count);

--- a/apps/hubble/src/storage/stores/store.ts
+++ b/apps/hubble/src/storage/stores/store.ts
@@ -281,6 +281,8 @@ export abstract class Store<TAdd extends Message, TRemove extends Message> {
           return true; // Can't continue pruning
         }
 
+        // Since the TS hash has the first 4 bytes be the timestamp (bigendian), we can use it to prune
+        // since the iteration will be implicitly sorted by timestamp
         if (
           count.value <= this._pruneSizeLimit &&
           (timestampToPrune === undefined || (message.value.data && message.value.data.timestamp >= timestampToPrune))


### PR DESCRIPTION
## Motivation

The `validateOrRevokeMessages` job is very intense, iterating over every message and re-validating it. Can take 2+ hours at 100% CPU while it locks an iterator

## Change Summary

- Do the `validateOrRevokeMessages` job fid-by-fid, using a new iterator for each FID
- Improve logging
- Built-in throttling

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the `ValidateOrRevokeMessagesJob` in the Hubble app. 

### Detailed summary
- Added the ability to validate or revoke messages fid-by-fid.
- Improved logging for the `forEachIterator` method.
- Updated the `prefixProfileToDataType` function to remove index data from UserData.
- Added error handling for the `validateOrRevokeMessagesJob` module.
- Added a delay between jobs to prevent running ahead of schedule.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->