### PR TITLE
chore: add @kencodes peer id back to allowedPeers after upgrade to 1.3.3 or newer

### DIFF
--- a/apps/hubble/src/allowedPeers.mainnet.ts
+++ b/apps/hubble/src/allowedPeers.mainnet.ts
@@ -52,7 +52,7 @@ export const MAINNET_ALLOWED_PEERS = [
   "12D3KooWDXSemEhSAidFCZT1HyRhTHayunCokg68VSuwStf8UEU5", // @98967eth
   "12D3KooWHcViME8KUZXo1wStoRF2jmg4edWidexGy5utVyoxNNnn", // @parthkohli
   "12D3KooWJtEEh7Bcx9T2oKUpcMb9K8xuMFFk5BQNNdJ63Rsx853C", // Jam.so Hub 4
-  // "12D3KooWH3FAGri9Ki4j7xBBjghav9nRTyu8jVVBsRh55odGxraM", // @kencodes (Add back once version updated to 1.3.3 or newer)
+  "12D3KooWH3FAGri9Ki4j7xBBjghav9nRTyu8jVVBsRh55odGxraM", // @kencodes
   "12D3KooWQ8fFUMipLC4Fm6DLN9vWQLX5XBbiewM1N5Vt6QxsPVxn", // @thezluf
   "12D3KooWPsSJu7jPS2UcroV4R1Ed1VJKVBxBkuNs4haDTEUnYBvm", // @sheldon
   "12D3KooWR5qBN6GraBd4DzAJVaGzVk9TZgUYFusoPhxt5suPFtqH", // @silent


### PR DESCRIPTION
## Motivation

Add the peer back after upgrade

## Change Summary

Uncomment a line in allowedPeers

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

n/a
