### PR TITLE
fix: enable updated hub peer id in allowedPeers.mainnet.ts

### DIFF
--- a/apps/hubble/src/allowedPeers.mainnet.ts
+++ b/apps/hubble/src/allowedPeers.mainnet.ts
@@ -18,7 +18,7 @@ export const MAINNET_ALLOWED_PEERS = [
   "12D3KooWFoPsstYWVH3a4uFpmxksF6nDEsgYizHnPpd9Atw9DRbH", // @gavi
   "12D3KooWKYqmj1bQJChn4hCAhsneg9sRKRd6Zzp3DkVMUL2pjyAB", // @16
   "12D3KooWReH654LePzAE4shSw6wuWqP3i9jSN2jBNswWJu2kiPQ5", // @vern
-  // "12D3KooWRxgeFVLTAxeVgj4QHPzuT6HaV3Hj93LNZQeRi7gAwUVk", // @stout (Add back once version updated to 1.3.3 or newer)
+  "12D3KooWRxgeFVLTAxeVgj4QHPzuT6HaV3Hj93LNZQeRi7gAwUVk", // @stout
   "12D3KooWSii9GJheDmFRBzii43fpzvb3WkmPn62QSoJ8MjvGKMxr", // @mp
   "12D3KooWQ76P8kBUvjNx2Q8EpYDL1BsqXdqZmAkHzTxE1uruuwRd", // @brianjckim
   "12D3KooWMZFw3bxWbU3RghVfr4yWHFZc8p5gymTkTaJqgqJ2EJ4r", // @rafi


### PR DESCRIPTION
## Motivation

Updated my hub to 1.4.3, reenabling peer id

## Change Summary

Removed comment that disabled peer id in allowedPeers.mainnet.ts

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the allowed peers in the mainnet configuration file. 

### Detailed summary
- Updated the allowed peer address for @stout
- Other allowed peer addresses remain unchanged

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->