### PR TITLE
fix: Fix typing for merge username proof events

### DIFF
--- a/.changeset/moody-cups-work.md
+++ b/.changeset/moody-cups-work.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/core": patch
+---
+
+fix: Fix typing for merge username proof events

--- a/packages/core/src/protobufs/types.ts
+++ b/packages/core/src/protobufs/types.ts
@@ -180,7 +180,5 @@ export type MergeStorageAdminRegistryEventHubEvent = hubEventProtobufs.HubEvent 
 
 export type MergeUsernameProofHubEvent = hubEventProtobufs.HubEvent & {
   type: hubEventProtobufs.HubEventType.MERGE_USERNAME_PROOF;
-  mergeUsernameProofBody: hubEventProtobufs.MergeUserNameProofBody & {
-    usernameProof: UserNameProof;
-  };
+  mergeUsernameProofBody: hubEventProtobufs.MergeUserNameProofBody;
 };


### PR DESCRIPTION
## Motivation

It's possible for usernameProof to be empty in case of a pure revoke (e.g. ens no longer valid).

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the typing for merge username proof events. 

### Detailed summary
- Fixed the typing for `MergeUsernameProofHubEvent` in `types.ts`.
- Removed the `usernameProof` property from `mergeUsernameProofBody` in `types.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->