### PR TITLE
feat: Create a deny list for PeerIDs

### DIFF
--- a/.changeset/light-chairs-approve.md
+++ b/.changeset/light-chairs-approve.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: Create a deny list for PeerIDs

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -103,6 +103,7 @@ app
 
   // Networking Options
   .option("-a, --allowed-peers <peerIds...>", "Only peer with specific peer ids. (default: all peers allowed)")
+  .option("--denied-peers <peerIds...>", "Do not peer with specific peer ids. (default: no peers denied)")
   .option("-b, --bootstrap <peer-multiaddrs...>", "Peers to bootstrap gossip and sync from. (default: none)")
   .option("-g, --gossip-port <port>", `Port to use for gossip (default: ${DEFAULT_GOSSIP_PORT})`)
   .option("-r, --rpc-port <port>", `Port to use for gRPC  (default: ${DEFAULT_RPC_PORT})`)
@@ -398,6 +399,7 @@ app
       l2RentExpiryOverride: cliOptions.l2RentExpiryOverride ?? hubConfig.l2RentExpiryOverride,
       bootstrapAddrs,
       allowedPeers: cliOptions.allowedPeers ?? hubConfig.allowedPeers,
+      deniedPeers: cliOptions.deniedPeers ?? hubConfig.deniedPeers,
       rpcPort: cliOptions.rpcPort ?? hubConfig.rpcPort ?? DEFAULT_RPC_PORT,
       rpcAuth,
       rpcRateLimit,

