### PR TITLE
feat (replicator): remove hubSubscriptions on migrate down, add utility functions

### DIFF
--- a/packages/hub-nodejs/examples/replicate-data-postgres/migrations/001_initial_migration.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/migrations/001_initial_migration.ts
@@ -205,4 +205,5 @@ export const down = async (db: Kysely<any>) => {
   await db.schema.dropTable("verifications").ifExists().execute();
   await db.schema.dropTable("userData").ifExists().execute();
   await db.schema.dropTable("messages").ifExists().execute();
+  await db.schema.dropTable("hubSubscriptions").ifExists().execute();
 };


### PR DESCRIPTION
## Motivation
For faster development cycles, it helps to have these additional utility functions around

## Change Summary
- drop the hubSubscriptions table on migrating down
- add utility functions to migrate down and migrate up by one h/t @davidfurlong 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding migration functionality to the `replicate-data-postgres` example in the `hub-nodejs` package.

### Detailed summary:
- Added `hubSubscriptions` table drop to the initial migration.
- Imported necessary dependencies for migration functionality.
- Added functions `migrateResetEntirely` and `migrateOneUp` for migration operations.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->