### PR TITLE
feat: Add an events-reset command to clear l2 events

### DIFF
--- a/.changeset/rare-pigs-teach.md
+++ b/.changeset/rare-pigs-teach.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: add an events-reset command to clear l2 events from the db

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -26,6 +26,7 @@
     "start": "node build/cli.js start",
     "identity": "node build/cli.js identity",
     "dbreset": "node build/cli.js dbreset",
+    "events-reset": "node build/cli.js events-reset",
     "console": "node build/cli.js console",
     "profile": "node --max-old-space-size=4096 build/cli.js profile",
     "status": "node build/cli.js status",


### PR DESCRIPTION
## Motivation

Allow clearing l2 events for testing the l2 migration

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new command called `events-reset` to the Hubble CLI. It allows clearing L2 contract events from the database. 

### Detailed summary
- Added a new command `events-reset` to the Hubble CLI.
- The command clears L2 contract events from the database.
- It also resets the hub state by setting the last L2 block to 0.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->