### PR TITLE
fix: Limit getSyncStatus to 30 peers

### DIFF
--- a/.changeset/violet-eggs-provide.md
+++ b/.changeset/violet-eggs-provide.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Limit SyncStatus to upto 30 peers

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -369,14 +369,13 @@ export default class Server {
             callback(toServiceError(new HubError("bad_request", "Hub isn't initialized")));
             return;
           }
+
           let peersToCheck: string[];
           if (call.request.peerId && call.request.peerId.length > 0) {
             peersToCheck = [call.request.peerId];
           } else {
-            // If no peerId is specified, check upto 30 random peers
-            const allPeers = this.gossipNode.allPeerIds();
-            // Shuffle the peers and pick 30
-            peersToCheck = allPeers.sort(() => Math.random() - 0.5).slice(0, 30);
+            // If no peerId is specified, check upto 20 peers
+            peersToCheck = this.gossipNode.allPeerIds().slice(0, 20);
           }
 
           const response = SyncStatusResponse.create({
@@ -385,24 +384,27 @@ export default class Server {
             engineStarted: this.syncEngine.isStarted(),
           });
 
-          for (const peerId of peersToCheck) {
-            const statusResult = await this.syncEngine.getSyncStatusForPeer(peerId, this.hub);
-            if (statusResult.isOk()) {
-              const status = statusResult.value;
-              response.isSyncing = status.isSyncing;
-              const peerStatus = SyncStatus.create({
-                peerId,
-                inSync: status.inSync,
-                shouldSync: status.shouldSync,
-                lastBadSync: status.lastBadSync,
-                divergencePrefix: status.divergencePrefix,
-                divergenceSecondsAgo: status.divergenceSecondsAgo,
-                ourMessages: status.ourSnapshot.numMessages,
-                theirMessages: status.theirSnapshot.numMessages,
-              });
-              response.syncStatus.push(peerStatus);
-            }
-          }
+          await Promise.all(
+            peersToCheck.map(async (peerId) => {
+              const statusResult = await this.syncEngine?.getSyncStatusForPeer(peerId, this.hub as HubInterface);
+              if (statusResult?.isOk()) {
+                const status = statusResult.value;
+                response.isSyncing = status.isSyncing;
+                response.syncStatus.push(
+                  SyncStatus.create({
+                    peerId,
+                    inSync: status.inSync,
+                    shouldSync: status.shouldSync,
+                    lastBadSync: status.lastBadSync,
+                    divergencePrefix: status.divergencePrefix,
+                    divergenceSecondsAgo: status.divergenceSecondsAgo,
+                    ourMessages: status.ourSnapshot.numMessages,
+                    theirMessages: status.theirSnapshot.numMessages,
+                  }),
+                );
+              }
+            }),
+          );
 
           callback(null, response);
         })();

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -373,7 +373,10 @@ export default class Server {
           if (call.request.peerId && call.request.peerId.length > 0) {
             peersToCheck = [call.request.peerId];
           } else {
-            peersToCheck = this.gossipNode.allPeerIds();
+            // If no peerId is specified, check upto 30 random peers
+            const allPeers = this.gossipNode.allPeerIds();
+            // Shuffle the peers and pick 30
+            peersToCheck = allPeers.sort(() => Math.random() - 0.5).slice(0, 30);
           }
 
           const response = SyncStatusResponse.create({


### PR DESCRIPTION
## Change Summary

- Limit getSyncStatus to 30 peers

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Fixed an issue where the SyncStatus was not limited to a maximum of 30 peers.
- Previously, allPeerIds() was used to get the list of peers, but now it is limited to 20 peers if no specific peerId is provided.
- Added async/await and Promise.all() to improve performance and handle multiple peer sync status requests concurrently.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->