### PR TITLE
fix: Db Migration for Username proof messages

### DIFF
--- a/.changeset/loud-phones-hang.md
+++ b/.changeset/loud-phones-hang.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: DB Migration for UserNameProof index messages

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -79,6 +79,7 @@ import { AddrInfo } from "@chainsafe/libp2p-gossipsub/types";
 import { CheckIncomingPortsJobScheduler } from "./storage/jobs/checkIncomingPortsJob.js";
 import { NetworkConfig, applyNetworkConfig, fetchNetworkConfig } from "./network/utils/networkConfig.js";
 import { UpdateNetworkConfigJobScheduler } from "./storage/jobs/updateNetworkConfigJob.js";
+import { LATEST_DB_SCHEMA_VERSION, performDbMigrations } from "./storage/db/migrations/migrations.js";
 
 export type HubSubmitSource = "gossip" | "rpc" | "eth-provider" | "l2-provider" | "sync" | "fname-registry";
 
@@ -515,6 +516,26 @@ export class Hub implements HubInterface {
           "Hub was NOT shutdown cleanly. Sync might re-fetch messages. Please re-run with --rebuild-sync-trie to rebuild the trie if needed.",
         );
       }
+    }
+
+    // Get the DB Schema version
+    const dbSchemaVersion = await this.getDbSchemaVersion();
+    if (dbSchemaVersion > LATEST_DB_SCHEMA_VERSION) {
+      throw new HubError(
+        "unavailable.storage_failure",
+        `DB schema version is unknown. Do you have the right version of Hubble? DB schema version: ${dbSchemaVersion}, latest supported version: ${LATEST_DB_SCHEMA_VERSION}`,
+      );
+    }
+    if (dbSchemaVersion < LATEST_DB_SCHEMA_VERSION) {
+      // We need a migration
+      log.info({ dbSchemaVersion, latestDbSchemaVersion: LATEST_DB_SCHEMA_VERSION }, "DB needs migrations");
+      const success = await performDbMigrations(this.rocksDB, dbSchemaVersion);
+      if (success) {
+        log.info({}, "All DB migrations successful");
+        await this.setDbSchemaVersion(LATEST_DB_SCHEMA_VERSION);
+      }
+    } else {
+      log.info({ dbSchemaVersion, latestDbSchemaVersion: LATEST_DB_SCHEMA_VERSION }, "DB schema is up-to-date");
     }
 
     // Get the Network ID from the DB
