### PR TITLE
chore: add "getting blockchain events" to hub status

### DIFF
--- a/.changeset/afraid-geckos-rescue.md
+++ b/.changeset/afraid-geckos-rescue.md
@@ -1,0 +1,7 @@
+---
+"@farcaster/hub-nodejs": patch
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+feat: Add "getting blockchain events" to hub status

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -578,6 +578,7 @@ app
       }
 
       let isSyncing = false;
+      const syncEngingStarted = syncResult.value.engineStarted;
       const msgPercents: number[] = [];
       for (const peerStatus of syncResult.value.syncStatus) {
         if (peerStatus.theirMessages === 0) {
@@ -589,8 +590,11 @@ app
           isSyncing = true;
         }
       }
+
       const numPeers = msgPercents.length;
-      if (numPeers === 0) {
+      if (!syncEngingStarted) {
+        logger.info("Sync Status: Getting blockchain events (Sync not started yet)");
+      } else if (numPeers === 0) {
         logger.info("Sync Status: No peers");
       } else {
         const avgMsgPercent = msgPercents.reduce((a, b) => a + b, 0) / numPeers;

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -149,6 +149,9 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
   private _messagesSinceLastCompaction = 0;
   private _isCompacting = false;
 
+  // Has the syncengine started yet?
+  private _started = false;
+
   constructor(
     hub: HubInterface,
     rocksDb: RocksDB,
@@ -208,6 +211,10 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     return this._syncMergeQ;
   }
 
+  public isStarted(): boolean {
+    return this._started;
+  }
+
   public async initialize(rebuildSyncTrie = false) {
     // Check if we need to rebuild sync trie
     if (rebuildSyncTrie) {
@@ -218,6 +225,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     }
     const rootHash = await this._trie.rootHash();
 
+    this._started = true;
     log.info({ rootHash }, "Sync engine initialized");
   }
 
@@ -253,6 +261,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
       log.error({ err: e }, "Interrupting sync timed out");
     }
 
+    this._started = false;
     this._currentSyncStatus.interruptSync = false;
   }
 

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -379,6 +379,7 @@ export default class Server {
           const response = SyncStatusResponse.create({
             isSyncing: false,
             syncStatus: [],
+            engineStarted: this.syncEngine.isStarted(),
           });
 
           for (const peerId of peersToCheck) {

--- a/packages/core/src/protobufs/generated/request_response.ts
+++ b/packages/core/src/protobufs/generated/request_response.ts
@@ -106,6 +106,7 @@ export interface SyncStatusRequest {
 export interface SyncStatusResponse {
   isSyncing: boolean;
   syncStatus: SyncStatus[];
+  engineStarted: boolean;
 }
 
 export interface SyncStatus {
@@ -216,10 +217,6 @@ export interface OnChainEventRequest {
 
 export interface OnChainEventResponse {
   events: OnChainEvent[];
-}
-
-export interface StorageAdminRegistryEventRequest {
-  transactionHash: Uint8Array;
 }
 
 export interface StorageLimitsResponse {
@@ -774,7 +771,7 @@ export const SyncStatusRequest = {
 };
 
 function createBaseSyncStatusResponse(): SyncStatusResponse {
-  return { isSyncing: false, syncStatus: [] };
+  return { isSyncing: false, syncStatus: [], engineStarted: false };
 }
 
 export const SyncStatusResponse = {
@@ -784,6 +781,9 @@ export const SyncStatusResponse = {
     }
     for (const v of message.syncStatus) {
       SyncStatus.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    if (message.engineStarted === true) {
+      writer.uint32(24).bool(message.engineStarted);
     }
     return writer;
   },
@@ -809,6 +809,13 @@ export const SyncStatusResponse = {
 
           message.syncStatus.push(SyncStatus.decode(reader, reader.uint32()));
           continue;
+        case 3:
+          if (tag != 24) {
+            break;
+          }
+
+          message.engineStarted = reader.bool();
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -822,6 +829,7 @@ export const SyncStatusResponse = {
     return {
       isSyncing: isSet(object.isSyncing) ? Boolean(object.isSyncing) : false,
       syncStatus: Array.isArray(object?.syncStatus) ? object.syncStatus.map((e: any) => SyncStatus.fromJSON(e)) : [],
+      engineStarted: isSet(object.engineStarted) ? Boolean(object.engineStarted) : false,
     };
   },
 
@@ -833,6 +841,7 @@ export const SyncStatusResponse = {
     } else {
       obj.syncStatus = [];
     }
+    message.engineStarted !== undefined && (obj.engineStarted = message.engineStarted);
     return obj;
   },
 
@@ -844,6 +853,7 @@ export const SyncStatusResponse = {
     const message = createBaseSyncStatusResponse();
     message.isSyncing = object.isSyncing ?? false;
     message.syncStatus = object.syncStatus?.map((e) => SyncStatus.fromPartial(e)) || [];
+    message.engineStarted = object.engineStarted ?? false;
     return message;
   },
 };
@@ -2453,71 +2463,6 @@ export const OnChainEventResponse = {
   fromPartial<I extends Exact<DeepPartial<OnChainEventResponse>, I>>(object: I): OnChainEventResponse {
     const message = createBaseOnChainEventResponse();
     message.events = object.events?.map((e) => OnChainEvent.fromPartial(e)) || [];
-    return message;
-  },
-};
-
-function createBaseStorageAdminRegistryEventRequest(): StorageAdminRegistryEventRequest {
-  return { transactionHash: new Uint8Array() };
-}
-
-export const StorageAdminRegistryEventRequest = {
-  encode(message: StorageAdminRegistryEventRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.transactionHash.length !== 0) {
-      writer.uint32(10).bytes(message.transactionHash);
-    }
-    return writer;
-  },
-
-  decode(input: _m0.Reader | Uint8Array, length?: number): StorageAdminRegistryEventRequest {
-    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
-    let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseStorageAdminRegistryEventRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1:
-          if (tag != 10) {
-            break;
-          }
-
-          message.transactionHash = reader.bytes();
-          continue;
-      }
-      if ((tag & 7) == 4 || tag == 0) {
-        break;
-      }
-      reader.skipType(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): StorageAdminRegistryEventRequest {
-    return {
-      transactionHash: isSet(object.transactionHash) ? bytesFromBase64(object.transactionHash) : new Uint8Array(),
-    };
-  },
-
-  toJSON(message: StorageAdminRegistryEventRequest): unknown {
-    const obj: any = {};
-    message.transactionHash !== undefined &&
-      (obj.transactionHash = base64FromBytes(
-        message.transactionHash !== undefined ? message.transactionHash : new Uint8Array(),
-      ));
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<StorageAdminRegistryEventRequest>, I>>(
-    base?: I,
-  ): StorageAdminRegistryEventRequest {
-    return StorageAdminRegistryEventRequest.fromPartial(base ?? {});
-  },
-
-  fromPartial<I extends Exact<DeepPartial<StorageAdminRegistryEventRequest>, I>>(
-    object: I,
-  ): StorageAdminRegistryEventRequest {
-    const message = createBaseStorageAdminRegistryEventRequest();
-    message.transactionHash = object.transactionHash ?? new Uint8Array();
     return message;
   },
 };

--- a/packages/hub-nodejs/src/generated/request_response.ts
+++ b/packages/hub-nodejs/src/generated/request_response.ts
@@ -106,6 +106,7 @@ export interface SyncStatusRequest {
 export interface SyncStatusResponse {
   isSyncing: boolean;
   syncStatus: SyncStatus[];
+  engineStarted: boolean;
 }
 
 export interface SyncStatus {
@@ -216,10 +217,6 @@ export interface OnChainEventRequest {
 
 export interface OnChainEventResponse {
   events: OnChainEvent[];
-}
-
-export interface StorageAdminRegistryEventRequest {
-  transactionHash: Uint8Array;
 }
 
 export interface StorageLimitsResponse {
@@ -774,7 +771,7 @@ export const SyncStatusRequest = {
 };
 
 function createBaseSyncStatusResponse(): SyncStatusResponse {
-  return { isSyncing: false, syncStatus: [] };
+  return { isSyncing: false, syncStatus: [], engineStarted: false };
 }
 
 export const SyncStatusResponse = {
@@ -784,6 +781,9 @@ export const SyncStatusResponse = {
     }
     for (const v of message.syncStatus) {
       SyncStatus.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    if (message.engineStarted === true) {
+      writer.uint32(24).bool(message.engineStarted);
     }
     return writer;
   },
@@ -809,6 +809,13 @@ export const SyncStatusResponse = {
 
           message.syncStatus.push(SyncStatus.decode(reader, reader.uint32()));
           continue;
+        case 3:
+          if (tag != 24) {
+            break;
+          }
+
+          message.engineStarted = reader.bool();
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -822,6 +829,7 @@ export const SyncStatusResponse = {
     return {
       isSyncing: isSet(object.isSyncing) ? Boolean(object.isSyncing) : false,
       syncStatus: Array.isArray(object?.syncStatus) ? object.syncStatus.map((e: any) => SyncStatus.fromJSON(e)) : [],
+      engineStarted: isSet(object.engineStarted) ? Boolean(object.engineStarted) : false,
     };
   },
 
@@ -833,6 +841,7 @@ export const SyncStatusResponse = {
     } else {
       obj.syncStatus = [];
     }
+    message.engineStarted !== undefined && (obj.engineStarted = message.engineStarted);
     return obj;
   },
 
@@ -844,6 +853,7 @@ export const SyncStatusResponse = {
     const message = createBaseSyncStatusResponse();
     message.isSyncing = object.isSyncing ?? false;
     message.syncStatus = object.syncStatus?.map((e) => SyncStatus.fromPartial(e)) || [];
+    message.engineStarted = object.engineStarted ?? false;
     return message;
   },
 };
@@ -2453,71 +2463,6 @@ export const OnChainEventResponse = {
   fromPartial<I extends Exact<DeepPartial<OnChainEventResponse>, I>>(object: I): OnChainEventResponse {
     const message = createBaseOnChainEventResponse();
     message.events = object.events?.map((e) => OnChainEvent.fromPartial(e)) || [];
-    return message;
-  },
-};
-
-function createBaseStorageAdminRegistryEventRequest(): StorageAdminRegistryEventRequest {
-  return { transactionHash: new Uint8Array() };
-}
-
-export const StorageAdminRegistryEventRequest = {
-  encode(message: StorageAdminRegistryEventRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.transactionHash.length !== 0) {
-      writer.uint32(10).bytes(message.transactionHash);
-    }
-    return writer;
-  },
-
-  decode(input: _m0.Reader | Uint8Array, length?: number): StorageAdminRegistryEventRequest {
-    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
-    let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseStorageAdminRegistryEventRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1:
-          if (tag != 10) {
-            break;
-          }
-
-          message.transactionHash = reader.bytes();
-          continue;
-      }
-      if ((tag & 7) == 4 || tag == 0) {
-        break;
-      }
-      reader.skipType(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): StorageAdminRegistryEventRequest {
-    return {
-      transactionHash: isSet(object.transactionHash) ? bytesFromBase64(object.transactionHash) : new Uint8Array(),
-    };
-  },
-
-  toJSON(message: StorageAdminRegistryEventRequest): unknown {
-    const obj: any = {};
-    message.transactionHash !== undefined &&
-      (obj.transactionHash = base64FromBytes(
-        message.transactionHash !== undefined ? message.transactionHash : new Uint8Array(),
-      ));
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<StorageAdminRegistryEventRequest>, I>>(
-    base?: I,
-  ): StorageAdminRegistryEventRequest {
-    return StorageAdminRegistryEventRequest.fromPartial(base ?? {});
-  },
-
-  fromPartial<I extends Exact<DeepPartial<StorageAdminRegistryEventRequest>, I>>(
-    object: I,
-  ): StorageAdminRegistryEventRequest {
-    const message = createBaseStorageAdminRegistryEventRequest();
-    message.transactionHash = object.transactionHash ?? new Uint8Array();
     return message;
   },
 };

--- a/protobufs/schemas/request_response.proto
+++ b/protobufs/schemas/request_response.proto
@@ -42,6 +42,7 @@ message SyncStatusRequest {
 message SyncStatusResponse {
   bool is_syncing = 1;
   repeated SyncStatus sync_status = 2;
+  bool engine_started = 3;
 }
 
 message SyncStatus {


### PR DESCRIPTION
## Motivation

When a hub has just stared, the status used to be reported as "no peers", which is misleading, since it is still getting the blockchain events. 

## Change Summary

- Add "getting blockchain events" if hub is still in startup mode.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a new field `engineStarted` to the `SyncStatusResponse` message in `request_response.proto`.
- Modified the `SyncEngine` class in `syncEngine.ts` to include a private `_started` property and a public `isStarted()` method.
- Updated the `cli.ts` file to use the `syncEngine.isStarted()` method and log the sync status accordingly.
- Updated the `server.ts` file to set the `engineStarted` field in the `SyncStatus` message using the `syncEngine.isStarted()` method.
- Updated the `generated/request_response.ts` file to include the `engineStarted` field in the `SyncStatusResponse` message.
- Removed the `StorageAdminRegistryEventRequest` message from the `generated/request_response.ts` file.
- Other minor changes and imports.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->