### PR TITLE
feat: Integrity checks during Sync

### DIFF
--- a/.changeset/itchy-carrots-tap.md
+++ b/.changeset/itchy-carrots-tap.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: Check integrity of messages during sync

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -29,7 +29,7 @@ import RocksDB from "../../storage/db/rocksdb.js";
 import { sleepWhile } from "../../utils/crypto.js";
 import { logger } from "../../utils/logger.js";
 import { RootPrefix } from "../../storage/db/types.js";
-import { fromFarcasterTime } from "@farcaster/core";
+import { bytesStartsWith, fromFarcasterTime } from "@farcaster/core";
 import { L2EventsProvider } from "../../eth/l2EventsProvider.js";
 import { SyncEngineProfiler } from "./syncEngineProfiler.js";
 import os from "os";
@@ -83,6 +83,13 @@ class MergeResult {
   }
 }
 
+type DbStats = {
+  numMessages: number;
+  numFids: number;
+  numFnames: number;
+};
+
+// The Status of the node's sync with the network.
 type SyncStatus = {
   isSyncing: boolean;
   inSync: "true" | "false" | "unknown" | "blocked";
@@ -94,18 +101,14 @@ type SyncStatus = {
   lastBadSync: number;
 };
 
-type DbStats = {
-  numMessages: number;
-  numFids: number;
-  numFnames: number;
-};
-
+// Status of the current (ongoing) sync.
 class CurrentSyncStatus {
   isSyncing = false;
   interruptSync = false;
   peerId: string | undefined;
   startTimestamp?: number;
   fidRetryMessageQ = new Map<number, Message[]>();
+  seriousValidationFailures = 0;
 
   constructor(peerId?: string) {
     if (peerId) {
@@ -554,11 +557,30 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     );
     await messagesResult.match(
       async (msgs) => {
-        result = await this.mergeMessages(msgs.messages, rpcClient);
+        // Make sure that the messages are actually for the SyncIDs
+        const syncIdHashes = new Set(
+          syncIds
+            .map((syncId) => bytesToHexString(SyncId.hashFromSyncId(syncId)).unwrapOr(""))
+            .filter((str) => str !== ""),
+        );
+
+        // Go over the SyncID hashes and the messages and make sure that the messages are for the SyncIDs
+        const mismatched = msgs.messages.some(
+          (msg) => !syncIdHashes.has(bytesToHexString(msg.hash).unwrapOr("0xUnknown")),
+        );
+
+        if (mismatched) {
+          log.warn(
+            { syncIds, messages: msgs.messages, peer: this._currentSyncStatus.peerId },
+            "PeerError: Fetched Messages do not match SyncIDs requested",
+          );
+        } else {
+          result = await this.mergeMessages(msgs.messages, rpcClient);
+        }
       },
       async (err) => {
         // e.g. Node goes down while we're performing the sync. No need to handle it, the next round of sync will retry.
-        log.warn(err, "Error fetching messages for sync");
+        log.warn(err, "PeerError: Error fetching messages for sync");
       },
     );
     return result;
@@ -613,6 +635,16 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
             // We'll push this message as a failure, and we'll retry it on the next sync.
             mergeResults.push(result);
             deferredCount += 1;
+          } else {
+            // These are very serious validation errors, caused only by
+            // 1. A malfunctioning or malicious peer
+            // 2. A bug in the Hub
+            // So log the errors as "warn"
+            log.warn(
+              { fid: msg.data?.fid, err: result.error.message, peerId: this._currentSyncStatus.peerId },
+              "PeerError: Unexpected validation error",
+            );
+            this._currentSyncStatus.seriousValidationFailures += 1;
           }
         } else if (result.error.errCode === "bad_request.duplicate") {
           // This message has been merged into the DB, but for some reason is not in the Trie.
@@ -711,6 +743,15 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
       if (result.isErr()) {
         log.warn(result.error, `Error fetching ids for prefix ${theirNode.prefix}`);
       } else {
+        // Verify that the returned syncIDs actually have the prefix we requested.
+        if (!this.verifySyncIdForPrefix(theirNode.prefix, result.value.syncIds)) {
+          log.warn(
+            { prefix: theirNode.prefix, syncIds: result.value.syncIds, peerId: this._currentSyncStatus.peerId },
+            "PeerError: Received syncIds that don't match prefix, aborting trie branch",
+          );
+          return;
+        }
+
         // Strip out all syncIds that we already have. This can happen if our node has more messages than the other
         // hub at this node.
         // Note that we can optimize this check for the common case of a single missing syncId, since the diff
@@ -900,6 +941,25 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     logger.info({ fid }, `Retrying events from block ${custodyEventBlockNumber}`);
     // We'll retry all events from this block number
     await this._ethEventsProvider?.retryEventsFromBlock(custodyEventBlockNumber);
+  }
+
+  /**
+   * Verify the peer is being honest by checking to make sure the syncIds actually have the
+   * prefix
+   */
+  private verifySyncIdForPrefix(prefix: Uint8Array, syncIds: Uint8Array[]): boolean {
+    for (const syncId of syncIds) {
+      // Make sure SyncId has the prefix
+      if (!bytesStartsWith(syncId, prefix)) {
+        log.warn(
+          { syncId, prefix, peerId: this._currentSyncStatus.peerId },
+          "PeerError: SyncId does not have the expected prefix",
+        );
+        return false;
+      }
+    }
+
+    return true;
   }
 
   private async syncUserAndRetryMessage(message: Message, rpcClient: HubRpcClient): Promise<HubResult<number>> {

--- a/apps/hubble/src/network/sync/syncId.ts
+++ b/apps/hubble/src/network/sync/syncId.ts
@@ -57,6 +57,11 @@ class SyncId {
 
     return Buffer.from(pk);
   }
+
+  /** Return the message hash for the SyncID */
+  static hashFromSyncId(syncId: Uint8Array): Uint8Array {
+    return syncId.slice(TIMESTAMP_LENGTH + 1 + FID_BYTES + 1);
+  }
 }
 
 /** Normalizes the timestamp in seconds to fixed length to ensure consistent depth in the trie */

--- a/packages/core/src/bytes.test.ts
+++ b/packages/core/src/bytes.test.ts
@@ -4,6 +4,7 @@ import {
   bytesCompare,
   bytesDecrement,
   bytesIncrement,
+  bytesStartsWith,
   bytesToHexString,
   bytesToUtf8String,
   hexStringToBytes,
@@ -187,6 +188,25 @@ describe("bigIntToBytes", () => {
   for (const [input, output] of passingCases) {
     test(`converts bigint to byte array: ${input?.toString()}`, () => {
       expect(bigIntToBytes(input)).toEqual(ok(output));
+    });
+  }
+});
+
+describe("bytesStartsWith", () => {
+  const passingCases: [Uint8Array, Uint8Array, boolean][] = [
+    [new Uint8Array([1, 2, 3]), new Uint8Array([]), true],
+    [new Uint8Array([1, 2, 3]), new Uint8Array([1]), true],
+    [new Uint8Array([1, 2, 3]), new Uint8Array([1, 2]), true],
+    [new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 3]), true],
+    [new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 3, 4]), false],
+    [new Uint8Array([1, 2, 3]), new Uint8Array([2]), false],
+    [new Uint8Array([1, 2, 3]), new Uint8Array([2, 3]), false],
+    [new Uint8Array([1, 2, 3]), new Uint8Array([3]), false],
+  ];
+
+  for (const [input, prefix, output] of passingCases) {
+    test(`checks if byte array starts with prefix: ${input} ${prefix}`, () => {
+      expect(bytesStartsWith(input, prefix)).toEqual(output);
     });
   }
 });

