### PR TITLE
fix: Fix a bug where hubs would report status incorrectly.

### DIFF
--- a/.changeset/lovely-parents-remain.md
+++ b/.changeset/lovely-parents-remain.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Handle sync status reporting properly

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -592,7 +592,7 @@ app
       }
 
       const numPeers = msgPercents.length;
-      if (!syncEngingStarted) {
+      if (syncEngingStarted === false && numPeers === 0) {
         logger.info("Sync Status: Getting blockchain events (Sync not started yet)");
       } else if (numPeers === 0) {
         logger.info("Sync Status: No peers");


### PR DESCRIPTION


## Change Summary

- Add peer check before saying not syncing

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the handling of sync status reporting in the Hubble app. 

### Detailed summary
- Added a condition to check if the sync engine is not started and there are no peers before logging a message about sync status.
- Updated the log messages for sync status when there are no peers.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->