### PR TITLE
fix: Fix ens proof message sync

### DIFF
--- a/.changeset/tender-dingos-punch.md
+++ b/.changeset/tender-dingos-punch.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: user name proofs weren't syncd correctly because they were not added to the sync trie

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -15,6 +15,7 @@ import {
   FidRequest,
   TrieNodeMetadataResponse,
   bytesToHexString,
+  MergeUsernameProofHubEvent,
 } from "@farcaster/hub-nodejs";
 import { PeerId } from "@libp2p/interface-peer-id";
 import { err, ok, Result, ResultAsync } from "neverthrow";
@@ -200,6 +201,18 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
       this._syncTrieQ += 1;
       await this.removeMessage(event.revokeMessageBody.message);
       this._syncTrieQ -= 1;
+    });
+    this._hub.engine.eventHandler.on("mergeUsernameProofEvent", async (event: MergeUsernameProofHubEvent) => {
+      if (event.mergeUsernameProofBody.usernameProofMessage) {
+        this._syncTrieQ += 1;
+        await this.addMessage(event.mergeUsernameProofBody.usernameProofMessage);
+        this._syncTrieQ -= 1;
+      }
+      if (event.mergeUsernameProofBody.deletedUsernameProofMessage) {
+        this._syncTrieQ += 1;
+        await this.removeMessage(event.mergeUsernameProofBody.deletedUsernameProofMessage);
+        this._syncTrieQ -= 1;
+      }
     });
   }
 


### PR DESCRIPTION
## Motivation

ENS proof messages weren't being sync'd between hubs because they were not added to the trie (need to listen to a different event).

## Change Summary

Ensure ENS proofs are added/removed from the sync trie correctly.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added event handling for `MergeUsernameProofHubEvent` in `SyncEngine`
- Updated `trie` for username proof messages in `SyncEngine` test

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->