### PR TITLE
feat: revoke signers 1hr after custody event

### DIFF
--- a/.changeset/fifty-feet-punch.md
+++ b/.changeset/fifty-feet-punch.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: revoke signers 1hr after custody event

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -981,7 +981,8 @@ class Engine {
         fid: idRegistryEvent.fid,
         signer: fromAddress,
       });
-      const enqueueRevoke = await this._revokeSignerQueue.enqueueJob(payload);
+      const oneHourFromNow = Date.now() + 60 * 60 * 1000;
+      const enqueueRevoke = await this._revokeSignerQueue.enqueueJob(payload, oneHourFromNow);
       if (enqueueRevoke.isErr()) {
         log.error(
           { errCode: enqueueRevoke.error.errCode },


### PR DESCRIPTION
## Motivation

To allow us to test the fid recovery flow. Revoking signers immediately will cascade delete all messages immediately.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a new feature to revoke signers 1 hour after a custody event
- Modified the `enqueueJob` function in `index.ts` to include a timestamp for the revoke job
- Added new imports and modified the `processJobs` function in `index.test.ts` to manually trigger the revoke job
- Added a new private function `_processJobs` in `revokeMessagesBySignerJob.ts` to process revoke jobs
- Modified the `start` and `stop` functions in `revokeMessagesBySignerJob.ts` to use the new `_processJobs` function
- Modified the `processJobs` function in `revokeMessagesBySignerJob.ts` to accept a timestamp parameter for tests
- Modified the `enqueueJob` function in `revokeMessagesBySignerJobQueue.ts` to include a delay for testing purposes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->