### PR TITLE
feat: enforce storage pruning 1 day after migration

### DIFF
--- a/.changeset/spotty-hats-visit.md
+++ b/.changeset/spotty-hats-visit.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+feat: enforce storage pruning 1 day after migration

--- a/apps/hubble/src/eth/l2EventsProvider.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.ts
@@ -439,7 +439,7 @@ export class L2EventsProvider {
           });
           await this.cacheOnChainEvent(
             OnChainEventType.EVENT_TYPE_ID_REGISTER,
-            0n,
+            transferEvent.args.id,
             blockNumber,
             blockHash,
             transactionHash,

--- a/apps/hubble/src/storage/stores/onChainEventStore.ts
+++ b/apps/hubble/src/storage/stores/onChainEventStore.ts
@@ -9,6 +9,7 @@ import {
   OnChainEvent,
   OnChainEventType,
   SignerEventType,
+  SignerMigratedOnChainEvent,
   SignerOnChainEvent,
 } from "@farcaster/hub-nodejs";
 import RocksDB, { Transaction } from "../db/rocksdb.js";
@@ -87,12 +88,15 @@ class OnChainEventStore {
     return getOnChainEventByKey(this._db, idRegisterEventPrimaryKey);
   }
 
-  async isSignerMigrated(): HubAsyncResult<boolean> {
-    const signerMigrated = await this.getOnChainEvents(OnChainEventType.EVENT_TYPE_SIGNER_MIGRATED, 0);
-    if (signerMigrated.length > 0) {
-      return ok(true);
+  async getSignerMigratedAt(): HubAsyncResult<number> {
+    const signerMigrated = await this.getOnChainEvents<SignerMigratedOnChainEvent>(
+      OnChainEventType.EVENT_TYPE_SIGNER_MIGRATED,
+      0,
+    );
+    if (signerMigrated[0]) {
+      return ok(signerMigrated[0].signerMigratedEventBody?.migratedAt);
     }
-    return ok(false);
+    return ok(0);
   }
 
   /**

--- a/apps/hubble/src/storage/stores/onchainEventStore.test.ts
+++ b/apps/hubble/src/storage/stores/onchainEventStore.test.ts
@@ -148,16 +148,17 @@ describe("OnChainEventStore", () => {
     });
   });
 
-  describe("isSignerMigrated", () => {
-    test("returns true if signer migrated", async () => {
-      await set.mergeOnChainEvent(Factories.SignerMigratedOnChainEvent.build());
-      const result = await set.isSignerMigrated();
-      expect(result).toEqual(ok(true));
+  describe("getSignerMigratedAt", () => {
+    test("returns timestamp of signer migrated event", async () => {
+      const event = Factories.SignerMigratedOnChainEvent.build();
+      await set.mergeOnChainEvent(event);
+      const result = await set.getSignerMigratedAt();
+      expect(result).toEqual(ok(event.signerMigratedEventBody.migratedAt));
     });
 
-    test("returns false if not migrated", async () => {
-      const result = await set.isSignerMigrated();
-      expect(result).toEqual(ok(false));
+    test("returns 0 if not migrated", async () => {
+      const result = await set.getSignerMigratedAt();
+      expect(result).toEqual(ok(0));
     });
   });
 

--- a/apps/hubble/src/storage/stores/storeEventHandler.test.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.test.ts
@@ -176,3 +176,23 @@ describe("pruneEvents", () => {
     expect(allEvents3._unsafeUnwrap()).toMatchObject([eventArgs3, eventArgs4]);
   });
 });
+
+describe("getCurrentStorageUnitsForFid", () => {
+  const fid = Factories.Fid.build();
+
+  test("defaults to 1 before migration", async () => {
+    expect(await eventHandler.getCurrentStorageUnitsForFid(fid)).toEqual(ok(1));
+  });
+
+  test("defaults to 1 during migration pruning grace period", async () => {
+    // Assume migration happened 1 minute ago
+    eventHandler.signerMigrated(Date.now() / 1000 - 60);
+    expect(await eventHandler.getCurrentStorageUnitsForFid(fid)).toEqual(ok(1));
+  });
+
+  test("returns actual storage available after migration pruning grace period", async () => {
+    // Assume migration happened 2 days
+    eventHandler.signerMigrated(Date.now() / 1000 - 60 * 60 * 24 * 2);
+    expect(await eventHandler.getCurrentStorageUnitsForFid(fid)).toEqual(ok(0));
+  });
+});

--- a/packages/core/src/factories.ts
+++ b/packages/core/src/factories.ts
@@ -687,7 +687,7 @@ const SignerMigratedOnChainEventFactory = Factory.define<SignerMigratedOnChainEv
     type: OnChainEventType.EVENT_TYPE_SIGNER_MIGRATED,
     fid: 0,
     signerMigratedEventBody: SignerMigratedEventBody.create({
-      migratedAt: Math.floor(faker.datatype.datetime().getTime() / 1000),
+      migratedAt: Math.floor(Date.now() / 1000) + 48 * 60 * 60, // Default to 48 hours in the future so pruning is not enabled
     }),
   }) as protobufs.SignerMigratedOnChainEvent;
 });


### PR DESCRIPTION
## Motivation

Enforce storage pruning 1 day after migration

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enforcing storage pruning 1 day after migration. 

### Detailed summary
- Added feature to enforce storage pruning 1 day after migration
- Updated code related to storage pruning and migration
- Added tests for storage pruning functionality

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->