### PR TITLE
feat: Add parameter to configure the max RPC subscribers per IP

### DIFF
--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -123,6 +123,10 @@ app
     "--rpc-rate-limit <number>",
     "RPC rate limit for peers specified in rpm. Set to -1 for none. (default: 20k/min)",
   )
+  .option(
+    "--rpc-subscribe-per-ip-limit <number>",
+    "Maximum RPC subscriptions per IP address (default: 4)",
+  )
 
   // Metrics
   .option(

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -494,6 +494,7 @@ app
       rpcPort: cliOptions.rpcPort ?? hubConfig.rpcPort ?? DEFAULT_RPC_PORT,
       rpcAuth,
       rpcRateLimit,
+      rpcSubscribePerIpLimit: cliOptions.rpcSubscribePerIpLimit ?? hubConfig.rpcSubscribePerIpLimit,
       rocksDBName: cliOptions.dbName ?? hubConfig.dbName,
       resetDB,
       rebuildSyncTrie,

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -123,10 +123,7 @@ app
     "--rpc-rate-limit <number>",
     "RPC rate limit for peers specified in rpm. Set to -1 for none. (default: 20k/min)",
   )
-  .option(
-    "--rpc-subscribe-per-ip-limit <number>",
-    "Maximum RPC subscriptions per IP address (default: 4)",
-  )
+  .option("--rpc-subscribe-per-ip-limit <number>", "Maximum RPC subscriptions per IP address. (default: 4)")
 
   // Metrics
   .option(

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -148,6 +148,9 @@ export interface HubOptions {
   /** Enable IP Rate limiting */
   rpcRateLimit?: number;
 
+  /** Overrides the maximum limit for RPC subscribers per IP address. Default is set to 4 */
+  rpcSubscribePerIpLimit?: number;
+
   /** Rank RPCs and use the ones with best stability and latency */
   rankRpcs?: boolean;
 
@@ -381,6 +384,7 @@ export class Hub implements HubInterface {
       this.gossipNode,
       options.rpcAuth,
       options.rpcRateLimit,
+      options.rpcSubscribePerIpLimit,
     );
     this.adminServer = new AdminServer(this, this.rocksDB, this.engine, this.syncEngine, options.rpcAuth);
 

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -63,8 +63,8 @@ import { statsd } from "../utils/statsd.js";
 
 const HUBEVENTS_READER_TIMEOUT = 1 * 60 * 60 * 1000; // 1 hour
 
-export const SUBSCRIBE_PERIP_LIMIT = 4; // Max 4 subscriptions per IP
-export const SUBSCRIBE_GLOBAL_LIMIT = 4096; // Max 4096 subscriptions globally
+export const DEFAULT_SUBSCRIBE_PERIP_LIMIT = 4; // Max 4 subscriptions per IP
+export const DEFAULT_SUBSCRIBE_GLOBAL_LIMIT = 4096; // Max 4096 subscriptions globally
 
 export type RpcUsers = Map<string, string[]>;
 
@@ -238,7 +238,7 @@ export default class Server {
 
   private rpcUsers: RpcUsers;
   private submitMessageRateLimiter: RateLimiterMemory;
-  private subscribeIpLimiter = new IpConnectionLimiter(SUBSCRIBE_PERIP_LIMIT, SUBSCRIBE_GLOBAL_LIMIT);
+  private subscribeIpLimiter: IpConnectionLimiter;
 
   constructor(
     hub?: HubInterface,
@@ -247,6 +247,7 @@ export default class Server {
     gossipNode?: GossipNode,
     rpcAuth?: string,
     rpcRateLimit?: number,
+    rpcSubscribePerIpLimit?: number,
   ) {
     this.hub = hub;
     this.engine = engine;
@@ -274,6 +275,10 @@ export default class Server {
     log.info({ rpcRateLimit }, "RPC rate limit enabled");
 
     this.submitMessageRateLimiter = new RateLimiterMemory(rateLimitPerMinute);
+    this.subscribeIpLimiter = new IpConnectionLimiter(
+      rpcSubscribePerIpLimit ?? DEFAULT_SUBSCRIBE_PERIP_LIMIT,
+      DEFAULT_SUBSCRIBE_GLOBAL_LIMIT,
+    );
   }
 
   async start(ip = "0.0.0.0", port = 0): Promise<number> {

--- a/apps/hubble/src/rpc/test/eventService.test.ts
+++ b/apps/hubble/src/rpc/test/eventService.test.ts
@@ -25,7 +25,7 @@ import {
   OnChainEvent,
   isMergeOnChainHubEvent,
 } from "@farcaster/hub-nodejs";
-import Server, { SUBSCRIBE_PERIP_LIMIT } from "../server.js";
+import Server from "../server.js";
 import { jestRocksDB } from "../../storage/db/jestUtils.js";
 import Engine from "../../storage/engine/index.js";
 import { MockHub } from "../../test/mocks.js";
@@ -40,9 +40,18 @@ let client: HubRpcClient;
 
 const rpcUser = "rpcUser";
 const rpcPass = "rpcPass";
+const testRpcSubscribePerIpLimit = 5;
 
 beforeAll(async () => {
-  server = new Server(hub, engine, undefined, undefined, `${rpcUser}:${rpcPass}`);
+  server = new Server(
+    hub,
+    engine,
+    undefined,
+    undefined,
+    `${rpcUser}:${rpcPass}`,
+    undefined,
+    testRpcSubscribePerIpLimit,
+  );
   const port = await server.start();
   client = getInsecureHubRpcClient(`127.0.0.1:${port}`);
 });
@@ -260,7 +269,7 @@ describe("subscribe", () => {
       const streams = [];
 
       // All these should succeed
-      for (let i = 0; i < SUBSCRIBE_PERIP_LIMIT; i++) {
+      for (let i = 0; i < testRpcSubscribePerIpLimit; i++) {
         const stream = await client.subscribe({ eventTypes: [] });
         expect(stream.isOk()).toBe(true);
         streams.push(stream._unsafeUnwrap());

--- a/apps/hubble/www/docs/docs/cli.md
+++ b/apps/hubble/www/docs/docs/cli.md
@@ -52,6 +52,7 @@ Networking Options:
   --announce-server-name <name>         Server name announced to peers, useful if SSL/TLS enabled. (default: "none")
   --direct-peers <peer-multiaddrs...>   A list of peers for libp2p to directly peer with (default: [])
   --rpc-rate-limit <number>             RPC rate limit for peers specified in rpm. Set to -1 for none. (default: 20k/min)
+  --rpc-subscribe-per-ip-limit <number> Maximum RPC subscriptions per IP address (default: 4)
 
 Debugging Options:
   --gossip-metrics-enabled              Generate tracing and metrics for the gossip network. (default: disabled)


### PR DESCRIPTION
## Motivation
Configure a way to increase the max RPC subscribers per IP without needing to run Hubble from source

## Change Summary
- Introduces `rpcSubscribePerIpLimit ` as a parameter in cli or hubConfig. Defaults to the current static value of 4.
- Updated test to verify the parameter passed into the Rpc Server works as expected

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a new command line option `--rpc-subscribe-per-ip-limit` to set the maximum number of RPC subscriptions per IP address.
- Added a new property `rpcSubscribePerIpLimit` to the `Hub` class and `rpcSubscribePerIpLimit` option to the `cli.ts` file.
- Updated the `Server` class to use the `rpcSubscribePerIpLimit` option for initializing the `subscribeIpLimiter`.
- Updated the `eventService.test.ts` file to use the `testRpcSubscribePerIpLimit` constant for testing the RPC subscription limit.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->