### PR TITLE
feat: Warn if there are no incoming connections to the hub.

### DIFF
--- a/.changeset/nervous-rivers-dance.md
+++ b/.changeset/nervous-rivers-dance.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: Warn if there are no incoming connections

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -76,6 +76,7 @@ import packageJson from "./package.json" assert { type: "json" };
 import { createPublicClient, fallback, http } from "viem";
 import { mainnet } from "viem/chains";
 import { AddrInfo } from "@chainsafe/libp2p-gossipsub/types";
+import { CheckIncomingPortsJobScheduler } from "./storage/jobs/checkIncomingPortsJob.js";
 
 export type HubSubmitSource = "gossip" | "rpc" | "eth-provider" | "l2-provider" | "sync" | "fname-registry";
 
@@ -256,6 +257,7 @@ export class Hub implements HubInterface {
   private checkFarcasterVersionJobScheduler: CheckFarcasterVersionJobScheduler;
   private validateOrRevokeMessagesJobScheduler: ValidateOrRevokeMessagesJobScheduler;
   private gossipContactInfoJobScheduler: GossipContactInfoJobScheduler;
+  private checkIncomingPortsJobScheduler: CheckIncomingPortsJobScheduler;
 
   private updateNameRegistryEventExpiryJobQueue: UpdateNameRegistryEventExpiryJobQueue;
   private updateNameRegistryEventExpiryJobWorker?: UpdateNameRegistryEventExpiryJobWorker;
@@ -396,6 +398,7 @@ export class Hub implements HubInterface {
     this.checkFarcasterVersionJobScheduler = new CheckFarcasterVersionJobScheduler(this);
     this.validateOrRevokeMessagesJobScheduler = new ValidateOrRevokeMessagesJobScheduler(this.rocksDB, this.engine);
     this.gossipContactInfoJobScheduler = new GossipContactInfoJobScheduler(this);
+    this.checkIncomingPortsJobScheduler = new CheckIncomingPortsJobScheduler(this.rpcServer, this.gossipNode);
 
     if (options.testUsers) {
       this.testDataJobScheduler = new PeriodicTestDataJobScheduler(this.rpcServer, options.testUsers as TestUser[]);

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -556,6 +556,8 @@ export class Hub implements HubInterface {
     this.pruneEventsJobScheduler.start(this.options.pruneEventsJobCron);
     this.checkFarcasterVersionJobScheduler.start();
     this.validateOrRevokeMessagesJobScheduler.start();
+    this.gossipContactInfoJobScheduler.start();
+    this.checkIncomingPortsJobScheduler.start();
 
     // Start the test data generator
     this.testDataJobScheduler?.start();
@@ -618,6 +620,8 @@ export class Hub implements HubInterface {
     this.testDataJobScheduler?.stop();
     this.updateNameRegistryEventExpiryJobWorker?.stop();
     this.validateOrRevokeMessagesJobScheduler.stop();
+    this.gossipContactInfoJobScheduler.stop();
+    this.checkIncomingPortsJobScheduler.stop();
 
     // Stop the ETH registry provider
     if (this.ethRegistryProvider) {

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -313,9 +313,17 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
     return err(new HubError("unavailable", { message: `cannot connect to peer: ${address}` }));
   }
 
+  /** Return if we have any inbound P2P connections */
+  hasInboundConnections(): boolean {
+    return this._node?.getConnections().some((conn) => conn.stat.direction === "inbound") ?? false;
+  }
+
   registerListeners() {
     this._node?.addEventListener("peer:connect", (event) => {
-      log.info({ peer: event.detail.remotePeer }, "P2P Connection established");
+      log.info(
+        { peer: event.detail.remotePeer, addrs: event.detail.remoteAddr, type: event.detail.stat.direction },
+        "P2P Connection established",
+      );
       this.emit("peerConnect", event.detail);
     });
     this._node?.addEventListener("peer:disconnect", (event) => {

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -184,8 +184,9 @@ export default class Server {
   private listenIp: string;
   private port: number;
 
-  private rpcUsers: RpcUsers;
+  private incomingConnections = 0;
 
+  private rpcUsers: RpcUsers;
   private submitMessageRateLimiter: RateLimiterMemory;
 
   constructor(
@@ -276,6 +277,10 @@ export default class Server {
 
   get listenPort() {
     return this.port;
+  }
+
+  public hasInboundConnections() {
+    return this.incomingConnections > 0;
   }
 
   getImpl = (): HubServiceServer => {
@@ -415,6 +420,10 @@ export default class Server {
         })();
       },
       getSyncSnapshotByPrefix: (call, callback) => {
+        // If someone is asking for our sync snapshot, that means we're getting incoming
+        // connections
+        this.incomingConnections += 1;
+
         const request = call.request;
 
         (async () => {

--- a/apps/hubble/src/storage/jobs/checkIncomingPortsJob.ts
+++ b/apps/hubble/src/storage/jobs/checkIncomingPortsJob.ts
@@ -23,8 +23,7 @@ export class CheckIncomingPortsJobScheduler {
   }
 
   start(cronSchedule?: string) {
-    const randomSecond = Math.floor(Math.random() * 59);
-    const defaultSchedule = `${randomSecond} 0 * * *`; // Random second (avoid stampede) every hour
+    const defaultSchedule = "15 * * * *"; // Every hour at :15
     this._cronTask = cron.schedule(cronSchedule ?? defaultSchedule, () => this.doJobs());
   }
 

--- a/apps/hubble/src/storage/jobs/checkIncomingPortsJob.ts
+++ b/apps/hubble/src/storage/jobs/checkIncomingPortsJob.ts
@@ -1,0 +1,52 @@
+import cron from "node-cron";
+import { logger } from "../../utils/logger.js";
+import { HubAsyncResult } from "@farcaster/core";
+import { GossipNode } from "../../network/p2p/gossipNode.js";
+import Server from "../../rpc/server.js";
+import { ok } from "neverthrow";
+
+const log = logger.child({
+  component: "CheckIncomingPortsJob",
+});
+
+type SchedulerStatus = "started" | "stopped";
+
+export class CheckIncomingPortsJobScheduler {
+  private _rpcServer: Server;
+  private _gossipNode: GossipNode;
+
+  private _cronTask?: cron.ScheduledTask;
+
+  constructor(rpcServer: Server, gossipNode: GossipNode) {
+    this._rpcServer = rpcServer;
+    this._gossipNode = gossipNode;
+  }
+
+  start(cronSchedule?: string) {
+    const randomSecond = Math.floor(Math.random() * 59);
+    const defaultSchedule = `${randomSecond} 0 * * *`; // Random second (avoid stampede) every hour
+    this._cronTask = cron.schedule(cronSchedule ?? defaultSchedule, () => this.doJobs());
+  }
+
+  stop() {
+    if (this._cronTask) {
+      this._cronTask.stop();
+    }
+  }
+
+  status(): SchedulerStatus {
+    return this._cronTask ? "started" : "stopped";
+  }
+
+  async doJobs(): HubAsyncResult<void> {
+    if (!this._gossipNode.hasInboundConnections()) {
+      log.warn({}, "No inbound Gossip connections!! Is your gossip port open?");
+    }
+
+    if (!this._rpcServer.hasInboundConnections()) {
+      log.warn({}, "No inbound RPC connections!! Is your RPC port open?");
+    }
+
+    return ok(undefined);
+  }
+}

--- a/apps/hubble/src/storage/jobs/gossipContactInfoJob.ts
+++ b/apps/hubble/src/storage/jobs/gossipContactInfoJob.ts
@@ -18,8 +18,7 @@ export class GossipContactInfoJobScheduler {
   }
 
   start(cronSchedule?: string) {
-    const randomSecond = Math.floor(Math.random() * 59);
-    const defaultSchedule = `${randomSecond} * */4 * *`; // Random second (avoid stampede) every 4 hours
+    const defaultSchedule = "10 */4 * * *"; // Every 4 hours at :10
     this._cronTask = cron.schedule(cronSchedule ?? defaultSchedule, () => this.doJobs());
   }
 


### PR DESCRIPTION
## Motivation

Gossip and RPC ports for production hubs should be open, and we should issue warnings if there are no incoming connections.

## Change Summary

- Run hourly job to warn if there are no incoming connections

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context
Fixes #1157 


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding functionality to warn if there are no incoming connections in the Hubble application. 

### Detailed summary
- Added `hasInboundConnections` method to check if there are any inbound P2P connections.
- Updated `gossipNode.ts` to log the details of the established P2P connection.
- Updated `server.ts` to keep track of the number of incoming connections.
- Added `hasInboundConnections` method to check if there are any inbound RPC connections.
- Added `CheckIncomingPortsJobScheduler` class to check for inbound Gossip and RPC connections.
- Updated `hubble.ts` to start and stop the `CheckIncomingPortsJobScheduler`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->