### PR TITLE
test: Add rust tests

### DIFF
--- a/packages/core/src/addon/src/lib.rs
+++ b/packages/core/src/addon/src/lib.rs
@@ -27,13 +27,12 @@ fn blake3_20(mut cx: FunctionContext) -> JsResult<JsBuffer> {
     let input = cx.argument::<JsBuffer>(0)?;
     let mut hasher = blake3::Hasher::new();
     hasher.update(&input.as_slice(&cx));
-    let hash = hasher.finalize();
+
+    // Create a 20 byte buffer to hold the output
     let mut output = cx.buffer(20)?;
 
-    // Copy 20 bytes
-    output
-        .as_mut_slice(&mut cx)
-        .copy_from_slice(&hash.as_bytes()[0..20]);
+    // Fill the buffer with the output
+    hasher.finalize_xof().fill(output.as_mut_slice(&mut cx));
 
     Ok(output)
 }

--- a/packages/core/src/rustfunctions.test.ts
+++ b/packages/core/src/rustfunctions.test.ts
@@ -1,0 +1,83 @@
+import { blake3 } from "@noble/hashes/blake3";
+import { nativeBlake3Hash20, nativeEd25519Verify } from "./rustfunctions";
+import { ed25519 } from "./crypto";
+import { Factories } from "./factories";
+
+describe("blake3 tests", () => {
+  test("hashes match rust", () => {
+    const data = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]);
+
+    const rusthash = nativeBlake3Hash20(data);
+    const hash = blake3.create({ dkLen: 20 }).update(data).digest();
+
+    expect(rusthash).toEqual(hash);
+  });
+
+  test("hashes match rust for empty data", () => {
+    const data = new Uint8Array([]);
+
+    const rusthash = nativeBlake3Hash20(data);
+    const hash = blake3(data, { dkLen: 20 });
+
+    expect(rusthash).toEqual(hash);
+  });
+});
+
+describe("ed25519 tests", () => {
+  test("create and verify signature", async () => {
+    const signer = Factories.Ed25519Signer.build();
+    const signerKey = (await signer.getSignerKey())._unsafeUnwrap();
+    const hash = Factories.Bytes.build({}, { transient: { length: 32 } });
+    const signature = (await signer.signMessageHash(hash))._unsafeUnwrap();
+
+    expect((await ed25519.verifyMessageHashSignature(signature, hash, signerKey))._unsafeUnwrap()).toBeTruthy();
+    expect(nativeEd25519Verify(signature, hash, signerKey)).toBeTruthy();
+  });
+
+  test("bad signature fails", async () => {
+    const signer = Factories.Ed25519Signer.build();
+    const signerKey = (await signer.getSignerKey())._unsafeUnwrap();
+    const hash = Factories.Bytes.build({}, { transient: { length: 32 } });
+    const signature = (await signer.signMessageHash(hash))._unsafeUnwrap();
+
+    const badHash = Factories.Bytes.build({}, { transient: { length: 32 } });
+
+    expect((await ed25519.verifyMessageHashSignature(signature, badHash, signerKey))._unsafeUnwrap()).toBeFalsy();
+    expect(nativeEd25519Verify(signature, badHash, signerKey)).toBeFalsy();
+  });
+
+  test("bad signer fails", async () => {
+    const signer = Factories.Ed25519Signer.build();
+    const hash = Factories.Bytes.build({}, { transient: { length: 32 } });
+    const signature = (await signer.signMessageHash(hash))._unsafeUnwrap();
+
+    const badSigner = Factories.Bytes.build({}, { transient: { length: 32 } });
+
+    expect((await ed25519.verifyMessageHashSignature(signature, hash, badSigner))._unsafeUnwrap()).toBeFalsy();
+    expect(nativeEd25519Verify(signature, hash, badSigner)).toBeFalsy();
+  });
+
+  test("bad signature fails", async () => {
+    const signer = Factories.Ed25519Signer.build();
+    const signerKey = (await signer.getSignerKey())._unsafeUnwrap();
+    const hash = Factories.Bytes.build({}, { transient: { length: 32 } });
+
+    const badSignature = Factories.Bytes.build({}, { transient: { length: 64 } });
+
+    expect((await ed25519.verifyMessageHashSignature(badSignature, hash, signerKey))._unsafeUnwrap()).toBeFalsy();
+    expect(nativeEd25519Verify(badSignature, hash, signerKey)).toBeFalsy();
+  });
+
+  test("0 length data fails", async () => {
+    const signer = Factories.Ed25519Signer.build();
+    const signerKey = (await signer.getSignerKey())._unsafeUnwrap();
+    const hash = Factories.Bytes.build({}, { transient: { length: 32 } });
+    const signature = (await signer.signMessageHash(hash))._unsafeUnwrap();
+
+    const empty = new Uint8Array([]);
+
+    expect(nativeEd25519Verify(empty, hash, signerKey)).toBeFalsy();
+    expect(nativeEd25519Verify(signature, empty, signerKey)).toBeFalsy();
+    expect(nativeEd25519Verify(signature, hash, empty)).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Motivation

Add tests to rust code

## Change Summary

- Test native rust calling, FFI and compare against pure JS code

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on updating the code to use the `blake3` crate for hashing and adding tests for `blake3` and `ed25519` functionality.

### Detailed summary:
- The code is updated to use the `blake3` crate for hashing.
- The `hasher.finalize()` function is replaced with `hasher.finalize_xof().fill(output.as_mut_slice(&mut cx))` to fill the output buffer.
- Tests are added to compare the `blake3` hashing results with the Rust implementation.
- Tests are added to verify the creation and verification of `ed25519` signatures.
- Tests are added to verify the failure cases for signature verification with different inputs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->