### PR TITLE
chore: Setup grpc server timeouts

### DIFF
--- a/.changeset/rare-bags-reflect.md
+++ b/.changeset/rare-bags-reflect.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/hub-nodejs": patch
+"@farcaster/hubble": patch
+---
+
+chore: Update grpc-js and setup grpc server timeouts

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -25,7 +25,7 @@
     "identity": "node build/cli.js identity",
     "dbreset": "node build/cli.js dbreset",
     "console": "node build/cli.js console",
-    "profile": "node build/cli.js profile",
+    "profile": "node --max-old-space-size=4096 build/cli.js profile",
     "status": "node build/cli.js status",
     "test": "NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096\" jest",
     "test:ci": "ENVIRONMENT=test NODE_OPTIONS=--experimental-vm-modules jest --ci --forceExit --coverage"
@@ -56,7 +56,7 @@
     "@faker-js/faker": "~7.6.0",
     "@farcaster/hub-nodejs": "^0.9.1",
     "@farcaster/rocksdb": "^5.5.0",
-    "@grpc/grpc-js": "~1.8.8",
+    "@grpc/grpc-js": "~1.8.21",
     "@libp2p/interface-connection": "^3.0.2",
     "@libp2p/interface-peer-id": "^2.0.0",
     "@libp2p/mplex": "^7.0.0",

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -11,13 +11,11 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "MIT",
   "dependencies": {
     "@farcaster/core": "0.11.1",
-    "@grpc/grpc-js": "^1.8.8",
+    "@grpc/grpc-js": "^1.8.21",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"
   },

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "@farcaster/core": "0.11.1",
-    "@grpc/grpc-js": "^1.8.21",
+    "@grpc/grpc-js": "~1.8.21",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"
   },

--- a/packages/hub-nodejs/src/client.ts
+++ b/packages/hub-nodejs/src/client.ts
@@ -120,7 +120,16 @@ export const getAuthMetadata = (username: string, password: string): Metadata =>
 };
 
 export const getServer = (): grpc.Server => {
-  const server = new grpc.Server();
+  // Set up timeouts for keepalive. This will cause the server to send keepalive message every 10 seconds,
+  // and close the connection if the client does not respond within 5 seconds.
+  // TODO: We should also consider setting up max_connection_age_ms.
+  // max_connection_age_ms will interfere with subscribe() which is a long-lived call, but maybe we should
+  // set it anyway.
+  const server = new grpc.Server({
+    "grpc.keepalive_time_ms": 10 * 1000,
+    "grpc.keepalive_timeout_ms": 5 * 1000,
+    "grpc.client_idle_timeout_ms": 60 * 1000,
+  });
 
   return server;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1160,14 +1160,6 @@
     napi-macros "^2.0.0"
     node-gyp-build "^4.3.0"
 
-"@grpc/grpc-js@^1.8.21":
-  version "1.9.0"
-  resolved "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz#bdb599e339adabb16aa7243e70c311f75a572867"
-  integrity sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==
-  dependencies:
-    "@grpc/proto-loader" "^0.7.0"
-    "@types/node" ">=12.12.47"
-
 "@grpc/grpc-js@~1.8.21":
   version "1.8.21"
   resolved "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.21.tgz#d282b122c71227859bf6c5866f4c40f4a2696513"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1160,10 +1160,18 @@
     napi-macros "^2.0.0"
     node-gyp-build "^4.3.0"
 
-"@grpc/grpc-js@^1.8.8", "@grpc/grpc-js@~1.8.8":
-  version "1.8.8"
-  resolved "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.8.tgz#a7c6765d0302f47ba67c0ce3cb79718d6b028248"
-  integrity sha512-4gfDqMLXTrorvYTKA1jL22zLvVwiHJ73t6Re1OHwdCFRjdGTDOVtSJuaWhtHaivyeDGg0LeCkmU77MTKoV3wPA==
+"@grpc/grpc-js@^1.8.21":
+  version "1.9.0"
+  resolved "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz#bdb599e339adabb16aa7243e70c311f75a572867"
+  integrity sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==
+  dependencies:
+    "@grpc/proto-loader" "^0.7.0"
+    "@types/node" ">=12.12.47"
+
+"@grpc/grpc-js@~1.8.21":
+  version "1.8.21"
+  resolved "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.21.tgz#d282b122c71227859bf6c5866f4c40f4a2696513"
+  integrity sha512-KeyQeZpxeEBSqFVTi3q2K7PiPXmgBfECc4updA1ejCLjYmoAlvvM3ZMp5ztTDUCUQmoY3CpDxvchjO1+rFkoHg==
   dependencies:
     "@grpc/proto-loader" "^0.7.0"
     "@types/node" ">=12.12.47"


### PR DESCRIPTION
## Motivation

We need to protect our grpc server with timeouts if clients don't close connections properly

## Change Summary

- Add grpc server timeouts
- Upgrade grpc-js

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary:
- Updated `@grpc/grpc-js` dependency from version `1.8.8` to `1.8.21`
- Added server timeouts for keepalive and client idle timeout in `packages/hub-nodejs/src/client.ts`
- Updated `profile` script in `apps/hubble/package.json` to include `--max-old-space-size=4096`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->