### PR TITLE
feat: Add statsd monitoring

### DIFF
--- a/.changeset/nice-bikes-notice.md
+++ b/.changeset/nice-bikes-notice.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: Add statsd monitoring for Hubble

--- a/apps/hubble/docker-compose.yml
+++ b/apps/hubble/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       "--eth-mainnet-rpc-url", "$ETH_MAINNET_RPC_URL",
       "--network", "${FC_NETWORK_ID:-1}",
       "-b", "${BOOTSTRAP_NODE:-/dns/nemes.farcaster.xyz/tcp/2282}",
+      "--statsd-metrics-server", 
+      "$STATSD_METRICS_SERVER"
     ]
     ports:
       - '2282:2282' # Gossip
@@ -25,12 +27,14 @@ services:
     volumes:
       - ./.hub:/home/node/app/apps/hubble/.hub
       - ./.rocks:/home/node/app/apps/hubble/.rocks
+    networks:
+      - my-network
     logging:
       driver: "json-file"
       options:
         max-size: "1g"
         max-file: "2"
-
+  
   # Start if you want to expose your hub over grpc-web (for browser clients)
   envoy:
     image: envoyproxy/envoy:v1.26.1
@@ -40,3 +44,32 @@ services:
       - '2285:2285'
     volumes:
       - ./envoy/envoy.yaml:/etc/envoy/envoy.yaml
+    networks:
+      - my-network
+
+  # Start this if you want perf metrics for your hubble node. Remember to start `grafana` as well.
+  statsd:
+    image: graphiteapp/graphite-statsd:1.1.10-5
+    restart: unless-stopped
+    ports:
+      # - '80:80' # Graphite web
+      # - '2003:2003' # Carbon line receiver
+      # - '2004:2004' # Carbon pickle receiver
+      # - '7002:7002' # Carbon cache query
+      - '8125:8125/udp' # StatsD
+      - '8126:8126' # StatsD admin
+    networks:
+      - my-network
+
+  # Start this if you want to see perf metrics for your hubble node. Remember to start `statsd` as well.
+  grafana:
+    image: grafana/grafana:10.0.3
+    restart: unless-stopped
+    ports:
+      - '3000:3000' # Grafana web
+    networks:
+      - my-network
+
+networks: 
+  my-network:
+ 

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -73,6 +73,7 @@
     "async-lock": "^1.4.0",
     "axios": "^1.4.0",
     "commander": "~10.0.0",
+    "hot-shots": "^10.0.0",
     "libp2p": "0.42.2",
     "neverthrow": "~6.0.0",
     "node-cron": "~3.0.2",

--- a/apps/hubble/src/defaultConfig.ts
+++ b/apps/hubble/src/defaultConfig.ts
@@ -57,6 +57,8 @@ export const Config = {
   adminServerEnabled: false,
   /** The admin server bind host */
   adminServerHost: "127.0.0.1",
+  /** StatsD server */
+  // statsdMetricsServer: "127.0.0.1:8125",
   /** A list of addresses the node directly peers with, provided in MultiAddr format */
   directPeers: [],
 };

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1084,7 +1084,8 @@ export class Hub implements HubInterface {
         }
       },
       (e) => {
-        logMessage.warn({ errCode: e.errCode }, `submitMessage error: ${e.message}`);
+        logMessage.warn({ errCode: e.errCode, source }, `submitMessage error: ${e.message}`);
+        statsd().increment(`submit_message.error.${source}.${e.errCode}`);
       },
     );
 

--- a/apps/hubble/src/network/sync/merkleTrie.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.ts
@@ -6,6 +6,7 @@ import { TrieNode, TrieSnapshot } from "./trieNode.js";
 import RocksDB from "../../storage/db/rocksdb.js";
 import { FID_BYTES, HASH_LENGTH, RootPrefix, UserMessagePostfixMax } from "../../storage/db/types.js";
 import { logger } from "../../utils/logger.js";
+import { statsd } from "../../utils/statsd.js";
 
 // The number of messages to process before unloading the trie from memory
 // Approx 25k * 10 nodes * 65 bytes per node = approx 16MB of cached data
