### PR TITLE
chore: Slightly update release instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -280,12 +280,13 @@ are at all unsure about how to proceed, please reach out to Varun ([Github](http
 2. Check that the version bumps are consistent with our versioning system
 3. Check that all CHANGELOG.mds represent the important changes made
 4. Check in all the files and merge the branch to main
-5. Checkout main, pull down to the merged commit (should be latest) and run `yarn changeset publish`
-6. Manually tag Hubble with `git tag -a @farcaster/hubble@<version>` if version was changed..
-7. Update the `@latest` tag: `git tag -f @latest`
-8. Push all tags to the remote repo: `git push origin @latest --force && git push origin HEAD --tags`
-9. Create a GitHub Release for Hubble, marking it as the latest.
-10. If this is a non-patch change, create an NFT for the release.
+5. Checkout main, pull down to the merged commit (should be latest) and run `yarn build`
+6. Publish changes by running `yarn changeset publish`
+7. Manually tag Hubble with `git tag -a @farcaster/hubble@<version>` if version was changed..
+8. Update the `@latest` tag: `git tag -f @latest`
+9. Push all tags to the remote repo: `git push origin @latest --force && git push origin HEAD --tags`
+10. Create a GitHub Release for Hubble, marking it as the latest.
+11. If this is a non-patch change, create an NFT for the release.
 
 ### 3.7 Working in Rust
 


### PR DESCRIPTION
## Motivation

Update release instructions to make sure to build all code before publishing

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the steps in the CONTRIBUTING.md file for working in Rust. 

### Detailed summary
- Updated step 5 to run `yarn build` instead of `yarn changeset publish`
- Added step 6 to publish changes by running `yarn changeset publish`
- Updated step 7 to manually tag Hubble with `git tag -a @farcaster/hubble@<version>`
- Updated step 8 to update the `@latest` tag with `git tag -f @latest`
- Updated step 9 to push all tags to the remote repo with `git push origin @latest --force && git push origin HEAD --tags`
- Added step 10 to create a GitHub Release for Hubble, marking it as the latest
- Added step 11 to create an NFT for the release if it is a non-patch change

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->