@@ -1194,6 +1215,33 @@ export class Hub implements HubInterface {
 
     // get the enum value from the number
     return networkNumber.map((n) => n as FarcasterNetwork);
+  }
+
+  async getDbSchemaVersion(): Promise<number> {
+    const dbResult = await ResultAsync.fromPromise(
+      this.rocksDB.get(Buffer.from([RootPrefix.DBSchemaVersion])),
+      (e) => e as HubError,
+    );
+    if (dbResult.isErr()) {
+      return 0;
+    }
+
+    // parse the buffer as an int
+    const schemaVersion = Result.fromThrowable(
+      () => dbResult.value.readUInt32BE(0),
+      (e) => e as HubError,
+    )();
+
+    return schemaVersion.unwrapOr(0);
+  }
+
+  async setDbSchemaVersion(version: number): HubAsyncResult<void> {
+    const txn = this.rocksDB.transaction();
+    const value = Buffer.alloc(4);
+    value.writeUInt32BE(version, 0);
+    txn.put(Buffer.from([RootPrefix.DBSchemaVersion]), value);
+
+    return ResultAsync.fromPromise(this.rocksDB.commit(txn), (e) => e as HubError);
   }
 
   async setDbNetwork(network: FarcasterNetwork): HubAsyncResult<void> {

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -533,6 +533,8 @@ export class Hub implements HubInterface {
       if (success) {
         log.info({}, "All DB migrations successful");
         await this.setDbSchemaVersion(LATEST_DB_SCHEMA_VERSION);
+      } else {
+        throw new HubError("unavailable.storage_failure", "DB migrations failed");
       }
     } else {
       log.info({ dbSchemaVersion, latestDbSchemaVersion: LATEST_DB_SCHEMA_VERSION }, "DB schema is up-to-date");

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -848,11 +848,11 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     this._messagesSinceLastCompaction += messagesLength;
     if (this.shouldCompactDb && !this._isCompacting) {
       this._isCompacting = true;
-      logger.info("Starting DB compaction");
+      log.info("Starting DB compaction");
 
       await this._db.compact().catch((e) => log.warn(e, `Error compacting DB: ${e.message}`));
 
-      logger.info("Completed DB compaction");
+      log.info("Completed DB compaction");
       this._messagesSinceLastCompaction = 0;
       this._isCompacting = false;
       return true;
@@ -960,7 +960,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     // Get the ethereum block number from the custody event
     const custodyEventBlockNumber = custodyEventResult.value.blockNumber;
 
-    logger.info({ fid }, `Retrying events from block ${custodyEventBlockNumber}`);
+    log.info({ fid }, `Retrying events from block ${custodyEventBlockNumber}`);
     // We'll retry all events from this block number
     await this._ethEventsProvider?.retryEventsFromBlock(custodyEventBlockNumber);
   }

--- a/apps/hubble/src/storage/db/migrations/1.usernameproof.test.ts
+++ b/apps/hubble/src/storage/db/migrations/1.usernameproof.test.ts
@@ -1,0 +1,51 @@
+import { faker } from "@faker-js/faker";
+import RocksDB from "../rocksdb.js";
+import { RootPrefix, UserPostfix } from "../types.js";
+import { performDbMigrations } from "./migrations.js";
+
+const dbName = "usernameproof.migration.test.db";
+
+describe("usernameproof migration", () => {
+  let db: RocksDB;
+
+  beforeAll(async () => {
+    db = new RocksDB(dbName);
+    await db.open();
+  });
+
+  afterAll(async () => {
+    await db.close();
+    await db.destroy();
+  });
+
+  test("should migrate usernameproof index", async () => {
+    // Write a key with the old postfix
+    const key = Buffer.concat([
+      Buffer.from([RootPrefix.User]),
+      Buffer.from([0, 0, 0, 10]), // FID
+      Buffer.from([UserPostfix.UsernameProofMessage]), // Postfix = 7
+      Buffer.from([10, 20, 30, 40, 50]),
+    ]);
+    // Create a 24-byte value
+    const value = Buffer.from(faker.random.alphaNumeric(24));
+
+    await db.put(key, value);
+
+    const success = await performDbMigrations(db, 0, 1); // Perform migration from 0 to 1
+    expect(success).toBe(true);
+
+    // Read the key with the new postfix
+    const expectedNewKey = Buffer.concat([
+      Buffer.from([RootPrefix.User]),
+      Buffer.from([0, 0, 0, 10]), // FID
+      Buffer.from([UserPostfix.UserNameProofAdds]), // Postfix = 99
+      Buffer.from([10, 20, 30, 40, 50]),
+    ]);
+
+    const newValue = await db.get(expectedNewKey);
+    expect(newValue).toEqual(value);
+
+    // Make sure the old key is gone. This should throw
+    await expect(db.get(key)).rejects.toThrow("NotFound");
+  });
+});

--- a/apps/hubble/src/storage/db/migrations/1.usernameproof.ts
+++ b/apps/hubble/src/storage/db/migrations/1.usernameproof.ts
@@ -1,0 +1,76 @@
+/**
+ * The UserNameProofStore had accidentally overloaded the `UserNameProofMessage` postfix. It was being
+ * used for storing both the `UserNameProofMessage` protobuf and the `UserNameProofMessageAdd` index messages.
+ *
+ * This migration moves the index postfix to `UserNameProofMessageAdd` and replaces the postfix for
+ * the index messages
+ */
+
+import { logger } from "../../../utils/logger.js";
+import RocksDB from "../rocksdb.js";
+import { FID_BYTES, RootPrefix, UserPostfix } from "../types.js";
+
+const log = logger.child({ component: "UsernameProofIndexMigration" });
+
+export async function usernameProofIndexMigration(db: RocksDB): Promise<boolean> {
+  // To do this migration, we'll go over all RootPrefix.User messages,
+  // looking for a postfix of UserNameProofMessage. If we find one, we'll
+  // check if the value is a 24-byte index (a TS Hash). If it is, we'll add new DB entry with
+  // postfix `UserNameProofMessageAdd` and delete the original entry
+
+  log.info({}, "Starting username proof index migration");
+  let count = 0;
+  const start = Date.now();
+
+  await db.forEachIteratorByPrefix(
+    Buffer.from([RootPrefix.User]),
+    async (key, value) => {
+      if (!key || !value) {
+        return;
+      }
+
+      const postfix = key.readUint8(1 + FID_BYTES);
+      if (postfix === UserPostfix.UsernameProofMessage) {
+        // Check if the value is an index
+        if (value.length === 24) {
+          // Replace the (1 + FID_BYTES) postfix with `UserPostfix.UserNameProofAdds`
+          const newKey = Buffer.concat([
+            key.subarray(0, 1 + FID_BYTES),
+            Buffer.from([UserPostfix.UserNameProofAdds]),
+            key.subarray(1 + FID_BYTES + 1),
+          ]);
+
+          // // Sanity check the key length
+          // if (newKey.length !== key.length) {
+          //   log.error({ key, newKey }, "New key length does not match old key length");
+          // }
+
+          // // Compare the key bytes, make sure only the 6th byte changed
+          // for (let i = 0; i < key.length; i++) {
+          //   if (i === 1 + FID_BYTES) {
+          //     if (newKey[i] !== UserPostfix.UserNameProofAdds) {
+          //       log.error({ key, newKey }, "New key does not have the correct postfix");
+          //     }
+          //   } else {
+          //     if (newKey[i] !== key[i]) {
+          //       log.error({ key, newKey }, "New key does not match old key");
+          //     }
+          //   }
+          // }
+
+          const txn = db.transaction();
+          txn.put(newKey, value);
+          txn.del(key);
+          await db.commit(txn);
+
+          count += 1;
+        }
+      }
+    },
+    {},
+    1 * 60 * 60 * 1000,
+  );
+
+  log.info({ count, duration: Date.now() - start }, "Finished username proof index migration");
+  return true;
+}

--- a/apps/hubble/src/storage/db/migrations/1.usernameproof.ts
+++ b/apps/hubble/src/storage/db/migrations/1.usernameproof.ts
@@ -40,24 +40,7 @@ export async function usernameProofIndexMigration(db: RocksDB): Promise<boolean>
             key.subarray(1 + FID_BYTES + 1),
           ]);
 
