### PR TITLE
feat: Make l2 rpc url required to start hubble ahead of mainnet migration

### DIFF
--- a/.changeset/new-penguins-end.md
+++ b/.changeset/new-penguins-end.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": minor
+---
+
+feat: Make l2 rpc url required to start hubble ahead of mainnet migration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run Hubble
         shell: bash
-        run: docker run --name hub --detach -p2282:2282 -p2283:2283 farcasterxyz/hubble:test sh -c 'node build/cli.js identity create && node build/cli.js start --rpc-port 2283 --ip 0.0.0.0 --gossip-port 2282 --eth-rpc-url "https://eth-goerli.g.alchemy.com/v2/IvjMoCKt1hT66f9OJoL_dMXypnvQYUdd" --eth-mainnet-rpc-url "https://eth-mainnet.g.alchemy.com/v2/8cz__IXnQ5FK_GNYDlfooLzYhBAW7ta0" --network 3 --allowed-peers none'
+        run: docker run --name hub --detach -p2282:2282 -p2283:2283 farcasterxyz/hubble:test sh -c 'node build/cli.js identity create && node build/cli.js start --rpc-port 2283 --ip 0.0.0.0 --gossip-port 2282 --eth-rpc-url "https://eth-goerli.g.alchemy.com/v2/IvjMoCKt1hT66f9OJoL_dMXypnvQYUdd" --eth-mainnet-rpc-url "https://eth-mainnet.g.alchemy.com/v2/8cz__IXnQ5FK_GNYDlfooLzYhBAW7ta0" --l2-rpc-url "https://opt-mainnet.g.alchemy.com/v2/3xWX-cWV-an3IPXmVCRXX51PpQzc-8iJ" --network 3 --allowed-peers none'
 
       - name: Download grpcurl
         shell: bash

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -513,7 +513,13 @@ app
 
     await startupCheck.rpcCheck(options.ethRpcUrl, goerli, "L1");
     await startupCheck.rpcCheck(options.ethMainnetRpcUrl, mainnet, "L1");
-    await startupCheck.rpcCheck(options.l2RpcUrl, optimism, "L2");
+    await startupCheck.rpcCheck(options.l2RpcUrl, optimism, "L2", options.l2ChainId);
+
+    if (startupCheck.anyFailedChecks()) {
+      logger.fatal({ reason: "Startup checks failed" }, "shutting down hub");
+      logger.flush();
+      process.exit(1);
+    }
 
     const hubResult = Result.fromThrowable(
       () => new Hub(options),

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -332,7 +332,8 @@ export class Hub implements HubInterface {
         options.l2RentExpiryOverride,
       );
     } else {
-      log.warn("No L2 RPC URL provided, not syncing with L2 contract events");
+      log.warn("No L2 RPC URL provided, unable to sync L2 contract events");
+      throw new HubError("bad_request.invalid_param", "Invalid l2 rpc url");
     }
 
     if (options.fnameServerUrl && options.fnameServerUrl !== "") {

--- a/apps/hubble/src/utils/startupCheck.ts
+++ b/apps/hubble/src/utils/startupCheck.ts
@@ -60,7 +60,13 @@ class StartupCheck {
     }
   }
 
-  async rpcCheck(rpcUrl: string | undefined, chain: Chain, prefix = "", status = StartupCheckStatus.ERROR) {
+  async rpcCheck(
+    rpcUrl: string | undefined,
+    chain: Chain,
+    prefix = "",
+    chainId?: number,
+    status = StartupCheckStatus.ERROR,
+  ) {
     const type = chain.name;
     if (!rpcUrl) {
       this.printStartupCheckStatus(
@@ -82,7 +88,7 @@ class StartupCheck {
     // Check that the publicClient is reachable and returns the goerli chainId
     const chainIdResult = await ResultAsync.fromPromise(publicClient.getChainId(), (err) => err);
 
-    if (chainIdResult.isErr() || chainIdResult.value !== chain.id) {
+    if (chainIdResult.isErr() || chainIdResult.value !== (chainId ?? chain.id)) {
       console.log(chainIdResult);
       this.printStartupCheckStatus(
         status,


### PR DESCRIPTION
## Motivation

L2 RPC url is required to start hubble 1.5+ so hubs can handle the migration to mainnet.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on making the l2 rpc url required to start hubble ahead of the mainnet migration.

### Detailed summary
- Made the l2 rpc url required to start hubble.
- Updated log message when no l2 rpc url is provided.
- Threw an error when an invalid l2 rpc url is provided.
- Added the l2 chain id as a parameter in the rpcCheck function.
- Added a fatal log message and process exit when startup checks fail.
- Updated the docker run command to include the l2 rpc url.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->