### PR TITLE
fix: Drop signer constraint in replicator temporarily

### DIFF
--- a/packages/hub-nodejs/examples/replicate-data-postgres/hubReplicator.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/hubReplicator.ts
@@ -415,7 +415,7 @@ export class HubReplicator {
             signer: event.signerEventBody.key,
           })
           // Do nothing on conflict since nothing should have changed if hash is the same.
-          .onConflict((oc) => oc.columns(["fid", "signer"]).doNothing())
+          // .onConflict((oc) => oc.columns(["fid", "signer"]).doNothing())
           .execute();
       } else if (event.signerEventBody.eventType === SignerEventType.REMOVE) {
         await this.db
@@ -683,7 +683,7 @@ export class HubReplicator {
         }),
       )
       // Do nothing on conflict since nothing should have changed if hash is the same.
-      .onConflict((oc) => oc.columns(["signer", "fid"]).doNothing())
+      // .onConflict((oc) => oc.columns(["signer", "fid"]).doNothing())
       .execute();
 
     for (const message of messages) {

--- a/packages/hub-nodejs/examples/replicate-data-postgres/migrations/002_mainnet.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/migrations/002_mainnet.ts
@@ -8,7 +8,7 @@ export const up = async (db: Kysely<any>) => {
 
   await db.schema.alterTable("signers").dropConstraint("signers_hash_foreign").execute();
 
-  await db.schema.alterTable("signers").addUniqueConstraint("signers_fid_signer_unique", ["fid", "signer"]).execute();
+  // await db.schema.alterTable("signers").addUniqueConstraint("signers_fid_signer_unique", ["fid", "signer"]).execute();
 
   await db.schema
     .alterTable("signers")
@@ -46,7 +46,7 @@ export const down = async (db: Kysely<any>) => {
     .alterColumn("custodyAddress", (c) => c.setNotNull())
     .execute();
   await db.schema.alterTable("signers").addUniqueConstraint("signers_hash_unique", ["hash"]).execute();
-  await db.schema.alterTable("signers").dropConstraint("signers_fid_signer_unique").execute();
+  // await db.schema.alterTable("signers").dropConstraint("signers_fid_signer_unique").execute();
   await db.schema
     .alterTable("signers")
     .addForeignKeyConstraint("signers_hash_foreign", ["hash"], "messages", ["hash"])


### PR DESCRIPTION
## Motivation

Before migration, duplicates were possible. After migration it's not. Drop the constraint for now, and we'll clean up the data after migration. 

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on making changes to the `hubReplicator.ts` and `002_mainnet.ts` files.

### Detailed summary:
- In `hubReplicator.ts`:
  - Commented out the `.onConflict` method calls.
- In `002_mainnet.ts`:
  - Commented out the `addUniqueConstraint` and `dropConstraint` method calls.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->