### PR TITLE
chore: Set final contract addresses as default

### DIFF
--- a/apps/hubble/src/eth/l2EventsProvider.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.ts
@@ -31,10 +31,10 @@ const log = logger.child({
 });
 
 export class OptimismConstants {
-  public static StorageRegistryAddress = undefined;
-  public static KeyRegistryAddress = undefined;
-  public static IdRegistryAddress = undefined;
-  public static FirstBlock = 108222360; // ~Aug 14 2023 8pm UTC, approx 1.5 weeks before planned migration
+  public static StorageRegistryAddress = "0x00000000fcce7f938e7ae6d3c335bd6a1a7c593d" as const;
+  public static KeyRegistryAddress = "0x00000000fc9e66f1c6d86d750b4af47ff0cc343d" as const;
+  public static IdRegistryAddress = "0x00000000fcaf86937e41ba038b4fa40baa4b780a" as const;
+  public static FirstBlock = 108864739; // ~Aug 29 2023 5:00pm UTC
   public static ChunkSize = 1000;
   public static ChainId = 10; // OP mainnet
 }


### PR DESCRIPTION
## Motivation

Update the default L2 contract addresses

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the addresses and block number in the `OptimismConstants` class in `l2EventsProvider.ts`.

### Detailed summary
- Updated `StorageRegistryAddress` to "0x00000000fcce7f938e7ae6d3c335bd6a1a7c593d"
- Updated `KeyRegistryAddress` to "0x00000000fc9e66f1c6d86d750b4af47ff0cc343d"
- Updated `IdRegistryAddress` to "0x00000000fcaf86937e41ba038b4fa40baa4b780a"
- Updated `FirstBlock` to 108864739

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->