### PR TITLE
chore: Release v1.4.6

### DIFF
--- a/.changeset/afraid-geckos-rescue.md
+++ b/.changeset/afraid-geckos-rescue.md
@@ -1,7 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
-"@farcaster/core": patch
-"@farcaster/hubble": patch
----
-
-feat: Add "getting blockchain events" to hub status

--- a/.changeset/cool-eagles-reflect.md
+++ b/.changeset/cool-eagles-reflect.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Handle network failures when fetching config

--- a/.changeset/eleven-mayflies-sell.md
+++ b/.changeset/eleven-mayflies-sell.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: getUserNameProofsByFid should return fname proofs as well

--- a/.changeset/fluffy-vans-bake.md
+++ b/.changeset/fluffy-vans-bake.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Fetch L2 events in parallel before processing, show progress

--- a/.changeset/green-kings-drop.md
+++ b/.changeset/green-kings-drop.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: Remove permissioned allowlist for mainnet hubs

--- a/.changeset/loud-phones-hang.md
+++ b/.changeset/loud-phones-hang.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: DB Migration for UserNameProof index messages

--- a/.changeset/lovely-parents-remain.md
+++ b/.changeset/lovely-parents-remain.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Handle sync status reporting properly

--- a/.changeset/lucky-insects-work.md
+++ b/.changeset/lucky-insects-work.md
@@ -1,7 +1,0 @@
----
-"@farcaster/hub-web": patch
-"@farcaster/core": patch
-"@farcaster/hubble": patch
----
-
-fix: fetching l2 events was not respecting --l2-first-block

--- a/.changeset/nice-bikes-notice.md
+++ b/.changeset/nice-bikes-notice.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: Add statsd monitoring for Hubble

--- a/.changeset/shiny-pugs-wave.md
+++ b/.changeset/shiny-pugs-wave.md
@@ -1,8 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
-"@farcaster/hub-web": patch
-"@farcaster/core": patch
-"@farcaster/hubble": patch
----
-
-feat: on chain event ordering updated to be more consistent

--- a/.changeset/sixty-trainers-battle.md
+++ b/.changeset/sixty-trainers-battle.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Make sure valid messages are inserted into Sync Trie

--- a/.changeset/tender-dingos-punch.md
+++ b/.changeset/tender-dingos-punch.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: user name proofs weren't syncd correctly because they were not added to the sync trie

--- a/.changeset/thin-countries-tickle.md
+++ b/.changeset/thin-countries-tickle.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Improve initial eth events fetching

--- a/.changeset/violet-eggs-provide.md
+++ b/.changeset/violet-eggs-provide.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Limit SyncStatus to upto 30 peers

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,27 @@
 # @farcaster/hubble
 
+## 1.4.6
+
+### Patch Changes
+
+- e55e571f: feat: Add "getting blockchain events" to hub status
+- 5e96e134: fix: Handle network failures when fetching config
+- 951793b1: fix: getUserNameProofsByFid should return fname proofs as well
+- 3e601f81: fix: Fetch L2 events in parallel before processing, show progress
+- 6ec14935: feat: Remove permissioned allowlist for mainnet hubs
+- c61728cb: fix: DB Migration for UserNameProof index messages
+- 6bb1b439: fix: Handle sync status reporting properly
+- 1fcfd495: fix: fetching l2 events was not respecting --l2-first-block
+- f9631488: feat: Add statsd monitoring for Hubble
+- c6d79cdb: feat: on chain event ordering updated to be more consistent
+- f241dcf4: fix: Make sure valid messages are inserted into Sync Trie
+- 36484022: fix: user name proofs weren't syncd correctly because they were not added to the sync trie
+- 8d61f5f2: fix: Improve initial eth events fetching
+- d8cb39ac: fix: Limit SyncStatus to upto 30 peers
+- Updated dependencies [e55e571f]
+- Updated dependencies [c6d79cdb]
+  - @farcaster/hub-nodejs@0.10.4
+
 ## 1.4.5
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -57,7 +57,7 @@
     "@chainsafe/libp2p-gossipsub": "6.1.0",
     "@chainsafe/libp2p-noise": "^11.0.0 ",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.10.3",
+    "@farcaster/hub-nodejs": "^0.10.4",
     "@farcaster/rocksdb": "^5.5.0",
     "@grpc/grpc-js": "~1.8.21",
     "@libp2p/interface-connection": "^3.0.2",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/core
 
+## 0.12.4
+
+### Patch Changes
+
+- e55e571f: feat: Add "getting blockchain events" to hub status
+- 1fcfd495: fix: fetching l2 events was not respecting --l2-first-block
+- c6d79cdb: feat: on chain event ordering updated to be more consistent
+
 ## 0.12.3
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @farcaster/hub-nodejs
 
+## 0.10.4
+
+### Patch Changes
+
+- e55e571f: feat: Add "getting blockchain events" to hub status
+- c6d79cdb: feat: on chain event ordering updated to be more consistent
+- Updated dependencies [e55e571f]
+- Updated dependencies [1fcfd495]
+- Updated dependencies [c6d79cdb]
+  - @farcaster/core@0.12.4
+
 ## 0.10.3
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@farcaster/core": "0.12.3",
+    "@farcaster/core": "0.12.4",
     "@grpc/grpc-js": "~1.8.21",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"

--- a/packages/hub-web/CHANGELOG.md
+++ b/packages/hub-web/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @farcaster/hub-web
 
+## 0.6.1
+
+### Patch Changes
+
+- 1fcfd495: fix: fetching l2 events was not respecting --l2-first-block
+- c6d79cdb: feat: on chain event ordering updated to be more consistent
+- Updated dependencies [e55e571f]
+- Updated dependencies [1fcfd495]
+- Updated dependencies [c6d79cdb]
+  - @farcaster/core@0.12.4
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-web",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -29,7 +29,7 @@
     "ts-proto": "^1.146.0"
   },
   "dependencies": {
-    "@farcaster/core": "^0.12.0",
+    "@farcaster/core": "^0.12.4",
     "@improbable-eng/grpc-web": "^0.15.0",
     "rxjs": "^7.8.0"
   }


### PR DESCRIPTION
## Motivation

v1.4.6 release


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version numbers and dependencies of the `@farcaster/core`, `@farcaster/hub-web`, `@farcaster/hub-nodejs`, and `@farcaster/hubble` packages. 

### Detailed summary
- `@farcaster/core` version updated from `0.12.3` to `0.12.4`
- `@farcaster/hub-web` version updated from `0.6.0` to `0.6.1`
- `@farcaster/hub-nodejs` version updated from `0.10.3` to `0.10.4`
- `@farcaster/hubble` version updated from `1.4.5` to `1.4.6`
- Various patch changes and new features implemented in the packages

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->