### PR TITLE
fix: Fix onchain event subscription not sending events correctly

### DIFF
--- a/.changeset/swift-ways-hear.md
+++ b/.changeset/swift-ways-hear.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Fix onchain event subscription not sending events correctly

--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -325,8 +325,8 @@ describe("SyncEngine", () => {
 
   test("getSyncStats is correct", async () => {
     await engine.mergeIdRegistryEvent(custodyEvent);
-    await engine.mergeNameRegistryEvent(Factories.NameRegistryEvent.build());
-    await engine.mergeNameRegistryEvent(Factories.NameRegistryEvent.build());
+    await engine.mergeUserNameProof(Factories.UserNameProof.build());
+    await engine.mergeUserNameProof(Factories.UserNameProof.build());
     await engine.mergeMessage(signerAdd);
     await addMessagesWithTimestamps([167, 169]);
 

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -851,7 +851,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     );
 
     await this._db.forEachIteratorByPrefix(
-      Buffer.from([RootPrefix.NameRegistryEvent]),
+      Buffer.from([RootPrefix.FNameUserNameProof]),
       () => {
         numFnames += 1;
       },

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -1164,6 +1164,7 @@ export default class Server {
           this.engine?.eventHandler.off("mergeIdRegistryEvent", eventListener);
           this.engine?.eventHandler.off("mergeNameRegistryEvent", eventListener);
           this.engine?.eventHandler.off("mergeUsernameProofEvent", eventListener);
+          this.engine?.eventHandler.off("mergeOnChainEvent", eventListener);
 
           this.subscribeIpLimiter.removeConnection(peer);
 
@@ -1251,6 +1252,7 @@ export default class Server {
           this.engine?.eventHandler.on("mergeIdRegistryEvent", eventListener);
           this.engine?.eventHandler.on("mergeNameRegistryEvent", eventListener);
           this.engine?.eventHandler.on("mergeUsernameProofEvent", eventListener);
+          this.engine?.eventHandler.on("mergeOnChainEvent", eventListener);
         } else {
           for (const eventType of request.eventTypes) {
             if (eventType === HubEventType.MERGE_MESSAGE) {
@@ -1265,6 +1267,8 @@ export default class Server {
               this.engine?.eventHandler.on("mergeNameRegistryEvent", eventListener);
             } else if (eventType === HubEventType.MERGE_USERNAME_PROOF) {
               this.engine?.eventHandler.on("mergeUsernameProofEvent", eventListener);
+            } else if (eventType === HubEventType.MERGE_ON_CHAIN_EVENT) {
+              this.engine?.eventHandler.on("mergeOnChainEvent", eventListener);
             }
           }
         }

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -218,6 +218,7 @@ class Engine {
     this.eventHandler.off("mergeMessage", this.handleMergeMessageEvent);
     this.eventHandler.off("revokeMessage", this.handleRevokeMessageEvent);
     this.eventHandler.off("pruneMessage", this.handlePruneMessageEvent);
+    this.eventHandler.off("mergeOnChainEvent", this.handleMergeOnChainEvent);
 
     this._revokeSignerWorker.start();
 


### PR DESCRIPTION
## Motivation

Missed subscribing to the event handler for the onchainevent hub events. 

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the issue with onchain event subscription not sending events correctly. 

### Detailed summary
- Fixed onchain event subscription not sending events correctly
- Updated event handling in syncEngine.ts, engine/index.ts, server.ts, syncEngine.test.ts, eventService.test.ts

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->