### PR TITLE
chore: Cut Hubble version 1.4.4 and other package upgrades

### DIFF
--- a/.changeset/brave-steaks-change.md
+++ b/.changeset/brave-steaks-change.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: Improve profiler for gen messages and storage

--- a/.changeset/breezy-swans-brake.md
+++ b/.changeset/breezy-swans-brake.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Bugfix where testnet would restrict peers

--- a/.changeset/cyan-foxes-wave.md
+++ b/.changeset/cyan-foxes-wave.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: Add fallback bootstrap peers for mainnet

--- a/.changeset/dull-glasses-admire.md
+++ b/.changeset/dull-glasses-admire.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": minor
----
-
-Adds support for logging would-be-pruned events, plus handles extra storage if purchased

--- a/.changeset/empty-eggs-cough.md
+++ b/.changeset/empty-eggs-cough.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Fetch network config only for mainnet

--- a/.changeset/fifty-feet-punch.md
+++ b/.changeset/fifty-feet-punch.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: revoke signers 1hr after custody event

--- a/.changeset/friendly-icons-sip.md
+++ b/.changeset/friendly-icons-sip.md
@@ -1,6 +1,0 @@
----
-"@farcaster/core": patch
-"@farcaster/hubble": patch
----
-
-feat: Move blake3 hash into rust

--- a/.changeset/healthy-ghosts-hide.md
+++ b/.changeset/healthy-ghosts-hide.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: handle revoking on chain signer and make l2 options customizable

--- a/.changeset/heavy-pants-poke.md
+++ b/.changeset/heavy-pants-poke.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: Rate limit merges per FID to the total messages storage available for the FID

--- a/.changeset/itchy-carrots-tap.md
+++ b/.changeset/itchy-carrots-tap.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: Check integrity of messages during sync

--- a/.changeset/khaki-clouds-attack.md
+++ b/.changeset/khaki-clouds-attack.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: validate name proofs against fids rather than custody address to enable smoother fid recovery process

--- a/.changeset/light-chairs-approve.md
+++ b/.changeset/light-chairs-approve.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: Create a deny list for PeerIDs

--- a/.changeset/little-fans-sort.md
+++ b/.changeset/little-fans-sort.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Limit the number of simultaneous subscribe() streams by IP address

--- a/.changeset/nervous-rivers-love.md
+++ b/.changeset/nervous-rivers-love.md
@@ -1,5 +1,0 @@
----
-"@farcaster/core": patch
----
-
-feat: Add Rust to the toolchain and use rust for ed25519 signature verification

--- a/.changeset/rare-bags-reflect.md
+++ b/.changeset/rare-bags-reflect.md
@@ -1,6 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
-"@farcaster/hubble": patch
----
-
-chore: Update grpc-js and setup grpc server timeouts

--- a/.changeset/rude-rabbits-tease.md
+++ b/.changeset/rude-rabbits-tease.md
@@ -1,8 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
-"@farcaster/hub-web": patch
-"@farcaster/core": patch
-"@farcaster/hubble": patch
----
-
-feat: support migrating to l2

--- a/.changeset/smart-hotels-punch.md
+++ b/.changeset/smart-hotels-punch.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Fix the TestData generation for testnet

--- a/.changeset/spicy-lamps-swim.md
+++ b/.changeset/spicy-lamps-swim.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: Add libp2p gossip server profiler

--- a/.changeset/swift-ways-hear.md
+++ b/.changeset/swift-ways-hear.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Fix onchain event subscription not sending events correctly

--- a/.changeset/thirty-radios-search.md
+++ b/.changeset/thirty-radios-search.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: Scale validation workers by number of CPUs and add a RPC profiler

--- a/.changeset/tidy-needles-greet.md
+++ b/.changeset/tidy-needles-greet.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: Deprecate time based pruning in sets

--- a/.changeset/tidy-panthers-speak.md
+++ b/.changeset/tidy-panthers-speak.md
@@ -1,8 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
-"@farcaster/hub-web": patch
-"@farcaster/core": patch
-"@farcaster/hubble": patch
----
-
-feat: refactor storage rent events to on chain events