@@ -126,6 +127,8 @@ class MerkleTrie {
       this._lock.writeLock(async (release) => {
         try {
           const { status, dbUpdatesMap } = await this._root.insert(id.syncId(), this._db, new Map());
+          statsd().gauge("merkle_trie.num_messages", this._root.items);
+
           this._updatePendingDbUpdates(dbUpdatesMap);
 
           // Write the transaction to the DB

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -58,6 +58,7 @@ import {
 } from "./bufferedStreamWriter.js";
 import { sleep } from "../utils/crypto.js";
 import { SUBMIT_MESSAGE_RATE_LIMIT, rateLimitByIp } from "../utils/rateLimits.js";
+import { statsd } from "../utils/statsd.js";
 
 const HUBEVENTS_READER_TIMEOUT = 1 * 60 * 60 * 1000; // 1 hour
 
@@ -498,6 +499,7 @@ export default class Server {
         // If someone is asking for our sync snapshot, that means we're getting incoming
         // connections
         this.incomingConnections += 1;
+        statsd().increment("rpc.get_sync_snapshot");
 
         const request = call.request;
 

--- a/apps/hubble/src/storage/db/rocksdb.ts
+++ b/apps/hubble/src/storage/db/rocksdb.ts
@@ -3,6 +3,7 @@ import { AbstractBatch, AbstractChainedBatch, AbstractIterator } from "abstract-
 import { mkdir } from "fs";
 import AbstractRocksDB from "@farcaster/rocksdb";
 import { logger } from "../../utils/logger.js";
+import { statsd } from "../../utils/statsd.js";
 
 export const DB_DIRECTORY = ".rocks";
 export const MAX_DB_ITERATOR_OPEN_MILLISECONDS = 60 * 1000; // 1 min
@@ -407,6 +408,14 @@ class RocksDB {
       // Compact all keys
       this._db.compactRange(Buffer.from([0]), Buffer.from([255]), (e?: Error) => {
         e ? reject(parseError(e)) : resolve(undefined);
+      });
+    });
+  }
+
+  async approximateSize(): Promise<number> {
+    return new Promise((resolve) => {
+      this._db.approximateSize(Buffer.from([0]), Buffer.from([255]), (e?: Error, size?: number) => {
+        resolve(size || -1);
       });
     });
   }

--- a/apps/hubble/src/utils/p2p.ts
+++ b/apps/hubble/src/utils/p2p.ts
@@ -34,6 +34,25 @@ export const extractIPAddress = (peerAddress: string): string | undefined => {
   }
 };
 
+export const hostPortFromString = (peerAddress: string): HubResult<NodeAddress> => {
+  const host = peerAddress.split(":")[0] || "";
+  const port = parseInt(peerAddress.split(":")[1] || "0", 10);
+
+  if (isNaN(port) || port === 0) {
+    return err(new HubError("bad_request", "invalid port"));
+  }
+
+  if (host === "") {
+    return err(new HubError("bad_request", "invalid host"));
+  }
+
+  return ok({
+    address: host,
+    port,
+    family: 4,
+  });
+};
+
 /** Checks that the IP address to bind to is valid and that the combined IP, transport, and port multiaddr is valid  */
 export const checkNodeAddrs = (listenIPAddr: string, listenCombinedAddr: string): HubResult<void> => {
   return Result.combine([checkIpAddr(listenIPAddr), checkCombinedAddr(listenCombinedAddr)]).map(() => undefined);

--- a/apps/hubble/src/utils/statsd.ts
+++ b/apps/hubble/src/utils/statsd.ts
@@ -1,0 +1,25 @@
+import { StatsD } from "hot-shots";
+
+// Unless configured, we don't want to send metrics to a StatsD server.
+const doNothingStatsd = {
+  increment: () => {},
+  decrement: () => {},
+  timing: () => {},
+  gauge: () => {},
+  histogram: () => {},
+  set: () => {},
+  unique: () => {},
+  close: () => {},
+  childClient: () => doNothingStatsd,
+} as unknown as StatsD;
+
+let statsdObject = doNothingStatsd;
+
+export function statsd(): StatsD {
+  return statsdObject;
+}
+
+// Configure the StatsD client to send metrics to the given host and port.
+export function initializeStatsd(host: string, port: number) {
+  statsdObject = new StatsD({ host, port, prefix: "hubble." });
+}

--- a/apps/hubble/www/docs/intro/install.md
+++ b/apps/hubble/www/docs/intro/install.md
@@ -80,21 +80,21 @@ docker compose exec hubble
 You can monitor your Hub by setting up grafana to monitor real time stats
 
 1. Start grafana and statsd
-```
+```bash
 docker compose up statsd grafana
 ```
 
 2. Enable monitoring on your Hub by setting this in your `.env`
-```
+```bash
 STATSD_METRICS_SERVER=statsd:8125
 ```
 
 If you are running hubble from source, you can pass this in as a command line argument
-```
+```bash
 yarn start --statsd-metrics-server 127.0.0.1:8125
 ```
 
-3. Open Grafana in a browser at `127.0.0.1:3000`. The default username/password is `admin` and `admin`. You will need to change your password on first login
+3. Open Grafana in a browser at `127.0.0.1:3000`. The default username/password is `admin`/`admin`. You will need to change your password on first login
 
 4. Go to `Settings -> Datasource -> Add new data source` and select `Graphite`. Set the URL to `http://statsd:80` and click `Save & Test` to make sure it is working
 

--- a/apps/hubble/www/docs/intro/install.md
+++ b/apps/hubble/www/docs/intro/install.md
@@ -76,6 +76,31 @@ Open up a shell inside the hubble container by running:
 docker compose exec hubble
 ```
 
+## Monitoring Hubble
+You can monitor your Hub by setting up grafana to monitor real time stats
+
+1. Start grafana and statsd
+```
+docker compose up statsd grafana
+```
+
+2. Enable monitoring on your Hub by setting this in your `.env`
+```
+STATSD_METRICS_SERVER=statsd:8125
+```
+
+If you are running hubble from source, you can pass this in as a command line argument
+```
+yarn start --statsd-metrics-server 127.0.0.1:8125
+```
+
+3. Open Grafana in a browser at `127.0.0.1:3000`. The default username/password is `admin` and `admin`. You will need to change your password on first login
+
+4. Go to `Settings -> Datasource -> Add new data source` and select `Graphite`. Set the URL to `http://statsd:80` and click `Save & Test` to make sure it is working
+
+5. Go to `Settings -> Dashboard -> Add New -> Import`, and in the `Import from Panel JSON`, paste the contents of the [Default Grafana Dashboard](https://github.com/farcasterxyz/hub-monorepo/blob/main/scripts/grafana-dashboard.json)
+
+
 ## Troubleshooting
 
 - If upgrading from a non-docker deployment, make sure `.hub` and `.rocks` directories are writable for all users.

--- a/scripts/grafana-dashboard.json
+++ b/scripts/grafana-dashboard.json
@@ -1,0 +1,1037 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 3,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "graphite",
+        "uid": "a3a06a7c-5aff-4ec4-b18d-f6edd5713883"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": 3600000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "graphite",
+            "uid": "a3a06a7c-5aff-4ec4-b18d-f6edd5713883"
+          },
+          "refCount": 0,
+          "refId": "A",
+          "target": "stats.timers.hubble.hub.merge_message.mean"
+        }
+      ],
+      "title": "Merge Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "graphite",
+        "uid": "a3a06a7c-5aff-4ec4-b18d-f6edd5713883"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": -1,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "stepBefore",
+            "lineWidth": 4,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "dtdurationms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refCount": 0,
+          "refId": "A",
+          "target": "stats.timers.hubble.syncengine.sync_time_ms.mean"
+        }
+      ],
+      "title": "Sync Engine Sync time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "graphite",
+        "uid": "a3a06a7c-5aff-4ec4-b18d-f6edd5713883"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "stats.gauges.hubble.rocksdb.approximate_size"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "decbytes"
+              },
+              {
+                "id": "displayName",
+                "value": "RocksDB Size on disk"
+              },
+              {
+                "id": "custom.spanNulls",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "stats.gauges.hubble.merkle_trie.num_messages"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Num Messages"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refCount": 0,
+          "refId": "A",
+          "target": "stats.gauges.hubble.merkle_trie.num_messages"
+        },
+        {
+          "hide": false,
+          "refCount": 0,
+          "refId": "B",
+          "target": "stats.gauges.hubble.rocksdb.approximate_size"
+        }
+      ],
+      "title": "Node Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "graphite",
+        "uid": "a3a06a7c-5aff-4ec4-b18d-f6edd5713883"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 3,
+        "x": 12,
+        "y": 8
+      },
+      "id": 10,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "10.0.3",
+      "targets": [
+        {
+          "refId": "A",
+          "target": "sum(stats.gauges.hubble.gossip.peers.*)",
+          "textEditor": false
+        }
+      ],
+      "title": "Num Peers",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "graphite",
+        "uid": "a3a06a7c-5aff-4ec4-b18d-f6edd5713883"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 3,
+        "x": 15,
+        "y": 8
+      },
+      "id": 11,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "10.0.3",
+      "targets": [
+        {
+          "refId": "A",
+          "target": "stats.gauges.hubble.gossip.denied_peers",
+          "textEditor": true
+        }
+      ],
+      "title": "Blocked Peers",
+      "type": "gauge"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 3,
+        "x": 18,
+        "y": 8
+      },
+      "id": 8,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "10.0.3",
+      "targets": [
+        {
+          "refId": "A",
+          "target": "stats.gauges.hubble.merkle_trie.merge_q",
+          "textEditor": true
+        }
+      ],
+      "title": "Merkle Trie Queue Size",
+      "type": "gauge"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 3,
+        "x": 21,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "10.0.3",
+      "targets": [
+        {
+          "refId": "A",
+          "target": "stats.gauges.hubble.syncengine.merge_q"
+        }
+      ],
+      "title": "Merge Queue Size",
+      "type": "gauge"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 16
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refCount": 0,
+          "refId": "A",
+          "target": "stats.gauges.hubble.gossip.peers.inbound"
+        },
+        {
+          "hide": false,
+          "refCount": 0,
+          "refId": "B",
+          "target": "stats.gauges.hubble.gossip.peers.outbound"
+        }
+      ],
+      "title": "Gossip Peers",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 16
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "target": "stats_counts.hubble.gossip.messages",
+          "textEditor": true
+        }
+      ],
+      "title": "Gossip Messages",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "index": 0,
+                  "text": "No Incoming Connection. Gossip port not open?"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 16,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": false,
+        "text": {}
+      },
+      "pluginVersion": "10.0.3",
+      "targets": [
+        {
+          "refId": "A",
+          "target": "stats.gauges.hubble.gossip.peers.inbound"
+        }
+      ],
+      "title": "Inbound Peers",
+      "type": "gauge"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "index": 0,
+                  "text": "No Incoming Connections! Are your ports open?"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "noValue": "No Incoming Connections! Are your ports open?",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 20,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "10.0.3",
+      "targets": [
+        {
+          "refId": "A",
+          "target": "stats_counts.hubble.rpc.get_sync_snapshot"
+        }
+      ],
+      "title": "Inbound Sync",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "graphite",
+        "uid": "a3a06a7c-5aff-4ec4-b18d-f6edd5713883"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "graphite",
+            "uid": "a3a06a7c-5aff-4ec4-b18d-f6edd5713883"
+          },
+          "refCount": 0,
+          "refId": "A",
+          "target": "stats_counts.hubble.hub.submit_message.error.source.*",
+          "textEditor": false
+        }
+      ],
+      "title": "Merge Errors By Source",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "graphite",
+        "uid": "a3a06a7c-5aff-4ec4-b18d-f6edd5713883"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "graphite",
+            "uid": "a3a06a7c-5aff-4ec4-b18d-f6edd5713883"
+          },
+          "refCount": 0,
+          "refId": "A",
+          "target": "stats_counts.hubble.hub.submit_message.error.code.*.*",
+          "textEditor": false
+        }
+      ],
+      "title": "Merge Errors By ErrorCode",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Hubble Dashboard",
+  "uid": "af04c037-bd8f-484a-b93e-0cb4b7d3b026",
+  "version": 1,
+  "weekStart": ""
+}

