### PR TITLE
feat: Use a web based allowlist

### DIFF
--- a/.changeset/spicy-radios-jump.md
+++ b/.changeset/spicy-radios-jump.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: Use a web based network config for hubble

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -113,15 +113,12 @@ app
   .option("--fnr-address <address>", "The address of the Farcaster Name Registry contract")
 
   .action(async (cliOptions) => {
-    const teardown = async (hub: Hub) => {
-      await hub.stop();
-    };
-
     const handleShutdownSignal = (signalName: string) => {
       logger.warn(`${signalName} received`);
       if (!isExiting) {
         isExiting = true;
-        teardown(hub)
+        hub
+          .teardown()
           .then(() => {
             logger.info("Hub stopped gracefully");
             process.exit(0);
@@ -398,7 +395,7 @@ app
       logger.fatal(startResult.error);
       logger.fatal({ reason: "Hub Startup failed" }, "shutting down hub");
       try {
-        await teardown(hub);
+        await hub.teardown();
       } finally {
         process.exit(1);
       }

--- a/apps/hubble/src/network/p2p/connectionFilter.ts
+++ b/apps/hubble/src/network/p2p/connectionFilter.ts
@@ -24,6 +24,10 @@ export class ConnectionFilter implements ConnectionGater {
     this.allowedPeers = addrs;
   }
 
+  updateAllowedPeers(addrs: string[]) {
+    this.allowedPeers = addrs;
+  }
+
   denyDialPeer = async (peerId: PeerId): Promise<boolean> => {
     const deny = this.shouldDeny(peerId.toString());
     if (deny) {

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -563,12 +563,13 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
           if (result.error.message.startsWith("invalid signer")) {
             // The user's signer was not found. So fetch all signers from the peer and retry.
             const retryResult = await this.syncUserAndRetryMessage(msg, rpcClient);
+            const retryResultErrorMessage = retryResult.isErr() ? retryResult.error.message : "";
             log.warn(
               {
                 fid: msg.data?.fid,
                 err: result.error.message,
                 signer: bytesToHexString(msg.signer)._unsafeUnwrap(),
-                retryResult,
+                retryResult: { ...retryResult, retryResultErrorMessage },
               },
               "Unknown signer, fetched all signers from peer",
             );

--- a/apps/hubble/src/network/utils/networkConfig.test.ts
+++ b/apps/hubble/src/network/utils/networkConfig.test.ts
@@ -1,0 +1,90 @@
+import semver from "semver";
+import { APP_VERSION } from "../../hubble.js";
+import { applyNetworkConfig } from "./networkConfig.js";
+
+describe("networkConfig", () => {
+  const network = 2;
+
+  test("add peerIDs", () => {
+    const existingPeerIds = ["1", "2", "3"];
+
+    const networkConfig = {
+      network,
+      allowedPeers: ["4", "5"],
+      deniedPeers: [],
+      minAppVersion: APP_VERSION,
+    };
+
+    const result = applyNetworkConfig(networkConfig, existingPeerIds, network);
+    expect(result.allowedPeerIds).toEqual(["1", "2", "3", "4", "5"]);
+    expect(result.shouldExit).toEqual(false);
+  });
+
+  test("remove peerIDs", () => {
+    const existingPeerIds = ["1", "2", "3", "4", "5"];
+
+    const networkConfig = {
+      network,
+      allowedPeers: [],
+      deniedPeers: ["4", "5"],
+      minAppVersion: APP_VERSION,
+    };
+
+    const result = applyNetworkConfig(networkConfig, existingPeerIds, network);
+    expect(result.allowedPeerIds).toEqual(["1", "2", "3"]);
+    expect(result.shouldExit).toEqual(false);
+  });
+
+  test("duplicate peerIDs", () => {
+    const existingPeerIds = ["1", "2", "3"];
+
+    const networkConfig = {
+      network,
+      allowedPeers: ["1", "2", "3", "4"],
+      deniedPeers: [],
+      minAppVersion: APP_VERSION,
+    };
+
+    const result = applyNetworkConfig(networkConfig, existingPeerIds, network);
+    expect(result.allowedPeerIds).toEqual(["1", "2", "3", "4"]);
+    expect(result.shouldExit).toEqual(false);
+  });
+
+  test("network mismatch", () => {
+    const existingPeerIds = ["1", "2", "3"];
+
+    const networkConfig = {
+      network: 1,
+      allowedPeers: ["4", "5"],
+      deniedPeers: [],
+      minAppVersion: APP_VERSION,
+    };
+
+    const result = applyNetworkConfig(networkConfig, existingPeerIds, network);
+    expect(result.allowedPeerIds).toEqual(["1", "2", "3"]);
+    expect(result.shouldExit).toEqual(false);
+  });
+
+  test("min app version", () => {
+    const networkConfig = {
+      network,
+      allowedPeers: [],
+      deniedPeers: [],
+      minAppVersion: semver.inc(APP_VERSION, "patch") ?? "",
+    };
+
+    const result = applyNetworkConfig(networkConfig, [], network);
+    expect(result.shouldExit).toEqual(true);
+
+    const prevVer = `${semver.major(APP_VERSION)}.${semver.minor(APP_VERSION)}.${semver.patch(APP_VERSION) - 1}`;
+    const networkConfig2 = {
+      network,
+      allowedPeers: [],
+      deniedPeers: [],
+      minAppVersion: prevVer,
+    };
+
+    const result2 = applyNetworkConfig(networkConfig2, [], network);
+    expect(result2.shouldExit).toEqual(false);
+  });
+});

--- a/apps/hubble/src/network/utils/networkConfig.test.ts
+++ b/apps/hubble/src/network/utils/networkConfig.test.ts
@@ -5,6 +5,21 @@ import { applyNetworkConfig } from "./networkConfig.js";
 describe("networkConfig", () => {
   const network = 2;
 
+  test("no change", () => {
+    const existingPeerIds = ["1", "2", "3"];
+
+    const networkConfig = {
+      network,
+      allowedPeers: ["1", "2", "3"],
+      deniedPeers: [],
+      minAppVersion: APP_VERSION,
+    };
+
+    const result = applyNetworkConfig(networkConfig, existingPeerIds, network);
+    expect(result.allowedPeerIds).toEqual(["1", "2", "3"]);
+    expect(result.shouldExit).toEqual(false);
+  });
+
   test("add peerIDs", () => {
     const existingPeerIds = ["1", "2", "3"];
 

--- a/apps/hubble/src/network/utils/networkConfig.test.ts
+++ b/apps/hubble/src/network/utils/networkConfig.test.ts
@@ -10,7 +10,7 @@ describe("networkConfig", () => {
 
     const networkConfig = {
       network,
-      allowedPeers: ["1", "2", "3"],
+      allowedPeers: [],
       deniedPeers: [],
       minAppVersion: APP_VERSION,
     };

--- a/apps/hubble/src/network/utils/networkConfig.ts
+++ b/apps/hubble/src/network/utils/networkConfig.ts
@@ -1,0 +1,47 @@
+import { HubAsyncResult, HubError } from "@farcaster/hub-nodejs";
+import https from "https";
+import { err, ok } from "neverthrow";
+import { logger } from "../../utils/logger.js";
+import vm from "vm";
+
+const log = logger.child({
+  component: "NetworkConfig",
+});
+
+const NETWORK_CONFIG_LOCATION =
+  "https://raw.githubusercontent.com/farcasterxyz/allowlist-mainnet/main/networkConfig.js";
+
+export type NetworkConfig = {
+  network: number;
+  allowedPeers: string[];
+  deniedPeers: string[];
+  minAppVersion: string;
+};
+
+export async function fetchNetworkConfig(): HubAsyncResult<NetworkConfig> {
+  return new Promise((resolve) => {
+    https
+      .get(NETWORK_CONFIG_LOCATION, (res) => {
+        let data = "";
+
+        res.on("data", (chunk) => {
+          data += chunk;
+        });
+
+        res.on("end", () => {
+          const script = new vm.Script(data);
+          // rome-ignore lint/suspicious/noExplicitAny: <explanation>
+          const context: any = {};
+          script.runInNewContext(context);
+
+          // Access the config object
+          const config = context["config"] as NetworkConfig;
+          resolve(ok(config));
+        });
+      })
+      .on("error", (error) => {
+        log.error({ error, msg: error.message }, "Error fetching network config");
+        resolve(err(new HubError("unavailable.network_failure", error)));
+      });
+  });
+}

--- a/apps/hubble/src/storage/jobs/updateNetworkConfigJob.ts
+++ b/apps/hubble/src/storage/jobs/updateNetworkConfigJob.ts
@@ -41,14 +41,13 @@ export class UpdateNetworkConfigJobScheduler {
       return err(networkConfig.error);
     }
 
-    const errMsg = this._hub.applyNetworkConfig(networkConfig.value);
-    if (errMsg) {
-      log.error({ err: errMsg }, "Network config exit signal");
+    const shouldExit = this._hub.applyNetworkConfig(networkConfig.value);
+    if (shouldExit) {
+      log.error({}, "Network config exit signal");
       process.kill(process.pid, "SIGQUIT");
     }
 
     log.info({}, "Network config updated");
-
     return ok(undefined);
   }
 }

--- a/apps/hubble/src/storage/jobs/updateNetworkConfigJob.ts
+++ b/apps/hubble/src/storage/jobs/updateNetworkConfigJob.ts
@@ -1,0 +1,54 @@
+import cron from "node-cron";
+import { Hub, HubInterface } from "../../hubble.js";
+import { logger } from "../../utils/logger.js";
+import { HubAsyncResult } from "@farcaster/core";
+import { fetchNetworkConfig } from "../../network/utils/networkConfig.js";
+import { err, ok } from "neverthrow";
+
+const log = logger.child({
+  component: "UpdateNetworkConfigJob",
+});
+
+type SchedulerStatus = "started" | "stopped";
+
+export class UpdateNetworkConfigJobScheduler {
+  private _hub: Hub;
+  private _cronTask?: cron.ScheduledTask;
+
+  constructor(hub: Hub) {
+    this._hub = hub;
+  }
+
+  start(cronSchedule?: string) {
+    const defaultSchedule = "59 * * * *"; // Every hour at :59
+    this._cronTask = cron.schedule(cronSchedule ?? defaultSchedule, () => this.doJobs());
+  }
+
+  stop() {
+    if (this._cronTask) {
+      this._cronTask.stop();
+    }
+  }
+
+  status(): SchedulerStatus {
+    return this._cronTask ? "started" : "stopped";
+  }
+
+  async doJobs(): HubAsyncResult<void> {
+    const networkConfig = await fetchNetworkConfig();
+    if (networkConfig.isErr()) {
+      log.error({ err: networkConfig.error }, "error fetching network config");
+      return err(networkConfig.error);
+    }
+
+    const errMsg = this._hub.applyNetworkConfig(networkConfig.value);
+    if (errMsg) {
+      log.error({ err: errMsg }, "Network config exit signal");
+      process.kill(process.pid, "SIGQUIT");
+    }
+
+    log.info({}, "Network config updated");
+
+    return ok(undefined);
+  }
+}


### PR DESCRIPTION
## Motivation

Mananing the mainnet allowlist is difficult. Move it to be on the web for faster turnaround

## Change Summary

- Add web based allow list here: https://github.com/farcasterxyz/allowlist-mainnet
- Add deny list to quickly deny peers
- Add min App version to exipre older hubs
- Fetch the new allowlist every hour

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a web-based network configuration for Hubble. 

### Detailed summary
- Added `updateAllowedPeers` method to `connectionFilter.ts`
- Updated `syncEngine.ts` to include retry result error message
- Refactored `cli.ts` to use `teardown` method
- Added `_connectionGater` property to `gossipNode.ts`
- Added `updateAllowedPeerIds` method to `gossipNode.ts`
- Added `UpdateNetworkConfigJobScheduler` class to `updateNetworkConfigJob.ts`
- Added `fetchNetworkConfig` and `applyNetworkConfig` functions to `networkConfig.ts`
- Updated `hubble.ts` to include `UpdateNetworkConfigJobScheduler`

> The following files were skipped due to too many changes: `apps/hubble/src/hubble.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->