### PR TITLE
fix: Count peer validation errors during sync

### DIFF
--- a/.changeset/sweet-planets-deliver.md
+++ b/.changeset/sweet-planets-deliver.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Count peer validation errors during sync

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -814,6 +814,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
               "PeerError: Unexpected validation error",
             );
             this._currentSyncStatus.seriousValidationFailures += 1;
+            errCount += 1;
           }
         } else if (result.error.errCode === "bad_request.duplicate") {
           // This message has been merged into the DB, but for some reason is not in the Trie.

--- a/packages/hub-nodejs/examples/chron-feed/index.ts
+++ b/packages/hub-nodejs/examples/chron-feed/index.ts
@@ -2,6 +2,7 @@ import {
   CastAddMessage,
   fromFarcasterTime,
   getSSLHubRpcClient,
+  getInsecureHubRpcClient,
   HubAsyncResult,
   HubRpcClient,
   isCastAddMessage,


### PR DESCRIPTION
## Motivation

Count peer validation errors during sync

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR
Fixing a bug related to counting peer validation errors during sync.

### Detailed summary
- Added a new dependency on `@farcaster/hubble` with a patch version.
- Added a new function `getInsecureHubRpcClient` in the file `packages/hub-nodejs/examples/chron-feed/index.ts`.
- Modified the function `syncEngine` in the file `apps/hubble/src/network/sync/syncEngine.ts` to count the validation errors during sync.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->