### PR TITLE
fix: Slow testdata job to avoid FID rate limit

### DIFF
--- a/apps/hubble/src/utils/periodicTestDataJob.ts
+++ b/apps/hubble/src/utils/periodicTestDataJob.ts
@@ -26,7 +26,7 @@ const log = logger.child({
 
 type SchedulerStatus = "started" | "stopped";
 
-const DEFAULT_PERIODIC_JOB_CRON = "*/10 * * * * *"; // Every 10 seconds
+const DEFAULT_PERIODIC_JOB_CRON = "*/30 * * * * *"; // Every 30 seconds
 
 export type TestUser = {
   fid: number;


### PR DESCRIPTION


## Change Summary

- Slow the test data job to 30s to avoid FID rate limit


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on changing the cron interval for the periodic test data job from every 10 seconds to every 30 seconds.

### Detailed summary
- Changed the value of `DEFAULT_PERIODIC_JOB_CRON` from "*/10 * * * * *" to "*/30 * * * * *"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->