### PR TITLE
chore: Release 1.5.1

### DIFF
--- a/.changeset/eighty-jeans-smell.md
+++ b/.changeset/eighty-jeans-smell.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-chore: Improve dashboard with sync %, versions

--- a/.changeset/funny-shoes-return.md
+++ b/.changeset/funny-shoes-return.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Handle both 'docker-compose' and 'docker compose' in hubble.sh

--- a/.changeset/warm-nails-type.md
+++ b/.changeset/warm-nails-type.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Stream buffer size to 5K and correct store size limits

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hubble
 
+## 1.5.1
+
+### Patch Changes
+
+- 9138ca9e: chore: Improve dashboard with sync %, versions
+- 8ea938ab: fix: Handle both 'docker-compose' and 'docker compose' in hubble.sh
+- 05e5ed1e: fix: Stream buffer size to 5K and correct store size limits
+
 ## 1.5.0
 
 ### Minor Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",


### PR DESCRIPTION
## Motivation

Release 1.5.1

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version number of the Hubble package to 1.5.1 and providing a detailed summary of the changes made in this version.

### Detailed summary
- Improved dashboard with sync % and versions
- Fixed handling of both 'docker-compose' and 'docker compose' in hubble.sh
- Stream buffer size set to 5K and corrected store size limits

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->