### PR TITLE
chore: Remove pre-fetching signers during sync

### DIFF
--- a/.changeset/fresh-wombats-sing.md
+++ b/.changeset/fresh-wombats-sing.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+chore: Remove signer pre-sync for initial sync

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -560,12 +560,6 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
         if (missingMessages > 10_000) {
           this._currentSyncStatus.initialSync = true;
           progressBar = addProgressBar("Initial Sync", missingMessages);
-
-          if (ourSnapshot.numMessages === 0) {
-            // If we have no messages, we need to fetch all messages from the peer
-            // so start with the signers
-            await this.getAllSignersFromPeer(rpcClient, progressBar);
-          }
         } else {
           this._currentSyncStatus.initialSync = false;
           finishAllProgressBars(true);
@@ -620,72 +614,6 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     }
 
     return fullSyncResult;
-  }
-
-  async getAllSignersFromPeer(rpcClient: HubRpcClient, progressBar?: SingleBar): Promise<boolean> {
-    // Get all signers from the peer to speed up the sync
-
-    // First, fetch all FIDs from the peer
-    let finished = false;
-    let pageToken: Uint8Array | undefined;
-    const fids: number[] = [];
-
-    do {
-      const fidRequest = FidRequest.create({ pageToken, pageSize: 1000 });
-      const fidResult = await rpcClient.getFids(fidRequest, new Metadata(), rpcDeadline());
-
-      if (fidResult.isErr()) {
-        log.error({ err: fidResult.error }, "Failed to fetch FIDs from peer");
-        return false;
-      }
-
-      const { fids: fetchedFids, nextPageToken } = fidResult.value;
-      fids.push(...fetchedFids);
-      if (!nextPageToken) {
-        finished = true;
-      } else {
-        pageToken = nextPageToken;
-      }
-    } while (!finished);
-
-    progressBar?.setTotal(progressBar.getTotal() + fids.length);
-
-    // Then, fetch all signers for the FIDs, in groups of 10
-    for (let i = 0; i < fids.length; i += 10) {
-      const fidsBatch = Array.from({ length: Math.min(10, fids.length - i) }, (_, j) => fids[i + j]);
-      await Promise.all(
-        fidsBatch.map(async (fid) => {
-          if (!fid || this._currentSyncStatus.interruptSync) {
-            return;
-          }
-
-          progressBar?.increment();
-
-          const signerResult = await rpcClient.getSignersByFid(
-            FidRequest.create({ fid }),
-            new Metadata(),
-            rpcDeadline(),
-          );
-          if (signerResult.isErr()) {
-            log.error({ err: signerResult.error }, "Failed to fetch signer from peer");
-
-            // Ignore this FID, we'll just sync the message without the signer
-            return;
-          }
-
-          const { messages } = signerResult.value;
-          for (const signer of messages) {
-            const signerResult = await this._hub.submitMessage(signer, "sync");
-            if (signerResult.isErr()) {
-              log.error({ err: signerResult.error, fid }, "Failed to submit signer");
-              break;
-            }
-          }
-        }),
-      );
-    }
-
-    return true;
   }
 
   async getAllMessagesBySyncIds(syncIds: Uint8Array[]): HubAsyncResult<Message[]> {


### PR DESCRIPTION
## Motivation

Now that we have on-chain signers, remove the signers pre-fetch during initial sync



## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on removing the signer pre-sync for initial sync in the `syncEngine.ts` file.

### Detailed summary:
- Removed the code for fetching all signers from the peer to speed up the sync.
- Removed the code for fetching all FIDs from the peer.
- Removed the code for fetching all signers for the FIDs in groups of 10.
- Removed the code for submitting the signer messages to the hub.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->