### PR TITLE
fix: last block bugs with events providers

### DIFF
--- a/.changeset/lucky-insects-work.md
+++ b/.changeset/lucky-insects-work.md
@@ -1,0 +1,7 @@
+---
+"@farcaster/hub-web": patch
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+fix: fetching l2 events was not respecting --l2-first-block

--- a/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
+++ b/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
@@ -146,7 +146,7 @@ describe("fnameRegistryEventsProvider", () => {
     });
 
     it("fetches events from where it left off", async () => {
-      await hub.putHubState({ lastFnameProof: transferEvents[0]?.id ?? 0, lastEthBlock: 0 });
+      await hub.putHubState({ lastFnameProof: transferEvents[0]?.id ?? 0, lastEthBlock: 0, lastL2Block: 0 });
       mockFnameRegistryClient.setMinimumSince(transferEvents[0]?.id ?? 0);
       await provider.start();
       expect(await getUserNameProof(db, utf8ToBytes("test2"))).toBeTruthy();

--- a/apps/hubble/src/eth/l2EventsProvider.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.ts
@@ -502,8 +502,8 @@ export class L2EventsProvider {
     let lastSyncedBlock = this._firstBlock;
 
     const hubState = await this._hub.getHubState();
-    if (hubState.isOk() && hubState.value.lastEthBlock) {
-      lastSyncedBlock = hubState.value.lastEthBlock;
+    if (hubState.isOk() && hubState.value.lastL2Block) {
+      lastSyncedBlock = hubState.value.lastL2Block;
     }
 
     if (this._resyncEvents) {
@@ -639,8 +639,13 @@ export class L2EventsProvider {
 
     // Update the last synced block if all the historical events have been synced
     if (this._isHistoricalSyncDone) {
-      const hubState = HubState.create({ lastEthBlock: blockNumber });
-      await this._hub.putHubState(hubState);
+      const hubState = await this._hub.getHubState();
+      if (hubState.isOk()) {
+        hubState.value.lastL2Block = blockNumber;
+        await this._hub.putHubState(hubState.value);
+      } else {
+        log.error({ errCode: hubState.error.errCode }, `failed to get hub state: ${hubState.error.message}`);
+      }
     }
 
     this._blockTimestampsCache.clear(); // Clear the cache periodically to avoid unbounded growth

--- a/apps/hubble/src/eth/l2EventsProvider.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.ts
@@ -33,9 +33,9 @@ export class OptimismConstants {
   public static StorageRegistryAddress = "0x000000fC0a4Fccee0b30E360773F7888D1bD9FAA" as const;
   public static KeyRegistryAddress = "0x000000fc6548800fc8265d8eb7061d88cefb87c2" as const;
   public static IdRegistryAddress = "0x000000fc99489b8cd629291d97dbca62b81173c4" as const;
-  public static FirstBlock = 12500000;
+  public static FirstBlock = 108222360; // ~Aug 14 2023 8pm UTC, approx 1.5 weeks before planned migration
   public static ChunkSize = 1000;
-  public static ChainId = 420; // OP Goerli
+  public static ChainId = 10; // OP mainnet
 }
 
 const RENT_EXPIRY_IN_SECONDS = 365 * 24 * 60 * 60; // One year

--- a/packages/core/src/protobufs/generated/hub_state.ts
+++ b/packages/core/src/protobufs/generated/hub_state.ts
@@ -5,10 +5,11 @@ import _m0 from "protobufjs/minimal";
 export interface HubState {
   lastEthBlock: number;
   lastFnameProof: number;
+  lastL2Block: number;
 }
 
 function createBaseHubState(): HubState {
-  return { lastEthBlock: 0, lastFnameProof: 0 };
+  return { lastEthBlock: 0, lastFnameProof: 0, lastL2Block: 0 };
 }
 
 export const HubState = {
@@ -18,6 +19,9 @@ export const HubState = {
     }
     if (message.lastFnameProof !== 0) {
       writer.uint32(16).uint64(message.lastFnameProof);
+    }
+    if (message.lastL2Block !== 0) {
+      writer.uint32(24).uint64(message.lastL2Block);
     }
     return writer;
   },
@@ -43,6 +47,13 @@ export const HubState = {
 
           message.lastFnameProof = longToNumber(reader.uint64() as Long);
           continue;
+        case 3:
+          if (tag != 24) {
+            break;
+          }
+
+          message.lastL2Block = longToNumber(reader.uint64() as Long);
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -56,6 +67,7 @@ export const HubState = {
     return {
       lastEthBlock: isSet(object.lastEthBlock) ? Number(object.lastEthBlock) : 0,
       lastFnameProof: isSet(object.lastFnameProof) ? Number(object.lastFnameProof) : 0,
+      lastL2Block: isSet(object.lastL2Block) ? Number(object.lastL2Block) : 0,
     };
   },
 
@@ -63,6 +75,7 @@ export const HubState = {
     const obj: any = {};
     message.lastEthBlock !== undefined && (obj.lastEthBlock = Math.round(message.lastEthBlock));
     message.lastFnameProof !== undefined && (obj.lastFnameProof = Math.round(message.lastFnameProof));
+    message.lastL2Block !== undefined && (obj.lastL2Block = Math.round(message.lastL2Block));
     return obj;
   },
 
@@ -74,6 +87,7 @@ export const HubState = {
     const message = createBaseHubState();
     message.lastEthBlock = object.lastEthBlock ?? 0;
     message.lastFnameProof = object.lastFnameProof ?? 0;
+    message.lastL2Block = object.lastL2Block ?? 0;
     return message;
   },
 };

--- a/packages/hub-web/src/generated/request_response.ts
+++ b/packages/hub-web/src/generated/request_response.ts
@@ -106,6 +106,7 @@ export interface SyncStatusRequest {
 export interface SyncStatusResponse {
   isSyncing: boolean;
   syncStatus: SyncStatus[];
+  engineStarted: boolean;
 }
 
 export interface SyncStatus {
@@ -770,7 +771,7 @@ export const SyncStatusRequest = {
 };
 
 function createBaseSyncStatusResponse(): SyncStatusResponse {
-  return { isSyncing: false, syncStatus: [] };
+  return { isSyncing: false, syncStatus: [], engineStarted: false };
 }
 
 export const SyncStatusResponse = {
@@ -780,6 +781,9 @@ export const SyncStatusResponse = {
     }
     for (const v of message.syncStatus) {
       SyncStatus.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    if (message.engineStarted === true) {
+      writer.uint32(24).bool(message.engineStarted);
     }
     return writer;
   },
@@ -805,6 +809,13 @@ export const SyncStatusResponse = {
 
           message.syncStatus.push(SyncStatus.decode(reader, reader.uint32()));
           continue;
+        case 3:
+          if (tag != 24) {
+            break;
+          }
+
+          message.engineStarted = reader.bool();
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -818,6 +829,7 @@ export const SyncStatusResponse = {
     return {
       isSyncing: isSet(object.isSyncing) ? Boolean(object.isSyncing) : false,
       syncStatus: Array.isArray(object?.syncStatus) ? object.syncStatus.map((e: any) => SyncStatus.fromJSON(e)) : [],
+      engineStarted: isSet(object.engineStarted) ? Boolean(object.engineStarted) : false,
     };
   },
 
@@ -829,6 +841,7 @@ export const SyncStatusResponse = {
     } else {
       obj.syncStatus = [];
     }
+    message.engineStarted !== undefined && (obj.engineStarted = message.engineStarted);
     return obj;
   },
 
@@ -840,6 +853,7 @@ export const SyncStatusResponse = {
     const message = createBaseSyncStatusResponse();
     message.isSyncing = object.isSyncing ?? false;
     message.syncStatus = object.syncStatus?.map((e) => SyncStatus.fromPartial(e)) || [];
+    message.engineStarted = object.engineStarted ?? false;
     return message;
   },
 };

--- a/protobufs/schemas/hub_state.proto
+++ b/protobufs/schemas/hub_state.proto
@@ -3,4 +3,5 @@ syntax = "proto3";
 message HubState {
   uint32 last_eth_block = 1;
   uint64 last_fname_proof = 2;
+  uint64 last_l2_block = 3;
 }


### PR DESCRIPTION
## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding support for tracking the last L2 block in the hub state. 

### Detailed summary
- Added `lastL2Block` field to the `HubState` protobuf message.
- Modified `L2EventsProvider` to use `lastL2Block` from `HubState` for syncing L2 events.
- Modified `L2EventsProvider` to update `lastL2Block` in `HubState` after syncing historical events.
- Updated `hub.putHubState()` in `fnameRegistryEventsProvider.test.ts` to include `lastL2Block`.
- Updated `l2EventsProvider.ts` to use new L2 contract addresses and chain ID.
- Updated `Hub` class to remove `UpdateNameRegistryEventExpiryJobQueue` and related code.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->