### PR TITLE
fix: stop revoking valid messages

### DIFF
--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -466,9 +466,6 @@ class Engine {
         case UserPostfix.ReactionMessage: {
           return this._reactionStore.revoke(message);
         }
-        case UserPostfix.SignerMessage: {
-          return this._signerStore.revoke(message);
-        }
         case UserPostfix.CastMessage: {
           return this._castStore.revoke(message);
         }


### PR DESCRIPTION
## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on removing the revocation of `SignerMessage` in the `index.ts` file of the `storage/engine` module.

### Detailed summary:
- Removed the revocation of `SignerMessage` in the `index.ts` file of the `storage/engine` module.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->