### PR TITLE
fix: Disable the rust codepath

### DIFF
--- a/.changeset/curly-sheep-tell.md
+++ b/.changeset/curly-sheep-tell.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/core": patch
+---
+
+fix: Disable the rust code path to make it pureJS for now

--- a/packages/core/src/rustfunctions.test.ts
+++ b/packages/core/src/rustfunctions.test.ts
@@ -31,7 +31,7 @@ describe("ed25519 tests", () => {
     const signature = (await signer.signMessageHash(hash))._unsafeUnwrap();
 
     expect((await ed25519.verifyMessageHashSignature(signature, hash, signerKey))._unsafeUnwrap()).toBeTruthy();
-    expect(nativeEd25519Verify(signature, hash, signerKey)).toBeTruthy();
+    expect(await nativeEd25519Verify(signature, hash, signerKey)).toBeTruthy();
   });
 
   test("bad signature fails", async () => {
@@ -43,7 +43,7 @@ describe("ed25519 tests", () => {
     const badHash = Factories.Bytes.build({}, { transient: { length: 32 } });
 
     expect((await ed25519.verifyMessageHashSignature(signature, badHash, signerKey))._unsafeUnwrap()).toBeFalsy();
-    expect(nativeEd25519Verify(signature, badHash, signerKey)).toBeFalsy();
+    expect(await nativeEd25519Verify(signature, badHash, signerKey)).toBeFalsy();
   });
 
   test("bad signer fails", async () => {
@@ -54,7 +54,7 @@ describe("ed25519 tests", () => {
     const badSigner = Factories.Bytes.build({}, { transient: { length: 32 } });
 
     expect((await ed25519.verifyMessageHashSignature(signature, hash, badSigner))._unsafeUnwrap()).toBeFalsy();
-    expect(nativeEd25519Verify(signature, hash, badSigner)).toBeFalsy();
+    expect(await nativeEd25519Verify(signature, hash, badSigner)).toBeFalsy();
   });
 
   test("bad signature fails", async () => {
@@ -65,7 +65,7 @@ describe("ed25519 tests", () => {
     const badSignature = Factories.Bytes.build({}, { transient: { length: 64 } });
 
     expect((await ed25519.verifyMessageHashSignature(badSignature, hash, signerKey))._unsafeUnwrap()).toBeFalsy();
-    expect(nativeEd25519Verify(badSignature, hash, signerKey)).toBeFalsy();
+    expect(await nativeEd25519Verify(badSignature, hash, signerKey)).toBeFalsy();
   });
 
   test("0 length data fails", async () => {
@@ -76,8 +76,8 @@ describe("ed25519 tests", () => {
 
     const empty = new Uint8Array([]);
 
-    expect(nativeEd25519Verify(empty, hash, signerKey)).toBeFalsy();
-    expect(nativeEd25519Verify(signature, empty, signerKey)).toBeFalsy();
-    expect(nativeEd25519Verify(signature, hash, empty)).toBeFalsy();
+    expect(await nativeEd25519Verify(empty, hash, signerKey)).toBeFalsy();
+    expect(await nativeEd25519Verify(signature, empty, signerKey)).toBeFalsy();
+    expect(await nativeEd25519Verify(signature, hash, empty)).toBeFalsy();
   });
 });

--- a/packages/core/src/rustfunctions.ts
+++ b/packages/core/src/rustfunctions.ts
@@ -1,11 +1,16 @@
-import { bridgeBlake3Hash20, bridgeEd25519Verify } from "./addon/addon.js";
+import { ed25519 } from "./crypto";
+import { blake3 } from "@noble/hashes/blake3";
 
 // Use this function in TypeScript to call the rust code.
 export function nativeBlake3Hash20(data: Uint8Array): Uint8Array {
-  return bridgeBlake3Hash20(data);
+  return blake3.create({ dkLen: 20 }).update(data).digest();
 }
 
 // Use this function in TypeScript to call the rust code.
-export function nativeEd25519Verify(signature: Uint8Array, hash: Uint8Array, signer: Uint8Array): boolean {
-  return bridgeEd25519Verify(signature, hash, signer);
+export async function nativeEd25519Verify(
+  signature: Uint8Array,
+  hash: Uint8Array,
+  signer: Uint8Array,
+): Promise<boolean> {
+  return (await ed25519.verifyMessageHashSignature(signature, hash, signer)).unwrapOr(false);
 }

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -145,7 +145,7 @@ export const validateMessage = async (message: protobufs.Message): HubAsyncResul
       return err(new HubError("bad_request.validation_failure", "signature does not match signer"));
     }
   } else if (message.signatureScheme === protobufs.SignatureScheme.ED25519 && !eip712SignerRequired) {
-    const signatureIsValid = nativeEd25519Verify(signature, hash, signer);
+    const signatureIsValid = await nativeEd25519Verify(signature, hash, signer);
 
     if (!signatureIsValid) {
       return err(new HubError("bad_request.validation_failure", "invalid signature"));


### PR DESCRIPTION
## Motivation

When publishing an npm package, we need to build the rust module for multiple platforms. Switch to pureJS for now

## Change Summary

- disable rust path, make it purejs for now

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Fixing a bug in the code by making changes to the `nativeEd25519Verify` function in the `rustfunctions.ts` file.

### Detailed summary:
- Added imports for `ed25519` and `blake3` in `rustfunctions.ts`.
- Replaced the call to `bridgeBlake3Hash20` with `blake3.create().update().digest()` in `nativeBlake3Hash20` function.
- Modified the `nativeEd25519Verify` function to be an async function and use `ed25519.verifyMessageHashSignature` instead of `bridgeEd25519Verify`.
- Updated the tests in `rustfunctions.test.ts` to use `await` with `nativeEd25519Verify` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->