### PR TITLE
chore: Update release instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -279,8 +279,11 @@ are at all unsure about how to proceed, please reach out to Varun ([Github](http
 3. Check that all CHANGELOG.mds represent the important changes made
 4. Check in all the files and merge the branch to main
 5. Checkout main, pull down to the merged commit (should be latest) and run `yarn changeset publish`
-6. Hubble is private and must be manually tagged with `git tag -a @farcaster/hubble@<version>` if bumped.
-7. Run `git push origin <tag>` on each tag to push up the tags.
+6. Manually tag Hubble with `git tag -a @farcaster/hubble@<version>` if version was changed..
+7. Update the `@latest` tag: `git tag -f @latest`
+8. Push all tags to the remote repo: `git push origin @latest --force && git push origin HEAD --tags`
+9. Create a GitHub Release for Hubble, marking it as the latest.
+10. If this is a non-patch change, create an NFT for the release.
 
 ### 3.7 Working in Rust
 


### PR DESCRIPTION
## Motivation

Ensure these are up to date.

## Change Summary

Update with latest instructions.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the contribution guidelines. 

### Detailed summary
- Step 6: Manually tag Hubble with `git tag -a @farcaster/hubble@<version>` if version was changed.
- Step 7: Update the `@latest` tag: `git tag -f @latest`
- Step 8: Push all tags to the remote repo: `git push origin @latest --force && git push origin HEAD --tags`
- Step 9: Create a GitHub Release for Hubble, marking it as the latest.
- Step 10: If this is a non-patch change, create an NFT for the release.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->