### PR TITLE
feat: Move blake3 hashing into Rust

### DIFF
--- a/.changeset/friendly-icons-sip.md
+++ b/.changeset/friendly-icons-sip.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+feat: Move blake3 hash into rust

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ All PR's should have supporting documentation that makes reviewing and understan
 - Add a `Safety: ..` comment explaining every use of `as`.
 - Prefer active, present-tense doing form (`Gets the connection`) over other forms (`Connection is obtained`, `Get the connection`, `We get the connection`, `will get a connection`)
 
-### 3.4. Handling Errors
+### 3.3. Handling Errors
 
 Errors are not handled using `throw` and `try / catch` as is common with Javascript programs. This pattern makes it hard for people to reason about whether methods are safe which leads to incomplete test coverage, unexpected errors and less safety. Instead we use a more functional approach to dealing with errors. See [this issue](https://github.com/farcasterxyz/hub/issues/213) for the rationale behind this approach.
 
@@ -281,6 +281,15 @@ are at all unsure about how to proceed, please reach out to Varun ([Github](http
 5. Checkout main, pull down to the merged commit (should be latest) and run `yarn changeset publish`
 6. Hubble is private and must be manually tagged with `git tag -a @farcaster/hubble@<version>` if bumped.
 7. Run `git push origin <tag>` on each tag to push up the tags.
+
+### 3.7 Working in Rust
+
+Some of the CPU intensive code is written in Rust for speed. We import the Rust modules via [Neon](https://neon-bindings.com/) that are built as a part of the `@farcaster/core` package. 
+
+To add new code to Rust, 
+1. Add it to `packages/core/src/addon/`
+2. Add a bridge implementation and types into `packages/core/src/addon/addon.js` and `packages/core/src/addon/addon.d.ts`
+3. Export the callable typescript function in `packages/core/src/rustfunctions.ts`. This function can then be used throught the project to transparently call into Rust from Typescript 
 
 ## 4. Troubleshooting
 

--- a/apps/hubble/src/network/sync/syncEngineProfiler.ts
+++ b/apps/hubble/src/network/sync/syncEngineProfiler.ts
@@ -203,46 +203,52 @@ export class SyncEngineProfiler {
           const end = Date.now();
 
           if (prop === "getSyncMetadataByPrefix") {
-            const logArgs = Buffer.from(args[0]["prefix"]).toString("hex");
-            const resultBytes = Math.floor(JSON.stringify(result).length / 2); // 2 hex chars per byte
-            // log.info(
-            //   {
-            //     method: prop,
-            //     duration: end - start,
-            //     args: logArgs,
-            //     bytes: resultBytes,
-            //   },
-            //   "RPC call",
-            // );
-            me._methodProfiles.get(prop)?.addCall(end - start, resultBytes, 1);
+            if (result.isOk()) {
+              const resultBytes = Math.floor(JSON.stringify(result).length / 2); // 2 hex chars per byte
+              // const logArgs = Buffer.from(args[0]["prefix"]).toString("hex");
+              // log.info(
+              //   {
+              //     method: prop,
+              //     duration: end - start,
+              //     args: logArgs,
+              //     bytes: resultBytes,
+              //   },
+              //   "RPC call",
+              // );
+              me._methodProfiles.get(prop)?.addCall(end - start, resultBytes, 1);
+            }
           } else if (prop === "getAllSyncIdsByPrefix") {
-            const logArgs = Buffer.from(args[0]["prefix"]).toString("hex");
-            const numSyncIds = result.value.syncIds.length;
-            const resultBytes = Math.floor(JSON.stringify(result).length / 2); // 2 hex chars per byte
-            // log.info(
-            //   {
-            //     method: prop,
-            //     duration: end - start,
-            //     args: logArgs,
-            //     numSyncIds,
-            //     bytes: resultBytes,
-            //   },
-            //   "RPC call",
-            // );
-            me._methodProfiles.get(prop)?.addCall(end - start, resultBytes, numSyncIds);
+            if (result.isOk() && result.value?.syncIds) {
+              const numSyncIds = result.value.syncIds.length;
+              const resultBytes = Math.floor(JSON.stringify(result).length / 2); // 2 hex chars per byte
+              // const logArgs = Buffer.from(args[0]["prefix"]).toString("hex");
+              // log.info(
+              //   {
+              //     method: prop,
+              //     duration: end - start,
+              //     args: logArgs,
+              //     numSyncIds,
+              //     bytes: resultBytes,
+              //   },
+              //   "RPC call",
+              // );
+              me._methodProfiles.get(prop)?.addCall(end - start, resultBytes, numSyncIds);
+            }
           } else if (prop === "getAllMessagesBySyncIds") {
-            const numMessages = result.value.messages.length;
-            const resultBytes = Math.floor(JSON.stringify(result).length / 2); // 2 hex chars per byte
-            // log.info(
-            //   {
-            //     method: prop,
-            //     duration: end - start,
-            //     numMessages,
-            //     bytes: resultBytes,
-            //   },
-            //   "RPC call",
-            // );
-            me._methodProfiles.get(prop)?.addCall(end - start, resultBytes, numMessages);
+            if (result.isOk() && result.value?.messages) {
+              const numMessages = result.value.messages.length;
+              const resultBytes = Math.floor(JSON.stringify(result).length / 2); // 2 hex chars per byte
+              // log.info(
+              //   {
+              //     method: prop,
+              //     duration: end - start,
+              //     numMessages,
+              //     bytes: resultBytes,
+              //   },
+              //   "RPC call",
+              // );
+              me._methodProfiles.get(prop)?.addCall(end - start, resultBytes, numMessages);
+            }
           }
 
           return result;

--- a/apps/hubble/src/profile/rpcProfile.ts
+++ b/apps/hubble/src/profile/rpcProfile.ts
@@ -52,7 +52,6 @@ async function profileSubmitMessages(
   rpcClient: HubRpcClient,
   adminRpcClient: AdminRpcClient,
   fid: number,
-  network = FarcasterNetwork.DEVNET,
   username?: string | Metadata,
   password?: string,
 ): Promise<string[]> {
@@ -74,6 +73,9 @@ async function profileSubmitMessages(
     metadata = getAuthMetadata(username, password);
   }
 
+  // Make sure the network matches
+  const network = FarcasterNetwork.DEVNET;
+
   const custodySigner = Factories.Eip712Signer.build();
   const custodySignerKey = (await custodySigner.getSignerKey())._unsafeUnwrap();
   const signer = Factories.Ed25519Signer.build();
@@ -93,7 +95,7 @@ async function profileSubmitMessages(
   const rentResult = await adminRpcClient.submitRentRegistryEvent(rentRegistryEvent, metadata);
 
   if (!rentResult.isOk()) {
-    throw `Failed to submit rent event for fid ${fid}: ${rentResult.error}`;
+    throw `Failed to submit rent event for fid ${fid}: ${rentResult.error}. NOTE: RPC profile only works on devnet`;
   }
 
   const signerAdd = await Factories.SignerAddMessage.create(

--- a/apps/hubble/src/utils/crypto.ts
+++ b/apps/hubble/src/utils/crypto.ts
@@ -1,3 +1,4 @@
+import { nativeBlake3Hash20 } from "@farcaster/hub-nodejs";
 import { blake3 } from "@noble/hashes/blake3";
 
 export const BLAKE3TRUNCATE160_EMPTY_HASH = Buffer.from(blake3(new Uint8Array(), { dkLen: 20 }));
@@ -33,5 +34,5 @@ export const blake3Truncate160 = (msg: Uint8Array | undefined): Uint8Array => {
   if (msg === undefined || msg.length === 0) {
     return BLAKE3TRUNCATE160_EMPTY_HASH;
   }
-  return blake3(msg, { dkLen: 20 });
+  return nativeBlake3Hash20(msg);
 };

--- a/packages/core/src/addon/Cargo.lock
+++ b/packages/core/src/addon/Cargo.lock
@@ -6,16 +6,36 @@ version = 3
 name = "addon"
 version = "0.1.0"
 dependencies = [
- "base64",
+ "blake3",
  "ed25519-dalek",
  "neon",
 ]
 
 [[package]]
-name = "base64"
-version = "0.21.2"
+name = "arrayref"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
+name = "blake3"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199c42ab6972d92c9f8995f086273d25c42fc0f7b2a1fcefba465c1352d25ba5"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "block-buffer"
@@ -27,16 +47,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "cpufeatures"
@@ -48,13 +89,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
 dependencies = [
  "byteorder",
- "digest",
+ "digest 0.9.0",
  "rand_core",
  "subtle",
  "zeroize",
@@ -67,6 +118,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -268,10 +330,10 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 

--- a/packages/core/src/addon/Cargo.toml
+++ b/packages/core/src/addon/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-base64 = "0.21.2"
+blake3 = "1.4.1"
 ed25519-dalek = "1.0.1"
 
 [dependencies.neon]

--- a/packages/core/src/addon/addon.d.ts
+++ b/packages/core/src/addon/addon.d.ts
@@ -1,1 +1,3 @@
-export function nativeEd25519Verify(signature: Uint8Array, hash: Uint8Array, signer: Uint8Array): boolean;
+// Types for the addon for use in TypeScript
+export function bridgeEd25519Verify(signature: Uint8Array, hash: Uint8Array, signer: Uint8Array): boolean;
+export function bridgeBlake3Hash20(data: Uint8Array): Uint8Array;

--- a/packages/core/src/addon/addon.js
+++ b/packages/core/src/addon/addon.js
@@ -1,15 +1,29 @@
+// This is a bridge between the Rust code and the TS code.
+// Note that this file is in JS, not TS, because it needs to load the 
+// Rust library, which is compiled into a cdylib, and we don't want the 
+// TS compiler to try to reinterpret the "import lib from './index.node';" 
+// line as a TS import or as a ESM import.
+
 import lib from "./index.node";
 
-function nativeEd25519Verify(signature, hash, signer) {
-  // NOTE: We should be able to pass the buffers directly, but it doesn't work with Node 20
-  // for some reason. We'll work around to use base64 strings. Still much faster
-  const sig_base64 = Buffer.from(signature).toString("base64");
-  const hash_base64 = Buffer.from(hash).toString("base64");
-  const signer_base64 = Buffer.from(signer).toString("base64");
+// JS function, so no types
+function bridgeEd25519Verify(signature, hash, signer) {
+  const sigBuf = Buffer.from(signature);
+  const hashBuf = Buffer.from(hash);
+  const signerBuf = Buffer.from(signer);
 
-  return lib.ed25519_verify(sig_base64, hash_base64, signer_base64) === 1;
+  return lib.ed25519_verify(sigBuf, hashBuf, signerBuf) === 1;
 }
 
+// JS function, so no types
+function bridgeBlake3Hash20(data) {
+  const dataBuf = Buffer.from(data);
+
+  return new Uint8Array(lib.blake3_20(dataBuf));
+}
+
+// Use the module.exports syntax
 module.exports = {
-  nativeEd25519Verify,
+  bridgeEd25519Verify,
+  bridgeBlake3Hash20,
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,3 +9,4 @@ export * from "./time";
 export * as validations from "./validations";
 export * from "./verifications";
 export * from "./userNameProof";
+export * from "./rustfunctions";

--- a/packages/core/src/rustfunctions.ts
+++ b/packages/core/src/rustfunctions.ts
@@ -1,0 +1,11 @@
+import { bridgeBlake3Hash20, bridgeEd25519Verify } from "./addon/addon.js";
+
+// Use this function in TypeScript to call the rust code.
+export function nativeBlake3Hash20(data: Uint8Array): Uint8Array {
+  return bridgeBlake3Hash20(data);
+}
+
+// Use this function in TypeScript to call the rust code.
+export function nativeEd25519Verify(signature: Uint8Array, hash: Uint8Array, signer: Uint8Array): boolean {
+  return bridgeEd25519Verify(signature, hash, signer);
+}


### PR DESCRIPTION
## Motivation

Move the blake3 hashing into Rust for improved perf

## Change Summary

- Move blake3 hashing into Rust
- Simplify the Rust bridge

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Move the blake3 hash calculation from JavaScript to Rust for improved performance.

### Detailed summary:
- Added `rustfunctions.ts` file to export TypeScript functions that call Rust code.
- Added `nativeBlake3Hash20` function in `rustfunctions.ts` to call the Rust implementation of blake3 hash calculation.
- Added `bridgeBlake3Hash20` function in `addon.js` to bridge the TypeScript function to the Rust implementation.
- Updated `crypto.ts` to use `nativeBlake3Hash20` function instead of importing `blake3` from a JavaScript library.
- Updated `validations.ts` to use `nativeBlake3Hash20` function instead of importing `blake3` from a JavaScript library.
- Updated `trieNode.ts` to use `nativeBlake3Hash20` function instead of importing `blake3` from a JavaScript library.
- Added `blake3_20` function in `addon.rs` to calculate blake3 hash in Rust.
- Updated `addon.js` to bridge the `blake3_20` function from Rust.
- Updated `syncEngineProfiler.ts` to remove logging of method arguments and result size.

> The following files were skipped due to too many changes: `apps/hubble/src/network/sync/syncEngineProfiler.ts`, `packages/core/src/addon/Cargo.lock`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->