### PR TITLE
chore: Cut patch release to fix neon shim

### DIFF
--- a/.changeset/clean-bags-kick.md
+++ b/.changeset/clean-bags-kick.md
@@ -1,5 +1,0 @@
----
-"@farcaster/core": patch
----
-
-fix: Remove neon shim to get compilation working

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/core
 
+## 0.12.2
+
+### Patch Changes
+
+- afd2146f: fix: Remove neon shim to get compilation working
+
 ## 0.12.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/hub-nodejs
 
+## 0.10.2
+
+### Patch Changes
+
+- Updated dependencies [afd2146f]
+  - @farcaster/core@0.12.2
+
 ## 0.10.1
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@farcaster/core": "0.12.1",
+    "@farcaster/core": "0.12.2",
     "@grpc/grpc-js": "~1.8.21",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"


### PR DESCRIPTION
## Motivation

This was preventing the package from working.

## Change Summary

Publish a patch release without the shim.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the versions of `@farcaster/core` and `@farcaster/hub-nodejs` packages. 

### Detailed summary
- Deleted `.changeset/clean-bags-kick.mdpackages/core/CHANGELOG.md`
- Updated `@farcaster/core` version from `0.12.1` to `0.12.2`
- Updated `@farcaster/hub-nodejs` version from `0.10.1` to `0.10.2`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->