--- a/.changeset/tiny-bears-peel.md
+++ b/.changeset/tiny-bears-peel.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-Adjusted rent prune log to debug instead of warn

--- a/.changeset/young-lobsters-peel.md
+++ b/.changeset/young-lobsters-peel.md
@@ -1,8 +1,0 @@
----
-"@farcaster/hub-nodejs": minor
-"@farcaster/hub-web": minor
-"@farcaster/core": minor
-"@farcaster/hubble": minor
----
-
-Added storage limits RPC

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,12 +284,12 @@ are at all unsure about how to proceed, please reach out to Varun ([Github](http
 
 ### 3.7 Working in Rust
 
-Some of the CPU intensive code is written in Rust for speed. We import the Rust modules via [Neon](https://neon-bindings.com/) that are built as a part of the `@farcaster/core` package. 
+Some of the CPU intensive code is written in Rust for speed. We import the Rust modules via [Neon](https://neon-bindings.com/) that are built as a part of the `@farcaster/core` package.
 
-To add new code to Rust, 
+To add new code to Rust,
 1. Add it to `packages/core/src/addon/`
 2. Add a bridge implementation and types into `packages/core/src/addon/addon.js` and `packages/core/src/addon/addon.d.ts`
-3. Export the callable typescript function in `packages/core/src/rustfunctions.ts`. This function can then be used throught the project to transparently call into Rust from Typescript 
+3. Export the callable typescript function in `packages/core/src/rustfunctions.ts`. This function can then be used throught the project to transparently call into Rust from Typescript
 
 ## 4. Troubleshooting
 

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,38 @@
 # @farcaster/hubble
 
+## 1.4.4
+
+### Patch Changes
+
+- 083762e5: feat: Improve profiler for gen messages and storage
+- 63260785: fix: Bugfix where testnet would restrict peers
+- 40c17c9b: feat: Add fallback bootstrap peers for mainnet
+- d443fbe9: Adds support for logging would-be-pruned events, plus handles extra storage if purchased
+- 571e5434: fix: Fetch network config only for mainnet
+- c7ec4ca9: feat: revoke signers 1hr after custody event
+- ec7734cf: feat: Move blake3 hash into rust
+- 996be825: fix: handle revoking on chain signer and make l2 options customizable
+- 1e0979b0: feat: Rate limit merges per FID to the total messages storage available for the FID
+- 503b379d: feat: Check integrity of messages during sync
+- b9efe14a: feat: validate name proofs against fids rather than custody address to enable smoother fid recovery process
+- 65a4faff: feat: Create a deny list for PeerIDs
+- a1b9aced: fix: Limit the number of simultaneous subscribe() streams by IP address
+- 3f180073: chore: Update grpc-js and setup grpc server timeouts
+- dcd7a149: feat: support migrating to l2
+- 39e0141d: fix: Fix the TestData generation for testnet
+- b598c4a2: feat: Add libp2p gossip server profiler
+- 9ae366b7: fix: Fix onchain event subscription not sending events correctly
+- 9f669b57: feat: Scale validation workers by number of CPUs and add a RPC profiler
+- 2df38497: feat: Deprecate time based pruning in sets
+- 67e9466e: feat: refactor storage rent events to on chain events
+- 50a6b8ac: Adjusted rent prune log to debug instead of warn
+- 86149d32: Added storage limits RPC
+- Updated dependencies [3f180073]
+- Updated dependencies [dcd7a149]
+- Updated dependencies [67e9466e]
+- Updated dependencies [86149d32]
+  - @farcaster/hub-nodejs@0.10.0
+
 ## 1.4.3
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -54,7 +54,7 @@
     "@chainsafe/libp2p-gossipsub": "6.1.0",
     "@chainsafe/libp2p-noise": "^11.0.0 ",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.9.1",
+    "@farcaster/hub-nodejs": "^0.10.0",
     "@farcaster/rocksdb": "^5.5.0",
     "@grpc/grpc-js": "~1.8.21",
     "@libp2p/interface-connection": "^3.0.2",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @farcaster/core
 
+## 0.12.0
+
+### Minor Changes
+
+- 86149d32: Added storage limits RPC
+
+### Patch Changes
+
+- ec7734cf: feat: Move blake3 hash into rust
+- 15fad467: feat: Add Rust to the toolchain and use rust for ed25519 signature verification
+- dcd7a149: feat: support migrating to l2
+- 67e9466e: feat: refactor storage rent events to on chain events
+
 ## 0.11.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -11,7 +11,9 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "license": "MIT",
   "dependencies": {
     "@noble/curves": "^1.0.0",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @farcaster/hub-nodejs
 
+## 0.10.0
+
+### Minor Changes
+
+- 86149d32: Added storage limits RPC
+
+### Patch Changes
+
+- 3f180073: chore: Update grpc-js and setup grpc server timeouts
+- dcd7a149: feat: support migrating to l2
+- 67e9466e: feat: refactor storage rent events to on chain events
+- Updated dependencies [ec7734cf]
+- Updated dependencies [15fad467]
+- Updated dependencies [dcd7a149]
+- Updated dependencies [67e9466e]
+- Updated dependencies [86149d32]
+  - @farcaster/core@0.12.0
+
 ## 0.9.1
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -11,10 +11,12 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "license": "MIT",
   "dependencies": {
-    "@farcaster/core": "0.11.1",
+    "@farcaster/core": "0.12.0",
     "@grpc/grpc-js": "~1.8.21",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"

--- a/packages/hub-web/CHANGELOG.md
+++ b/packages/hub-web/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @farcaster/hub-web
 
+## 0.6.0
+
+### Minor Changes
+
+- 86149d32: Added storage limits RPC
+
+### Patch Changes
+
+- dcd7a149: feat: support migrating to l2
+- 67e9466e: feat: refactor storage rent events to on chain events
+- Updated dependencies [ec7734cf]
+- Updated dependencies [15fad467]
+- Updated dependencies [dcd7a149]
+- Updated dependencies [67e9466e]
+- Updated dependencies [86149d32]
+  - @farcaster/core@0.12.0
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-web",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -29,7 +29,7 @@
     "ts-proto": "^1.146.0"
   },
   "dependencies": {
-    "@farcaster/core": "^0.11.0",
+    "@farcaster/core": "^0.12.0",
     "@improbable-eng/grpc-web": "^0.15.0",
     "rxjs": "^7.8.0"
   }


### PR DESCRIPTION
## Motivation

Regular update.

## Change Summary

Ran `yarn changeset version`.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on version updates and minor changes to various packages. 

### Detailed summary
- Updated `@farcaster/core` package version from `0.11.1` to `0.12.0`
- Updated `@farcaster/hub-web` package version from `0.5.0` to `0.6.0`
- Updated `@farcaster/hubble` package version from `1.4.3` to `1.4.4`
- Updated `@farcaster/hub-nodejs` package version from `0.9.1` to `0.10.0`
- Added storage limits RPC to `@farcaster/core`
- Moved blake3 hash into Rust for `@farcaster/core`
- Added support for migrating to L2 for `@farcaster/core` and `@farcaster/hub-nodejs`
- Refactored storage rent events to on-chain events for `@farcaster/core` and `@farcaster/hub-nodejs`
- Improved profiler for generating messages and storage in `@farcaster/hubble`
- Added fallback bootstrap peers for mainnet in `@farcaster/hubble`
- Added support for logging would-be-pruned events and handling extra storage if purchased in `@farcaster/hubble`
- Fetch network config only for mainnet in `@farcaster/hubble`
- Revoked signers 1 hour after custody event in `@farcaster/hubble`
- Rate limited merges per FID to the total messages storage available for the FID in `@farcaster/hubble`
- Checked integrity of messages during sync in `@farcaster/hubble`
- Validated name proofs against FIDs instead of custody address for smoother FID recovery process in `@farcaster/hubble`
- Created a deny list for PeerIDs in `@farcaster/hubble`
- Limited the number of simultaneous subscribe() streams by IP address in `@farcaster/hubble`
- Updated dependencies for `@farcaster/hubble` and `@farcaster/hub-nodejs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->