### PR TITLE
feat: speed up l2 sync and allow rent expiry override for testing

### DIFF
--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -95,6 +95,11 @@ app
     parseNumber,
   )
   .option("--l2-chain-id <number>", "The chain ID of the L2 Farcaster contracts are deployed to", parseNumber)
+  .option(
+    "--l2-rent-expiry-override <number>",
+    "The storage rent expiry in seconds to use instead of the default 1 year (ONLY FOR TESTS)",
+    parseNumber,
+  )
 
   // Networking Options
   .option("-a, --allowed-peers <peerIds...>", "Only peer with specific peer ids. (default: all peers allowed)")
@@ -390,6 +395,7 @@ app
       l2ChunkSize: cliOptions.l2ChunkSize ?? hubConfig.l2ChunkSize,
       l2ChainId: cliOptions.l2ChainId ?? hubConfig.l2ChainId,
       l2ResyncEvents: cliOptions.l2ResyncEvents ?? hubConfig.l2ResyncEvents ?? false,
+      l2RentExpiryOverride: cliOptions.l2RentExpiryOverride ?? hubConfig.l2RentExpiryOverride,
       bootstrapAddrs,
       allowedPeers: cliOptions.allowedPeers ?? hubConfig.allowedPeers,
       rpcPort: cliOptions.rpcPort ?? hubConfig.rpcPort ?? DEFAULT_RPC_PORT,

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -186,6 +186,9 @@ export interface HubOptions {
   /** Chain Id for L2 */
   l2ChainId?: number;
 
+  /** Storage rent expiry override for tests */
+  l2RentExpiryOverride?: number;
+
   /** Resync l2 events */
   l2ResyncEvents?: boolean;
 
@@ -321,6 +324,7 @@ export class Hub implements HubInterface {
         options.l2ChunkSize ?? OptimismConstants.ChunkSize,
         options.l2ChainId ?? OptimismConstants.ChainId,
         options.l2ResyncEvents ?? false,
+        options.l2RentExpiryOverride,
       );
     } else {
       log.warn("No L2 RPC URL provided, not syncing with L2 contract events");


### PR DESCRIPTION
## Motivation

We were needlessly fetching the timestamp for the same block multiple times. Caching it speeds up historical sync significantly. Also, add a cli flag to override storage expiry for testing the migration.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `l2RentExpiryOverride` option to `Hub` class for overriding storage rent expiry in tests.
- Added `--l2-rent-expiry-override` CLI option to set storage rent expiry override.
- Added `_rentExpiry` property to `L2EventsProvider` class for storing the rent expiry value.
- Added `_blockTimestampsCache` property to `L2EventsProvider` class for caching block timestamps.
- Added `_getBlockTimestamp()` method to `L2EventsProvider` class for fetching block timestamps and caching them.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->