### PR TITLE
fix: Fix progress bar for non-tty

### DIFF
--- a/.changeset/clever-students-join.md
+++ b/.changeset/clever-students-join.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Fix progress bar for docker (non-TTY)

--- a/apps/hubble/docker-compose.yml
+++ b/apps/hubble/docker-compose.yml
@@ -8,7 +8,6 @@ version: '3.9'
 services:
   hubble:
     image: farcasterxyz/hubble:latest
-    tty: true 
     restart: unless-stopped
     command: [
       "node", "--no-warnings",  "build/cli.js", "start",

--- a/apps/hubble/src/utils/progressBars.ts
+++ b/apps/hubble/src/utils/progressBars.ts
@@ -1,27 +1,33 @@
 import cliProgress, { SingleBar } from "cli-progress";
 import { logger } from "./logger.js";
 
-// The global multibar, to which all progress bars are added
-const multiBar = new cliProgress.MultiBar(
-  {
-    format: " {bar} {percentage}% | {name} | {value}/{total} | ETA: {eta_formatted}",
-    hideCursor: true,
-    clearOnComplete: false,
-    etaBuffer: 1_000,
-    autopadding: true,
-  },
-  cliProgress.Presets.shades_grey,
-);
+const allBars: SingleBar[] = [];
 let finished = false;
 
 // Add a progress bar to the console. Returns undefined if the progress bar
 // cannot be added (e.g. if the process is shutting down).
 // Call finishAllProgressBars() to stop all progress bars.
-export function addProgressBar(name: string, total: number, options?: cliProgress.Options): SingleBar | undefined {
+export function addProgressBar(name: string, total: number): SingleBar | undefined {
   if (finished) {
     return undefined;
   }
-  return multiBar.create(total, 0, { name, ...options });
+
+  const bar = new cliProgress.SingleBar(
+    {
+      format: ` {bar} {percentage}% | ${name} | {value}/{total} | ETA: {eta_formatted}`,
+      hideCursor: true,
+      clearOnComplete: false,
+      etaBuffer: 1_000,
+      autopadding: true,
+      noTTYOutput: true,
+      notTTYSchedule: 3000,
+    },
+    cliProgress.Presets.shades_grey,
+  );
+
+  bar.start(total, 0);
+  allBars.push(bar);
+  return bar;
 }
 
 // Finish all progress bars. This should be called when the process is shutting
@@ -44,7 +50,7 @@ export function finishAllProgressBars(showDelay = false): void {
         finished = true;
       }
 
-      multiBar.stop();
+      allBars.forEach((bar) => bar.stop());
       logger.flush();
     })();
   }


### PR DESCRIPTION
## Motivation

Fix progress bar on non-tty (docker) to just print updates in new lines


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Fixed the progress bar for Docker (non-TTY) in the Hubble app.
- Replaced the global multibar with a single progress bar for each task.
- Added a function to add and manage progress bars.
- Updated the finishAllProgressBars function to stop all progress bars.
- Removed the `tty` option from the Hubble Docker configuration.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->