### PR TITLE
fix: Stabilize and format ETA during progress

### DIFF
--- a/apps/hubble/src/eth/ethEventsProvider.ts
+++ b/apps/hubble/src/eth/ethEventsProvider.ts
@@ -305,7 +305,7 @@ export class EthEventsProvider {
 
       let progressBar;
       if (totalBlocks > 100) {
-        progressBar = addProgressBar("Syncing Farcaster Contracts", totalBlocks);
+        progressBar = addProgressBar("Syncing Farcaster L1 Contracts", totalBlocks);
       }
 
       for (let i = 0; i < numOfRuns; i++) {
@@ -542,7 +542,7 @@ export class EthEventsProvider {
       const lastBlock = cachedBlocks[cachedBlocks.length - 1] ?? 0;
       firstBlock = cachedBlocks[0] ?? 0;
       totalBlocks = lastBlock - firstBlock;
-      progressBar = addProgressBar("Processing Farcaster Contract Events", totalBlocks);
+      progressBar = addProgressBar("Processing Farcaster L1 Contract Events", totalBlocks);
     }
 
     for (const cachedBlock of cachedBlocks) {

--- a/apps/hubble/src/eth/l2EventsProvider.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.ts
@@ -569,7 +569,7 @@ export class L2EventsProvider {
 
     let progressBar;
     if (totalBlocks > 100) {
-      progressBar = addProgressBar("Syncing Farcaster Contracts", totalBlocks);
+      progressBar = addProgressBar("Syncing Farcaster L2 Contracts", totalBlocks);
     }
 
     for (let i = 0; i < numOfRuns; i++) {
@@ -649,7 +649,7 @@ export class L2EventsProvider {
       const lastBlock = cachedBlocks[cachedBlocks.length - 1] ?? 0;
       firstBlock = cachedBlocks[0] ?? 0;
       totalBlocks = lastBlock - firstBlock;
-      progressBar = addProgressBar("Processing Farcaster Contract Events", totalBlocks);
+      progressBar = addProgressBar("Processing Farcaster L2 Contract Events", totalBlocks);
     }
 
     for (const cachedBlock of cachedBlocks) {

--- a/apps/hubble/src/utils/progressBars.ts
+++ b/apps/hubble/src/utils/progressBars.ts
@@ -4,7 +4,7 @@ import { logger } from "./logger.js";
 // The global multibar, to which all progress bars are added
 const multiBar = new cliProgress.MultiBar(
   {
-    format: " {bar} {percentage}% | {name} | {value}/{total} | ETA: {eta}s",
+    format: " {bar} {percentage}% | {name} | {value}/{total} | ETA: {eta_formatted}",
     hideCursor: true,
     clearOnComplete: false,
     etaBuffer: 1_000,


### PR DESCRIPTION
## Change Summary

- Fix eta formatting and stability for progress bars

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating progress bar labels in different files. 

### Detailed summary
- Updated progress bar label in `progressBars.ts` from `eta` to `eta_formatted`.
- Updated progress bar label in `l2EventsProvider.ts` from "Syncing Farcaster Contracts" to "Syncing Farcaster L2 Contracts".
- Updated progress bar label in `l2EventsProvider.ts` from "Processing Farcaster Contract Events" to "Processing Farcaster L2 Contract Events".
- Updated progress bar label in `ethEventsProvider.ts` from "Syncing Farcaster Contracts" to "Syncing Farcaster L1 Contracts".
- Updated progress bar label in `ethEventsProvider.ts` from "Processing Farcaster Contract Events" to "Processing Farcaster L1 Contract Events".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->