### PR TITLE
fix: Add sync timing information to grafana

### DIFF
--- a/.changeset/blue-swans-clean.md
+++ b/.changeset/blue-swans-clean.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+devex: Add timing information for sync to grafana dashboard

--- a/apps/hubble/grafana/grafana-dashboard.json
+++ b/apps/hubble/grafana/grafana-dashboard.json
@@ -1476,6 +1476,282 @@
       ],
       "title": "Num Peers",
       "type": "gauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      },
+      "id": 28,
+      "panels": [],
+      "title": "Sync Details",
+      "type": "row"
+    },
+    {
+      "datasource": "Graphite",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 7,
+        "x": 0,
+        "y": 44
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "Graphite",
+          "refId": "A",
+          "target": "stats_counts.hubble.syncengine.sync_messages.*"
+        }
+      ],
+      "title": "Sync Messages",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Graphite",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 10,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "stats.timers.hubble.syncengine.peer.get_all_messages_by_syncids_ms.mean"
+            },
+            "properties": [
+              {
+                "id": "custom.drawStyle",
+                "value": "bars"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 9,
+        "x": 7,
+        "y": 44
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "Graphite",
+          "refId": "A",
+          "target": "stats.timers.hubble.syncengine.peer.*.mean"
+        }
+      ],
+      "title": "Peer Sync Timings",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Graphite",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 44
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "Graphite",
+          "refId": "A",
+          "target": "stats_counts.hubble.syncengine.peer_counts.*"
+        }
+      ],
+      "title": "Sync Messages Fetched",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",
@@ -1493,6 +1769,6 @@
   "timezone": "",
   "title": "Hubble Dashboard",
   "uid": "af04c037-bd8f-484a-b93e-0cb4b7d3b026",
-  "version": 3,
+  "version": 2,
   "weekStart": ""
 }

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -538,7 +538,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
   }
 
   async performSync(peerId: string, otherSnapshot: TrieSnapshot, rpcClient: HubRpcClient): Promise<MergeResult> {
-    log.debug({ peerId }, "Perform sync: Start");
+    log.info({ peerId }, "Perform sync: Start");
 
     const start = Date.now();
 
@@ -592,6 +592,10 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
             "syncengine.sync_percent",
             avgPeerNumMessages > 0 ? Math.min(1, (await this.trie.items()) / avgPeerNumMessages) : 0,
           );
+
+          statsd().increment("syncengine.sync_messages.success", result.successCount);
+          statsd().increment("syncengine.sync_messages.error", result.errCount);
+          statsd().increment("syncengine.sync_messages.deferred", result.deferredCount);
         });
 
         log.info({ syncResult: fullSyncResult }, "Perform sync: Sync Complete");
@@ -718,11 +722,14 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     }
 
     let result = new MergeResult();
+    const start = Date.now();
     const messagesResult = await rpcClient.getAllMessagesBySyncIds(
       SyncIds.create({ syncIds }),
       new Metadata(),
       rpcDeadline(),
     );
+    statsd().timing("syncengine.peer.get_all_messages_by_syncids_ms", Date.now() - start);
+
     await messagesResult.match(
       async (msgs) => {
         // Make sure that the messages are actually for the SyncIDs
@@ -743,6 +750,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
             "PeerError: Fetched Messages do not match SyncIDs requested",
           );
         } else {
+          statsd().increment("syncengine.peer_counts.get_all_messages_by_syncids", msgs.messages.length);
           result = await this.mergeMessages(msgs.messages, rpcClient);
         }
       },
@@ -857,11 +865,13 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     }
 
     const ourNode = await this._trie.getTrieNodeMetadata(prefix);
+    const start = Date.now();
     const theirNodeResult = await rpcClient.getSyncMetadataByPrefix(
       TrieNodePrefix.create({ prefix }),
       new Metadata(),
       rpcDeadline(),
     );
+    statsd().timing("syncengine.peer.get_syncmetadata_by_prefix_ms", Date.now() - start);
 
     if (theirNodeResult.isErr()) {
       log.warn(theirNodeResult.error, `Error fetching metadata for prefix ${prefix}`);
@@ -904,11 +914,13 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     // If the other hub's node has fewer than the fetchMessagesThreshold, just fetch them all in go, otherwise, iterate through
     // the node's children and fetch them in batches.
     if (theirNode.numMessages <= fetchMessagesThreshold) {
+      const start = Date.now();
       const result = await rpcClient.getAllSyncIdsByPrefix(
         TrieNodePrefix.create({ prefix: theirNode.prefix }),
         new Metadata(),
         rpcDeadline(),
       );
+      statsd().timing("syncengine.peer.get_all_syncids_by_prefix_ms", Date.now() - start);
 
       if (result.isErr()) {
         log.warn(result.error, `Error fetching ids for prefix ${theirNode.prefix}`);
@@ -922,6 +934,8 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
           return;
         }
 
+        statsd().increment("syncengine.peer_counts.get_all_syncids_by_prefix", result.value.syncIds.length);
+
         // Strip out all syncIds that we already have. This can happen if our node has more messages than the other
         // hub at this node.
         // Note that we can optimize this check for the common case of a single missing syncId, since the diff
@@ -930,6 +944,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
         if (result.value.syncIds.length === 1) {
           if (await this._trie.existsByBytes(missingHashes[0] as Uint8Array)) {
             missingHashes = [];
+            statsd().increment("syncengine.peer_counts.get_all_syncids_by_prefix_already_exists", 1);
           }
         }
         await onMissingHashes(missingHashes);


### PR DESCRIPTION
## Motivation

Improve grafana dashboard with sync timing info


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Changed log level from debug to info in `performSync` function in `syncEngine.ts`.
- Added timing information for `getAllMessagesBySyncIds` and `getSyncMetadataByPrefix` functions in `syncEngine.ts`.
- Incremented statsd counters for successful, error, and deferred sync messages in `performSync` function in `syncEngine.ts`.
- Added statsd timing for `getAllSyncIdsByPrefix` function in `performSync` function in `syncEngine.ts`.
- Incremented statsd counter for `get_all_messages_by_syncids` in `performSync` function in `syncEngine.ts`.
- Added Grafana dashboard panels for sync messages and peer sync timings.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->