### PR TITLE
feat: Sync latest messages first

### DIFF
--- a/.changeset/purple-windows-travel.md
+++ b/.changeset/purple-windows-travel.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: Sync latest messages first

--- a/apps/hubble/src/network/sync/syncId.test.ts
+++ b/apps/hubble/src/network/sync/syncId.test.ts
@@ -1,7 +1,12 @@
-import { Factories, Message } from "@farcaster/hub-nodejs";
+import { Factories, FarcasterNetwork, Message } from "@farcaster/hub-nodejs";
 import { SyncId } from "./syncId.js";
+import { makeMessagePrimaryKeyFromMessage } from "../../storage/db/message.js";
 
 let message: Message;
+
+const network = FarcasterNetwork.TESTNET;
+const fid = Factories.Fid.build();
+const signer = Factories.Ed25519Signer.build();
 
 beforeAll(async () => {
   message = await Factories.CastAddMessage.create();
@@ -11,5 +16,11 @@ describe("SyncId", () => {
   test("succeeds", async () => {
     const syncId = new SyncId(message).syncId();
     expect(syncId).toBeDefined();
+  });
+
+  test("Test pkFromSyncId", async () => {
+    // Create a new castAdd
+    const castAdd1 = await Factories.CastAddMessage.create({ data: { fid, network } }, { transient: { signer } });
+    expect(makeMessagePrimaryKeyFromMessage(castAdd1)).toEqual(SyncId.pkFromSyncId(new SyncId(castAdd1).syncId()));
   });
 });

--- a/apps/hubble/src/network/sync/syncId.ts
+++ b/apps/hubble/src/network/sync/syncId.ts
@@ -42,7 +42,7 @@ class SyncId {
   static pkFromSyncId(syncId: Uint8Array): Buffer {
     const ts = syncId.slice(0, TIMESTAMP_LENGTH);
     const tsBE = Buffer.alloc(4);
-    tsBE.writeUInt32BE(parseInt(ts.toString(), 10), 0);
+    tsBE.writeUInt32BE(parseInt(Buffer.from(ts).toString(), 10), 0);
 
     const syncIDpart = syncId.slice(TIMESTAMP_LENGTH); // Skips the timestamp
 


### PR DESCRIPTION
## Motivation

Now that we have on-chain signers, we can sync latest-message-first to improve incremental sync times

## Change Summary

- Small bugfixes for tests
- Sync latest branches of the sync trie first, improving incremental sync perf. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Sync latest messages first
- Updated code in `syncId.ts` to use `Buffer.from` instead of `toString` for parsing `ts`
- Added import statements in `syncId.test.ts`
- Updated code in `server.ts` to use `syncEngine?.findCorruptedSyncIDs` and `syncEngine?.revokeSyncIds` methods
- Updated code in `syncEngine.ts` to use `revokeSyncIds` instead of `rebuildSyncIds`
- Added `findCorruptedSyncIDs` method in `syncEngine.ts`
- Updated code in `multiPeerSyncEngine.test.ts` to use `await` for `sleepWhile` calls and added new test cases for recovery scenarios

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->