--- a/scripts/grafana-dashboard.json
+++ b/scripts/grafana-dashboard.json
@@ -23,10 +23,20 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "graphite",
-        "uid": "a3a06a7c-5aff-4ec4-b18d-f6edd5713883"
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
       },
+      "id": 14,
+      "panels": [],
+      "title": "Hub",
+      "type": "row"
+    },
+    {
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -84,7 +94,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 0
+        "y": 1
       },
       "id": 9,
       "options": {
@@ -101,10 +111,7 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "graphite",
-            "uid": "a3a06a7c-5aff-4ec4-b18d-f6edd5713883"
-          },
+          "datasource": null,
           "refCount": 0,
           "refId": "A",
           "target": "stats.timers.hubble.hub.merge_message.mean"
@@ -114,10 +121,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "graphite",
-        "uid": "a3a06a7c-5aff-4ec4-b18d-f6edd5713883"
-      },
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -175,7 +179,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 0
+        "y": 1
       },
       "id": 3,
       "options": {
@@ -201,10 +205,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "graphite",
-        "uid": "a3a06a7c-5aff-4ec4-b18d-f6edd5713883"
-      },
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -299,7 +300,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 8
+        "y": 9
       },
       "id": 4,
       "options": {
@@ -331,10 +332,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "graphite",
-        "uid": "a3a06a7c-5aff-4ec4-b18d-f6edd5713883"
-      },
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -361,7 +359,7 @@
         "h": 8,
         "w": 3,
         "x": 12,
