### PR TITLE
docs(hubble): update allow-list instructions

### DIFF
--- a/apps/hubble/www/docs/intro/networks.md
+++ b/apps/hubble/www/docs/intro/networks.md
@@ -23,5 +23,6 @@ FC_NETWORK_ID=1
 BOOTSTRAP_NODE=/dns/nemes.farcaster.xyz/tcp/2282
 ```
 2. Get your PeerId from the file `apps/hubble/.hub/<PEER_ID>_id.protobuf`
-3. Make a PR to add it to the [allowed peers list](https://github.com/farcasterxyz/hub-monorepo/blob/main/apps/hubble/src/allowedPeers.mainnet.ts), and wait for a deploy (usually 48 hours).
+3. Make a PR to add it to the [allowed peers list](https://github.com/farcasterxyz/allowlist-mainnet/blob/main/networkConfig.js)
+4. Once merged, other Hubs will start peering with you after 1 hour.
 


### PR DESCRIPTION
## Motivation

Update the instructions to follow the new allowlist process.

## Change Summary

See above. 

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary:

This PR focuses on updating the location to add the PeerId to the allowed peers list. It also updates the location for the allowed peers list.

Notable changes:
- The PeerId is now added to the allowed peers list in a different location.
- The location for the allowed peers list is updated to a different repository.
- After the merge, other Hubs will start peering with you after 1 hour.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->