### PR TITLE
chore: Cut Hubble version v1.4.5 and update packages

### DIFF
--- a/.changeset/big-kangaroos-cross.md
+++ b/.changeset/big-kangaroos-cross.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Log when network config is updated

--- a/.changeset/proud-books-impress.md
+++ b/.changeset/proud-books-impress.md
@@ -1,6 +1,0 @@
----
-"@farcaster/core": patch
-"@farcaster/hubble": patch
----
-
-fix: Move rust code to apps/hubble, making core package PureJS

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hubble
 
+## 1.4.5
+
+### Patch Changes
+
+- 437545cc: fix: Log when network config is updated
+- 41334ab8: fix: Move rust code to apps/hubble, making core package PureJS
+  - @farcaster/hub-nodejs@0.10.3
+
 ## 1.4.4
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -57,7 +57,7 @@
     "@chainsafe/libp2p-gossipsub": "6.1.0",
     "@chainsafe/libp2p-noise": "^11.0.0 ",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.10.0",
+    "@farcaster/hub-nodejs": "^0.10.3",
     "@farcaster/rocksdb": "^5.5.0",
     "@grpc/grpc-js": "~1.8.21",
     "@libp2p/interface-connection": "^3.0.2",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/core
 
+## 0.12.3
+
+### Patch Changes
+
+- 41334ab8: fix: Move rust code to apps/hubble, making core package PureJS
+
 ## 0.12.2
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -11,7 +11,9 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "license": "MIT",
   "dependencies": {
     "@noble/curves": "^1.0.0",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/hub-nodejs
 
+## 0.10.3
+
+### Patch Changes
+
+- Updated dependencies [41334ab8]
+  - @farcaster/core@0.12.3
+
 ## 0.10.2
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@farcaster/core": "0.12.2",
+    "@farcaster/core": "0.12.3",
     "@grpc/grpc-js": "~1.8.21",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"


### PR DESCRIPTION
## Motivation

Hubble release to v1.4.5

## Change Summary

Move rust code to hubble, make other packages PureJS

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating dependencies and versions in multiple packages. 

### Detailed summary
- Updated dependencies in `@farcaster/core` to version `0.12.3`
- Updated dependencies in `@farcaster/hub-nodejs` to version `0.10.3`
- Moved rust code to `apps/hubble`, making `@farcaster/core` package PureJS
- Updated version of `@farcaster/core` to `0.12.3`
- Updated version of `@farcaster/hub-nodejs` to `0.10.3`
- Updated version of `@farcaster/hubble` to `1.4.5`
- Added logging when network config is updated in `apps/hubble`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->