-        "y": 8
+        "y": 9
       },
       "id": 10,
       "options": {
@@ -386,10 +384,7 @@
       "type": "gauge"
     },
     {
-      "datasource": {
-        "type": "graphite",
-        "uid": "a3a06a7c-5aff-4ec4-b18d-f6edd5713883"
-      },
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -417,7 +412,7 @@
         "h": 8,
         "w": 3,
         "x": 15,
-        "y": 8
+        "y": 9
       },
       "id": 11,
       "options": {
@@ -468,7 +463,7 @@
         "h": 8,
         "w": 3,
         "x": 18,
-        "y": 8
+        "y": 9
       },
       "id": 8,
       "options": {
@@ -519,7 +514,7 @@
         "h": 8,
         "w": 3,
         "x": 21,
-        "y": 8
+        "y": 9
       },
       "id": 5,
       "options": {
@@ -599,7 +594,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 16
+        "y": 17
       },
       "id": 2,
       "options": {
@@ -687,7 +682,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 16
+        "y": 17
       },
       "id": 1,
       "options": {
@@ -749,7 +744,7 @@
         "h": 8,
         "w": 4,
         "x": 16,
-        "y": 16
+        "y": 17
       },
       "id": 6,
       "options": {
@@ -811,7 +806,7 @@
         "h": 8,
         "w": 4,
         "x": 20,
-        "y": 16
+        "y": 17
       },
       "id": 7,
       "options": {
@@ -835,10 +830,20 @@
       "type": "gauge"
     },
     {
-      "datasource": {
-        "type": "graphite",
-        "uid": "a3a06a7c-5aff-4ec4-b18d-f6edd5713883"
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
       },
+      "id": 15,
+      "panels": [],
+      "title": "Errors",
+      "type": "row"
+    },
+    {
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -895,9 +900,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 24
+        "y": 26
       },