-          // // Sanity check the key length
-          // if (newKey.length !== key.length) {
-          //   log.error({ key, newKey }, "New key length does not match old key length");
-          // }
-
-          // // Compare the key bytes, make sure only the 6th byte changed
-          // for (let i = 0; i < key.length; i++) {
-          //   if (i === 1 + FID_BYTES) {
-          //     if (newKey[i] !== UserPostfix.UserNameProofAdds) {
-          //       log.error({ key, newKey }, "New key does not have the correct postfix");
-          //     }
-          //   } else {
-          //     if (newKey[i] !== key[i]) {
-          //       log.error({ key, newKey }, "New key does not match old key");
-          //     }
-          //   }
-          // }
-
+          // Write the new key and delete the old one
           const txn = db.transaction();
           txn.put(newKey, value);
           txn.del(key);

--- a/apps/hubble/src/storage/db/migrations/migrations.ts
+++ b/apps/hubble/src/storage/db/migrations/migrations.ts
@@ -1,0 +1,29 @@
+import RocksDB from "../rocksdb.js";
+import { usernameProofIndexMigration } from "./1.usernameproof.js";
+
+export const LATEST_DB_SCHEMA_VERSION = 1;
+
+type MigrationFunctionType = (db: RocksDB) => Promise<boolean>;
+
+const migrations = new Map<number, MigrationFunctionType>();
+
+// Add all DB Migrations here. The key is the schema version number.
+migrations.set(1, async (db: RocksDB) => {
+    // Migration to move the postfix for indexes for UserNameProof from `UsernameProofMessage`
+    // to `UsernameProofMessageAdd`
+    return await usernameProofIndexMigration(db);
+});
+
+export async function performDbMigrations(db: RocksDB, currentDbSchemaVersion: number): Promise<boolean> {
+  // Starting at schema version + 1 until LATEST_DB_SCHEMA_VERSION, perform migrations
+  // one by one.
+  for (let i = currentDbSchemaVersion + 1; i <= LATEST_DB_SCHEMA_VERSION; i++) {
+    const migration = migrations.get(i) as MigrationFunctionType;
+    const success = await migration(db);
+    if (!success) {
+      return false;
+    }    
+  }
+
+  return true;
+}

--- a/apps/hubble/src/storage/db/migrations/migrations.ts
+++ b/apps/hubble/src/storage/db/migrations/migrations.ts
@@ -14,10 +14,14 @@ migrations.set(1, async (db: RocksDB) => {
   return await usernameProofIndexMigration(db);
 });
 
