### PR TITLE
fix: Fix initial Eth events fetching and logging

### DIFF
--- a/.changeset/thin-countries-tickle.md
+++ b/.changeset/thin-countries-tickle.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Improve initial eth events fetching


### PR DESCRIPTION
## Motivation

Improve initial eth events fetching performance and improve logging. 
- Improves initial eth events sync from 9.8 min down to -> 1.7 m
- 80% fewer alchemy calls

## Change Summary

- Fix perf bug where unnecessary blocks were being fetched
- Fix all events in parallel, since we are io bound
- Still merge events serially
- Improve logging

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context
![Screenshot from 2023-08-13 12-08-29](https://github.com/farcasterxyz/hub-monorepo/assets/31996805/0820b8bc-0b13-4946-9ad8-65a3dfbe0deb)