-      "id": 12,
+      "id": 16,
       "options": {
         "legend": {
           "calcs": [],
@@ -912,24 +917,16 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "graphite",
-            "uid": "a3a06a7c-5aff-4ec4-b18d-f6edd5713883"
-          },
-          "refCount": 0,
+          "datasource": null,
           "refId": "A",
-          "target": "stats_counts.hubble.hub.submit_message.error.source.*",
-          "textEditor": false
+          "target": "sumSeriesWithWildcards(stats_counts.hubble.submit_message.error.*.*.*, 5,6)"
         }
       ],
-      "title": "Merge Errors By Source",
+      "title": "Errors by Source",
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "graphite",
-        "uid": "a3a06a7c-5aff-4ec4-b18d-f6edd5713883"
-      },
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -986,9 +983,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 24
+        "y": 26
       },
-      "id": 13,
+      "id": 17,
       "options": {
         "legend": {
           "calcs": [],
@@ -1003,17 +1000,13 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "graphite",
-            "uid": "a3a06a7c-5aff-4ec4-b18d-f6edd5713883"
-          },
-          "refCount": 0,
+          "datasource": null,
           "refId": "A",
-          "target": "stats_counts.hubble.hub.submit_message.error.code.*.*",
-          "textEditor": false
+          "target": "sumSeriesWithWildcards(stats_counts.hubble.submit_message.error.*.*.*, 4,5)",
+          "textEditor": true
         }
       ],
