### PR TITLE
feat: Rate limit merges by FID

### DIFF
--- a/.changeset/heavy-pants-poke.md
+++ b/.changeset/heavy-pants-poke.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: Rate limit merges per FID to the total messages storage available for the FID

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -49,13 +49,14 @@ import Engine from "../storage/engine/index.js";
 import { MessagesPage } from "../storage/stores/types.js";
 import { logger } from "../utils/logger.js";
 import { addressInfoFromParts, extractIPAddress } from "../utils/p2p.js";
-import { RateLimiterAbstract, RateLimiterMemory } from "rate-limiter-flexible";
+import { RateLimiterMemory } from "rate-limiter-flexible";
 import {
   BufferedStreamWriter,
   STREAM_MESSAGE_BUFFER_SIZE,
   SLOW_CLIENT_GRACE_PERIOD_MS,
 } from "./bufferedStreamWriter.js";
 import { sleep } from "../utils/crypto.js";
+import { SUBMIT_MESSAGE_RATE_LIMIT, rateLimitByIp } from "../utils/rateLimits.js";
 
 const HUBEVENTS_READER_TIMEOUT = 1 * 60 * 60 * 1000; // 1 hour
 
@@ -65,18 +66,6 @@ export const SUBSCRIBE_GLOBAL_LIMIT = 4096; // Max 4096 subscriptions globally
 export type RpcUsers = Map<string, string[]>;
 
 const log = logger.child({ component: "rpcServer" });
