### PR TITLE
chore: Improve gen.submitMessages() for testing

### DIFF
--- a/.changeset/sweet-tools-act.md
+++ b/.changeset/sweet-tools-act.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+chore: Improve gen.submitMessages() for testing


### PR DESCRIPTION


## Change Summary

- make gen.submitMessages() parallel

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves the `gen.submitMessages()` function for testing purposes.

### Detailed summary
- Added a new class `GenMessages` to handle message generation and submission.
- Added `generate()` method to generate and submit messages.
- Added `genForFid()` method to generate and submit messages for a specific FID.
- Added tracking of success and failure message counts.
- Added batch processing to limit concurrent message submissions.
- Added logging of success and failure messages.
- Refactored `gen.submitMessages()` to use `GenMessages` class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->