### PR TITLE
feat: Storage RPC

### DIFF
--- a/.changeset/young-lobsters-peel.md
+++ b/.changeset/young-lobsters-peel.md
@@ -1,0 +1,8 @@
+---
+"@farcaster/hub-nodejs": minor
+"@farcaster/hub-web": minor
+"@farcaster/core": minor
+"@farcaster/hubble": minor
+---
+
+Added storage limits RPC

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -35,6 +35,7 @@ import {
   SignerAddMessage,
   SignerRemoveMessage,
   StorageAdminRegistryEvent,
+  StorageLimitsResponse,
   StorageRegistryEventType,
   UserDataAddMessage,
   UserDataType,
@@ -694,6 +695,15 @@ class Engine {
     return ResultAsync.fromPromise(this._storageEventsDataStore.getRentRegistryEvents(fid), (e) => e as HubError).map(
       (events) => RentRegistryEventsResponse.create({ events }),
     );
+  }
+
+  async getCurrentStorageLimitsByFid(fid: number): HubAsyncResult<StorageLimitsResponse> {
+    const validatedFid = validations.validateFid(fid);
+    if (validatedFid.isErr()) {
+      return err(validatedFid.error);
+    }
+
+    return this._storageEventsDataStore.getCurrentStorageLimitsForFid(fid);
   }
 
   async getUserNameProof(name: Uint8Array): HubAsyncResult<UserNameProof> {

--- a/apps/hubble/src/storage/stores/castStore.ts
+++ b/apps/hubble/src/storage/stores/castStore.ts
@@ -23,6 +23,8 @@ import { RootPrefix, TRUE_VALUE, UserMessagePostfix, UserPostfix } from "../db/t
 import { MessagesPage, PageOptions } from "../stores/types.js";
 import { Store } from "./store.js";
 
+export const CAST_PRUNE_SIZE_LIMIT_DEFAULT = 10_000;
+
 /**
  * Generates unique keys used to store or fetch CastAdd messages in the adds set index
  *
@@ -132,7 +134,7 @@ class CastStore extends Store<CastAddMessage, CastRemoveMessage> {
   override _removeMessageType = MessageType.CAST_REMOVE;
 
   protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return 10_000;
+    return CAST_PRUNE_SIZE_LIMIT_DEFAULT;
   }
 
   protected override get PRUNE_TIME_LIMIT_DEFAULT() {

--- a/apps/hubble/src/storage/stores/linkStore.ts
+++ b/apps/hubble/src/storage/stores/linkStore.ts
@@ -21,7 +21,7 @@ import { Store } from "./store.js";
 import { ResultAsync, err, ok } from "neverthrow";
 import { Transaction } from "../db/rocksdb.js";
 
-const PRUNE_SIZE_LIMIT_DEFAULT = 2_500;
+export const LINK_PRUNE_SIZE_LIMIT_DEFAULT = 2_500;
 
 const makeTargetKey = (target: number): Buffer => {
   return makeFidKey(target);
@@ -152,7 +152,7 @@ class LinkStore extends Store<LinkAddMessage, LinkRemoveMessage> {
   override _removeMessageType = MessageType.LINK_REMOVE;
 
   protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return PRUNE_SIZE_LIMIT_DEFAULT;
+    return LINK_PRUNE_SIZE_LIMIT_DEFAULT;
   }
 
   override async buildSecondaryIndices(txn: Transaction, message: LinkAddMessage): HubAsyncResult<void> {

--- a/apps/hubble/src/storage/stores/reactionStore.ts
+++ b/apps/hubble/src/storage/stores/reactionStore.ts
@@ -24,7 +24,7 @@ import { RootPrefix, TSHASH_LENGTH, UserMessagePostfix, UserPostfix } from "../d
 import { MessagesPage, PAGE_SIZE_MAX, PageOptions } from "../stores/types.js";
 import { Store } from "./store.js";
 
-const PRUNE_SIZE_LIMIT_DEFAULT = 5_000;
+export const REACTION_PRUNE_SIZE_LIMIT_DEFAULT = 5_000;
 const PRUNE_TIME_LIMIT_DEFAULT = 60 * 60 * 24 * 90; // 90 days
 
 const makeTargetKey = (target: CastId | string): Buffer => {
@@ -147,7 +147,7 @@ class ReactionStore extends Store<ReactionAddMessage, ReactionRemoveMessage> {
   override _removeMessageType = MessageType.REACTION_REMOVE;
 
   protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return PRUNE_SIZE_LIMIT_DEFAULT;
+    return REACTION_PRUNE_SIZE_LIMIT_DEFAULT;
   }
 
   protected override get PRUNE_TIME_LIMIT_DEFAULT() {

--- a/apps/hubble/src/storage/stores/signerStore.ts
+++ b/apps/hubble/src/storage/stores/signerStore.ts
@@ -22,7 +22,7 @@ import { MessagesPage, PAGE_SIZE_MAX, PageOptions } from "./types.js";
 import { eventCompare } from "./utils.js";
 import { Store } from "./store.js";
 
-const PRUNE_SIZE_LIMIT_DEFAULT = 100;
+export const SIGNER_PRUNE_SIZE_LIMIT_DEFAULT = 100;
 
 /**
  * Generates a unique key used to store a SignerAdd message key in the SignerAdds set index
@@ -98,7 +98,7 @@ class SignerStore extends Store<SignerAddMessage, SignerRemoveMessage> {
   override _removeMessageType = MessageType.SIGNER_REMOVE;
 
   protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return PRUNE_SIZE_LIMIT_DEFAULT;
+    return SIGNER_PRUNE_SIZE_LIMIT_DEFAULT;
   }
 
   override async findMergeAddConflicts(_message: SignerAddMessage): HubAsyncResult<void> {

--- a/apps/hubble/src/storage/stores/userDataStore.ts
+++ b/apps/hubble/src/storage/stores/userDataStore.ts
@@ -24,7 +24,7 @@ import { eventCompare, usernameProofCompare } from "../stores/utils.js";
 import { Store } from "./store.js";
 import { Transaction } from "../db/rocksdb.js";
 
-const PRUNE_SIZE_LIMIT_DEFAULT = 100;
+export const USER_DATA_PRUNE_SIZE_LIMIT_DEFAULT = 100;
 
 /**
  * Generates unique keys used to store or fetch UserDataAdd messages in the UserDataAdd set index
@@ -85,7 +85,7 @@ class UserDataStore extends Store<UserDataAddMessage, never> {
   override _removeMessageType = undefined;
 
   protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return PRUNE_SIZE_LIMIT_DEFAULT;
+    return USER_DATA_PRUNE_SIZE_LIMIT_DEFAULT;
   }
 
   /**

--- a/apps/hubble/src/storage/stores/verificationStore.ts
+++ b/apps/hubble/src/storage/stores/verificationStore.ts
@@ -12,7 +12,7 @@ import { UserMessagePostfix, UserPostfix } from "../db/types.js";
 import { MessagesPage, PageOptions } from "./types.js";
 import { Store } from "./store.js";
 
-const PRUNE_SIZE_LIMIT_DEFAULT = 50;
+export const VERIFICATION_PRUNE_SIZE_LIMIT_DEFAULT = 50;
 
 /**
  * Generates a unique key used to store a VerificationAdds message key in the VerificationsAdds
@@ -94,7 +94,7 @@ class VerificationStore extends Store<VerificationAddEthAddressMessage, Verifica
   override _removeMessageType = MessageType.VERIFICATION_REMOVE;
 
   protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return PRUNE_SIZE_LIMIT_DEFAULT;
+    return VERIFICATION_PRUNE_SIZE_LIMIT_DEFAULT;
   }
 
   /**

--- a/packages/core/src/protobufs/generated/request_response.ts
+++ b/packages/core/src/protobufs/generated/request_response.ts
@@ -164,6 +164,15 @@ export interface StorageAdminRegistryEventRequest {
   transactionHash: Uint8Array;
 }
 
+export interface StorageLimitsResponse {
+  limits: StorageLimit[];
+}
+
+export interface StorageLimit {
+  storeType: string;
+  limit: number;
+}
+
 export interface UsernameProofRequest {
   name: Uint8Array;
 }
@@ -2382,6 +2391,137 @@ export const StorageAdminRegistryEventRequest = {
   ): StorageAdminRegistryEventRequest {
     const message = createBaseStorageAdminRegistryEventRequest();
     message.transactionHash = object.transactionHash ?? new Uint8Array();
+    return message;
+  },
+};
+
+function createBaseStorageLimitsResponse(): StorageLimitsResponse {
+  return { limits: [] };
+}
+
+export const StorageLimitsResponse = {
+  encode(message: StorageLimitsResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    for (const v of message.limits) {
+      StorageLimit.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): StorageLimitsResponse {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseStorageLimitsResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.limits.push(StorageLimit.decode(reader, reader.uint32()));
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): StorageLimitsResponse {
+    return { limits: Array.isArray(object?.limits) ? object.limits.map((e: any) => StorageLimit.fromJSON(e)) : [] };
+  },
+
+  toJSON(message: StorageLimitsResponse): unknown {
+    const obj: any = {};
+    if (message.limits) {
+      obj.limits = message.limits.map((e) => e ? StorageLimit.toJSON(e) : undefined);
+    } else {
+      obj.limits = [];
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<StorageLimitsResponse>, I>>(base?: I): StorageLimitsResponse {
+    return StorageLimitsResponse.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<StorageLimitsResponse>, I>>(object: I): StorageLimitsResponse {
+    const message = createBaseStorageLimitsResponse();
+    message.limits = object.limits?.map((e) => StorageLimit.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBaseStorageLimit(): StorageLimit {
+  return { storeType: "", limit: 0 };
+}
+
+export const StorageLimit = {
+  encode(message: StorageLimit, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.storeType !== "") {
+      writer.uint32(10).string(message.storeType);
+    }
+    if (message.limit !== 0) {
+      writer.uint32(16).uint64(message.limit);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): StorageLimit {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseStorageLimit();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.storeType = reader.string();
+          continue;
+        case 2:
+          if (tag != 16) {
+            break;
+          }
+
+          message.limit = longToNumber(reader.uint64() as Long);
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): StorageLimit {
+    return {
+      storeType: isSet(object.storeType) ? String(object.storeType) : "",
+      limit: isSet(object.limit) ? Number(object.limit) : 0,
+    };
+  },
+
+  toJSON(message: StorageLimit): unknown {
+    const obj: any = {};
+    message.storeType !== undefined && (obj.storeType = message.storeType);
+    message.limit !== undefined && (obj.limit = Math.round(message.limit));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<StorageLimit>, I>>(base?: I): StorageLimit {
+    return StorageLimit.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<StorageLimit>, I>>(object: I): StorageLimit {
+    const message = createBaseStorageLimit();
+    message.storeType = object.storeType ?? "";
+    message.limit = object.limit ?? 0;
     return message;
   },
 };

--- a/packages/hub-nodejs/src/generated/request_response.ts
+++ b/packages/hub-nodejs/src/generated/request_response.ts
@@ -164,6 +164,15 @@ export interface StorageAdminRegistryEventRequest {
   transactionHash: Uint8Array;
 }
 
+export interface StorageLimitsResponse {
+  limits: StorageLimit[];
+}
+
+export interface StorageLimit {
+  storeType: string;
+  limit: number;
+}
+
 export interface UsernameProofRequest {
   name: Uint8Array;
 }
@@ -2382,6 +2391,137 @@ export const StorageAdminRegistryEventRequest = {
   ): StorageAdminRegistryEventRequest {
     const message = createBaseStorageAdminRegistryEventRequest();
     message.transactionHash = object.transactionHash ?? new Uint8Array();
+    return message;
+  },
+};
+
+function createBaseStorageLimitsResponse(): StorageLimitsResponse {
+  return { limits: [] };
+}
+
+export const StorageLimitsResponse = {
+  encode(message: StorageLimitsResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    for (const v of message.limits) {
+      StorageLimit.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): StorageLimitsResponse {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseStorageLimitsResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.limits.push(StorageLimit.decode(reader, reader.uint32()));
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): StorageLimitsResponse {
+    return { limits: Array.isArray(object?.limits) ? object.limits.map((e: any) => StorageLimit.fromJSON(e)) : [] };
+  },
+
+  toJSON(message: StorageLimitsResponse): unknown {
+    const obj: any = {};
+    if (message.limits) {
+      obj.limits = message.limits.map((e) => e ? StorageLimit.toJSON(e) : undefined);
+    } else {
+      obj.limits = [];
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<StorageLimitsResponse>, I>>(base?: I): StorageLimitsResponse {
+    return StorageLimitsResponse.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<StorageLimitsResponse>, I>>(object: I): StorageLimitsResponse {
+    const message = createBaseStorageLimitsResponse();
+    message.limits = object.limits?.map((e) => StorageLimit.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBaseStorageLimit(): StorageLimit {
+  return { storeType: "", limit: 0 };
+}
+
+export const StorageLimit = {
+  encode(message: StorageLimit, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.storeType !== "") {
+      writer.uint32(10).string(message.storeType);
+    }
+    if (message.limit !== 0) {
+      writer.uint32(16).uint64(message.limit);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): StorageLimit {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseStorageLimit();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.storeType = reader.string();
+          continue;
+        case 2:
+          if (tag != 16) {
+            break;
+          }
+
+          message.limit = longToNumber(reader.uint64() as Long);
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): StorageLimit {
+    return {
+      storeType: isSet(object.storeType) ? String(object.storeType) : "",
+      limit: isSet(object.limit) ? Number(object.limit) : 0,
+    };
+  },
+
+  toJSON(message: StorageLimit): unknown {
+    const obj: any = {};
+    message.storeType !== undefined && (obj.storeType = message.storeType);
+    message.limit !== undefined && (obj.limit = Math.round(message.limit));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<StorageLimit>, I>>(base?: I): StorageLimit {
+    return StorageLimit.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<StorageLimit>, I>>(object: I): StorageLimit {
+    const message = createBaseStorageLimit();
+    message.storeType = object.storeType ?? "";
+    message.limit = object.limit ?? 0;
     return message;
   },
 };

--- a/packages/hub-nodejs/src/generated/rpc.ts
+++ b/packages/hub-nodejs/src/generated/rpc.ts
@@ -39,6 +39,7 @@ import {
   RentRegistryEventsRequest,
   RentRegistryEventsResponse,
   SignerRequest,
+  StorageLimitsResponse,
   SubscribeRequest,
   SyncIds,
   SyncStatusRequest,
@@ -198,6 +199,15 @@ export const HubServiceService = {
     responseSerialize: (value: RentRegistryEventsResponse) =>
       Buffer.from(RentRegistryEventsResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => RentRegistryEventsResponse.decode(value),
+  },
+  getCurrentStorageLimitsByFid: {
+    path: "/HubService/GetCurrentStorageLimitsByFid",
+    requestStream: false,
+    responseStream: false,
+    requestSerialize: (value: FidRequest) => Buffer.from(FidRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => FidRequest.decode(value),
+    responseSerialize: (value: StorageLimitsResponse) => Buffer.from(StorageLimitsResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer) => StorageLimitsResponse.decode(value),
   },
   /** Username Proof */
   getUsernameProof: {
@@ -448,6 +458,7 @@ export interface HubServiceServer extends UntypedServiceImplementation {
   getUserDataByFid: handleUnaryCall<FidRequest, MessagesResponse>;
   getNameRegistryEvent: handleUnaryCall<NameRegistryEventRequest, NameRegistryEvent>;
   getRentRegistryEvents: handleUnaryCall<RentRegistryEventsRequest, RentRegistryEventsResponse>;
+  getCurrentStorageLimitsByFid: handleUnaryCall<FidRequest, StorageLimitsResponse>;
   /** Username Proof */
   getUsernameProof: handleUnaryCall<UsernameProofRequest, UserNameProof>;
   getUserNameProofsByFid: handleUnaryCall<FidRequest, UsernameProofsResponse>;
@@ -693,6 +704,21 @@ export interface HubServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: RentRegistryEventsResponse) => void,
+  ): ClientUnaryCall;
+  getCurrentStorageLimitsByFid(
+    request: FidRequest,
+    callback: (error: ServiceError | null, response: StorageLimitsResponse) => void,
+  ): ClientUnaryCall;
+  getCurrentStorageLimitsByFid(
+    request: FidRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: StorageLimitsResponse) => void,
+  ): ClientUnaryCall;
+  getCurrentStorageLimitsByFid(
+    request: FidRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: StorageLimitsResponse) => void,
   ): ClientUnaryCall;
   /** Username Proof */
   getUsernameProof(

--- a/packages/hub-web/src/generated/request_response.ts
+++ b/packages/hub-web/src/generated/request_response.ts
@@ -164,6 +164,15 @@ export interface StorageAdminRegistryEventRequest {
   transactionHash: Uint8Array;
 }
 
+export interface StorageLimitsResponse {
+  limits: StorageLimit[];
+}
+
+export interface StorageLimit {
+  storeType: string;
+  limit: number;
+}
+
 export interface UsernameProofRequest {
   name: Uint8Array;
 }
@@ -2382,6 +2391,137 @@ export const StorageAdminRegistryEventRequest = {
   ): StorageAdminRegistryEventRequest {
     const message = createBaseStorageAdminRegistryEventRequest();
     message.transactionHash = object.transactionHash ?? new Uint8Array();
+    return message;
+  },
+};
+
+function createBaseStorageLimitsResponse(): StorageLimitsResponse {
+  return { limits: [] };
+}
+
+export const StorageLimitsResponse = {
+  encode(message: StorageLimitsResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    for (const v of message.limits) {
+      StorageLimit.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): StorageLimitsResponse {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseStorageLimitsResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.limits.push(StorageLimit.decode(reader, reader.uint32()));
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): StorageLimitsResponse {
+    return { limits: Array.isArray(object?.limits) ? object.limits.map((e: any) => StorageLimit.fromJSON(e)) : [] };
+  },
+
+  toJSON(message: StorageLimitsResponse): unknown {
+    const obj: any = {};
+    if (message.limits) {
+      obj.limits = message.limits.map((e) => e ? StorageLimit.toJSON(e) : undefined);
+    } else {
+      obj.limits = [];
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<StorageLimitsResponse>, I>>(base?: I): StorageLimitsResponse {
+    return StorageLimitsResponse.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<StorageLimitsResponse>, I>>(object: I): StorageLimitsResponse {
+    const message = createBaseStorageLimitsResponse();
+    message.limits = object.limits?.map((e) => StorageLimit.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBaseStorageLimit(): StorageLimit {
+  return { storeType: "", limit: 0 };
+}
+
+export const StorageLimit = {
+  encode(message: StorageLimit, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.storeType !== "") {
+      writer.uint32(10).string(message.storeType);
+    }
+    if (message.limit !== 0) {
+      writer.uint32(16).uint64(message.limit);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): StorageLimit {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseStorageLimit();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.storeType = reader.string();
+          continue;
+        case 2:
+          if (tag != 16) {
+            break;
+          }
+
+          message.limit = longToNumber(reader.uint64() as Long);
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): StorageLimit {
+    return {
+      storeType: isSet(object.storeType) ? String(object.storeType) : "",
+      limit: isSet(object.limit) ? Number(object.limit) : 0,
+    };
+  },
+
+  toJSON(message: StorageLimit): unknown {
+    const obj: any = {};
+    message.storeType !== undefined && (obj.storeType = message.storeType);
+    message.limit !== undefined && (obj.limit = Math.round(message.limit));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<StorageLimit>, I>>(base?: I): StorageLimit {
+    return StorageLimit.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<StorageLimit>, I>>(object: I): StorageLimit {
+    const message = createBaseStorageLimit();
+    message.storeType = object.storeType ?? "";
+    message.limit = object.limit ?? 0;
     return message;
   },
 };

--- a/packages/hub-web/src/generated/rpc.ts
+++ b/packages/hub-web/src/generated/rpc.ts
@@ -29,6 +29,7 @@ import {
   RentRegistryEventsRequest,
   RentRegistryEventsResponse,
   SignerRequest,
+  StorageLimitsResponse,
   SubscribeRequest,
   SyncIds,
   SyncStatusRequest,
@@ -78,6 +79,10 @@ export interface HubService {
     request: DeepPartial<RentRegistryEventsRequest>,
     metadata?: grpc.Metadata,
   ): Promise<RentRegistryEventsResponse>;
+  getCurrentStorageLimitsByFid(
+    request: DeepPartial<FidRequest>,
+    metadata?: grpc.Metadata,
+  ): Promise<StorageLimitsResponse>;
   /** Username Proof */
   getUsernameProof(request: DeepPartial<UsernameProofRequest>, metadata?: grpc.Metadata): Promise<UserNameProof>;
   getUserNameProofsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<UsernameProofsResponse>;
@@ -142,6 +147,7 @@ export class HubServiceClientImpl implements HubService {
     this.getUserDataByFid = this.getUserDataByFid.bind(this);
     this.getNameRegistryEvent = this.getNameRegistryEvent.bind(this);
     this.getRentRegistryEvents = this.getRentRegistryEvents.bind(this);
+    this.getCurrentStorageLimitsByFid = this.getCurrentStorageLimitsByFid.bind(this);
     this.getUsernameProof = this.getUsernameProof.bind(this);
     this.getUserNameProofsByFid = this.getUserNameProofsByFid.bind(this);
     this.getVerification = this.getVerification.bind(this);
@@ -242,6 +248,13 @@ export class HubServiceClientImpl implements HubService {
       RentRegistryEventsRequest.fromPartial(request),
       metadata,
     );
+  }
+
+  getCurrentStorageLimitsByFid(
+    request: DeepPartial<FidRequest>,
+    metadata?: grpc.Metadata,
+  ): Promise<StorageLimitsResponse> {
+    return this.rpc.unary(HubServiceGetCurrentStorageLimitsByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
   getUsernameProof(request: DeepPartial<UsernameProofRequest>, metadata?: grpc.Metadata): Promise<UserNameProof> {
@@ -694,6 +707,29 @@ export const HubServiceGetRentRegistryEventsDesc: UnaryMethodDefinitionish = {
   responseType: {
     deserializeBinary(data: Uint8Array) {
       const value = RentRegistryEventsResponse.decode(data);
+      return {
+        ...value,
+        toObject() {
+          return value;
+        },
+      };
+    },
+  } as any,
+};
+
+export const HubServiceGetCurrentStorageLimitsByFidDesc: UnaryMethodDefinitionish = {
+  methodName: "GetCurrentStorageLimitsByFid",
+  service: HubServiceDesc,
+  requestStream: false,
+  responseStream: false,
+  requestType: {
+    serializeBinary() {
+      return FidRequest.encode(this).finish();
+    },
+  } as any,
+  responseType: {
+    deserializeBinary(data: Uint8Array) {
+      const value = StorageLimitsResponse.decode(data);
       return {
         ...value,
         toObject() {

--- a/protobufs/docs/rpc.md
+++ b/protobufs/docs/rpc.md
@@ -42,11 +42,13 @@ Used to retrieve valid and revoked Signers
 
 Users to retrieve the current metadata associated with a user
 
-| Method Name                 | Request Type    | Response Type    | Description                            |
-| --------------------------- | --------------- | ---------------- | -------------------------------------- |
-| GetUserData                 | UserDataRequest | Message          | Returns a specific UserData for an Fid |
-| GetUserDataByFid            | FidRequest      | MessagesResponse | Returns all UserData for an Fid        |
-| GetAllUserDataMessagesByFid | FidRequest      | MessagesResponse | Returns all UserData for an Fid        |
+| Method Name                  | Request Type              | Response Type              | Description                               |
+| ---------------------------- | ------------------------- | -------------------------- | ----------------------------------------- |
+| GetUserData                  | UserDataRequest           | Message                    | Returns a specific UserData for an Fid    |
+| GetUserDataByFid             | FidRequest                | MessagesResponse           | Returns all UserData for an Fid           |
+| GetAllUserDataMessagesByFid  | FidRequest                | MessagesResponse           | Returns all UserData for an Fid           |
+| GetRentRegistryEvents        | RentRegistryEventsRequest | RentRegistryEventsResponse | Returns all RentRegistryEvents for an Fid |
+| GetCurrentStorageLimitsByFid | FidRequest                | StorageLimitsResponse      | Returns StorageLimits for an Fid          |
 
 #### UserData Request
 
@@ -54,6 +56,39 @@ Users to retrieve the current metadata associated with a user
 | -------------- | ----------------- | ----- | --------------------------------------------------- |
 | fid            | [uint64](#)       |       | Farcaster ID of the user who generated the UserData |
 | user_data_type | [UserDataType](#) |       | Type of UserData being requested                    |
+
+#### RentRegistryEvents Response
+
+| Field          | Type                         | Label    | Description          |
+| -------------- | ---------------------------- | -------- | -------------------- |
+| events         | [RentRegistryEvent](#)       | repeated | Rent registry events |
+
+#### RentRegistryEvent
+
+| Field            | Type                          | Label | Description                                                           |
+| ---------------- | ----------------------------- | ----- | --------------------------------------------------------------------- |
+| block_number     | [uint32](#)                   |       | The block number the event appeared in                                |
+| block_hash       | [bytes](#)                    |       | The hash of the block the event appeared in                           |
+| transaction_hash | [bytes](#)                    |       | The transaction hash which produced the event                         |
+| log_index        | [uint32](#)                   |       | The index of the logs the event appeared in                           |
+| payer            | [bytes](#)                    |       | The paying address                                                    |
+| fid              | [uint64](#)                   |       | The fid receiving the rent allocation                                 |
+| type             | [StorageRegistryEventType](#) |       | The type of the event, for rent is `STORAGE_REGISTRY_EVENT_TYPE_RENT` |
+| units            | [uint32](#)                   |       | The number of units rented                                            |
+| expiry           | [uint32](#)                   |       | The expiration time of the rent                                       |
+
+#### StorageLimitsResponse
+
+| Field          | Type                         | Label    | Description                   |
+| -------------- | ---------------------------- | -------- | ----------------------------- |
+| limits         | [StorageLimit](#)            | repeated | Storage limits per store type |
+
+#### StorageLimit
+
+| Field      | Type        | Label | Description                                            |
+| ---------- | ----------- | ----- | ------------------------------------------------------ |
+| store_type | [string](#) |       | The specific type being managed by the store           |
+| limit      | [uint64](#) |       | The limit of the store type, scaled by the user's rent |
 
 ## 3. Cast Service
 

--- a/protobufs/schemas/request_response.proto
+++ b/protobufs/schemas/request_response.proto
@@ -159,6 +159,15 @@ message StorageAdminRegistryEventRequest {
   bytes transaction_hash = 1;
 }
 
+message StorageLimitsResponse {
+  repeated StorageLimit limits = 1;
+}
+
+message StorageLimit {
+  string store_type = 1;
+  uint64 limit = 2;
+}
+
 message UsernameProofRequest {
   bytes name = 1;
 }

--- a/protobufs/schemas/rpc.proto
+++ b/protobufs/schemas/rpc.proto
@@ -33,6 +33,7 @@ service HubService {
   rpc GetUserDataByFid(FidRequest) returns (MessagesResponse);
   rpc GetNameRegistryEvent(NameRegistryEventRequest) returns (NameRegistryEvent);
   rpc GetRentRegistryEvents(RentRegistryEventsRequest) returns (RentRegistryEventsResponse);
+  rpc GetCurrentStorageLimitsByFid(FidRequest) returns (StorageLimitsResponse);
 
   // Username Proof
   rpc GetUsernameProof(UsernameProofRequest) returns (UserNameProof);


### PR DESCRIPTION
## Motivation

Consumers of hubs may want to know how much storage is allocated per fid so as to reflect that similarly in content being replicated, or to display a warning within a client about approaching limits.

## Change Summary

Adds a new RPC endpoint to return the current limits for a given fid.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added storage limits RPC
- Added `StorageLimitsResponse` message to `request_response.proto`
- Added `GetCurrentStorageLimitsByFid` RPC to `rpc.proto`
- Updated `castStore.ts`, `userDataStore.ts`, `verificationStore.ts`, `signerStore.ts`, `linkStore.ts`, `reactionStore.ts`, `engine.ts`, `server.ts`, `storageEventStore.ts` to use new storage limits logic

> The following files were skipped due to too many changes: `packages/hub-web/src/generated/rpc.ts`, `packages/hub-web/src/generated/request_response.ts`, `packages/hub-nodejs/src/generated/request_response.ts`, `packages/core/src/protobufs/generated/request_response.ts`, `protobufs/docs/rpc.md`, `apps/hubble/src/storage/stores/storageEventStore.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->