-
-export const rateLimitByIp = async (ip: string, limiter: RateLimiterAbstract): HubAsyncResult<boolean> => {
-  // Get the IP part of the address
-  const ipPart = ip.split(":")[0] ?? "";
-
-  try {
-    await limiter.consume(ipPart);
-    return ok(true);
-  } catch (e) {
-    return err(new HubError("unavailable", "Too many requests"));
-  }
-};
 
 // Check if the user is authenticated via the metadata
 export const authenticateUser = async (metadata: Metadata, rpcUsers: RpcUsers): HubAsyncResult<boolean> => {
@@ -275,16 +264,13 @@ export default class Server {
     this.grpcServer.addService(HubServiceService, this.getImpl());
 
     // Submit message are rate limited by default to 20k per minute
-    let rateLimitPerMinute = 20_000;
+    const rateLimitPerMinute = SUBMIT_MESSAGE_RATE_LIMIT;
     if (rpcRateLimit !== undefined && rpcRateLimit >= 0) {
-      rateLimitPerMinute = rpcRateLimit;
+      rateLimitPerMinute.points = rpcRateLimit;
     }
     log.info({ rpcRateLimit }, "RPC rate limit enabled");
 
-    this.submitMessageRateLimiter = new RateLimiterMemory({
-      points: rateLimitPerMinute,
-      duration: 60,
-    });
+    this.submitMessageRateLimiter = new RateLimiterMemory(rateLimitPerMinute);
   }
 
   async start(ip = "0.0.0.0", port = 0): Promise<number> {
@@ -500,10 +486,7 @@ export default class Server {
       },
       getSyncSnapshotByPrefix: (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
-        log.debug(
-          { method: "getSyncSnapshotByPrefix", req: call.request, reqStr: JSON.stringify(call.request) },
-          `RPC call from ${peer}`,
-        );
+        log.debug({ method: "getSyncSnapshotByPrefix", req: call.request }, `RPC call from ${peer}`);
 
         // If someone is asking for our sync snapshot, that means we're getting incoming
         // connections

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -71,6 +71,7 @@ import { normalize } from "viem/ens";
 import os from "os";
 import UsernameProofStore from "../stores/usernameProofStore.js";
 import OnChainEventStore from "../stores/onChainEventStore.js";
+import { getRateLimiterForTotalMessages, rateLimitByKey } from "../../utils/rateLimits.js";
 
 const log = logger.child({
   component: "Engine",
@@ -106,6 +107,8 @@ class Engine {
   private _revokeSignerQueue: RevokeMessagesBySignerJobQueue;
   private _revokeSignerWorker: RevokeMessagesBySignerJobWorker;
 
+  private _totalPruneSize: number;
+
   constructor(db: RocksDB, network: FarcasterNetwork, eventHandler?: StoreEventHandler, publicClient?: PublicClient) {
     this._db = db;
     this._network = network;
@@ -121,6 +124,16 @@ class Engine {
     this._verificationStore = new VerificationStore(db, this.eventHandler);
     this._onchainEventsStore = new OnChainEventStore(db, this.eventHandler);
     this._usernameProofStore = new UsernameProofStore(db, this.eventHandler);
+
+    this._totalPruneSize =
+      this._linkStore.pruneSizeLimit +
+      this._reactionStore.pruneSizeLimit +
+      this._signerStore.pruneSizeLimit +
+      this._castStore.pruneSizeLimit +
+      this._userDataStore.pruneSizeLimit +
+      this._verificationStore.pruneSizeLimit +
+      // this._onchainEventsStore.pruneSizeLimit +
+      this._usernameProofStore.pruneSizeLimit;
 
     this._revokeSignerQueue = new RevokeMessagesBySignerJobQueue(db);
     this._revokeSignerWorker = new RevokeMessagesBySignerJobWorker(this._revokeSignerQueue, db, this);
@@ -222,6 +235,21 @@ class Engine {
   }
 
   async mergeMessage(message: Message): HubAsyncResult<number> {
+    // Extract the FID that this message was signed by
+    const fid = message.data?.fid ?? 0;
+    const storageUnits = await this.eventHandler.getCurrentStorageUnitsForFid(fid);
+
+    if (storageUnits.isOk()) {
+      // We rate limit the number of messages that can be merged per FID
+      const limiter = getRateLimiterForTotalMessages(storageUnits.value * this._totalPruneSize);
+
+      const rateLimitResult = await rateLimitByKey(`${fid}`, limiter);
+      if (rateLimitResult.isErr()) {
+        logger.warn({ fid, err: rateLimitResult.error }, "rate limit exceeded for FID");
+        return err(rateLimitResult.error);
+      }
+    }
+
     const validatedMessage = await this.validateMessage(message);
     if (validatedMessage.isErr()) {
       return err(validatedMessage.error);

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -125,6 +125,8 @@ class Engine {
     this._onchainEventsStore = new OnChainEventStore(db, this.eventHandler);
     this._usernameProofStore = new UsernameProofStore(db, this.eventHandler);
 
+    // Calculate total storage available per unit of store. Note that OnChainEventStore
+    // is not included in this calculation because it is not pruned.
     this._totalPruneSize =
       this._linkStore.pruneSizeLimit +
       this._reactionStore.pruneSizeLimit +
@@ -132,8 +134,9 @@ class Engine {
       this._castStore.pruneSizeLimit +
       this._userDataStore.pruneSizeLimit +
       this._verificationStore.pruneSizeLimit +
-      // this._onchainEventsStore.pruneSizeLimit +
       this._usernameProofStore.pruneSizeLimit;
+
+    log.info({ totalPruneSize: this._totalPruneSize }, "total default storage limit size");
 
     this._revokeSignerQueue = new RevokeMessagesBySignerJobQueue(db);
     this._revokeSignerWorker = new RevokeMessagesBySignerJobWorker(this._revokeSignerQueue, db, this);

--- a/apps/hubble/src/storage/stores/store.ts
+++ b/apps/hubble/src/storage/stores/store.ts
@@ -248,13 +248,6 @@ export abstract class Store<TAdd extends Message, TRemove extends Message> {
       return err(units.error);
     }
 
-    if (units.value === 0) {
-      logger.debug({ fid }, "fid has no registered storage, would be pruned");
-    }
-
-    // This is temporary, when all fids are migrated to using storage rent, we'll just use the units directly.
-    const unitsMultiplier = units.value > 0 ? units.value : 1;
-
     // Require storage cache to be synced to prune
     if (cachedCount.isErr()) {
       return err(cachedCount.error);
@@ -296,7 +289,7 @@ export abstract class Store<TAdd extends Message, TRemove extends Message> {
         // Since the TS hash has the first 4 bytes be the timestamp (bigendian), we can use it to prune
         // since the iteration will be implicitly sorted by timestamp
         if (
-          count.value <= this._pruneSizeLimit * unitsMultiplier &&
+          count.value <= this._pruneSizeLimit * units.value &&
           (timestampToPrune === undefined || (message.value.data && message.value.data.timestamp >= timestampToPrune))
         ) {
           return true; // Nothing left to prune

--- a/apps/hubble/src/utils/rateLimits.test.ts
+++ b/apps/hubble/src/utils/rateLimits.test.ts
@@ -1,14 +1,14 @@
 import { RateLimiterMemory } from "rate-limiter-flexible";
-import { rateLimitByIp } from "./rateLimits.js";
+import { getRateLimiterForTotalMessages, rateLimitByIp, rateLimitByKey } from "./rateLimits.js";
 import { sleep } from "./crypto.js";
 
 describe("test rate limits", () => {
-  test("test rate limiting", async () => {
-    const Limit10PerSecond = new RateLimiterMemory({
-      points: 10,
-      duration: 1,
-    });
+  const Limit10PerSecond = new RateLimiterMemory({
+    points: 10,
+    duration: 1,
+  });
 
+  test("test rate limiting", async () => {
     // 10 Requests should be fine
     for (let i = 0; i < 10; i++) {
       const result = await rateLimitByIp("testip:3000", Limit10PerSecond);
@@ -25,6 +25,42 @@ describe("test rate limits", () => {
         expect(result.isOk()).toBeTruthy();
       } else {
         expect(result._unsafeUnwrapErr().message).toEqual("Too many requests");
+      }
+    }
+  });
+
+  test("test dynamic rate limiting", async () => {
+    // 10 Requests should be fine for 1st set of messages
+    const rateLimiter1 = getRateLimiterForTotalMessages(10, 1);
+    const rateLimiter2 = getRateLimiterForTotalMessages(11, 1);
+
+    for (let i = 0; i < 10; i++) {
+      const result1 = await rateLimitByKey("3000", rateLimiter1);
+      expect(result1.isOk()).toBeTruthy();
+
+      // same key, but different rate limiter should also be fine
+      const result2 = await rateLimitByKey("3000", rateLimiter2);
+      expect(result2.isOk()).toBeTruthy();
+    }
+
+    // Sleep for 1 second to reset the rate limiter
+    await sleep(1100);
+
+    // 11th+ request should fail
+    for (let i = 0; i < 20; i++) {
+      const result1 = await rateLimitByKey("3000", rateLimiter1);
+      if (i < 10) {
+        expect(result1.isOk()).toBeTruthy();
+      } else {
+        expect(result1._unsafeUnwrapErr().message).toEqual("Too many requests");
+      }
+
+      // same key, but different rate limiter should pass till the 11th message
+      const result2 = await rateLimitByKey("3000", rateLimiter2);
+      if (i < 11) {
+        expect(result2.isOk()).toBeTruthy();
+      } else {
+        expect(result2._unsafeUnwrapErr().message).toEqual("Too many requests");
       }
     }
   });

--- a/apps/hubble/src/utils/rateLimits.test.ts
+++ b/apps/hubble/src/utils/rateLimits.test.ts
@@ -1,0 +1,31 @@
+import { RateLimiterMemory } from "rate-limiter-flexible";
+import { rateLimitByIp } from "./rateLimits.js";
+import { sleep } from "./crypto.js";
+
+describe("test rate limits", () => {
+  test("test rate limiting", async () => {
+    const Limit10PerSecond = new RateLimiterMemory({
+      points: 10,
+      duration: 1,
+    });
+
+    // 10 Requests should be fine
+    for (let i = 0; i < 10; i++) {
+      const result = await rateLimitByIp("testip:3000", Limit10PerSecond);
+      expect(result.isOk()).toBeTruthy();
+    }
+
+    // Sleep for 1 second to reset the rate limiter
+    await sleep(1100);
+
+    // 11th+ request should fail
+    for (let i = 0; i < 20; i++) {
+      const result = await rateLimitByIp("testip:3000", Limit10PerSecond);
+      if (i < 10) {
+        expect(result.isOk()).toBeTruthy();
+      } else {
+        expect(result._unsafeUnwrapErr().message).toEqual("Too many requests");
+      }
+    }
+  });
+});

--- a/apps/hubble/src/utils/rateLimits.ts
+++ b/apps/hubble/src/utils/rateLimits.ts
@@ -1,0 +1,44 @@
+import { HubAsyncResult, HubError } from "@farcaster/hub-nodejs";
+import { err, ok } from "neverthrow";
+import { RateLimiterAbstract } from "rate-limiter-flexible";
+
+// Number of submit messages (total) that can be merged per 60 seconds
+export const SUBMIT_MESSAGE_RATE_LIMIT = {
+  points: 20_000,
+  duration: 60,
+};
+
+// We keep a map of rate limiters per total messages allowed, since each fid has a different limit
+// The totalMessages are always num of storage units purchased * totalPruneSize limit, so there will
+// be as many rate limiters as the number of distinct storage units purchased, which is a small number
+const rateLimiters = new Map<number, RateLimiterAbstract>();
+export function getRateLimiterForTotalMessages(totalMessages: number): RateLimiterAbstract {
+  if (rateLimiters.has(totalMessages)) {
+    return rateLimiters.get(totalMessages) as RateLimiterAbstract;
+  }
+
+  const limiter = new RateLimiterAbstract({
+    points: totalMessages,
+    duration: 60 * 60 * 24,
+  });
+  rateLimiters.set(totalMessages, limiter);
+  return limiter;
+}
+
+/** Rate limit by IP address */
+export const rateLimitByIp = async (ip: string, limiter: RateLimiterAbstract): HubAsyncResult<boolean> => {
+  // Get the IP part of the address
+  const ipPart = ip.split(":")[0] ?? "";
+
+  return rateLimitByKey(ipPart, limiter);
+};
+
+/** Rate limit by key for the limiter */
+export const rateLimitByKey = async (fid: string, limiter: RateLimiterAbstract): HubAsyncResult<boolean> => {
+  try {
+    await limiter.consume(fid);
+    return ok(true);
+  } catch (e) {
+    return err(new HubError("unavailable", "Too many requests"));
+  }
+};

--- a/apps/hubble/src/utils/rateLimits.ts
+++ b/apps/hubble/src/utils/rateLimits.ts
@@ -1,6 +1,6 @@
 import { HubAsyncResult, HubError } from "@farcaster/hub-nodejs";
 import { err, ok } from "neverthrow";
-import { RateLimiterAbstract } from "rate-limiter-flexible";
+import { RateLimiterAbstract, RateLimiterMemory } from "rate-limiter-flexible";
 
 // Number of submit messages (total) that can be merged per 60 seconds
 export const SUBMIT_MESSAGE_RATE_LIMIT = {
@@ -11,15 +11,15 @@ export const SUBMIT_MESSAGE_RATE_LIMIT = {
 // We keep a map of rate limiters per total messages allowed, since each fid has a different limit
 // The totalMessages are always num of storage units purchased * totalPruneSize limit, so there will
 // be as many rate limiters as the number of distinct storage units purchased, which is a small number
-const rateLimiters = new Map<number, RateLimiterAbstract>();
-export function getRateLimiterForTotalMessages(totalMessages: number): RateLimiterAbstract {
+const rateLimiters = new Map<number, RateLimiterMemory>();
+export function getRateLimiterForTotalMessages(totalMessages: number, duration = 60 * 60 * 24): RateLimiterAbstract {
   if (rateLimiters.has(totalMessages)) {
     return rateLimiters.get(totalMessages) as RateLimiterAbstract;
   }
 
-  const limiter = new RateLimiterAbstract({
+  const limiter = new RateLimiterMemory({
     points: totalMessages,
-    duration: 60 * 60 * 24,
+    duration,
   });
   rateLimiters.set(totalMessages, limiter);
   return limiter;


### PR DESCRIPTION
## Motivation

When we have permissionless hubs, a rogue FID might be able to send millions of messages, overwhelming hubs. So rate limit merges (across gossip, sync, submitMessages) to the amount of storage available per FID per day.

## Change Summary

- Add per FID merge limit
- Limit to amount of storage available per FID per day

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on implementing rate limiting for message merges based on the available storage units. 

### Detailed summary
- Adds rate limiting for message merges based on available storage units
- Uses rate limiter to limit the number of messages merged per FID
- Calculates total storage available per unit of store
- Updates unit tests for rate limiting functionality

> The following files were skipped due to too many changes: `apps/hubble/src/rpc/server.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->