### PR TITLE
Update index.ts

### DIFF
--- a/packages/hub-nodejs/examples/chron-feed/index.ts
+++ b/packages/hub-nodejs/examples/chron-feed/index.ts
@@ -2,6 +2,7 @@ import {
   CastAddMessage,
   fromFarcasterTime,
   getSSLHubRpcClient,
+  getInsecureHubRpcClient,
   HubAsyncResult,
   HubRpcClient,
   isCastAddMessage,


### PR DESCRIPTION
Imports getInsecureHubRpcClient by default. (Needed when connecting to a node without SSL, like a local hub.)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new function `getInsecureHubRpcClient` to the `chron-feed` example. 

### Detailed summary
- Added new function `getInsecureHubRpcClient` to the `chron-feed` example.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->