--- a/apps/hubble/src/defaultConfig.ts
+++ b/apps/hubble/src/defaultConfig.ts
@@ -27,8 +27,8 @@ export const Config = {
   /** An "allow list" of Peer Ids. Blocks all other connections */
   // allowedPeers: [
   //   '12D3KooWGNNs8uJkmJfThyrnESRBhfuNUAGeGrLb1PYssNnwQy11', // prod hub
-  //   '12D3KooWMDdQaMWCkQ8Gf3C6zdJdMEfFs8R2pw8YQw2HgoY8qhzA', // @adityapk00
   // ],
+  // deniedPeers: [],
   /** The IP address libp2p should listen on. */
   ip: "0.0.0.0",
   /** The IP address that libp2p should announce to peers */

--- a/apps/hubble/src/eth/ethEventsProvider.test.ts
+++ b/apps/hubble/src/eth/ethEventsProvider.test.ts
@@ -133,17 +133,23 @@ describe("EthEventsProvider", () => {
     });
 
     const waitForBlock = async (blockNumber: number) => {
-      while (ethEventsProvider.getLatestBlockNumber() <= blockNumber) {
+      while (ethEventsProvider.getLatestBlockNumber() < blockNumber) {
         // Wait for all async promises to resolve
-        await new Promise((resolve) => setTimeout(resolve, 0));
+        await new Promise((resolve) => setTimeout(resolve, 10));
       }
     };
 
     test("handles new blocks", async () => {
-      await testClient.mine({ blocks: 1 });
       const latestBlockNumber = await publicClient.getBlockNumber();
+      await testClient.mine({ blocks: 1 });
       await waitForBlock(Number(latestBlockNumber));
       expect(ethEventsProvider.getLatestBlockNumber()).toBeGreaterThanOrEqual(latestBlockNumber);
+
+      // Mine another block to make sure the block number is updated
+      const nextBlockNumber = Number(latestBlockNumber) + 1;
+      await testClient.mine({ blocks: 1 });
+      await waitForBlock(nextBlockNumber);
+      expect(ethEventsProvider.getLatestBlockNumber()).toBeGreaterThanOrEqual(nextBlockNumber);
     });
 
     test("processes IdRegistry events", async () => {

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -628,7 +628,10 @@ export class Hub implements HubInterface {
         this.gossipNode.updateAllowedPeerIds(allowedPeerIds);
         this.allowedPeerIds = allowedPeerIds;
       }
+
+      this.gossipNode.updateDeniedPeerIds(deniedPeerIds);
       this.deniedPeerIds = deniedPeerIds;
+
       return false;
     }
   }

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -117,6 +117,9 @@ export interface HubOptions {
   /** A list of PeerId strings to allow connections with */
   allowedPeers?: string[];
 
+  /** A list of PeerId strings to disallow connections with */
+  deniedPeers?: string[];
+
   /** IP address string in MultiAddr format to bind the gossip node to */
   ipMultiAddr?: string;
 
@@ -263,6 +266,7 @@ export class Hub implements HubInterface {
   private rocksDB: RocksDB;
   private syncEngine: SyncEngine;
   private allowedPeerIds: string[] | undefined;
+  private deniedPeerIds: string[];
 
   private pruneMessagesJobScheduler: PruneMessagesJobScheduler;
   private periodSyncJobScheduler: PeriodicSyncJobScheduler;
@@ -438,6 +442,11 @@ export class Hub implements HubInterface {
       // Append and de-dup the allowed peers
       this.allowedPeerIds = [...new Set([...(this.allowedPeerIds ?? []), ...MAINNET_ALLOWED_PEERS])];
     }
+    this.deniedPeerIds = this.options.deniedPeers ?? [];
+    if (this.options.network === FarcasterNetwork.MAINNET) {
+      // Append and de-dup the denied peers
+      this.deniedPeerIds = [...new Set([...(this.deniedPeerIds ?? [])])];
+    }
   }
 
   get rpcAddress() {
@@ -571,6 +580,7 @@ export class Hub implements HubInterface {
       announceIp: this.options.announceIp,
       gossipPort: this.options.gossipPort,
       allowedPeerIdStrs: this.allowedPeerIds,
+      deniedPeerIdStrs: this.deniedPeerIds,
       directPeers: this.options.directPeers,
     });
 
@@ -604,7 +614,12 @@ export class Hub implements HubInterface {
 
   /** Apply the new the network config. Will return true if the Hub should exit */
   public applyNetworkConfig(networkConfig: NetworkConfig): boolean {
-    const { allowedPeerIds, shouldExit } = applyNetworkConfig(networkConfig, this.allowedPeerIds, this.options.network);
+    const { allowedPeerIds, deniedPeerIds, shouldExit } = applyNetworkConfig(
+      networkConfig,
+      this.allowedPeerIds,
+      this.deniedPeerIds,
+      this.options.network,
+    );
 
     if (shouldExit) {
       return true;
@@ -613,6 +628,7 @@ export class Hub implements HubInterface {
         this.gossipNode.updateAllowedPeerIds(allowedPeerIds);
         this.allowedPeerIds = allowedPeerIds;
       }
+      this.deniedPeerIds = deniedPeerIds;
       return false;
     }
   }

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -398,6 +398,10 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
     this._connectionGater?.updateAllowedPeers(peerIds);
   }
 
+  updateDeniedPeerIds(peerIds: string[]) {
+    this._connectionGater?.updateDeniedPeers(peerIds);
+  }
+
   //TODO: Needs better typesafety
   static encodeMessage(message: GossipMessage): HubResult<Uint8Array> {
     return ok(GossipMessage.encode(message).finish());

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -37,7 +37,7 @@ const MultiaddrLocalHost = "/ip4/127.0.0.1";
 /** The maximum number of pending merge messages before we drop new incoming gossip or sync messages. */
 export const MAX_MESSAGE_QUEUE_SIZE = 100_000;
 
-const log = logger.child({ component: "Node" });
+const log = logger.child({ component: "GossipNode" });
 
 /** Events emitted by a Farcaster Gossip Node */
 interface NodeEvents {
@@ -61,6 +61,8 @@ interface NodeOptions {
   gossipPort?: number | undefined;
   /** A list of PeerIds that are allowed to connect to this node */
   allowedPeerIdStrs?: string[] | undefined;
+  /** A list of peerIds that are not allowed to connect to this node */
+  deniedPeerIdStrs?: string[] | undefined;
   /** A list of addresses the node directly peers with, provided in MultiAddr format */
   directPeers?: AddrInfo[] | undefined;
   /** Override peer scoring. Useful for tests */
@@ -490,16 +492,21 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
 
     if (options.allowedPeerIdStrs) {
       log.info(
-        { identity: this.identity, function: "createNode", allowedPeerIds: options.allowedPeerIdStrs },
+        {
+          identity: this.identity,
+          function: "createNode",
+          allowedPeerIds: options.allowedPeerIdStrs,
+          deniedPeerIds: options.deniedPeerIdStrs,
+        },
         "!!! PEER-ID RESTRICTIONS ENABLED !!!",
       );
     } else {
       log.warn(
-        { identity: this.identity, function: "createNode" },
+        { identity: this.identity, deniedPeerIds: options.deniedPeerIdStrs, function: "createNode" },
         "No PEER-ID RESTRICTIONS ENABLED. This node will accept connections from any peer",
       );
     }
-    this._connectionGater = new ConnectionFilter(options.allowedPeerIdStrs);
+    this._connectionGater = new ConnectionFilter(options.allowedPeerIdStrs, options.deniedPeerIdStrs);
 
     return ResultAsync.fromPromise(
       createLibp2p({

--- a/apps/hubble/src/network/utils/networkConfig.test.ts
+++ b/apps/hubble/src/network/utils/networkConfig.test.ts
@@ -15,8 +15,22 @@ describe("networkConfig", () => {
       minAppVersion: APP_VERSION,
     };
 
-    const result = applyNetworkConfig(networkConfig, existingPeerIds, network);
+    const result = applyNetworkConfig(networkConfig, existingPeerIds, [], network);
     expect(result.allowedPeerIds).toEqual(["1", "2", "3"]);
+    expect(result.shouldExit).toEqual(false);
+  });
+
+  test("no change with undefined", () => {
+    const networkConfig = {
+      network,
+      allowedPeers: undefined,
+      deniedPeers: [],
+      minAppVersion: APP_VERSION,
+    };
+
+    const result = applyNetworkConfig(networkConfig, undefined, [], network);
+    expect(result.allowedPeerIds).toEqual(undefined);
+    expect(result.deniedPeerIds).toEqual([]);
     expect(result.shouldExit).toEqual(false);
   });
 
@@ -30,7 +44,7 @@ describe("networkConfig", () => {
       minAppVersion: APP_VERSION,
     };
 
-    const result = applyNetworkConfig(networkConfig, existingPeerIds, network);
+    const result = applyNetworkConfig(networkConfig, existingPeerIds, [], network);
     expect(result.allowedPeerIds).toEqual(["1", "2", "3", "4", "5"]);
     expect(result.shouldExit).toEqual(false);
   });
@@ -45,8 +59,9 @@ describe("networkConfig", () => {
       minAppVersion: APP_VERSION,
     };
 
-    const result = applyNetworkConfig(networkConfig, existingPeerIds, network);
+    const result = applyNetworkConfig(networkConfig, existingPeerIds, [], network);
     expect(result.allowedPeerIds).toEqual(["1", "2", "3"]);
+    expect(result.deniedPeerIds).toEqual(["4", "5"]);
     expect(result.shouldExit).toEqual(false);
   });
 
@@ -60,8 +75,22 @@ describe("networkConfig", () => {
       minAppVersion: APP_VERSION,
     };
 
-    const result = applyNetworkConfig(networkConfig, existingPeerIds, network);
+    const result = applyNetworkConfig(networkConfig, existingPeerIds, [], network);
     expect(result.allowedPeerIds).toEqual(["1", "2", "3", "4"]);
+    expect(result.shouldExit).toEqual(false);
+  });
+
+  test("denied peerIDs", () => {
+    const networkConfig = {
+      network,
+      allowedPeers: undefined,
+      deniedPeers: ["1", "2", "3"],
+      minAppVersion: APP_VERSION,
+    };
+
+    const result = applyNetworkConfig(networkConfig, undefined, [], network);
+    expect(result.allowedPeerIds).toEqual(undefined);
+    expect(result.deniedPeerIds).toEqual(["1", "2", "3"]);
     expect(result.shouldExit).toEqual(false);
   });
 
@@ -75,7 +104,7 @@ describe("networkConfig", () => {
       minAppVersion: APP_VERSION,
     };
 
-    const result = applyNetworkConfig(networkConfig, existingPeerIds, network);
+    const result = applyNetworkConfig(networkConfig, existingPeerIds, [], network);
     expect(result.allowedPeerIds).toEqual(["1", "2", "3"]);
     expect(result.shouldExit).toEqual(false);
   });
@@ -88,7 +117,7 @@ describe("networkConfig", () => {
       minAppVersion: semver.inc(APP_VERSION, "patch") ?? "",
     };
 
-    const result = applyNetworkConfig(networkConfig, [], network);
+    const result = applyNetworkConfig(networkConfig, [], [], network);
     expect(result.shouldExit).toEqual(true);
 
     const prevVer = `${semver.major(APP_VERSION)}.${semver.minor(APP_VERSION)}.${semver.patch(APP_VERSION) - 1}`;
@@ -99,7 +128,7 @@ describe("networkConfig", () => {
       minAppVersion: prevVer,
     };
 
-    const result2 = applyNetworkConfig(networkConfig2, [], network);
+    const result2 = applyNetworkConfig(networkConfig2, [], [], network);
     expect(result2.shouldExit).toEqual(false);
   });
 });

--- a/apps/hubble/src/rpc/test/server.test.ts
+++ b/apps/hubble/src/rpc/test/server.test.ts
@@ -109,7 +109,13 @@ describe("server rpc tests", () => {
     test("succeeds for user with no storage", async () => {
       const result = await client.getCurrentStorageLimitsByFid(FidRequest.create({ fid }));
       // Default storage limits
-      expect(result._unsafeUnwrap().limits.map((l) => l.limit)).toEqual([10000, 2500, 5000, 100, 50]);
+      expect(result._unsafeUnwrap().limits.map((l) => l.limit)).toEqual([
+        CAST_PRUNE_SIZE_LIMIT_DEFAULT,
+        LINK_PRUNE_SIZE_LIMIT_DEFAULT,
+        REACTION_PRUNE_SIZE_LIMIT_DEFAULT,
+        USER_DATA_PRUNE_SIZE_LIMIT_DEFAULT,
+        VERIFICATION_PRUNE_SIZE_LIMIT_DEFAULT,
+      ]);
     });
 
     test("succeeds for user with storage", async () => {


### PR DESCRIPTION
## Motivation

If Hubs want to block certain peerIds, they can now use the deny list. 

## Change Summary

- Add `deniedPeerIds` to CLI and to the network config.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding a deny list for PeerIDs in the Hubble app.

### Detailed summary:
- Added a `deniedPeers` option in the `defaultConfig.ts` file.
- Modified the `cli.ts` file to include the `--denied-peers` option.
- Updated the `ConnectionFilter` class in the `connectionFilter.ts` file to handle denied peers.
- Modified the `GossipNode` class in the `gossipNode.ts` file to handle denied peers.
- Updated the `Hub` class in the `hubble.ts` file to include the `deniedPeers` property.
- Updated the `networkConfig.ts` file to handle denied peers.
- Added tests for the changes made.

> The following files were skipped due to too many changes: `apps/hubble/src/network/utils/networkConfig.test.ts`, `apps/hubble/src/network/p2p/connectionFilter.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->