### PR TITLE
[fix] Post migration fixes

### DIFF
--- a/.changeset/warm-nails-type.md
+++ b/.changeset/warm-nails-type.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Stream buffer size to 5K and correct store size limits

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           # Pinning until https://github.com/foundry-rs/foundry/issues/5749 is fixed
-          version: nightly-bff4ed912bb023d7bf9b20eda581aa4867a1cf70
+          version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
 
       - name: Install dependencies
         run: yarn install

--- a/apps/hubble/src/rpc/bufferedStreamWriter.ts
+++ b/apps/hubble/src/rpc/bufferedStreamWriter.ts
@@ -4,7 +4,7 @@ import { err, ok } from "neverthrow";
 export const STREAM_DRAIN_TIMEOUT_MS = 10_000;
 export const SLOW_CLIENT_GRACE_PERIOD_MS = 60_000;
 // TODO: Make this configurable via CLI
-export const STREAM_MESSAGE_BUFFER_SIZE = 10_000;
+export const STREAM_MESSAGE_BUFFER_SIZE = 5_000;
 
 /**
  * A BufferedStreamWriter is a wrapper around a gRPC stream that will buffer messages when the stream is backed up.

--- a/apps/hubble/src/storage/engine/index.test.ts
+++ b/apps/hubble/src/storage/engine/index.test.ts
@@ -998,31 +998,6 @@ describe("with listeners and workers", () => {
       // Revokes messages after 1 hr
       await worker.processJobs(Date.now() + 1000 * 60 * 60 + 5000);
       expect(revokedMessages).toContainEqual(signerAdd);
-      expect(revokedMessages).toContainEqual(castAdd);
-      expect(revokedMessages).toContainEqual(reactionAdd);
-      expect(revokedMessages).toContainEqual(linkAdd);
-    });
-
-    test("revokes messages when SignerAdd is pruned", async () => {
-      const event = HubEvent.create({
-        type: HubEventType.PRUNE_MESSAGE,
-        pruneMessageBody: { message: signerAdd },
-      });
-      liveEngine.eventHandler.emit("pruneMessage", event as PruneMessageHubEvent); // Hack to force prune
-      expect(revokedMessages).toEqual([]);
-      await sleep(200); // Wait for engine to revoke messages
-      expect(revokedMessages).toEqual([castAdd, reactionAdd, linkAdd]);
-    });
-
-    test("revokes messages when SignerAdd is revoked", async () => {
-      const event = HubEvent.create({
-        type: HubEventType.REVOKE_MESSAGE,
-        revokeMessageBody: { message: signerAdd },
-      });
-      liveEngine.eventHandler.emit("revokeMessage", event as RevokeMessageHubEvent); // Hack to force revoke
-      expect(revokedMessages).toEqual([signerAdd]);
-      await sleep(200); // Wait for engine to revoke messages
-      expect(revokedMessages).toEqual([signerAdd, castAdd, reactionAdd, linkAdd]);
     });
 
     test("revokes messages when onchain signer is removed", async () => {
@@ -1111,7 +1086,7 @@ describe("with listeners and workers", () => {
 
 describe("stop", () => {
   test("removes all event listeners", async () => {
-    const eventNames: (keyof StoreEvents)[] = ["mergeMessage", "mergeIdRegistryEvent", "pruneMessage", "revokeMessage"];
+    const eventNames: (keyof StoreEvents)[] = ["mergeMessage", "mergeIdRegistryEvent"];
     const scopedEngine = new Engine(db, FarcasterNetwork.TESTNET);
     for (const eventName of eventNames) {
       expect(scopedEngine.eventHandler.listenerCount(eventName)).toEqual(0);

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -56,14 +56,14 @@ import { Worker } from "worker_threads";
 import { getMessage, getMessagesBySignerIterator, typeToSetPostfix } from "../db/message.js";
 import RocksDB from "../db/rocksdb.js";
 import { TSHASH_LENGTH, UserPostfix } from "../db/types.js";
-import CastStore, { CAST_PRUNE_SIZE_LIMIT_DEFAULT } from "../stores/castStore.js";
-import LinkStore, { LINK_PRUNE_SIZE_LIMIT_DEFAULT } from "../stores/linkStore.js";
-import ReactionStore, { REACTION_PRUNE_SIZE_LIMIT_DEFAULT } from "../stores/reactionStore.js";
+import CastStore from "../stores/castStore.js";
+import LinkStore from "../stores/linkStore.js";
+import ReactionStore from "../stores/reactionStore.js";
 import SignerStore from "../stores/signerStore.js";
 import StoreEventHandler from "../stores/storeEventHandler.js";
 import { MessagesPage, PageOptions } from "../stores/types.js";
-import UserDataStore, { USER_DATA_PRUNE_SIZE_LIMIT_DEFAULT } from "../stores/userDataStore.js";
-import VerificationStore, { VERIFICATION_PRUNE_SIZE_LIMIT_DEFAULT } from "../stores/verificationStore.js";
+import UserDataStore from "../stores/userDataStore.js";
+import VerificationStore from "../stores/verificationStore.js";
 import { logger } from "../../utils/logger.js";
 import { RevokeMessagesBySignerJobQueue, RevokeMessagesBySignerJobWorker } from "../jobs/revokeMessagesBySignerJob.js";
 import { ensureAboveTargetFarcasterVersion } from "../../utils/versions.js";
@@ -803,23 +803,23 @@ class Engine {
       limits: [
         {
           storeType: StoreType.CASTS,
-          limit: CAST_PRUNE_SIZE_LIMIT_DEFAULT * units.value,
+          limit: this._castStore.pruneSizeLimit * units.value,
         },
         {
           storeType: StoreType.LINKS,
-          limit: LINK_PRUNE_SIZE_LIMIT_DEFAULT * units.value,
+          limit: this._linkStore.pruneSizeLimit * units.value,
         },
         {
           storeType: StoreType.REACTIONS,
-          limit: REACTION_PRUNE_SIZE_LIMIT_DEFAULT * units.value,
+          limit: this._reactionStore.pruneSizeLimit * units.value,
         },
         {
           storeType: StoreType.USER_DATA,
-          limit: USER_DATA_PRUNE_SIZE_LIMIT_DEFAULT * units.value,
+          limit: this._userDataStore.pruneSizeLimit * units.value,
         },
         {
           storeType: StoreType.VERIFICATIONS,
-          limit: VERIFICATION_PRUNE_SIZE_LIMIT_DEFAULT * units.value,
+          limit: this._verificationStore.pruneSizeLimit * units.value,
         },
       ],
     });

--- a/apps/hubble/src/storage/jobs/pruneMessagesJob.test.ts
+++ b/apps/hubble/src/storage/jobs/pruneMessagesJob.test.ts
@@ -118,10 +118,10 @@ describe("doJobs", () => {
 
         // These are pruned based on size
         const verifications = await engine.getVerificationsByFid(fid);
-        expect(verifications._unsafeUnwrap().messages.length).toEqual(50);
+        expect(verifications._unsafeUnwrap().messages.length).toEqual(25);
       }
 
-      expect(prunedMessages.length).toEqual(2);
+      expect(prunedMessages.length).toEqual(52); // 26 verifications * 2 fids
       expect(prunedMessages.filter((m) => m.data?.type !== MessageType.VERIFICATION_ADD_ETH_ADDRESS)).toEqual([]);
     },
     15 * 1000,


### PR DESCRIPTION
## Motivation

 - Set stream buffer size to 5K
 - Do not cascade revoke valid messages when old signer messages are revoked
 - Reduce store sizes by half on 2023-09-06 (we're currently over provisioning storage)

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing issues related to stream buffer size and store size limits in the `@farcaster/hubble` package. 

### Detailed summary
- Fixed the stream buffer size to 5,000.
- Corrected the store size limits.
- Updated the version of `@farcaster/hubble` to `nightly-ca67d15f4abd46394b324c50e21e66f306a1162d`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->