### PR TITLE
fix: Bugfix where testnet would restrict peers

### DIFF
--- a/.changeset/breezy-swans-brake.md
+++ b/.changeset/breezy-swans-brake.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Bugfix where testnet would restrict peers

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -588,17 +588,15 @@ export class Hub implements HubInterface {
 
   /** Apply the new the network config. Will return true if the Hub should exit */
   public applyNetworkConfig(networkConfig: NetworkConfig): boolean {
-    const { allowedPeerIds, shouldExit } = applyNetworkConfig(
-      networkConfig,
-      this.allowedPeerIds ?? [],
-      this.options.network,
-    );
+    const { allowedPeerIds, shouldExit } = applyNetworkConfig(networkConfig, this.allowedPeerIds, this.options.network);
 
     if (shouldExit) {
       return true;
     } else {
-      this.gossipNode.updateAllowedPeerIds(allowedPeerIds);
-      this.allowedPeerIds = allowedPeerIds;
+      if (allowedPeerIds) {
+        this.gossipNode.updateAllowedPeerIds(allowedPeerIds);
+        this.allowedPeerIds = allowedPeerIds;
+      }
       return false;
     }
   }

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -488,6 +488,11 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
         { identity: this.identity, function: "createNode", allowedPeerIds: options.allowedPeerIdStrs },
         "!!! PEER-ID RESTRICTIONS ENABLED !!!",
       );
+    } else {
+      log.warn(
+        { identity: this.identity, function: "createNode" },
+        "No PEER-ID RESTRICTIONS ENABLED. This node will accept connections from any peer",
+      );
     }
     this._connectionGater = new ConnectionFilter(options.allowedPeerIdStrs);
 

--- a/apps/hubble/src/network/utils/networkConfig.ts
+++ b/apps/hubble/src/network/utils/networkConfig.ts
@@ -21,7 +21,7 @@ export type NetworkConfig = {
 };
 
 export type NetworkConfigResult = {
-  allowedPeerIds: string[];
+  allowedPeerIds: string[] | undefined;
   shouldExit: boolean;
 };
 
@@ -55,7 +55,7 @@ export async function fetchNetworkConfig(): HubAsyncResult<NetworkConfig> {
 
 export function applyNetworkConfig(
   networkConfig: NetworkConfig,
-  existingPeerIds: string[],
+  existingPeerIds: string[] | undefined,
   currentNetwork: number,
 ): NetworkConfigResult {
   if (networkConfig.network !== currentNetwork) {
@@ -80,7 +80,7 @@ export function applyNetworkConfig(
 
   if (networkConfig.allowedPeers) {
     // Add the network.allowedPeers to the list of allowed peers
-    newPeerIdList = [...new Set([...existingPeerIds, ...networkConfig.allowedPeers])];
+    newPeerIdList = [...new Set([...(existingPeerIds ?? []), ...networkConfig.allowedPeers])];
   } else {
     log.error({ networkConfig }, "network config does not contain 'allowedPeers'");
   }


### PR DESCRIPTION


## Change Summary

- Handle cases where peerID allowlist is undefined (like it is for testnet)

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)




<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a bug where the testnet would restrict peers. 

### Detailed summary
- Added a condition to check if peer-id restrictions are enabled or not.
- Updated the `applyNetworkConfig` function to handle `allowedPeerIds` properly.
- Updated the `fetchNetworkConfig` function to handle `existingPeerIds` properly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->