### PR TITLE
chore: Adjust rent-based prune warning to debug for now

### DIFF
--- a/.changeset/tiny-bears-peel.md
+++ b/.changeset/tiny-bears-peel.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+Adjusted rent prune log to debug instead of warn

--- a/apps/hubble/src/storage/stores/store.ts
+++ b/apps/hubble/src/storage/stores/store.ts
@@ -249,7 +249,7 @@ export abstract class Store<TAdd extends Message, TRemove extends Message> {
     }
 
     if (units.value === 0) {
-      logger.warn({ fid }, "fid has no registered storage, would be pruned");
+      logger.debug({ fid }, "fid has no registered storage, would be pruned");
     }
 
     // This is temporary, when all fids are migrated to using storage rent, we'll just use the units directly.

--- a/apps/hubble/src/storage/stores/storeEventHandler.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.ts
@@ -265,7 +265,7 @@ class StoreEventHandler extends TypedEmitter<StoreEvents> {
     }
 
     if (units.value === 0) {
-      logger.warn({ fid: message.data.fid }, "fid has no registered storage, would be pruned");
+      logger.debug({ fid: message.data.fid }, "fid has no registered storage, would be pruned");
     }
 
     const unitsMultiplier = units.value > 0 ? units.value : 1;


### PR DESCRIPTION
## Motivation

We enabled partial support for rent-based pruning, with the caveat that data for fids with no rent do not get pruned, only warned. Until we are closer to fully migrating to storage rent, let's bump this down to debug instead of warn.

## Change Summary

Changes the prune `warning` for rent to `debug`.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
