### PR TITLE
fix: Fix fname migration to handle corrupt data

### DIFF
--- a/apps/hubble/src/storage/db/migrations/2.fnameproof.test.ts
+++ b/apps/hubble/src/storage/db/migrations/2.fnameproof.test.ts
@@ -31,4 +31,13 @@ describe("fnameproof migration", () => {
 
     await expect(getFNameProofByFid(db, proof.fid)).resolves.toEqual(proof);
   });
+
+  test("should not fail when proof is not decodable", async () => {
+    const badProof = Buffer.from([1, 2, 3]);
+    await db.put(makeFNameUserNameProofKey(Buffer.from([])), badProof);
+    await expect(db.get(makeFNameUserNameProofKey(Buffer.from([])))).resolves.toBeDefined();
+    const success = await performDbMigrations(db, 1, 2);
+    expect(success).toBe(true);
+    await expect(db.get(makeFNameUserNameProofKey(Buffer.from([])))).rejects.toThrow("NotFound");
+  });
 });

--- a/apps/hubble/src/storage/db/migrations/2.fnameproof.ts
+++ b/apps/hubble/src/storage/db/migrations/2.fnameproof.ts
@@ -23,9 +23,16 @@ export async function fnameProofIndexMigration(db: RocksDB): Promise<boolean> {
         return;
       }
 
-      const proof = UserNameProof.decode(new Uint8Array(value));
-      if (proof.fid) {
-        const secondaryKey = makeFNameUserNameProofByFidKey(proof.fid);
+      let proof: UserNameProof | undefined = undefined;
+      try {
+        proof = UserNameProof.decode(new Uint8Array(value));
+      } catch (e) {
+        log.error({ key: key.toString("hex"), error: e }, "Failed to decode proof, deleting");
+        await db.del(key);
+      }
+
+      if (proof?.fid) {
+        const secondaryKey = makeFNameUserNameProofByFidKey(proof?.fid);
         await db.put(secondaryKey, key);
         count += 1;
       }

--- a/apps/hubble/src/storage/db/migrations/2.fnameproof.ts
+++ b/apps/hubble/src/storage/db/migrations/2.fnameproof.ts
@@ -8,7 +8,6 @@ import RocksDB from "../rocksdb.js";
 import { RootPrefix } from "../types.js";
 import { UserNameProof } from "@farcaster/hub-nodejs";
 import { makeFNameUserNameProofByFidKey } from "../nameRegistryEvent.js";
-import { Result } from "neverthrow";
 
 const log = logger.child({ component: "FNameProofIndexMigration" });
 
@@ -24,20 +23,11 @@ export async function fnameProofIndexMigration(db: RocksDB): Promise<boolean> {
         return;
       }
 
-      const proof = Result.fromThrowable(
-        () => UserNameProof.decode(new Uint8Array(value)),
-        (e) => e,
-      )();
-      if (proof.isOk() && proof.value.fid) {
-        try {
-          const secondaryKey = makeFNameUserNameProofByFidKey(proof.value.fid);
-          await db.put(secondaryKey, key);
-          count += 1;
-        } catch (e) {
-          log.error({ key: key.toString("hex"), errorStr: JSON.stringify(e) }, "Failed to add fname proof index");
-        }
-      } else {
-        log.error({ key: key.toString("hex"), errorStr: JSON.stringify(proof) }, "Failed to decode fname proof");
+      const proof = UserNameProof.decode(new Uint8Array(value));
+      if (proof.fid) {
+        const secondaryKey = makeFNameUserNameProofByFidKey(proof.fid);
+        await db.put(secondaryKey, key);
+        count += 1;
       }
     },
     {},

--- a/apps/hubble/src/storage/db/migrations/migrations.test.ts
+++ b/apps/hubble/src/storage/db/migrations/migrations.test.ts
@@ -1,0 +1,23 @@
+import RocksDB from "../rocksdb.js";
+import { LATEST_DB_SCHEMA_VERSION, performDbMigrations } from "./migrations.js";
+
+const dbName = "migrations.test.db";
+
+describe("migration", () => {
+  let db: RocksDB;
+
+  beforeAll(async () => {
+    db = new RocksDB(dbName);
+    await db.open();
+  });
+
+  afterAll(async () => {
+    await db.close();
+    await db.destroy();
+  });
+
+  test("should not fail for an empty database", async () => {
+    const success = await performDbMigrations(db, 1, LATEST_DB_SCHEMA_VERSION);
+    expect(success).toBe(true);
+  });
+});

--- a/apps/hubble/src/storage/db/migrations/migrations.ts
+++ b/apps/hubble/src/storage/db/migrations/migrations.ts
@@ -40,7 +40,7 @@ export async function performDbMigrations(
     const migration = migrations.get(i) as MigrationFunctionType;
     const success = await ResultAsync.fromPromise(migration(db), (e) => e);
     if (success.isErr() || success.value === false) {
-      log.error({ errorStr: JSON.stringify(success), i }, "DB migration failed");
+      log.error({ error: success, i }, "DB migration failed");
       return false;
     }
   }


### PR DESCRIPTION
## Motivation

Testnet had a corrupt entry for an fname proof which was preventing migration. Delete the key if we're not able to decode it. 

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Updated error logging in `migrations.ts` to include the `success` value.
- Added tests and functionality for performing database migrations in `migrations.test.ts`.
- Added a test for handling undecodable proof in `2.fnameproof.test.ts`.
- Refactored `fnameProofIndexMigration` in `2.fnameproof.ts` to handle undecodable proof and delete the key.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->