### PR TITLE
bug: Fix revoking messages on onchain signer revoke and make l2 options cutomizable

### DIFF
--- a/.changeset/healthy-ghosts-hide.md
+++ b/.changeset/healthy-ghosts-hide.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: handle revoking on chain signer and make l2 options customizable

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -72,11 +72,28 @@ app
   // Ethereum Options
   .option("-m, --eth-mainnet-rpc-url <url>", "RPC URL of a Mainnet ETH Node (or comma separated list of URLs)")
   .option("-e, --eth-rpc-url <url>", "RPC URL of a Goerli ETH Node (or comma separated list of URLs)")
-  .option("-l, --l2-rpc-url <url>", "RPC URL of a Goerli Optimism Node (or comma separated list of URLs)")
   .option("--rank-rpcs", "Rank the RPCs by latency/stability and use the fastest one (default: disabled)")
   .option("--fname-server-url <url>", `The URL for the FName registry server (default: ${DEFAULT_FNAME_SERVER_URL}`)
   .option("--fir-address <address>", "The address of the Farcaster ID Registry contract")
   .option("--first-block <number>", "The block number to begin syncing events from Farcaster contracts", parseNumber)
+
+  // L2 Options
+  .option("-l, --l2-rpc-url <url>", "RPC URL of a Goerli Optimism Node (or comma separated list of URLs)")
+  .option("--l2-id-registry-address <address>", "The address of the L2 Farcaster ID Registry contract")
+  .option("--l2-key-registry-address <address>", "The address of the L2 Farcaster Key Registry contract")
+  .option("--l2-storage-registry-address <address>", "The address of the L2 Farcaster Storage Registry contract")
+  .option("--l2-resync-events", "Resync events from the L2 Farcaster contracts before starting (default: disabled)")
+  .option(
+    "--l2-first-block <number>",
+    "The block number to begin syncing events from L2 Farcaster contracts",
+    parseNumber,
+  )
+  .option(
+    "--l2-chunk-size <number>",
+    "The number of events to fetch from L2 Farcaster contracts at a time",
+    parseNumber,
+  )
+  .option("--l2-chain-id <number>", "The chain ID of the L2 Farcaster contracts are deployed to", parseNumber)
 
   // Networking Options
   .option("-a, --allowed-peers <peerIds...>", "Only peer with specific peer ids. (default: all peers allowed)")
@@ -359,12 +376,19 @@ app
       ethRpcUrl: cliOptions.ethRpcUrl ?? hubConfig.ethRpcUrl,
       ethMainnetRpcUrl: cliOptions.ethMainnetRpcUrl ?? hubConfig.ethMainnetRpcUrl,
       fnameServerUrl: cliOptions.fnameServerUrl ?? hubConfig.fnameServerUrl ?? DEFAULT_FNAME_SERVER_URL,
-      l2RpcUrl: cliOptions.l2RpcUrl ?? hubConfig.l2RpcUrl,
       rankRpcs: cliOptions.rankRpcs ?? hubConfig.rankRpcs ?? false,
       idRegistryAddress: cliOptions.firAddress ?? hubConfig.firAddress,
       nameRegistryAddress: cliOptions.fnrAddress ?? hubConfig.fnrAddress,
       firstBlock: cliOptions.firstBlock ?? hubConfig.firstBlock,
       chunkSize: cliOptions.chunkSize ?? hubConfig.chunkSize ?? DEFAULT_CHUNK_SIZE,
+      l2RpcUrl: cliOptions.l2RpcUrl ?? hubConfig.l2RpcUrl,
+      l2IdRegistryAddress: cliOptions.l2IdRegistryAddress ?? hubConfig.l2IdRegistryAddress,
+      l2KeyRegistryAddress: cliOptions.l2KeyRegistryAddress ?? hubConfig.l2KeyRegistryAddress,
+      l2StorageRegistryAddress: cliOptions.l2StorageRegistryAddress ?? hubConfig.l2StorageRegistryAddress,
+      l2FirstBlock: cliOptions.l2FirstBlock ?? hubConfig.l2FirstBlock,
+      l2ChunkSize: cliOptions.l2ChunkSize ?? hubConfig.l2ChunkSize,
+      l2ChainId: cliOptions.l2ChainId ?? hubConfig.l2ChainId,
+      l2ResyncEvents: cliOptions.l2ResyncEvents ?? hubConfig.l2ResyncEvents ?? false,
       bootstrapAddrs,
       allowedPeers: cliOptions.allowedPeers ?? hubConfig.allowedPeers,
       rpcPort: cliOptions.rpcPort ?? hubConfig.rpcPort ?? DEFAULT_RPC_PORT,

