### PR TITLE
fix: Switch startup checks to check against OP Mainnet

### DIFF
--- a/.changeset/short-seals-invite.md
+++ b/.changeset/short-seals-invite.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+Switch startup checks to check against OP Mainnet

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -29,7 +29,7 @@ import { profileGossipServer } from "./profile/gossipProfile.js";
 import { initializeStatsd } from "./utils/statsd.js";
 import OnChainEventStore from "./storage/stores/onChainEventStore.js";
 import { printStartupCheckStatus, StartupChecks, StartupCheckStatus } from "./utils/startupCheck.js";
-import { goerli, mainnet, optimismGoerli } from "viem/chains";
+import { goerli, mainnet, optimism } from "viem/chains";
 import { finishAllProgressBars } from "./utils/progressBars.js";
 import { MAINNET_BOOTSTRAP_PEERS } from "./bootstrapPeers.mainnet.js";
 
@@ -85,7 +85,7 @@ app
   .option("--first-block <number>", "The block number to begin syncing events from Farcaster contracts", parseNumber)
 
   // L2 Options
-  .option("-l, --l2-rpc-url <url>", "RPC URL of a Goerli Optimism Node (or comma separated list of URLs)")
+  .option("-l, --l2-rpc-url <url>", "RPC URL of a mainnet Optimism Node (or comma separated list of URLs)")
   .option("--l2-id-registry-address <address>", "The address of the L2 Farcaster ID Registry contract")
   .option("--l2-key-registry-address <address>", "The address of the L2 Farcaster Key Registry contract")
   .option("--l2-storage-registry-address <address>", "The address of the L2 Farcaster Storage Registry contract")
@@ -503,7 +503,7 @@ app
 
     await StartupChecks.rpcCheck(options.ethRpcUrl, goerli);
     await StartupChecks.rpcCheck(options.ethMainnetRpcUrl, mainnet);
-    await StartupChecks.rpcCheck(options.l2RpcUrl, optimismGoerli);
+    await StartupChecks.rpcCheck(options.l2RpcUrl, optimism);
 
     const hubResult = Result.fromThrowable(
       () => new Hub(options),


### PR DESCRIPTION
## Motivation

We're going to be migrating to OP Mainnet, so don't reference OP Goerli here.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on switching the startup checks in the Hubble app to check against the mainnet Optimism node. 

### Detailed summary
- Updated import of `optimismGoerli` to `optimism` in `cli.ts`
- Updated description of the `-l, --l2-rpc-url` option to mention mainnet Optimism node
- Updated the `StartupChecks.rpcCheck()` call to check against the mainnet Optimism node

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->