### PR TITLE
feat: validate name proofs against fid instead of custody address

### DIFF
--- a/.changeset/khaki-clouds-attack.md
+++ b/.changeset/khaki-clouds-attack.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: validate name proofs against fids rather than custody address to enable smoother fid recovery process

--- a/apps/hubble/src/rpc/test/userDataService.test.ts
+++ b/apps/hubble/src/rpc/test/userDataService.test.ts
@@ -148,7 +148,7 @@ describe("getUserData", () => {
     const display = await client.getUserData(UserDataRequest.create({ fid, userDataType: UserDataType.DISPLAY }));
     expect(Message.toJSON(display._unsafeUnwrap())).toEqual(Message.toJSON(displayAdd));
 
-    const fnameProof = Factories.UserNameProof.build({ name: fname, owner: custodySignerKey });
+    const fnameProof = Factories.UserNameProof.build({ name: fname, fid });
     await engine.mergeUserNameProof(fnameProof);
 
     expect(await engine.mergeMessage(addFname)).toBeInstanceOf(Ok);


### PR DESCRIPTION
## Motivation

Currently, if an fid is transferred to a new address, the fname proof is "stuck" on the old address and considered invalid by the hub. The fname will be revoked immediately, and the user has to take manual action to provide a new proof from the new address.

Make it so that hubs will only validate the fid and not the current custody address to enable name proofs to be used even after a recovery. 

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the fid recovery process by validating name proofs against fids instead of custody addresses. 

### Detailed summary
- Changed the validation of custody addresses to validate fids instead for smoother fid recovery process.
- Updated tests to reflect the changes in validation logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->