--- a/apps/hubble/src/eth/l2EventsProvider.test.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.test.ts
@@ -6,7 +6,7 @@ import { MockHub } from "../test/mocks.js";
 import { deployStorageRegistry, publicClient, testClient, walletClientWithAccount } from "../test/utils.js";
 import { accounts } from "../test/constants.js";
 import { sleep } from "../utils/crypto.js";
-import { L2EventsProvider } from "./l2EventsProvider.js";
+import { L2EventsProvider, OptimismConstants } from "./l2EventsProvider.js";
 import {
   getNextRentRegistryEventFromIterator,
   getNextStorageAdminRegistryEventFromIterator,
@@ -45,6 +45,7 @@ describe("build", () => {
       idRegistryAddress,
       1,
       10000,
+      OptimismConstants.ChainId,
       false,
     );
 
@@ -64,6 +65,7 @@ describe("build", () => {
       idRegistryAddress,
       1,
       10000,
+      OptimismConstants.ChainId,
       false,
     );
 
@@ -88,6 +90,7 @@ describe("process events", () => {
       idRegistryAddress,
       1,
       10000,
+      OptimismConstants.ChainId,
       false,
     );
 

--- a/apps/hubble/src/eth/l2EventsProvider.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.ts
@@ -30,13 +30,13 @@ const log = logger.child({
   component: "L2EventsProvider",
 });
 
-export class OPGoerliEthConstants {
+export class OptimismConstants {
   public static StorageRegistryAddress = "0x000000fC0a4Fccee0b30E360773F7888D1bD9FAA" as const;
   public static KeyRegistryAddress = "0x000000fc6548800fc8265d8eb7061d88cefb87c2" as const;
   public static IdRegistryAddress = "0x000000fc99489b8cd629291d97dbca62b81173c4" as const;
   public static FirstBlock = 12500000;
   public static ChunkSize = 1000;
-  public static chainId = BigInt(420); // OP Goerli
+  public static ChainId = 420; // OP Goerli
 }
 
 /**
@@ -48,6 +48,7 @@ export class L2EventsProvider {
 
   private _firstBlock: number;
   private _chunkSize: number;
+  private _chainId: number;
   private _resyncEvents: boolean;
 
   private _rentEventsByBlock: Map<number, Array<RentRegistryEvent>>;
@@ -85,12 +86,14 @@ export class L2EventsProvider {
     idRegistryAddress: `0x${string}`,
     firstBlock: number,
     chunkSize: number,
+    chainId: number,
     resyncEvents: boolean,
   ) {
     this._hub = hub;
     this._publicClient = publicClient;
     this._firstBlock = firstBlock;
     this._chunkSize = chunkSize;
+    this._chainId = chainId;
     this._resyncEvents = resyncEvents;
 
     this._lastBlockNumber = 0;
@@ -161,6 +164,7 @@ export class L2EventsProvider {
     idRegistryAddress: `0x${string}`,
     firstBlock: number,
     chunkSize: number,
+    chainId: number,
     resyncEvents: boolean,
   ): L2EventsProvider {
     const l2RpcUrls = l2RpcUrl.split(",");
@@ -179,6 +183,7 @@ export class L2EventsProvider {
       idRegistryAddress,
       firstBlock,
       chunkSize,
+      chainId,
       resyncEvents,
     );
 
@@ -563,7 +568,7 @@ export class L2EventsProvider {
       log.info({ fromBlock: nextFromBlock, toBlock: nextToBlock }, "syncing events from block range");
 
       const idFilter = await this._publicClient.createContractEventFilter({
-        address: OPGoerliEthConstants.IdRegistryAddress,
+        address: OptimismConstants.IdRegistryAddress,
         abi: IdRegistryV2.abi,
         fromBlock: BigInt(nextFromBlock),
         toBlock: BigInt(nextToBlock),
@@ -573,7 +578,7 @@ export class L2EventsProvider {
       await this.processIdRegistryEvents(idLogs);
 
       const storageFilter = await this._publicClient.createContractEventFilter({
-        address: OPGoerliEthConstants.StorageRegistryAddress,
+        address: OptimismConstants.StorageRegistryAddress,
         abi: StorageRegistry.abi,
         fromBlock: BigInt(nextFromBlock),
         toBlock: BigInt(nextToBlock),
@@ -585,7 +590,7 @@ export class L2EventsProvider {
       await this.processStorageEvents(storageLogs);
 
       const keyFilter = await this._publicClient.createContractEventFilter({
-        address: OPGoerliEthConstants.KeyRegistryAddress,
+        address: OptimismConstants.KeyRegistryAddress,
         abi: KeyRegistry.abi,
         fromBlock: BigInt(nextFromBlock),
         toBlock: BigInt(nextToBlock),
@@ -794,7 +799,7 @@ export class L2EventsProvider {
 
     const onChainEvent = OnChainEvent.create({
       type,
-      chainId: Number(OPGoerliEthConstants.chainId),
+      chainId: this._chainId,
       fid: Number(fid),
       blockNumber: Number(blockNumber),
       blockHash: blockHashBytes,

--- a/apps/hubble/src/eth/watchContractEvent.ts
+++ b/apps/hubble/src/eth/watchContractEvent.ts
@@ -41,7 +41,7 @@ export class WatchContractEvent<
       },
     });
 
-    this._log.info("Started watching contract events");
+    this._log.info(`Started watching contract events at address ${this._params.address}`);
   }
 
   public stop() {

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -72,7 +72,7 @@ import { GossipContactInfoJobScheduler } from "./storage/jobs/gossipContactInfoJ
 import { MAINNET_ALLOWED_PEERS } from "./allowedPeers.mainnet.js";
 import StoreEventHandler from "./storage/stores/storeEventHandler.js";
 import { FNameRegistryClient, FNameRegistryEventsProvider } from "./eth/fnameRegistryEventsProvider.js";
-import { L2EventsProvider, OPGoerliEthConstants } from "./eth/l2EventsProvider.js";
+import { L2EventsProvider, OptimismConstants } from "./eth/l2EventsProvider.js";
 import { GOSSIP_PROTOCOL_VERSION } from "./network/p2p/protocol.js";
 import { prettyPrintTable } from "./profile/profile.js";
 import packageJson from "./package.json" assert { type: "json" };
@@ -169,8 +169,14 @@ export interface HubOptions {
   /** Address of the NameRegistryAddress contract  */
   nameRegistryAddress?: `0x${string}`;
 
-  /** Address of the StorageRegistryAddress contract  */
-  storageRegistryAddress?: `0x${string}`;
+  /** Address of the Id Registry contract  */
+  l2IdRegistryAddress?: `0x${string}`;
+
+  /** Address of the Key Registry contract  */
+  l2KeyRegistryAddress?: `0x${string}`;
+
+  /** Address of the StorageRegistry contract  */
+  l2StorageRegistryAddress?: `0x${string}`;
 
   /** Block number to begin syncing events from  */
   firstBlock?: number;
@@ -183,6 +189,12 @@ export interface HubOptions {
 
   /** Number of blocks to batch when syncing historical events for L2 */
   l2ChunkSize?: number;
+
+  /** Chain Id for L2 */
+  l2ChainId?: number;
+
+  /** Resync l2 events */
+  l2ResyncEvents?: boolean;
 
   /** Resync events */
   resyncEthEvents?: boolean;
@@ -309,12 +321,13 @@ export class Hub implements HubInterface {
         this,
         options.l2RpcUrl,
         options.rankRpcs ?? false,
-        options.storageRegistryAddress ?? OPGoerliEthConstants.StorageRegistryAddress,
-        OPGoerliEthConstants.KeyRegistryAddress,
-        OPGoerliEthConstants.IdRegistryAddress,
-        options.l2FirstBlock ?? OPGoerliEthConstants.FirstBlock,
-        options.l2ChunkSize ?? OPGoerliEthConstants.ChunkSize,
-        options.resyncEthEvents ?? false,
+        options.l2StorageRegistryAddress ?? OptimismConstants.StorageRegistryAddress,
+        options.l2KeyRegistryAddress ?? OptimismConstants.KeyRegistryAddress,
+        options.l2IdRegistryAddress ?? OptimismConstants.IdRegistryAddress,
+        options.l2FirstBlock ?? OptimismConstants.FirstBlock,
+        options.l2ChunkSize ?? OptimismConstants.ChunkSize,
+        options.l2ChainId ?? OptimismConstants.ChainId,
+        options.l2ResyncEvents ?? false,
       );
     } else {
       log.warn("No L2 RPC URL provided, not syncing with L2 contract events");

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -14,6 +14,7 @@ import {
   IdRegistryEvent,
   IdRegistryEventType,
   isSignerAddMessage,
+  isSignerOnChainEvent,
   isSignerRemoveMessage,
   isUserDataAddMessage,
   isUsernameProofMessage,
@@ -21,6 +22,7 @@ import {
   LinkRemoveMessage,
   MergeIdRegistryEventHubEvent,
   MergeMessageHubEvent,
+  MergeOnChainEventHubEvent,
   MergeUsernameProofHubEvent,
   Message,
   NameRegistryEvent,
@@ -37,6 +39,7 @@ import {
   RevokeMessageHubEvent,
   RevokeMessagesBySignerJobPayload,
   SignerAddMessage,
+  SignerEventType,
   SignerRemoveMessage,
   StorageAdminRegistryEvent,
   StorageRegistryEventType,
@@ -133,6 +136,7 @@ class Engine {
     this.handleMergeUsernameProofEvent = this.handleMergeUsernameProofEvent.bind(this);
     this.handleRevokeMessageEvent = this.handleRevokeMessageEvent.bind(this);
     this.handlePruneMessageEvent = this.handlePruneMessageEvent.bind(this);
+    this.handleMergeOnChainEvent = this.handleMergeOnChainEvent.bind(this);
   }
 
   async start(): Promise<void> {
@@ -180,6 +184,7 @@ class Engine {
     this.eventHandler.on("mergeMessage", this.handleMergeMessageEvent);
     this.eventHandler.on("revokeMessage", this.handleRevokeMessageEvent);
     this.eventHandler.on("pruneMessage", this.handlePruneMessageEvent);
+    this.eventHandler.on("mergeOnChainEvent", this.handleMergeOnChainEvent);
 
     await this.eventHandler.syncCache();
     const isMigrated = await this._onchainEventsStore.isSignerMigrated();
@@ -1196,6 +1201,26 @@ class Engine {
       const payload = RevokeMessagesBySignerJobPayload.create({
         fid: message.data.fid,
         signer: message.data.signerAddBody.signer,
+      });
+      const enqueueRevoke = await this._revokeSignerQueue.enqueueJob(payload);
+      if (enqueueRevoke.isErr()) {
+        log.error(
+          { errCode: enqueueRevoke.error.errCode },
+          `failed to enqueue revoke signer job: ${enqueueRevoke.error.message}`,
+        );
+      }
+    }
+
+    return ok(undefined);
+  }
+
+  private async handleMergeOnChainEvent(event: MergeOnChainEventHubEvent): HubAsyncResult<void> {
+    const onChainEvent = event.mergeOnChainEventBody.onChainEvent;
+
+    if (isSignerOnChainEvent(onChainEvent) && onChainEvent.signerEventBody.eventType === SignerEventType.REMOVE) {
+      const payload = RevokeMessagesBySignerJobPayload.create({
+        fid: onChainEvent.fid,
+        signer: onChainEvent.signerEventBody.key,
       });
       const enqueueRevoke = await this._revokeSignerQueue.enqueueJob(payload);
       if (enqueueRevoke.isErr()) {

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -1217,7 +1217,11 @@ class Engine {
   private async handleMergeOnChainEvent(event: MergeOnChainEventHubEvent): HubAsyncResult<void> {
     const onChainEvent = event.mergeOnChainEventBody.onChainEvent;
 
-    if (isSignerOnChainEvent(onChainEvent) && onChainEvent.signerEventBody.eventType === SignerEventType.REMOVE) {
+    if (
+      onChainEvent &&
+      isSignerOnChainEvent(onChainEvent) &&
+      onChainEvent.signerEventBody.eventType === SignerEventType.REMOVE
+    ) {
       const payload = RevokeMessagesBySignerJobPayload.create({
         fid: onChainEvent.fid,
         signer: onChainEvent.signerEventBody.key,


### PR DESCRIPTION
## Motivation

We weren't revoking messages on onchain signer revoke.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing issues related to handling revoking on-chain signers and making L2 options customizable. 

### Detailed summary
- Added logging for watching contract events at a specific address
- Updated imports in test files
- Added handling for merging on-chain events in the storage engine
- Added a test case for revoking messages when on-chain signer is removed
- Updated L2 options in the Hub class
- Renamed OPGoerliEthConstants to OptimismConstants
- Updated L2EventsProvider to include chainId in event processing

> The following files were skipped due to too many changes: `apps/hubble/src/cli.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->