### PR TITLE
fix: Log when network config is updated

### DIFF
--- a/.changeset/big-kangaroos-cross.md
+++ b/.changeset/big-kangaroos-cross.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Log when network config is updated

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -543,7 +543,7 @@ export class Hub implements HubInterface {
           throw new HubError("unavailable", "Quitting due to network config");
         }
 
-        log.info({}, "Network config applied");
+        log.info({ networkConfig }, "Network config applied");
       }
     }
     await this.engine.start();
@@ -648,6 +648,8 @@ export class Hub implements HubInterface {
 
       this.gossipNode.updateDeniedPeerIds(deniedPeerIds);
       this.deniedPeerIds = deniedPeerIds;
+
+      log.info({ allowedPeerIds, deniedPeerIds }, "Updated Network Config");
 
       return false;
     }


### PR DESCRIPTION


## Change Summary

- Log when network config is updated

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a logging issue in the Hubble application when the network configuration is updated. 

### Detailed summary
- Added logging when the network config is updated
- Updated the log message to include the network configuration details

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->