### PR TITLE
fix: fix username proof timestamp validation + add builders for UsernameProofData and UsernameProofMessage

### DIFF
--- a/.changeset/early-trains-shake.md
+++ b/.changeset/early-trains-shake.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/core": patch
+---
+
+Fix username proof timestamp validation + add builders for UsernameProofData and UsernameProofMessage

--- a/apps/hubble/src/storage/engine/index.test.ts
+++ b/apps/hubble/src/storage/engine/index.test.ts
@@ -29,6 +29,7 @@ import {
   RevokeMessageHubEvent,
   SignerAddMessage,
   SignerRemoveMessage,
+  toFarcasterTime,
   UserDataAddMessage,
   UserDataType,
   UserNameProof,
@@ -476,7 +477,8 @@ describe("mergeMessage", () => {
     });
 
     const createProof = async (name: string, timestamp?: number | null, owner?: string | null) => {
-      const ts = timestamp ?? getFarcasterTime()._unsafeUnwrap();
+      // Proof time is in Unix seconds and should match the message time which is in Farcaster milliseconds
+      const timestampSec = Math.floor((timestamp || Date.now()) / 1000);
       const ownerAsBytes = owner ? hexStringToBytes(owner)._unsafeUnwrap() : Factories.EthAddress.build();
       return await Factories.UsernameProofMessage.create(
         {
@@ -486,10 +488,10 @@ describe("mergeMessage", () => {
               name: utf8StringToBytes(name)._unsafeUnwrap(),
               fid,
               owner: ownerAsBytes,
-              timestamp: fromFarcasterTime(ts)._unsafeUnwrap(),
+              timestamp: timestampSec,
               type: UserNameType.USERNAME_TYPE_ENS_L1,
             }),
-            timestamp: ts,
+            timestamp: toFarcasterTime(timestampSec * 1000)._unsafeUnwrap(),
             type: MessageType.USERNAME_PROOF,
           },
         },

--- a/packages/core/src/builders.ts
+++ b/packages/core/src/builders.ts
@@ -25,6 +25,7 @@ type MessageBodyOptions = Pick<
   | "signerRemoveBody"
   | "userDataBody"
   | "linkBody"
+  | "usernameProofBody"
 >;
 
 /** Generic Methods */
@@ -333,4 +334,23 @@ export const makeUserDataAddData = (
   dataOptions: MessageDataOptions,
 ): HubAsyncResult<protobufs.UserDataAddData> => {
   return makeMessageData({ userDataBody: body }, protobufs.MessageType.USER_DATA_ADD, dataOptions);
+};
+
+export const makeUsernameProof = async (
+  body: protobufs.UserNameProof,
+  dataOptions: MessageDataOptions,
+  signer: Signer,
+): HubAsyncResult<protobufs.UsernameProofMessage> => {
+  const data = await makeUsernameProofData(body, dataOptions);
+  if (data.isErr()) {
+    return err(data.error);
+  }
+  return makeMessage(data.value, signer);
+};
+
+export const makeUsernameProofData = (
+  body: protobufs.UserNameProof,
+  dataOptions: MessageDataOptions,
+): HubAsyncResult<protobufs.UsernameProofData> => {
+  return makeMessageData({ usernameProofBody: body }, protobufs.MessageType.USERNAME_PROOF, dataOptions);
 };

--- a/packages/core/src/factories.ts
+++ b/packages/core/src/factories.ts
@@ -560,7 +560,8 @@ const UsernameProofDataFactory = Factory.define<protobufs.UsernameProofData>(() 
   return MessageDataFactory.build({
     usernameProofBody: proofBody,
     type: protobufs.MessageType.USERNAME_PROOF,
-    timestamp: toFarcasterTime(proofBody.timestamp)._unsafeUnwrap(),
+    // Proof timestamp is in Unix seconds
+    timestamp: toFarcasterTime(proofBody.timestamp * 1000)._unsafeUnwrap(),
     fid: proofBody.fid,
   }) as protobufs.UsernameProofData;
 });
@@ -657,7 +658,7 @@ const StorageAdminRegistryEventFactory = Factory.define<protobufs.StorageAdminRe
 
 const UserNameProofFactory = Factory.define<protobufs.UserNameProof>(() => {
   return protobufs.UserNameProof.create({
-    timestamp: Date.now(),
+    timestamp: Math.floor(Date.now() / 1000),
     signature: Eip712SignatureFactory.build(),
     owner: EthAddressFactory.build(),
     name: FnameFactory.build(),

--- a/packages/core/src/signers/testUtils.ts
+++ b/packages/core/src/signers/testUtils.ts
@@ -72,7 +72,7 @@ export const testEip712Signer = async (signer: Eip712Signer) => {
     beforeAll(async () => {
       claim = makeUserNameProofClaim({
         name: "0x000",
-        timestamp: Date.now(),
+        timestamp: Math.floor(Date.now() / 1000),
         owner: bytesToHex(signerKey),
       });
       const signatureResult = await signer.signUserNameProofClaim(claim);

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -538,7 +538,8 @@ export const validateUsernameProofBody = (
     );
   }
 
-  const proofFarcasterTimestamp = toFarcasterTime(body.timestamp);
+  // Proof time is in Unix seconds
+  const proofFarcasterTimestamp = toFarcasterTime(body.timestamp * 1000);
   if (proofFarcasterTimestamp.isErr()) {
     return err(proofFarcasterTimestamp.error);
   }


### PR DESCRIPTION
## Motivation

* We are inconsistent in the timestamp we expect as part of the UserNameProof (we validate differently in the proof vs in the message causing messages to currently be broken) - in some places we use Unix  milliseconds, in others Unix seconds. The fname registry is submitting Unix seconds, so standardizing validations & tests on that. 
* We are missing builder functionality in `core` for the new `UsernameProofData` and `UsernameProofMessage`.

## Change Summary

* Fix treatment of UserNameProof timestamps, including tests and validations
* Added builders for `UsernameProofData` and `UsernameProofMessage` to `core`.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

N/A

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Fix username proof timestamp validation
- Add builders for UsernameProofData and UsernameProofMessage

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->