### PR TITLE
fix: Handle network errors when fetching config

### DIFF
--- a/.changeset/cool-eagles-reflect.md
+++ b/.changeset/cool-eagles-reflect.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Handle network failures when fetching config


### PR DESCRIPTION


## Change Summary

- Handle errors when network config fetch fails/returns invalid values

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)



<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Fixing a network failure issue when fetching config in the Hubble app.

### Detailed summary:
- Updated import statement for `Result` from `neverthrow` library.
- Added a timeout option when making the network request to fetch the config.
- Wrapped the creation of a `vm.Script` object and its execution in `Result.fromThrowable()` to handle any errors that may occur.
- Added error handling for parsing and running the network config script.
- Updated the way the network config object is accessed.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->