### PR TITLE
feat: fetch contract addresses from network config

### DIFF
--- a/.changeset/green-camels-roll.md
+++ b/.changeset/green-camels-roll.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: fetch l2 contract addresses from network config

--- a/apps/hubble/src/eth/l2EventsProvider.test.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.test.ts
@@ -1,4 +1,4 @@
-import { FarcasterNetwork, OnChainEventType } from "@farcaster/hub-nodejs";
+import { bytesToHexString, Factories, FarcasterNetwork, OnChainEventType } from "@farcaster/hub-nodejs";
 import { StorageRegistry } from "./abis.js";
 import { jestRocksDB } from "../storage/db/jestUtils.js";
 import Engine from "../storage/engine/index.js";
@@ -23,6 +23,9 @@ let idRegistryAddress: `0x${string}`;
 
 beforeAll(() => {
   // Poll aggressively for fast testing
+  storageRegistryAddress = bytesToHexString(Factories.EthAddress.build())._unsafeUnwrap();
+  idRegistryAddress = bytesToHexString(Factories.EthAddress.build())._unsafeUnwrap();
+  keyRegistryAddress = bytesToHexString(Factories.EthAddress.build())._unsafeUnwrap();
   L2EventsProvider.blockPollingInterval = 10;
   L2EventsProvider.eventPollingInterval = 10;
 });

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -631,6 +631,21 @@ export class Hub implements HubInterface {
       this.gossipNode.updateDeniedPeerIds(deniedPeerIds);
       this.deniedPeerIds = deniedPeerIds;
 
+      if (!this.l2RegistryProvider?.ready) {
+        if (
+          networkConfig.storageRegistryAddress &&
+          networkConfig.keyRegistryAddress &&
+          networkConfig.idRegistryAddress
+        ) {
+          this.l2RegistryProvider?.setAddresses(
+            networkConfig.storageRegistryAddress,
+            networkConfig.keyRegistryAddress,
+            networkConfig.idRegistryAddress,
+          );
+          this.l2RegistryProvider?.start();
+        }
+      }
+
       log.info({ allowedPeerIds, deniedPeerIds }, "Network config applied");
 
       return false;

--- a/apps/hubble/src/network/utils/networkConfig.test.ts
+++ b/apps/hubble/src/network/utils/networkConfig.test.ts
@@ -13,6 +13,9 @@ describe("networkConfig", () => {
       allowedPeers: [],
       deniedPeers: [],
       minAppVersion: APP_VERSION,
+      storageRegistryAddress: undefined,
+      keyRegistryAddress: undefined,
+      idRegistryAddress: undefined,
     };
 
     const result = applyNetworkConfig(networkConfig, existingPeerIds, [], network);
@@ -26,6 +29,9 @@ describe("networkConfig", () => {
       allowedPeers: undefined,
       deniedPeers: [],
       minAppVersion: APP_VERSION,
+      storageRegistryAddress: undefined,
+      keyRegistryAddress: undefined,
+      idRegistryAddress: undefined,
     };
 
     const result = applyNetworkConfig(networkConfig, undefined, [], network);
@@ -42,6 +48,9 @@ describe("networkConfig", () => {
       allowedPeers: ["1", "2", "3"],
       deniedPeers: [],
       minAppVersion: APP_VERSION,
+      storageRegistryAddress: undefined,
+      keyRegistryAddress: undefined,
+      idRegistryAddress: undefined,
     };
 
     const result = applyNetworkConfig(networkConfig, existingPeerIds, [], network);
@@ -58,6 +67,9 @@ describe("networkConfig", () => {
       allowedPeers: ["4", "5"],
       deniedPeers: [],
       minAppVersion: APP_VERSION,
+      storageRegistryAddress: undefined,
+      keyRegistryAddress: undefined,
+      idRegistryAddress: undefined,
     };
 
     const result = applyNetworkConfig(networkConfig, existingPeerIds, [], network);
@@ -73,6 +85,9 @@ describe("networkConfig", () => {
       allowedPeers: [],
       deniedPeers: ["4", "5"],
       minAppVersion: APP_VERSION,
+      storageRegistryAddress: undefined,
+      keyRegistryAddress: undefined,
+      idRegistryAddress: undefined,
     };
 
     const result = applyNetworkConfig(networkConfig, existingPeerIds, [], network);
@@ -89,6 +104,9 @@ describe("networkConfig", () => {
       allowedPeers: ["1", "2", "3", "4"],
       deniedPeers: [],
       minAppVersion: APP_VERSION,
+      storageRegistryAddress: undefined,
+      keyRegistryAddress: undefined,
+      idRegistryAddress: undefined,
     };
 
     const result = applyNetworkConfig(networkConfig, existingPeerIds, [], network);
@@ -102,6 +120,9 @@ describe("networkConfig", () => {
       allowedPeers: undefined,
       deniedPeers: ["1", "2", "3"],
       minAppVersion: APP_VERSION,
+      storageRegistryAddress: undefined,
+      keyRegistryAddress: undefined,
+      idRegistryAddress: undefined,
     };
 
     const result = applyNetworkConfig(networkConfig, undefined, [], network);
@@ -118,6 +139,9 @@ describe("networkConfig", () => {
       allowedPeers: ["4", "5"],
       deniedPeers: [],
       minAppVersion: APP_VERSION,
+      storageRegistryAddress: undefined,
+      keyRegistryAddress: undefined,
+      idRegistryAddress: undefined,
     };
 
     const result = applyNetworkConfig(networkConfig, existingPeerIds, [], network);
@@ -131,6 +155,9 @@ describe("networkConfig", () => {
       allowedPeers: [],
       deniedPeers: [],
       minAppVersion: semver.inc(APP_VERSION, "patch") ?? "",
+      storageRegistryAddress: undefined,
+      keyRegistryAddress: undefined,
+      idRegistryAddress: undefined,
     };
 
     const result = applyNetworkConfig(networkConfig, [], [], network);
@@ -142,6 +169,9 @@ describe("networkConfig", () => {
       allowedPeers: [],
       deniedPeers: [],
       minAppVersion: prevVer,
+      storageRegistryAddress: undefined,
+      keyRegistryAddress: undefined,
+      idRegistryAddress: undefined,
     };
 
     const result2 = applyNetworkConfig(networkConfig2, [], [], network);

--- a/apps/hubble/src/network/utils/networkConfig.ts
+++ b/apps/hubble/src/network/utils/networkConfig.ts
@@ -18,6 +18,9 @@ export type NetworkConfig = {
   allowedPeers: string[] | undefined;
   deniedPeers: string[];
   minAppVersion: string;
+  storageRegistryAddress: `0x${string}` | undefined;
+  keyRegistryAddress: `0x${string}` | undefined;
+  idRegistryAddress: `0x${string}` | undefined;
 };
 
 export type NetworkConfigResult = {


### PR DESCRIPTION
## Motivation

To allow for a smoother migration process, fetch the contract addresses from the network config.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding the ability to fetch L2 contract addresses from the network config. 

### Detailed summary
- Added `storageRegistryAddress`, `keyRegistryAddress`, and `idRegistryAddress` fields to `NetworkConfig` type.
- Updated `Hubble` class to set L2 contract addresses from the network config.
- Updated `L2EventsProvider` class to use L2 contract addresses from the network config.
- Added tests for the changes.

> The following files were skipped due to too many changes: `apps/hubble/src/eth/l2EventsProvider.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->