### PR TITLE
chore: Deprecate "status" command

### DIFF
--- a/.changeset/empty-sloths-drum.md
+++ b/.changeset/empty-sloths-drum.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+chore: Deprecate "status" command

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -655,7 +655,7 @@ app
 /*//////////////////////////////////////////////////////////////
                           STATUS COMMAND
 //////////////////////////////////////////////////////////////*/
-
+// Deprecated. Please use grafana monitoring instead.
 app
   .command("status")
   .description("Reports the db and sync status of the hub")
@@ -687,6 +687,9 @@ app
       `Hub Version: ${infoResult.value.version} Messages: ${dbStats?.numMessages} FIDs: ${dbStats?.numFidEvents} FNames: ${dbStats?.numFnameEvents}}`,
     );
     for (;;) {
+      logger.warn(
+        "The 'status' command has been deprecated, and will be removed in a future release. Please use grafana monitoring. See https://www.thehubble.xyz/intro/monitoring.html",
+      );
       const syncResult = await rpcClient.getSyncStatus(SyncStatusRequest.create({ peerId: cliOptions.peerId }));
       if (syncResult.isErr()) {
         logger.error(

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -688,7 +688,9 @@ app
     );
     for (;;) {
       logger.warn(
-        "The 'status' command has been deprecated, and will be removed in a future release. Please use grafana monitoring. See https://www.thehubble.xyz/intro/monitoring.html",
+        "DEPRECATION WARNING:" +
+          "The 'status' command has been deprecated, and will be removed in a future release." +
+          "Please use Grafana monitoring. See https://www.thehubble.xyz/intro/monitoring.html",
       );
       const syncResult = await rpcClient.getSyncStatus(SyncStatusRequest.create({ peerId: cliOptions.peerId }));
       if (syncResult.isErr()) {

--- a/apps/hubble/www/docs/docs/cli.md
+++ b/apps/hubble/www/docs/docs/cli.md
@@ -93,6 +93,7 @@ Commands:
 Usage: yarn status [options]
 
 Reports the db and sync status of the hub
+WARNING: This command has been deprecated, and will be removed in a future release. Please use Grafana monitoring. See https://www.thehubble.xyz/intro/monitoring.html
 
 Options:
   -s, --server <url>     Farcaster RPC server address:port to connect to (eg. 127.0.0.1:2283) (default: "127.0.0.1:2283")

--- a/apps/hubble/www/docs/intro/install.md
+++ b/apps/hubble/www/docs/intro/install.md
@@ -134,13 +134,6 @@ Check the logs to ensure your hub is running successfully:
 docker compose logs -f hubble
 ```
 
-Check the sync status to see how your Hub is doing:
-
-```bash
-docker compose exec hubble yarn status --insecure
-```
-
-
 Open up a shell inside the hubble container by running:
 
 ```bash


### PR DESCRIPTION
## Motivation

Deprecate the `yarn status` command. It will be removed in a future release. Switch to using grafana monitoring.


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR deprecates the "status" command in the Hubble app and provides a warning message. 

### Detailed summary
- Deprecates the "status" command in the Hubble app.
- Adds a warning message for the deprecated command.
- Provides a link to Grafana monitoring as an alternative.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->