### PR TITLE
chore: Improve grafana dashboard

### DIFF
--- a/.changeset/eighty-jeans-smell.md
+++ b/.changeset/eighty-jeans-smell.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+chore: Improve dashboard with sync %, versions

--- a/apps/hubble/grafana/grafana-dashboard.json
+++ b/apps/hubble/grafana/grafana-dashboard.json
@@ -509,7 +509,7 @@
       },
       "id": 14,
       "panels": [],
-      "title": "Hubble Stats",
+      "title": "Performance",
       "type": "row"
     },
     {
@@ -978,7 +978,7 @@
           "target": "stats.gauges.hubble.rocksdb.approximate_size"
         }
       ],
-      "title": "Node Size",
+      "title": "DB Size on disk",
       "type": "timeseries"
     },
     {

--- a/apps/hubble/grafana/grafana-dashboard.json
+++ b/apps/hubble/grafana/grafana-dashboard.json
@@ -45,6 +45,116 @@
       "fieldConfig": {
         "defaults": {
           "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 50
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 0,
+        "y": 1
+      },
+      "id": 22,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.3",
+      "targets": [
+        {
+          "datasource": "Graphite",
+          "refId": "A",
+          "target": "stats.gauges.hubble.syncengine.sync_percent"
+        }
+      ],
+      "title": "Synced",
+      "type": "stat"
+    },
+    {
+      "datasource": "Graphite",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 2,
+        "y": 1
+      },
+      "id": 25,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.3",
+      "targets": [
+        {
+          "refId": "A",
+          "target": "sum(stats.gauges.hubble.gossip.peers.*)",
+          "textEditor": false
+        }
+      ],
+      "title": "Peers",
+      "type": "stat"
+    },
+    {
+      "datasource": "Graphite",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
             "mode": "palette-classic"
           },
           "custom": {
@@ -53,7 +163,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "line",
+            "drawStyle": "bars",
             "fillOpacity": 0,
             "gradientMode": "none",
             "hideFrom": {
@@ -94,8 +204,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 7,
-        "x": 0,
+        "w": 6,
+        "x": 4,
         "y": 1
       },
       "id": 10,
@@ -114,9 +224,18 @@
       "targets": [
         {
           "datasource": "Graphite",
+          "refCount": 0,
           "refId": "A",
-          "target": "stats.gauges.hubble.contracts.block_number",
+          "target": "stats_counts.hubble.ethevents.blocks",
           "textEditor": false
+        },
+        {
+          "datasource": "Graphite",
+          "hide": false,
+          "refCount": 0,
+          "refId": "B",
+          "target": "stats_counts.hubble.l2events.blocks",
+          "textEditor": true
         }
       ],
       "title": "Synced Blocks",
@@ -179,8 +298,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 7,
+        "w": 7,
+        "x": 10,
         "y": 1
       },
       "id": 1,
@@ -293,8 +412,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 9,
-        "x": 15,
+        "w": 7,
+        "x": 17,
         "y": 1
       },
       "id": 19,
@@ -320,6 +439,65 @@
       ],
       "title": "Synced Messages",
       "type": "timeseries"
+    },
+    {
+      "datasource": "Graphite",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 5
+      },
+      "id": 24,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "titleSize": 26,
+          "valueSize": 1
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.3",
+      "targets": [
+        {
+          "datasource": "Graphite",
+          "refId": "A",
+          "target": "aliasByNode(stats.gauges.hubble.farcaster.*.*.*.*, 5, 6, 7)",
+          "textEditor": true
+        }
+      ],
+      "title": "Hub Version",
+      "type": "stat"
     },
     {
       "collapsed": false,

--- a/apps/hubble/src/eth/ethEventsProvider.ts
+++ b/apps/hubble/src/eth/ethEventsProvider.ts
@@ -320,6 +320,8 @@ export class EthEventsProvider {
 
         progressBar?.update(Math.max(nextFromBlock - fromBlock - 1, 0));
 
+        statsd().increment("ethevents.blocks", Math.min(toBlock, nextToBlock) - nextFromBlock);
+
         // Sync old Id events
         await this.syncHistoricalIdEvents(nextFromBlock, nextToBlock);
 
@@ -525,6 +527,7 @@ export class EthEventsProvider {
 
     this._isHandlingBlock = true;
     log.info({ blockNumber }, `new block: ${blockNumber}`);
+    statsd().increment("ethevents.blocks");
 
     // Get all blocks that have been confirmed into a single array and sort.
     const cachedBlocksSet = new Set([

--- a/apps/hubble/src/eth/l2EventsProvider.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.ts
@@ -623,6 +623,7 @@ export class L2EventsProvider {
         `syncing events (${formatPercentage((nextFromBlock - fromBlock) / totalBlocks)})`,
       );
       progressBar?.update(Math.max(nextFromBlock - fromBlock - 1, 0));
+      statsd().increment("l2events.blocks", Math.min(toBlock, nextToBlock - nextFromBlock));
 
       const idFilter = await this._publicClient.createContractEventFilter({
         address: this.idRegistryAddress,
@@ -671,6 +672,7 @@ export class L2EventsProvider {
 
     this._isHandlingBlock = true;
     log.info({ blockNumber }, `new block: ${blockNumber}`);
+    statsd().increment("l2events.blocks");
 
     // Get all blocks that have been confirmed into a single array and sort.
     const cachedBlocksSet = new Set([...this._onChainEventsByBlock.keys()]);

--- a/apps/hubble/src/utils/progressBars.ts
+++ b/apps/hubble/src/utils/progressBars.ts
@@ -34,14 +34,16 @@ export function finishAllProgressBars(showDelay = false): void {
 
         // Wait a few seconds so that the user can see all the status. Do it async, so we don't block the startup
         const progress = addProgressBar("Starting Hubble", waitForSec);
+        finished = true;
 
         for (let i = 0; i < waitForSec; i++) {
           progress?.increment();
           await new Promise((resolve) => setTimeout(resolve, 1000));
         }
+      } else {
+        finished = true;
       }
 
-      finished = true;
       multiBar.stop();
       logger.flush();
     })();


### PR DESCRIPTION
## Change Summary

- Add Hubble version to dashboard
- Add sync completion % 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on improving the Hubble dashboard with sync percentage and version information.

### Detailed summary:
- Added sync percentage and versions to the Hubble dashboard
- Updated progress bars in the Hubble startup process
- Incremented stats for `ethevents.blocks` and `l2events.blocks`
- Added gauge for `farcaster.version` and `farcaster.hubversion`
- Added gauge for `syncengine.sync_percent`
- Added new panels for "Synced" and "Peers" in the Grafana dashboard
- Updated graph styles and configurations in the Grafana dashboard
- Added new panel for "Hub Version" in the Grafana dashboard
- Renamed panel "Hubble Stats" to "Performance" in the Grafana dashboard
- Updated panel title "Node Size" to "DB Size on disk" in the Grafana dashboard

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->