### PR TITLE
feat: Improve storage and gen profiler

### DIFF
--- a/.changeset/brave-steaks-change.md
+++ b/.changeset/brave-steaks-change.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: Improve profiler for gen messages and storage

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -237,6 +237,14 @@ app
       rpcAuth = hubConfig.rpcAuth;
     }
 
+    // Read the rpcRateLimit
+    let rpcRateLimit;
+    if (cliOptions.rpcRateLimit) {
+      rpcRateLimit = cliOptions.rpcRateLimit;
+    } else {
+      rpcRateLimit = hubConfig.rpcRateLimit;
+    }
+
     // Check if the DB_RESET_TOKEN env variable is set. If it is, we might need to reset the DB.
     let resetDB = false;
     const dbResetToken = process.env["DB_RESET_TOKEN"];
@@ -360,6 +368,7 @@ app
       allowedPeers: cliOptions.allowedPeers ?? hubConfig.allowedPeers,
       rpcPort: cliOptions.rpcPort ?? hubConfig.rpcPort ?? DEFAULT_RPC_PORT,
       rpcAuth,
+      rpcRateLimit,
       rocksDBName: cliOptions.dbName ?? hubConfig.dbName,
       resetDB,
       rebuildSyncTrie,
@@ -577,6 +586,7 @@ const storageProfileCommand = new Command("storage")
   .description("Profile the storage layout of the hub, accounting for all the storage")
   .option("--db-name <name>", "The name of the RocksDB instance")
   .option("-c, --config <filepath>", "Path to a config file with options")
+  .option("-o, --output <filepath>", "Path to a file to write the profile to")
   .action(async (cliOptions) => {
     const hubConfig = cliOptions.config ? (await import(resolve(cliOptions.config))).Config : DefaultConfig;
     const rocksDBName = cliOptions.dbName ?? hubConfig.dbName ?? "";
@@ -587,7 +597,7 @@ const storageProfileCommand = new Command("storage")
     if (dbResult.isErr()) {
       logger.warn({ rocksDBName }, "Failed to open RocksDB. The Hub needs to be stopped to run this command.");
     } else {
-      await profileStorageUsed(rocksDB);
+      await profileStorageUsed(rocksDB, cliOptions.output);
     }
 
     await rocksDB.close();

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -220,6 +220,7 @@ export default class Server {
     if (rpcRateLimit !== undefined && rpcRateLimit >= 0) {
       rateLimitPerMinute = rpcRateLimit;
     }
+    log.info({ rpcRateLimit }, "RPC rate limit enabled");
 
     this.submitMessageRateLimiter = new RateLimiterMemory({
       points: rateLimitPerMinute,


### PR DESCRIPTION
## Motivation

Small improvements to profilers

## Change Summary

- Allow storage profiler to write output to file
- gen Profiler now supports custom FIDs and cast/reaction messages in the same batch. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the profiler for generating messages and storage. 

### Detailed summary
- Added RPC rate limit feature
- Improved storage profile command to write profile to a file
- Enhanced message generation command to support multiple FIDs
- Updated value statistics in the profile to include p95
- Added CSV file output for FID profile

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->