### PR TITLE
Update allowedPeers.mainnet.ts

### DIFF
--- a/apps/hubble/src/allowedPeers.mainnet.ts
+++ b/apps/hubble/src/allowedPeers.mainnet.ts
@@ -64,8 +64,8 @@ export const MAINNET_ALLOWED_PEERS = [
   "12D3KooWHguasQqxAK9px8i5NDMFSG7VYhHRt4C7d2brpjakh5Sk", // @mboyle
   "12D3KooWDfxjnmTTk2nb89dBZZrCQ7g71BoJELKnVpUQUTt4YcL4", // @razzle
   "12D3KooWEoXRpLMjiRo9KxVHqg8Ng5gJxkJdd9uDotSNfYy8jFNv", // @pseudobun
-  // "12D3KooWPcrf4XYUQrxsLniTJR4u4roQJre2T6ev14JeJcAFzZZv", // airstack.xyz (add back once version updated to 1.3.3 or newer)
-  // "12D3KooWLCAqhHempm8C8ZCLMMnK4pBPAyjS3HM2BMBopsC2HZDS", // airstack.xyz (add back once version updated to 1.3.3 or newer)
+  "12D3KooWPcrf4XYUQrxsLniTJR4u4roQJre2T6ev14JeJcAFzZZv", // airstack.xyz
+  "12D3KooWLCAqhHempm8C8ZCLMMnK4pBPAyjS3HM2BMBopsC2HZDS", // airstack.xyz
   "12D3KooWCDxDVkirzdV6Ze8zgDq2i1X3tQLGgwTGRxwuYeHD6XDE", // @wrdwccz
   "12D3KooWHkYUwM3PeRqdYniuxAGXWhPYx6EzPhDY39J3cyNciQhE", // @naratech-eng
   "12D3KooWGU1ebBRwdTBrfb2jQniip7FsWfr22PJhZQwwAf4d8jgX", // Gvozdaryova43654.telegram


### PR DESCRIPTION
Add airstack peer IDs back in

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the allowed peers in the mainnet configuration file. The notable changes include:
- Adding two new peers from airstack.xyz
- Removing two peers from airstack.xyz
- Adding new peers from @wrdwccz, @naratech-eng, and Gvozdaryova43654.telegram

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->