### PR TITLE
fix: Fetch L2 network events in parallel

### DIFF
--- a/.changeset/fluffy-vans-bake.md
+++ b/.changeset/fluffy-vans-bake.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Fetch L2 events in parallel before processing, show progress

--- a/apps/hubble/src/eth/l2EventsProvider.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.ts
@@ -694,7 +694,7 @@ export class L2EventsProvider {
     }
     onChainEvents.push(onChainEvent);
 
-    logEvent.debug(
+    logEvent.info(
       `cacheOnChainEvent: recorded ${onChainEventTypeToJSON(type)} for fid: ${fid} in block ${blockNumber}`,
     );
 


### PR DESCRIPTION
## Motivation

Port some of the logging improvements from eth events provider to l2 provider

## Change Summary

- Show progress in logs
- Fetch network events in parallel

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the L2EventsProvider in the Hubble app. 

### Detailed summary
- Fetch L2 events in parallel before processing
- Show progress while syncing events from block range

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->