### PR TITLE
fix: Limit calls to subscribe()

### DIFF
--- a/.changeset/little-fans-sort.md
+++ b/.changeset/little-fans-sort.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Limit the number of simultaneous subscribe() streams by IP address

--- a/apps/hubble/src/utils/p2p.ts
+++ b/apps/hubble/src/utils/p2p.ts
@@ -19,6 +19,21 @@ export const parseAddress = (multiaddrStr: string): HubResult<Multiaddr> => {
   )();
 };
 
+/* Extracts the ip part from "ip:port" */
+export const extractIPAddress = (peerAddress: string): string | undefined => {
+  // This regex matches both IPv4 and IPv6 addresses
+  const ipRegex = /((?:[0-9]{1,3}\.){3}[0-9]{1,3}|(?:[a-fA-F0-9]{1,4}:){7}[a-fA-F0-9]{1,4}):[0-9]+/;
+
+  const match = peerAddress.match(ipRegex);
+
+  // If the address matches the regex, we remove the port part
+  if (match) {
+    return match[0].split(":")[0];
+  } else {
+    return undefined;
+  }
+};
+
 /** Checks that the IP address to bind to is valid and that the combined IP, transport, and port multiaddr is valid  */
 export const checkNodeAddrs = (listenIPAddr: string, listenCombinedAddr: string): HubResult<void> => {
   return Result.combine([checkIpAddr(listenIPAddr), checkCombinedAddr(listenCombinedAddr)]).map(() => undefined);


### PR DESCRIPTION
## Motivation

The `subscribe()` RPC is a long-lived one, which causes excessive resource consumption for every open connection. Limit these to 4 per IP and 4096 total per Node.

## Change Summary

- Limit subscribe() to 4 per IP
- Limit 4096 total
- Tests

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on limiting the number of simultaneous subscribe() streams by IP address in the Hubble app. 

### Detailed summary
- Added `extractIPAddress` function to extract the IP part from "ip:port"
- Modified `checkNodeAddrs` function to check the IP address to bind to and the combined IP, transport, and port multiaddr
- Added `SUBSCRIBE_PERIP_LIMIT` and `SUBSCRIBE_GLOBAL_LIMIT` constants in `server.ts`
- Added `IpConnectionLimiter` class to limit the number of simultaneous connections by IP address
- Modified `Server` class to use `IpConnectionLimiter` for rate limiting in `subscribe` method
- Added `clearRateLimiters` method in `Server` class to clear rate limiters
- Updated tests in `eventService.test.ts` and `server.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->