### PR TITLE
feat: Scale validation workers by number of CPUs

### DIFF
--- a/.changeset/thirty-radios-search.md
+++ b/.changeset/thirty-radios-search.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: Scale validation workers by number of CPUs and add a RPC profiler

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -71,7 +71,7 @@ import StoreEventHandler from "./storage/stores/storeEventHandler.js";
 import { FNameRegistryClient, FNameRegistryEventsProvider } from "./eth/fnameRegistryEventsProvider.js";
 import { L2EventsProvider, OPGoerliEthConstants } from "./eth/l2EventsProvider.js";
 import { GOSSIP_PROTOCOL_VERSION } from "./network/p2p/protocol.js";
-import { prettyPrintTable } from "./profile.js";
+import { prettyPrintTable } from "./profile/profile.js";
 import packageJson from "./package.json" assert { type: "json" };
 import { createPublicClient, fallback, http } from "viem";
 import { mainnet } from "viem/chains";

--- a/apps/hubble/src/network/sync/syncEngineProfiler.ts
+++ b/apps/hubble/src/network/sync/syncEngineProfiler.ts
@@ -1,5 +1,5 @@
 import { HubRpcClient } from "@farcaster/hub-nodejs";
-import { formatNumber } from "../../profile.js";
+import { formatNumber } from "../../profile/profile.js";
 
 // Class to collect stats
 export class MethodCallProfile {

--- a/apps/hubble/src/profile/profile.ts
+++ b/apps/hubble/src/profile/profile.ts
@@ -1,6 +1,6 @@
-import { RootPrefix, UserMessagePostfixMax, UserPostfix } from "./storage/db/types.js";
-import { logger } from "./utils/logger.js";
-import RocksDB from "./storage/db/rocksdb.js";
+import { RootPrefix, UserMessagePostfixMax, UserPostfix } from "../storage/db/types.js";
+import { logger } from "../utils/logger.js";
+import RocksDB from "../storage/db/rocksdb.js";
 import { createWriteStream, unlinkSync } from "fs";
 
 // rome-ignore lint/suspicious/noExplicitAny: Generic check for enums needs 'any'

--- a/apps/hubble/src/profile/rpcProfile.ts
+++ b/apps/hubble/src/profile/rpcProfile.ts
@@ -1,0 +1,195 @@
+import {
+  AdminRpcClient,
+  Factories,
+  FarcasterNetwork,
+  HubResult,
+  HubRpcClient,
+  Message,
+  Metadata,
+  getAdminRpcClient,
+  getAuthMetadata,
+  getInsecureHubRpcClient,
+  getSSLHubRpcClient,
+} from "@farcaster/hub-nodejs";
+import { formatNumber, prettyPrintTable } from "./profile.js";
+import { ADMIN_SERVER_PORT } from "../rpc/adminServer.js";
+
+export async function profileRPCServer(addressString: string, useInsecure: boolean) {
+  const data: string[][] = [];
+
+  // Push headers
+  data.push(["RPC Method", "Total Duration (ms)", "Total Objects", "Avg Duration (ms)"]);
+
+  let rpcClient;
+  if (useInsecure) {
+    rpcClient = getInsecureHubRpcClient(addressString);
+  } else {
+    rpcClient = getSSLHubRpcClient(addressString);
+  }
+
+  // Admin server is only available on localhost
+  const adminClient = await getAdminRpcClient(`127.0.0.1:${ADMIN_SERVER_PORT}`);
+
+  // Get FIDs
+  const { fidsProfile, maxFid } = await profileGetFIDs(rpcClient);
+  data.push(fidsProfile);
+
+  // Get all casts by FID
+  const casts = await profileGetAllCastsByFID(rpcClient);
+  data.push(casts);
+
+  // SubmitMessages
+  const submitMessages = await profileSubmitMessages(rpcClient, adminClient, maxFid + 1);
+  data.push(submitMessages);
+
+  // Pretty print the results
+  console.log("\nRPC Server Profile\n");
+  console.log(prettyPrintTable(data));
+}
+
+async function profileSubmitMessages(
+  rpcClient: HubRpcClient,
+  adminRpcClient: AdminRpcClient,
+  fid: number,
+  network = FarcasterNetwork.MAINNET,
+  username?: string | Metadata,
+  password?: string,
+): Promise<string[]> {
+  const submitMessage = async (
+    msg: Message,
+    metadata: Metadata,
+  ): Promise<{ timeTakenMs: number; result: HubResult<Message> }> => {
+    const start = Date.now();
+    const result = await rpcClient.submitMessage(msg, metadata);
+    const end = Date.now();
+
+    return { timeTakenMs: end - start, result };
+  };
+
+  let metadata = new Metadata();
+  if (username && typeof username !== "string") {
+    metadata = username;
+  } else if (username && password) {
+    metadata = getAuthMetadata(username, password);
+  }
+
+  const custodySigner = Factories.Eip712Signer.build();
+  const custodySignerKey = (await custodySigner.getSignerKey())._unsafeUnwrap();
+  const signer = Factories.Ed25519Signer.build();
+  const signerKey = (await signer.getSignerKey())._unsafeUnwrap();
+
+  const custodyEvent = Factories.IdRegistryEvent.build({ fid, to: custodySignerKey });
+  const idResult = await adminRpcClient.submitIdRegistryEvent(custodyEvent, metadata);
+  if (!idResult.isOk()) {
+    throw `Failed to submit custody event for fid ${fid}: ${idResult.error}`;
+  }
+
+  const signerAdd = await Factories.SignerAddMessage.create(
+    { data: { fid, network, signerAddBody: { signer: signerKey } } },
+    { transient: { signer: custodySigner } },
+  );
+
+  let totalTimeTakenMs = 0;
+
+  const { result, timeTakenMs } = await submitMessage(signerAdd, metadata);
+  totalTimeTakenMs += timeTakenMs;
+  if (!result.isOk()) {
+    throw `Failed to submit signer add message for fid ${fid}: ${result.error}`;
+  }
+
+  const castAdd = await Factories.CastAddMessage.create({ data: { fid, network } }, { transient: { signer } });
+
+  const { result: castAddResult, timeTakenMs: castAddTimeTakenMs } = await submitMessage(castAdd, metadata);
+  totalTimeTakenMs += castAddTimeTakenMs;
+  if (!castAddResult.isOk()) {
+    throw `Failed to submit cast add message for fid ${fid}: ${castAddResult.error}`;
+  }
+
+  const reactionAdd = await Factories.ReactionAddMessage.create(
+    { data: { fid, network, reactionBody: { targetCastId: { fid, hash: castAdd.hash } } } },
+    { transient: { signer } },
+  );
+  const { result: reactionAddResult, timeTakenMs: reactionAddTimeTakenMs } = await submitMessage(reactionAdd, metadata);
+  if (!reactionAddResult.isOk()) {
+    throw `Failed to submit reaction add message for fid ${fid}: ${reactionAddResult.error}`;
+  }
+
+  totalTimeTakenMs += reactionAddTimeTakenMs;
+
+  return ["submitMessages", `${totalTimeTakenMs}`, `${formatNumber(3)}`, `${formatNumber(totalTimeTakenMs / 3)}`];
+}
+
+async function profileGetAllCastsByFID(rpcClient: HubRpcClient): Promise<string[]> {
+  const fid = 100_002;
+
+  const data = [];
+  let pageToken;
+  let finished = false;
+  let allCastsLength = 0;
+
+  const start = Date.now();
+  do {
+    // First, get all the FIDs
+    const castsResult = await rpcClient.getAllCastMessagesByFid({ pageSize: 100, pageToken, fid });
+    if (castsResult.isErr()) {
+      console.log("Error getting casts: ", castsResult.error);
+      return [];
+    }
+
+    const { messages, nextPageToken } = castsResult.value;
+    if (nextPageToken && nextPageToken.length > 0) {
+      pageToken = nextPageToken;
+    } else {
+      finished = true;
+    }
+
+    allCastsLength += messages.length;
+  } while (!finished);
+
+  const end = Date.now();
+
+  data.push(
+    "getAllCastsByFID",
+    `${end - start}`,
+    `${formatNumber(allCastsLength)}`,
+    `${formatNumber((end - start) / allCastsLength)}`,
+  );
+
+  return data;
+}
+
+async function profileGetFIDs(rpcClient: HubRpcClient): Promise<{ fidsProfile: string[]; maxFid: number }> {
+  const data = [];
+  let pageToken;
+  let finished = false;
+  const allFids = [];
+
+  const start = Date.now();
+  do {
+    // First, get all the FIDs
+    const fidsResult = await rpcClient.getFids({ pageSize: 100, pageToken });
+    if (fidsResult.isErr()) {
+      console.log("Error getting FIDs: ", fidsResult.error);
+      return { fidsProfile: [], maxFid: 0 };
+    }
+
+    const { fids, nextPageToken } = fidsResult.value;
+    if (nextPageToken && nextPageToken.length > 0) {
+      pageToken = nextPageToken;
+    } else {
+      finished = true;
+    }
+
+    allFids.push(...fids);
+  } while (!finished);
+
+  const end = Date.now();
+  data.push(
+    "getFids",
+    `${end - start}`,
+    `${formatNumber(allFids.length)}`,
+    `${formatNumber((end - start) / allFids.length)}`,
+  );
+
+  return { fidsProfile: data, maxFid: Math.max(...allFids) };
+}

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -73,8 +73,8 @@ const log = logger.child({
   component: "Engine",
 });
 
-// 1 < validation_workers < 16
-const NUM_VALIDATION_WORKERS = Math.max(1, Math.min(16, Math.floor(os.cpus().length - 1)));
+// 1 < validation_workers < 4
+const NUM_VALIDATION_WORKERS = Math.max(1, Math.min(4, Math.floor(os.cpus().length - 1)));
 
 class Engine {
   public eventHandler: StoreEventHandler;

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -66,11 +66,15 @@ import StorageEventStore from "../stores/storageEventStore.js";
 import { RentRegistryEventsResponse } from "@farcaster/hub-nodejs";
 import { PublicClient } from "viem";
 import { normalize } from "viem/ens";
+import os from "os";
 import UsernameProofStore from "../stores/usernameProofStore.js";
 
 const log = logger.child({
   component: "Engine",
 });
+
+// 1 < validation_workers < 16
+const NUM_VALIDATION_WORKERS = Math.max(1, Math.min(16, Math.floor(os.cpus().length - 1)));
 
 class Engine {
   public eventHandler: StoreEventHandler;
@@ -88,7 +92,9 @@ class Engine {
   private _storageEventsDataStore: StorageEventStore;
   private _usernameProofStore: UsernameProofStore;
 
-  private _validationWorker: Worker | undefined;
+  private _validationWorkers: Worker[] | undefined;
+  private _nextValidationWorker = 0;
+
   private _validationWorkerJobId = 0;
   private _validationWorkerPromiseMap = new Map<number, (resolve: HubResult<Message>) => void>();
 
@@ -126,29 +132,33 @@ class Engine {
 
     this._revokeSignerWorker.start();
 
-    if (!this._validationWorker) {
+    if (!this._validationWorkers) {
       const workerPath = "./build/storage/engine/validation.worker.js";
       try {
         if (fs.existsSync(workerPath)) {
-          this._validationWorker = new Worker(workerPath);
+          this._validationWorkers = [];
+          for (let i = 0; i < NUM_VALIDATION_WORKERS; i++) {
+            const validationWorker = new Worker(workerPath);
+            logger.info({ workerPath, i }, "created validation worker thread");
 
-          logger.info({ workerPath }, "created validation worker thread");
+            validationWorker.on("message", (data) => {
+              const { id, message, errCode, errMessage } = data;
+              const resolve = this._validationWorkerPromiseMap.get(id);
 
-          this._validationWorker.on("message", (data) => {
-            const { id, message, errCode, errMessage } = data;
-            const resolve = this._validationWorkerPromiseMap.get(id);
-
-            if (resolve) {
-              this._validationWorkerPromiseMap.delete(id);
-              if (message) {
-                resolve(ok(message));
+              if (resolve) {
+                this._validationWorkerPromiseMap.delete(id);
+                if (message) {
+                  resolve(ok(message));
+                } else {
+                  resolve(err(new HubError(errCode, errMessage)));
+                }
               } else {
-                resolve(err(new HubError(errCode, errMessage)));
+                logger.warn({ id }, "validation worker promise.response not found");
               }
-            } else {
-              logger.warn({ id }, "validation worker promise.response not found");
-            }
-          });
+            });
+
+            this._validationWorkers.push(validationWorker);
+          }
         } else {
           logger.warn({ workerPath }, "validation.worker.js not found, falling back to main thread");
         }
@@ -177,9 +187,12 @@ class Engine {
 
     this._revokeSignerWorker.start();
 
-    if (this._validationWorker) {
-      await this._validationWorker.terminate();
-      this._validationWorker = undefined;
+    if (this._validationWorkers) {
+      for (const validationWorker of this._validationWorkers) {
+        await validationWorker.terminate();
+      }
+
+      this._validationWorkers = undefined;
     }
     log.info("engine stopped");
   }
@@ -921,12 +934,13 @@ class Engine {
     }
 
     // 6. Check message body and envelope
-    if (this._validationWorker) {
+    if (this._validationWorkers) {
       return new Promise<HubResult<Message>>((resolve) => {
         const id = this._validationWorkerJobId++;
         this._validationWorkerPromiseMap.set(id, resolve);
 
-        this._validationWorker?.postMessage({ id, message });
+        (this._validationWorkers as Worker[])[this._nextValidationWorker]?.postMessage({ id, message });
+        this._nextValidationWorker = (this._nextValidationWorker + 1) % (this._validationWorkers?.length || 1);
       });
     } else {
       return validations.validateMessage(message);


### PR DESCRIPTION
## Motivation

Some ~47% of time is spent doing validations. Scale the number of validation workers to take advantage of any additional CPUs

## Change Summary

- Scale validation workers by number of CPUs
- Add RPC profiler to measure CPU usage

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

![Screenshot from 2023-07-24 11-33-54](https://github.com/farcasterxyz/hub-monorepo/assets/31996805/cc29a018-b3bf-415e-88ca-64bd21a8c20d)

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a scale validation workers feature that scales the workers based on the number of CPUs.
- Added an RPC profiler feature to profile the performance of the RPC server.
- Updated import paths for `formatNumber` and `prettyPrintTable` functions.
- Updated import paths for various files in the `hubble` and `profile` directories.

> The following files were skipped due to too many changes: `apps/hubble/src/profile/rpcProfile.ts`, `apps/hubble/src/network/sync/syncEngine.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->