-      "title": "Merge Errors By ErrorCode",
+      "title": "Errors by Type",
       "type": "timeseries"
     }
   ],
@@ -1025,13 +1018,13 @@
     "list": []
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Hubble Dashboard",
   "uid": "af04c037-bd8f-484a-b93e-0cb4b7d3b026",
-  "version": 1,
+  "version": 3,
   "weekStart": ""
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3195,6 +3195,13 @@ binary-extensions@^2.0.0:
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
+bindings@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
 bn.js@^4.11.9:
   version "4.12.0"
   resolved "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
@@ -4582,6 +4589,11 @@ file-type@^17.1.6:
     strtok3 "^7.0.0-alpha.9"
     token-types "^5.0.0-alpha.2"
 
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
 filename-reserved-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz#3d5dd6d4e2d73a3fed2ebc4cd0b3448869a081f7"
@@ -5076,6 +5088,13 @@ hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
+
+hot-shots@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.npmjs.org/hot-shots/-/hot-shots-10.0.0.tgz#d360f9dd252da78297aca1cb08fd84a8936739c2"
+  integrity sha512-uy/uGpuJk7yuyiKRfZMBNkF1GAOX5O2ifO9rDCaX9jw8fu6eW9QeWC7WRPDI+O98frW1HQgV3+xwjWsZPECIzQ==
+  optionalDependencies:
+    unix-dgram "2.x"
 
 html-escaper@^2.0.0:
   version "2.0.2"
@@ -6727,6 +6746,11 @@ mz@^2.7.0:
     any-promise "^1.0.0"
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
+
+nan@^2.16.0:
+  version "2.17.0"
+  resolved "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz#c0150a2368a182f033e9aa5195ec76ea41a199cb"
+  integrity sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==
 
 nanoid@^4.0.0:
   version "4.0.1"
@@ -8627,6 +8651,14 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+unix-dgram@2.x:
+  version "2.0.6"
+  resolved "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.6.tgz#6d567b0eb6d7a9504e561532b598a46e34c5968b"
+  integrity sha512-AURroAsb73BZ6CdAyMrTk/hYKNj3DuYYEuOaB8bYMOHGKupRNScw90Q5C71tWJc3uE7dIeXRyuwN0xLLq3vDTg==
+  dependencies:
+    bindings "^1.5.0"
+    nan "^2.16.0"
 
 update-browserslist-db@^1.0.10:
   version "1.0.10"


### PR DESCRIPTION
## Motivation

We need a way to get real-time metrics from the hubs (Like mergeMessage latency, number of peers connected etc...)

## Change Summary

- Add statsd monitoring (off by default)
- grafana/statsd docker config to do local monitoring

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

### Grafana Dashboard looks like this:
![image](https://github.com/farcasterxyz/hub-monorepo/assets/31996805/2c3f1441-7091-4e59-a50c-e2c87655b4d0)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding statsd monitoring for Hubble. 

### Detailed summary
- Added `hot-shots` package for statsd monitoring
- Updated various files to include statsd metrics
- Updated documentation to include instructions for setting up monitoring with Grafana

> The following files were skipped due to too many changes: `apps/hubble/src/cli.ts`, `yarn.lock`, `apps/hubble/src/network/sync/syncEngine.ts`, `scripts/grafana-dashboard.json`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->