### PR TITLE
fix: Ensure valid messages during insert into sync trie

### DIFF
--- a/.changeset/sixty-trainers-battle.md
+++ b/.changeset/sixty-trainers-battle.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Make sure valid messages are inserted into Sync Trie

--- a/apps/hubble/src/network/sync/merkleTrie.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.ts
@@ -4,7 +4,7 @@ import { HubError, Message } from "@farcaster/hub-nodejs";
 import { SyncId } from "./syncId.js";
 import { TrieNode, TrieSnapshot } from "./trieNode.js";
 import RocksDB from "../../storage/db/rocksdb.js";
-import { FID_BYTES, RootPrefix, UserMessagePostfixMax } from "../../storage/db/types.js";
+import { FID_BYTES, HASH_LENGTH, RootPrefix, UserMessagePostfixMax } from "../../storage/db/types.js";
 import { logger } from "../../utils/logger.js";
 
 // The number of messages to process before unloading the trie from memory
@@ -107,7 +107,7 @@ class MerkleTrie {
             () => Message.decode(new Uint8Array(value as Buffer)),
             (e) => e as HubError,
           )();
-          if (message.isOk()) {
+          if (message.isOk() && message.value.hash.length === HASH_LENGTH) {
             await this.insert(new SyncId(message.value));
             count += 1;
             if (count % 10_000 === 0) {

--- a/apps/hubble/src/network/sync/trieNode.test.ts
+++ b/apps/hubble/src/network/sync/trieNode.test.ts
@@ -116,6 +116,11 @@ describe("TrieNode", () => {
       expect(secondChild[1].isLeaf).toBeTruthy();
       expect(Buffer.from(secondChild[1].value ?? [])).toEqual(id2.syncId());
     });
+
+    test("Inserting wrong keylength throws", async () => {
+      const root = new TrieNode();
+      await expect(root.insert(Buffer.from([1, 2, 3]), db, new Map(), 3)).rejects.toThrow("Key length exceeded");
+    });
   });
 
   describe("delete", () => {

--- a/apps/hubble/src/network/sync/trieNode.ts
+++ b/apps/hubble/src/network/sync/trieNode.ts
@@ -75,7 +75,7 @@ class TrieNode {
     current_index = 0,
   ): Promise<TrieNodeOpResult> {
     if (current_index >= key.length) {
-      throw "Key length exceeded";
+      throw new Error("Key length exceeded");
     }
     const char = key.at(current_index) as number;
 


### PR DESCRIPTION
## Change Summary

- When rebuilding sync trie, make sure to insert only valid messages

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an issue related to inserting valid messages into the Sync Trie. 

### Detailed summary
- Fixed an error where a string was being thrown instead of an Error object when the key length exceeded in `trieNode.ts`.
- Added a test case to ensure that inserting a wrong key length throws an error in `trieNode.test.ts`.
- Updated the import statement in `merkleTrie.ts` to include `HASH_LENGTH` from `types.js`.
- Added a condition to check the length of the message hash before inserting it in `merkleTrie.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->