### PR TITLE
chore: Cut patch release for core and hub-nodejs

### DIFF
--- a/.changeset/curly-sheep-tell.md
+++ b/.changeset/curly-sheep-tell.md
@@ -1,5 +1,0 @@
----
-"@farcaster/core": patch
----
-
-fix: Disable the rust code path to make it pureJS for now

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/core
 
+## 0.12.1
+
+### Patch Changes
+
+- cfec7767: fix: Disable the rust code path to make it pureJS for now
+
 ## 0.12.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/hub-nodejs
 
+## 0.10.1
+
+### Patch Changes
+
+- Updated dependencies [cfec7767]
+  - @farcaster/core@0.12.1
+
 ## 0.10.0
 
 ### Minor Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@farcaster/core": "0.12.0",
+    "@farcaster/core": "0.12.1",
     "@grpc/grpc-js": "~1.8.21",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"


### PR DESCRIPTION
## Change Summary

This removes Rust for now, until we have prebuilt packages for multiple architectures.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating dependencies and version numbers for the `@farcaster/core` and `@farcaster/hub-nodejs` packages.

### Detailed summary
- Updated `@farcaster/core` dependency to version 0.12.1
- Updated `@farcaster/hub-nodejs` dependency to version 0.10.1
- Disabled the rust code path in `@farcaster/core` to make it pureJS for now

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->