### PR TITLE
fix: Use a queue when retrying messages

### DIFF
--- a/.changeset/silver-dolls-accept.md
+++ b/.changeset/silver-dolls-accept.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: When retring messages due to failed signers, use a queue

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -1022,10 +1022,7 @@ export default class Server {
                   if (process.memoryUsage().rss > rssUsage + RSS_USAGE_THRESHOLD) {
                     // more than 1G, so we're writing a lot of data to the stream, but the client is not reading it.
                     // We'll destroy the stream.
-                    const error = new HubError(
-                      "unavailable.network_failure",
-                      `stream memory usage too much for peer: ${stream.getPeer()}`,
-                    );
+                    const error = new HubError("unavailable.network_failure", "stream memory usage too much");
                     logger.error({ errCode: error.errCode }, error.message);
                     stream.destroy(error);
 

--- a/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
@@ -72,11 +72,16 @@ export class ValidateOrRevokeMessagesJobScheduler {
 
     const numFids = allFids.length;
     const scheduledTimePerFidMs = (6 * 60 * 60 * 1000) / numFids; // 6 hours for all FIDs
+    log.info({ numFids, scheduledTimePerFidMs }, "ValidateOrRevokeMessagesJob: got FIDs");
 
     for (let i = 0; i < numFids; i++) {
       const fid = allFids[i] as number;
       const numChecked = await this.doJobForFid(fid);
       totalMessagesChecked += numChecked.unwrapOr(0);
+
+      if (i % 1000 === 0) {
+        log.info({ fid, totalMessagesChecked }, "ValidateOrRevokeMessagesJob: progress");
+      }
 
       // If we are running ahead of schedule, sleep for a bit to let the other jobs catch up.
       if (Date.now() - start < (i + 1) * scheduledTimePerFidMs) {
@@ -132,7 +137,7 @@ export class ValidateOrRevokeMessagesJobScheduler {
         }
       },
       {},
-      5 * 60 * 1000, // 5 minutes
+      15 * 60 * 1000, // 15 minutes
     );
 
     return ok(count);


### PR DESCRIPTION
## Motivation

When retrying messages due to invalid signers, we should use a queue so we don't hammer the DB

## Change Summary

- Add queue when retrying messages
- Improve logging

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the diff sync process in the Hubble application. 

### Detailed summary
- Fixes an issue with memory usage in the server when retrying messages.
- Adds logging for progress during the ValidateOrRevokeMessagesJob.
- Changes the scheduled time for the job from 5 minutes to 15 minutes.
- Refactors the `MergeResult` type to a class and adds a method to add results.
- Updates the `performSync` method to return a `MergeResult` instead of a boolean.
- Adds a queue for retrying messages with failed signers during sync.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->