### PR TITLE
fix: Fetch network config only on mainnet

### DIFF
--- a/.changeset/empty-eggs-cough.md
+++ b/.changeset/empty-eggs-cough.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Fetch network config only for mainnet


### PR DESCRIPTION


## Change Summary

- Fetch network config only for mainnet, since that's the only network config we have now. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an issue with fetching network configuration only for the mainnet. 

### Detailed summary
- Fetch network config only for the mainnet
- Start the test data generator only for testnet/Devnet
- Remove updateNetworkConfigJobScheduler for non-mainnet networks

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->