### PR TITLE
fix: typo's regarding time utilities in hub-nodejs

### DIFF
--- a/packages/hub-nodejs/docs/Utils.md
+++ b/packages/hub-nodejs/docs/Utils.md
@@ -133,13 +133,14 @@ HubErrorCode defines all the types of errors that can be raised in the Hub.
 
 ## Time
 
-Farcaster timestamps are counted as milliseconds since the Farcaster epoch, which began on Jan 1, 2021 00:00:00 UTC.
+Farcaster timestamps are counted as seconds since the Farcaster epoch, which began on Jan 1, 2021 00:00:00 UTC.
 
-Using a more recent epoch lets Farcaster use shorter 32-bit values to hold times which reduces the size of messages. Timestamps are usually measured as milliseconds since the Unix epoch and can be converted to Farcaster time by subtracting 1609459200000.
+Using a more recent epoch lets Farcaster use shorter 32-bit values to hold times which reduces the size of messages. Timestamps are usually measured as milliseconds since the Unix epoch and can be converted to Farcaster time by following this equation:\
+`Farcaster Time (seconds) = (Unix Time (milliseconds) / 1000) - 1609459200`
 
 ### getFarcasterTime
 
-Returns the current time in milliseconds as a Farcaster timestamp.
+Returns the current time in seconds as a Farcaster timestamp.
 
 #### Usage
 
@@ -152,15 +153,15 @@ console.log(timestamp); // 70117755
 
 #### Returns
 
-| Value               | Description                                                |
-| :------------------ | :--------------------------------------------------------- |
-| `HubResult<number>` | The current time in milliseconds as a Farcaster timestamp. |
+| Value               | Description                                           |
+| :------------------ |:------------------------------------------------------|
+| `HubResult<number>` | The current time in seconds as a Farcaster timestamp. |
 
 ---
 
 ### toFarcasterTime
 
-Converts a Unix milliseconds timestamp to a Farcaster milliseconds timestamp.
+Converts a Unix milliseconds timestamp to a Farcaster seconds timestamp.
 
 #### Usage
 
@@ -174,9 +175,9 @@ console.log(timestamp); // 70117500
 
 #### Returns
 
-| Value               | Description                                                  |
-| :------------------ | :----------------------------------------------------------- |
-| `HubResult<number>` | The converted time in milliseconds as a Farcaster timestamp. |
+| Value               | Description                                             |
+| :------------------ |:--------------------------------------------------------|
+| `HubResult<number>` | The converted time in seconds as a Farcaster timestamp. |
 
 #### Parameters
 
@@ -188,14 +189,14 @@ console.log(timestamp); // 70117500
 
 ### fromFarcasterTime
 
-Converts a Farcaster milliseconds timestamp to a Unix milliseconds timestamp.
+Converts a Farcaster seconds timestamp to a Unix milliseconds timestamp.
 
 #### Usage
 
 ```typescript
 import { fromFarcasterTime } from '@farcaster/hub-nodejs';
 
-const timestamp = 70160902; // Farcaster timestamp in milliseconds
+const timestamp = 70160902; // Farcaster timestamp in seconds
 const msTimestamp = fromFarcasterTime(timestamp)._unsafeUnwrap();
 console.log(msTimestamp); // 1679620102000
 ```
@@ -208,9 +209,9 @@ console.log(msTimestamp); // 1679620102000
 
 #### Parameters
 
-| Name   | Type     | Description                                                             |
-| :----- | :------- | :---------------------------------------------------------------------- |
-| `time` | `number` | The Farcaster timestamp in milliseconds to convert to a Unix timestamp. |
+| Name   | Type     | Description                                                        |
+| :----- | :------- |:-------------------------------------------------------------------|
+| `time` | `number` | The Farcaster timestamp in seconds to convert to a Unix timestamp. |
 
 ## Verifications
 


### PR DESCRIPTION
## Motivation

Farcaster timestamps are seconds since the Farcaster epoch, some documentation still referenced the Farcaster timestamp as milliseconds since the epoch, which can be misleading.

## Change Summary

Updated the hub-nodejs Utils documentation to update the time unit for Farcaster timestamps.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

Reference for this documentation being a typo:
https://t.me/farcasterdevchat/6364
<img width="759" alt="Screenshot 2023-08-07 at 01 31 41" src="https://github.com/farcasterxyz/hub-monorepo/assets/29960599/034f777f-53e2-4fe7-9690-4f0f24cdf3cc">

Updated Unix Millis -> Farcaster Seconds equation proof:
```typescript
import { toFarcasterTime } from "@farcaster/hub-nodejs";

const to = toFarcasterTime(1691393545202);
// ^^ Returns: 81934345
let testFcTime = 1691393545202 / 1000 - 1609459200;
// ^^ Returns: 81934345.2019999
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Farcaster timestamp representation from milliseconds to seconds. 

### Detailed summary:
- Updates the Farcaster timestamp representation from milliseconds to seconds.
- Provides an equation to convert Unix timestamps to Farcaster timestamps in seconds.
- Updates the return type and description for the `getFarcasterTime` function.
- Updates the return type and description for the `toFarcasterTime` function.
- Updates the parameter description for the `fromFarcasterTime` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->