--- a/packages/core/src/bytes.ts
+++ b/packages/core/src/bytes.ts
@@ -99,3 +99,17 @@ export const bigIntToBytes = (value: bigint): HubResult<Uint8Array> => {
 export const bytesToBigInt = (bytes: Uint8Array): HubResult<bigint> => {
   return bytesToHexString(bytes).map((hexString) => BigInt(hexString));
 };
+
+export const bytesStartsWith = (haystack: Uint8Array, needle: Uint8Array): boolean => {
+  if (needle.length > haystack.length) {
+    return false;
+  }
+
+  for (let i = 0; i < needle.length; i++) {
+    if (haystack[i] !== needle[i]) {
+      return false;
+    }
+  }
+
+  return true;
+};


### PR DESCRIPTION
## Motivation

When syncing, we should check the integrity of messages that are being sent over

## Change Summary

- Check that the syncIds actually have the correct prefixes
- Check that the messages are actually for the correct syncIDs
- Check that messages are validated properly, or mark the peer as bad for egregious validation failures

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the integrity of messages during sync. 

### Detailed summary
- Added a new feature to check the integrity of messages during sync.
- Added a new function `hashFromSyncId` to calculate the message hash for the SyncID.
- Added a new function `bytesStartsWith` to check if a byte array starts with a prefix.
- Updated the `SyncEngine` class to handle missing messages and recover from sync failures.
- Added validation checks for received syncIDs to ensure their integrity.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->