-export async function performDbMigrations(db: RocksDB, currentDbSchemaVersion: number): Promise<boolean> {
+export async function performDbMigrations(
+  db: RocksDB,
+  currentDbSchemaVersion: number,
+  toDbSchemaVersion = LATEST_DB_SCHEMA_VERSION,
+): Promise<boolean> {
   // Starting at schema version + 1 until LATEST_DB_SCHEMA_VERSION, perform migrations
   // one by one.
-  for (let i = currentDbSchemaVersion + 1; i <= LATEST_DB_SCHEMA_VERSION; i++) {
+  for (let i = currentDbSchemaVersion + 1; i <= toDbSchemaVersion; i++) {
     const migration = migrations.get(i) as MigrationFunctionType;
     const success = await migration(db);
     if (!success) {

--- a/apps/hubble/src/storage/db/migrations/migrations.ts
+++ b/apps/hubble/src/storage/db/migrations/migrations.ts
@@ -9,9 +9,9 @@ const migrations = new Map<number, MigrationFunctionType>();
 
 // Add all DB Migrations here. The key is the schema version number.
 migrations.set(1, async (db: RocksDB) => {
-    // Migration to move the postfix for indexes for UserNameProof from `UsernameProofMessage`
-    // to `UsernameProofMessageAdd`
-    return await usernameProofIndexMigration(db);
+  // Migration to move the postfix for indexes for UserNameProof from `UsernameProofMessage`
+  // to `UsernameProofMessageAdd`
+  return await usernameProofIndexMigration(db);
 });
 
 export async function performDbMigrations(db: RocksDB, currentDbSchemaVersion: number): Promise<boolean> {
@@ -22,7 +22,7 @@ export async function performDbMigrations(db: RocksDB, currentDbSchemaVersion: n
     const success = await migration(db);
     if (!success) {
       return false;
-    }    
+    }
   }
 
   return true;

--- a/apps/hubble/src/storage/db/migrations/migrations.ts
+++ b/apps/hubble/src/storage/db/migrations/migrations.ts
@@ -1,3 +1,4 @@
+import { ResultAsync } from "neverthrow";
 import RocksDB from "../rocksdb.js";
 import { usernameProofIndexMigration } from "./1.usernameproof.js";
 
@@ -23,8 +24,8 @@ export async function performDbMigrations(
   // one by one.
   for (let i = currentDbSchemaVersion + 1; i <= toDbSchemaVersion; i++) {
     const migration = migrations.get(i) as MigrationFunctionType;
-    const success = await migration(db);
-    if (!success) {
+    const success = await ResultAsync.fromPromise(migration(db), (e) => e);
+    if (success.isErr() || success.value === false) {
       return false;
     }
   }

--- a/apps/hubble/src/storage/db/types.ts
+++ b/apps/hubble/src/storage/db/types.ts
@@ -119,7 +119,7 @@ export enum UserPostfix {
   UserDataAdds = 97,
 
   /* UserNameProof add set */
-  UserNameProofAdds = 98,
+  UserNameProofAdds = 99,
 }
 
 export enum OnChainEventPostfix {

--- a/apps/hubble/src/storage/db/types.ts
+++ b/apps/hubble/src/storage/db/types.ts
@@ -67,6 +67,9 @@ export enum RootPrefix {
 
   /* Used to store on chain events */
   OnChainEvent = 23,
+
+  /** DB Schema version */
+  DBSchemaVersion = 24,
 }
 
 /**
@@ -114,6 +117,9 @@ export enum UserPostfix {
 
   /* UserDataStore add set */
   UserDataAdds = 97,
+
+  /* UserNameProof add set */
+  UserNameProofAdds = 98,
 }
 
 export enum OnChainEventPostfix {

--- a/apps/hubble/src/storage/stores/usernameProofStore.ts
+++ b/apps/hubble/src/storage/stores/usernameProofStore.ts
@@ -25,7 +25,7 @@ const PRUNE_SIZE_LIMIT_DEFAULT = 10;
  * @returns RocksDB index key of the form <RootPrefix>:<fid?>:<tsHash?>
  */
 const makeUserNameProofByFidKey = (fid: number, name: Uint8Array): Buffer => {
-  return Buffer.concat([makeUserKey(fid), Buffer.from([UserPostfix.UsernameProofMessage]), Buffer.from(name)]);
+  return Buffer.concat([makeUserKey(fid), Buffer.from([UserPostfix.UserNameProofAdds]), Buffer.from(name)]);
 };
 
 const makeUserNameProofByNameKey = (name: Uint8Array): Buffer => {


### PR DESCRIPTION
## Motivation

The UserNameProofStore had accidentally overloaded the `UserNameProofMessage` postfix. It was being used for storing both the `UserNameProofMessage` protobuf and the `UserNameProofMessageAdd` index messages. This migration moves the index postfix to `UserNameProofMessageAdd` and replaces the postfix for the index messages

## Change Summary

- Add DB Migrations
- UserNameProofMessage migration

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a DB migration issue related to the UserNameProof index messages. 

### Detailed summary
- Added a new DB schema version
- Created a migration function to update the UserNameProof index postfix
- Added a test for the usernameproof migration
- Perform DB migrations if the schema version is outdated

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->