### PR TITLE
feat: Adds support for storage/logging if would be pruned

### DIFF
--- a/.changeset/dull-glasses-admire.md
+++ b/.changeset/dull-glasses-admire.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": minor
+---
+
+Adds support for logging would-be-pruned events, plus handles extra storage if purchased

--- a/apps/hubble/src/storage/stores/storageCache.test.ts
+++ b/apps/hubble/src/storage/stores/storageCache.test.ts
@@ -78,7 +78,7 @@ describe("syncFromDb", () => {
       await expect(cache.getMessageCount(fidUsage.fid, UserPostfix.SignerMessage)).resolves.toEqual(
         ok(fidUsage.usage.signer),
       );
-      expect(cache.getCurrentStorageUnitsForFid(fidUsage.fid)).toEqual(ok(4));
+      await expect(cache.getCurrentStorageUnitsForFid(fidUsage.fid)).resolves.toEqual(ok(4));
     }
   });
 });

--- a/apps/hubble/src/storage/stores/storageCache.test.ts
+++ b/apps/hubble/src/storage/stores/storageCache.test.ts
@@ -83,6 +83,24 @@ describe("syncFromDb", () => {
   });
 });
 
+describe("getCurrentStorageUnitsForFid", () => {
+  test("cache invalidation happens when expected", async () => {
+    const fid = Factories.Fid.build();
+    for (let i = 1; i < 3; i++) {
+      const message = await Factories.RentRegistryEvent.create({
+        fid: fid,
+        expiry: getFarcasterTime()._unsafeUnwrap() + i,
+        units: 2,
+      });
+      await putRentRegistryEvent(db, message);
+    }
+    await cache.syncFromDb();
+    await expect(cache.getCurrentStorageUnitsForFid(fid)).resolves.toEqual(ok(4));
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await expect(cache.getCurrentStorageUnitsForFid(fid)).resolves.toEqual(ok(2));
+  });
+});
+
 describe("getMessageCount", () => {
   test("returns the correct count even if the cache is not synced", async () => {
     const fid = Factories.Fid.build();

--- a/apps/hubble/src/storage/stores/storageEventStore.ts
+++ b/apps/hubble/src/storage/stores/storageEventStore.ts
@@ -53,6 +53,8 @@ class StorageEventStore {
       events.push(event);
     }
 
+    iterator.end();
+
     if (events.length === 0) throw new HubError("not_found", "record not found");
 
     return events;

--- a/apps/hubble/src/storage/stores/store.test.ts
+++ b/apps/hubble/src/storage/stores/store.test.ts
@@ -5,12 +5,14 @@ import { MessageType, HubAsyncResult } from "@farcaster/hub-nodejs";
 import { UserMessagePostfix, UserPostfix } from "../db/types.js";
 import { Message } from "@farcaster/hub-nodejs";
 import { isCastAddMessage } from "@farcaster/hub-nodejs";
-import { isCastRemoveMessage } from "@farcaster/hub-nodejs";
 import StoreEventHandler from "./storeEventHandler.js";
 import { jestRocksDB } from "../db/jestUtils.js";
-import { ResultAsync, ok } from "neverthrow";
+import { ResultAsync, err, ok } from "neverthrow";
 import { HubError } from "@farcaster/hub-nodejs";
 import { Transaction } from "../db/rocksdb.js";
+import { Factories } from "@farcaster/hub-nodejs";
+import { getFarcasterTime } from "@farcaster/hub-nodejs";
+import { putRentRegistryEvent } from "../db/storageRegistryEvent.js";
 
 const db = jestRocksDB("protobufs.generalStore.test");
 const eventHandler = new StoreEventHandler(db);
@@ -19,26 +21,15 @@ class TestStore extends Store<CastAddMessage, CastRemoveMessage> {
   override makeAddKey(data: DeepPartial<CastAddMessage>) {
     return data.hash as Uint8Array as Buffer;
   }
-  override makeRemoveKey(data: DeepPartial<CastRemoveMessage>) {
-    return data.hash as Uint8Array as Buffer;
+  override makeRemoveKey(_data: DeepPartial<CastRemoveMessage>): Buffer {
+    throw new Error("Method not implemented");
   }
   override _isAddType: (message: Message) => message is CastAddMessage = isCastAddMessage;
-  override _isRemoveType: ((message: Message) => message is CastRemoveMessage) | undefined = isCastRemoveMessage;
+  override _isRemoveType: ((message: Message) => message is CastRemoveMessage) | undefined = undefined;
   override _postfix: UserMessagePostfix = UserPostfix.CastMessage;
   override _addMessageType: MessageType = MessageType.CAST_ADD;
   override _removeMessageType: MessageType | undefined = MessageType.CAST_REMOVE;
   override async findMergeAddConflicts(message: CastAddMessage): HubAsyncResult<void> {
-    // Look up the remove tsHash for this cast
-    const castRemoveTsHash = await ResultAsync.fromPromise(
-      this._db.get(this.makeRemoveKey(message as unknown as CastRemoveMessage)),
-      () => undefined,
-    );
-
-    // If remove tsHash exists, fail because this cast has already been removed
-    if (castRemoveTsHash.isOk()) {
-      throw new HubError("bad_request.conflict", "message conflicts with a CastRemove");
-    }
-
     // Look up the add tsHash for this cast
     const castAddTsHash = await ResultAsync.fromPromise(this._db.get(this.makeAddKey(message)), () => undefined);
 
@@ -49,32 +40,10 @@ class TestStore extends Store<CastAddMessage, CastRemoveMessage> {
 
     return ok(undefined);
   }
-  override async findMergeRemoveConflicts(message: CastRemoveMessage): HubAsyncResult<void> {
-    // Look up the remove tsHash for this cast
-    const castRemoveTsHash = await ResultAsync.fromPromise(
-      this._db.get(this.makeRemoveKey(message as unknown as CastRemoveMessage)),
-      () => undefined,
-    );
-
-    // If remove tsHash exists, fail because this cast has already been removed
-    if (castRemoveTsHash.isOk()) {
-      throw new HubError("bad_request.conflict", "message conflicts with a CastRemove");
-    }
-
-    return ok(undefined);
+  override async findMergeRemoveConflicts(_message: CastRemoveMessage): HubAsyncResult<void> {
+    throw new Error("Method not implemented");
   }
   override async validateAdd(message: CastAddMessage): HubAsyncResult<void> {
-    // Look up the remove tsHash for this cast
-    const castRemoveTsHash = await ResultAsync.fromPromise(
-      this._db.get(this.makeRemoveKey(message as unknown as CastRemoveMessage)),
-      () => undefined,
-    );
-
-    // If remove tsHash exists, fail because this cast has already been removed
-    if (castRemoveTsHash.isOk()) {
-      throw new HubError("bad_request.conflict", "message conflicts with a CastRemove");
-    }
-
     // Look up the add tsHash for this cast
     const castAddTsHash = await ResultAsync.fromPromise(this._db.get(this.makeAddKey(message)), () => undefined);
 
@@ -119,5 +88,91 @@ describe("store", () => {
     await store.merge(castAdd._unsafeUnwrap());
 
     await store.getAdd({ hash: castAdd._unsafeUnwrap().hash, data: { fid: castAdd._unsafeUnwrap().data.fid } });
+  });
+  test("prunes respected when units are allocated, warned when not", async () => {
+    const privKey2 = ed.utils.randomPrivateKey();
+    const privKey3 = ed.utils.randomPrivateKey();
+    const privKey4 = ed.utils.randomPrivateKey();
+    const ed25519Signer2 = new NobleEd25519Signer(privKey2);
+    const ed25519Signer3 = new NobleEd25519Signer(privKey3);
+    const ed25519Signer4 = new NobleEd25519Signer(privKey4);
+
+    const store = new TestStore(db, eventHandler, {
+      pruneSizeLimit: 100,
+    });
+
+    const message3 = await Factories.RentRegistryEvent.create({
+      fid: 3,
+      expiry: getFarcasterTime()._unsafeUnwrap() + 365 * 24 * 60 * 60,
+      units: 2,
+    });
+
+    const message4 = await Factories.RentRegistryEvent.create({
+      fid: 4,
+      expiry: getFarcasterTime()._unsafeUnwrap() + 365 * 24 * 60 * 60,
+      units: 1,
+    });
+
+    await putRentRegistryEvent(db, message3);
+    await putRentRegistryEvent(db, message4);
+    await eventHandler.syncCache();
+
+    for (let i = 0; i < 200; i++) {
+      // don't use fid = 1, will conflict with other test
+      const castAddFid2 = await makeCastAdd(
+        {
+          text: i.toString(),
+          embeds: [],
+          embedsDeprecated: [],
+          mentions: [],
+          mentionsPositions: [],
+        },
+        { fid: 2, network: 2 },
+        ed25519Signer2,
+      );
+
+      await store.merge(castAddFid2._unsafeUnwrap());
+
+      const castAddFid3 = await makeCastAdd(
+        {
+          text: i.toString(),
+          embeds: [],
+          embedsDeprecated: [],
+          mentions: [],
+          mentionsPositions: [],
+        },
+        { fid: 3, network: 2 },
+        ed25519Signer3,
+      );
+
+      await store.merge(castAddFid3._unsafeUnwrap());
+
+      const castAddFid4 = await makeCastAdd(
+        {
+          text: i.toString(),
+          embeds: [],
+          embedsDeprecated: [],
+          mentions: [],
+          mentionsPositions: [],
+        },
+        { fid: 4, network: 2 },
+        ed25519Signer4,
+      );
+
+      await store.merge(castAddFid4._unsafeUnwrap());
+    }
+
+    // For now, this should match the storage size, we follow existing behavior
+    // for users without storage rent. Adjust this later.
+    const pruneCount2 = await store.pruneMessages(2);
+    expect(pruneCount2._unsafeUnwrap()).toHaveLength(100);
+
+    // This user has two slots, should be double.
+    const pruneCount3 = await store.pruneMessages(3);
+    expect(pruneCount3._unsafeUnwrap()).toHaveLength(0);
+
+    // This user has one slot, should mirror existing behavior.
+    const pruneCount4 = await store.pruneMessages(4);
+    expect(pruneCount4._unsafeUnwrap()).toHaveLength(100);
   });
 });

--- a/apps/hubble/src/storage/stores/store.test.ts
+++ b/apps/hubble/src/storage/stores/store.test.ts
@@ -127,7 +127,7 @@ describe("store", () => {
           mentions: [],
           mentionsPositions: [],
         },
-        { fid: 2, network: 2 },
+        { fid: 2, network: 2, timestamp: getFarcasterTime()._unsafeUnwrap() + i },
         ed25519Signer2,
       );
 
@@ -141,7 +141,7 @@ describe("store", () => {
           mentions: [],
           mentionsPositions: [],
         },
-        { fid: 3, network: 2 },
+        { fid: 3, network: 2, timestamp: getFarcasterTime()._unsafeUnwrap() + i },
         ed25519Signer3,
       );
 
@@ -155,7 +155,7 @@ describe("store", () => {
           mentions: [],
           mentionsPositions: [],
         },
-        { fid: 4, network: 2 },
+        { fid: 4, network: 2, timestamp: getFarcasterTime()._unsafeUnwrap() + i },
         ed25519Signer4,
       );
 

--- a/apps/hubble/src/storage/stores/store.ts
+++ b/apps/hubble/src/storage/stores/store.ts
@@ -242,7 +242,7 @@ export abstract class Store<TAdd extends Message, TRemove extends Message> {
     const commits: number[] = [];
 
     const cachedCount = await this._eventHandler.getCacheMessageCount(fid, this._postfix);
-    const units = this._eventHandler.getCurrentStorageUnitsForFid(fid);
+    const units = await this._eventHandler.getCurrentStorageUnitsForFid(fid);
 
     if (units.isErr()) {
       return err(units.error);

--- a/apps/hubble/src/storage/stores/storeEventHandler.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.ts
@@ -41,6 +41,7 @@ import {
   VerificationAddEthAddressMessage,
   VerificationRemoveMessage,
 } from "@farcaster/core";
+import { logger } from "../../utils/logger.js";
 
 const PRUNE_TIME_LIMIT_DEFAULT = 60 * 60 * 24 * 3 * 1000; // 3 days in ms
 const DEFAULT_LOCK_MAX_PENDING = 1_000;
@@ -189,8 +190,8 @@ class StoreEventHandler extends TypedEmitter<StoreEvents> {
     this._storageCache = new StorageCache(this._db);
   }
 
-  getCurrentStorageUnitsForFid(fid: number): HubResult<number> {
-    return this._storageCache.getCurrentStorageUnitsForFid(fid);
+  async getCurrentStorageUnitsForFid(fid: number): HubAsyncResult<number> {
+    return await this._storageCache.getCurrentStorageUnitsForFid(fid);
   }
 
   async getCacheMessageCount(fid: number, set: UserMessagePostfix): HubAsyncResult<number> {
@@ -257,12 +258,24 @@ class StoreEventHandler extends TypedEmitter<StoreEvents> {
       }
     }
 
+    const units = await this.getCurrentStorageUnitsForFid(message.data.fid);
+
+    if (units.isErr()) {
+      return err(units.error);
+    }
+
+    if (units.value === 0) {
+      logger.warn({ fid: message.data.fid }, "fid has no registered storage, would be pruned");
+    }
+
+    const unitsMultiplier = units.value > 0 ? units.value : 1;
+
     const messageCount = await this.getCacheMessageCount(message.data.fid, set);
     if (messageCount.isErr()) {
       return err(messageCount.error);
     }
 
-    if (messageCount.value < sizeLimit) {
+    if (messageCount.value < sizeLimit * unitsMultiplier) {
       return ok(false);
     }
 

--- a/apps/hubble/src/storage/stores/storeEventHandler.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.ts
@@ -17,13 +17,12 @@ import {
   MergeUsernameProofHubEvent,
   PruneMessageHubEvent,
   RevokeMessageHubEvent,
-  MessageType,
 } from "@farcaster/hub-nodejs";
 import AbstractRocksDB from "@farcaster/rocksdb";
 import AsyncLock from "async-lock";
 import { err, ok, ResultAsync } from "neverthrow";
 import { TypedEmitter } from "tiny-typed-emitter";
-import RocksDB, { Iterator, Transaction } from "../db/rocksdb.js";
+import RocksDB, { Transaction } from "../db/rocksdb.js";
 import { RootPrefix, UserMessagePostfix } from "../db/types.js";
 import { StorageCache } from "./storageCache.js";
 import { makeTsHash } from "../db/message.js";
@@ -188,6 +187,10 @@ class StoreEventHandler extends TypedEmitter<StoreEvents> {
     });
 
     this._storageCache = new StorageCache(this._db);
+  }
+
+  getCurrentStorageUnitsForFid(fid: number): HubResult<number> {
+    return this._storageCache.getCurrentStorageUnitsForFid(fid);
   }
 
   async getCacheMessageCount(fid: number, set: UserMessagePostfix): HubAsyncResult<number> {

--- a/packages/core/src/factories.ts
+++ b/packages/core/src/factories.ts
@@ -619,7 +619,10 @@ const RentRegistryEventTypeFactory = Factory.define<protobufs.StorageRegistryEve
   return faker.helpers.arrayElement([protobufs.StorageRegistryEventType.RENT]);
 });
 
-const RentRegistryEventFactory = Factory.define<protobufs.RentRegistryEvent>(() => {
+const RentRegistryEventFactory = Factory.define<protobufs.RentRegistryEvent>(({ onCreate }) => {
+  onCreate(async (data) => {
+    return data;
+  });
   return protobufs.RentRegistryEvent.create({
     blockNumber: faker.datatype.number({ min: 1, max: 100_000 }),
     blockHash: BlockHashFactory.build(),


### PR DESCRIPTION
## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Change Summary

Adds storage rent support to pruning logic, only warns about pruning if storage rent has not been purchased.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding support for logging would-be-pruned events and handling extra storage if purchased in the `@farcaster/hubble` package. 

### Detailed summary
- Adds support for logging would-be-pruned events
- Handles extra storage if purchased

> The following files were skipped due to too many changes: `apps/hubble/src/storage/stores/store.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->