### PR TITLE
fix: Handle both 'docker-compose' and 'docker compose'

### DIFF
--- a/.changeset/funny-shoes-return.md
+++ b/.changeset/funny-shoes-return.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Handle both 'docker-compose' and 'docker compose' in hubble.sh


### PR DESCRIPTION


## Change Summary

- Handle both 'docker compose' and 'docker-compose' in hubble.sh

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the `hubble.sh` script by handling both 'docker-compose' and 'docker compose' commands. 

### Detailed summary
- Added support for both 'docker-compose' and 'docker compose' commands in the script.
- Replaced all instances of `docker compose` with a variable `$COMPOSE_CMD`.
- Updated commands like `docker compose ps`, `docker compose restart`, `docker compose up`, `docker compose pull`, `docker compose run`, `docker compose stop`, and `docker compose logs` with `$COMPOSE_CMD` variable.
- Added a new function `set_compose_command()` to detect the availability of either 'docker-compose' or 'docker compose' command and set the `$COMPOSE_CMD` variable accordingly.
- Updated the `start_hubble()` function to use `$COMPOSE_CMD` variable for running docker-compose commands.
- Updated the `upgrade` command to call `set_compose_command()` function.
- Updated the `upgrade` command to use `$COMPOSE_CMD` variable for running `docker compose logs` command.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->