### PR TITLE
fix: Fix TestData generator for testnet

### DIFF
--- a/.changeset/smart-hotels-punch.md
+++ b/.changeset/smart-hotels-punch.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Fix the TestData generation for testnet

--- a/apps/hubble/src/utils/periodicTestDataJob.ts
+++ b/apps/hubble/src/utils/periodicTestDataJob.ts
@@ -18,7 +18,7 @@ import { ed25519 as ed } from "@noble/curves/ed25519";
 import { faker } from "@faker-js/faker";
 import Server from "../rpc/server.js";
 import { Result } from "neverthrow";
-import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { mnemonicToAccount } from "viem/accounts";
 
 const log = logger.child({
   component: "PeriodicTestDataJob",
@@ -69,7 +69,7 @@ export class PeriodicTestDataJobScheduler {
         continue;
       }
 
-      const account = privateKeyToAccount(generatePrivateKey());
+      const account = mnemonicToAccount(testUser.mnemonic);
       const eip712Signer = new ViemLocalEip712Signer(account);
 
       // Generate a new Ed25519 key pair which will become the Signer and store the private key securely
@@ -101,7 +101,10 @@ export class PeriodicTestDataJobScheduler {
 
       const result = await client.submitMessage(signerAdd, getAuthMetadata(user, password));
       if (result.isErr()) {
-        log.error({ error: result.error, dataOptions }, "TestData: failed to submit SignerAdd message");
+        log.error(
+          { error: result.error, errMsg: result.error.message, dataOptions },
+          "TestData: failed to submit SignerAdd message",
+        );
       }
 
       this._userEd25519KeyPairs.set(testUser.fid, ed25519Signer);
@@ -153,7 +156,10 @@ export class PeriodicTestDataJobScheduler {
 
         const result = await client.submitMessage(castAdd._unsafeUnwrap(), getAuthMetadata(rpcUsername, rpcPassword));
         if (result.isErr()) {
-          log.error({ error: result.error, dataOptions }, "TestData: failed to submit CastAdd message");
+          log.error(
+            { error: result.error, errMsg: result.error.message, dataOptions },
+            "TestData: failed to submit CastAdd message",
+          );
         }
         targetCastIds.push({ fid: testUser.fid, hash: castAdd._unsafeUnwrap().hash });
       }
@@ -179,7 +185,10 @@ export class PeriodicTestDataJobScheduler {
               getAuthMetadata(rpcUsername, rpcPassword),
             );
             if (result.isErr()) {
-              log.error({ error: result.error, dataOptions }, "TestData: failed to submit ReactionAdd message");
+              log.error(
+                { error: result.error, errMsg: result.error.message, dataOptions },
+                "TestData: failed to submit ReactionAdd message",
+              );
             }
           }
         }


### PR DESCRIPTION

## Change Summary

- Fix bug with testnet TestData generator

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the TestData generation for testnet. 

### Detailed summary
- Changed `generatePrivateKey` to `mnemonicToAccount` for generating test account.
- Updated error logging messages for failed message submissions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->