### PR TITLE
fix: hubble.sh fixes

### DIFF
--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -174,7 +174,7 @@ write_env_file() {
 setup_grafana() {
     local grafana_url="http://127.0.0.1:3000"
     local credentials="admin:admin"
-    local response dashboard_uid
+    local response dashboard_uid prefs
 
     add_datasource() {
         response=$(curl -s -o /dev/null -w "%{http_code}" -X "POST" "$grafana_url/api/datasources" \

--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -263,10 +263,10 @@ setup_grafana() {
         dashboard_uid=$(echo "$response" | jq -r '.uid')
 
         # Set the default home dashboard for the organization
-        curl -s -X "PUT" "$grafana_url/api/org/preferences" \
+        prefs=$(curl -s -X "PUT" "$grafana_url/api/org/preferences" \
             -u "$credentials" \
             -H "Content-Type: application/json" \
-            --data "{\"homeDashboardUID\":\"$dashboard_uid\"}"
+            --data "{\"homeDashboardUID\":\"$dashboard_uid\"}")
 
         echo "✅ Dashboard is installed."
     else


### PR DESCRIPTION


## Change Summary

- Remove a stray console print statement

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a preference field to the `setup_grafana` function in `hubble.sh`. 

### Detailed summary
- Added `prefs` variable to store the response of the PUT request to set the default home dashboard for the organization.
- Updated the PUT request to include the `prefs` variable in the request data.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->