### PR TITLE
fix: resolves conflicts for links_fid_target_fid_type_unique

### DIFF
--- a/packages/hub-nodejs/examples/replicate-data-postgres/hubReplicator.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/hubReplicator.ts
@@ -637,6 +637,8 @@ export class HubReplicator {
       )
       // Do nothing on conflict since nothing should have changed if hash is the same.
       .onConflict((oc) => oc.columns(["hash"]).doNothing())
+      // Do nothing on conflict since nothing should have changed if the fid, targetFid & type are the same.
+      .onConflict((oc) => oc.columns(["fid", "targetFid", "type"]).doNothing())
       .execute();
 
     for (const message of messages) {


### PR DESCRIPTION
## Motivation

Fixes #1221 

## Change Summary

Add a way to handle conflicts for this constraint links_fid_target_fid_type_unique

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the `onConflict` clause in the `hubReplicator.ts` file to include additional columns and update their values if a conflict occurs.

### Detailed summary:
- Updated the `onConflict` clause in the `hubReplicator.ts` file.
- Added columns `fid`, `targetFid`, and `type` to the `onConflict` clause.
- Added an update set for the columns `updatedAt`, `deletedAt`, `hash`, `timestamp`, and `displayTimestamp`.
- Added a condition to the `where` clause to check if `links.timestamp` is less than `excluded.timestamp`.
- Executed the updated `onConflict` clause.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->