### PR TITLE
fix: Remove neon shim

### DIFF
--- a/.changeset/clean-bags-kick.md
+++ b/.changeset/clean-bags-kick.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/core": patch
+---
+
+fix: Remove neon shim to get compilation working

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -7,5 +7,4 @@ export default defineConfig({
   dts: true,
   clean: true,
   shims: true,
-  banner: { js: 'import { createRequire } from "module";const require = createRequire(import.meta.url);' },
 });


### PR DESCRIPTION
## Motivation

Remove the neon shim to make it OK to import pureJS lib into other modules

## Change Summary

- Remove neon shim

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the compilation issue by removing the neon shim. 

### Detailed summary:
- Patched "@farcaster/core" package
- Removed neon shim to fix compilation issue

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->