### PR TITLE
feat: move storage limit constants to core

### DIFF
--- a/.changeset/tricky-fans-confess.md
+++ b/.changeset/tricky-fans-confess.md
@@ -1,0 +1,8 @@
+---
+"@farcaster/hub-nodejs": patch
+"@farcaster/hub-web": patch
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+feat: Add storage limit constants to core

--- a/apps/hubble/src/rpc/test/server.test.ts
+++ b/apps/hubble/src/rpc/test/server.test.ts
@@ -15,17 +15,18 @@ import {
   StorageLimit,
   StorageLimitsResponse,
   StoreType,
+  CASTS_SIZE_LIMIT_DEFAULT,
+  REACTIONS_SIZE_LIMIT_DEFAULT,
+  LINKS_SIZE_LIMIT_DEFAULT,
+  USER_DATA_SIZE_LIMIT_DEFAULT,
+  VERIFICATIONS_SIZE_LIMIT_DEFAULT,
+  USERNAME_PROOFS_SIZE_LIMIT_DEFAULT,
 } from "@farcaster/hub-nodejs";
 import Engine from "../../storage/engine/index.js";
 import { MockHub } from "../../test/mocks.js";
 import Server from "../server.js";
 import SyncEngine from "../../network/sync/syncEngine.js";
 import { Ok } from "neverthrow";
-import { CAST_PRUNE_SIZE_LIMIT_DEFAULT } from "../../storage/stores/castStore.js";
-import { REACTION_PRUNE_SIZE_LIMIT_DEFAULT } from "../../storage/stores/reactionStore.js";
-import { LINK_PRUNE_SIZE_LIMIT_DEFAULT } from "../../storage/stores/linkStore.js";
-import { USER_DATA_PRUNE_SIZE_LIMIT_DEFAULT } from "../../storage/stores/userDataStore.js";
-import { VERIFICATION_PRUNE_SIZE_LIMIT_DEFAULT } from "../../storage/stores/verificationStore.js";
 
 const db = jestRocksDB("protobufs.rpc.server.test");
 const network = FarcasterNetwork.TESTNET;
@@ -110,11 +111,12 @@ describe("server rpc tests", () => {
       const result = await client.getCurrentStorageLimitsByFid(FidRequest.create({ fid }));
       // Default storage limits
       expect(result._unsafeUnwrap().limits.map((l) => l.limit)).toEqual([
-        CAST_PRUNE_SIZE_LIMIT_DEFAULT,
-        LINK_PRUNE_SIZE_LIMIT_DEFAULT,
-        REACTION_PRUNE_SIZE_LIMIT_DEFAULT,
-        USER_DATA_PRUNE_SIZE_LIMIT_DEFAULT,
-        VERIFICATION_PRUNE_SIZE_LIMIT_DEFAULT,
+        CASTS_SIZE_LIMIT_DEFAULT,
+        LINKS_SIZE_LIMIT_DEFAULT,
+        REACTIONS_SIZE_LIMIT_DEFAULT,
+        USER_DATA_SIZE_LIMIT_DEFAULT,
+        USERNAME_PROOFS_SIZE_LIMIT_DEFAULT,
+        VERIFICATIONS_SIZE_LIMIT_DEFAULT,
       ]);
     });
 
@@ -127,19 +129,22 @@ describe("server rpc tests", () => {
       const result = await client.getCurrentStorageLimitsByFid(FidRequest.create({ fid }));
       const storageLimits = StorageLimitsResponse.fromJSON(result._unsafeUnwrap()).limits;
       expect(storageLimits).toContainEqual(
-        StorageLimit.create({ limit: CAST_PRUNE_SIZE_LIMIT_DEFAULT, storeType: StoreType.CASTS }),
+        StorageLimit.create({ limit: CASTS_SIZE_LIMIT_DEFAULT, storeType: StoreType.CASTS }),
       );
       expect(storageLimits).toContainEqual(
-        StorageLimit.create({ limit: REACTION_PRUNE_SIZE_LIMIT_DEFAULT, storeType: StoreType.REACTIONS }),
+        StorageLimit.create({ limit: REACTIONS_SIZE_LIMIT_DEFAULT, storeType: StoreType.REACTIONS }),
       );
       expect(storageLimits).toContainEqual(
-        StorageLimit.create({ limit: LINK_PRUNE_SIZE_LIMIT_DEFAULT, storeType: StoreType.LINKS }),
+        StorageLimit.create({ limit: LINKS_SIZE_LIMIT_DEFAULT, storeType: StoreType.LINKS }),
       );
       expect(storageLimits).toContainEqual(
-        StorageLimit.create({ limit: USER_DATA_PRUNE_SIZE_LIMIT_DEFAULT, storeType: StoreType.USER_DATA }),
+        StorageLimit.create({ limit: USER_DATA_SIZE_LIMIT_DEFAULT, storeType: StoreType.USER_DATA }),
       );
       expect(storageLimits).toContainEqual(
-        StorageLimit.create({ limit: VERIFICATION_PRUNE_SIZE_LIMIT_DEFAULT, storeType: StoreType.VERIFICATIONS }),
+        StorageLimit.create({ limit: VERIFICATIONS_SIZE_LIMIT_DEFAULT, storeType: StoreType.VERIFICATIONS }),
+      );
+      expect(storageLimits).toContainEqual(
+        StorageLimit.create({ limit: USERNAME_PROOFS_SIZE_LIMIT_DEFAULT, storeType: StoreType.USERNAME_PROOFS }),
       );
 
       // add 2 more units
@@ -151,19 +156,22 @@ describe("server rpc tests", () => {
       const result2 = await client.getCurrentStorageLimitsByFid(FidRequest.create({ fid }));
       const newLimits = StorageLimitsResponse.fromJSON(result2._unsafeUnwrap()).limits;
       expect(newLimits).toContainEqual(
-        StorageLimit.create({ limit: CAST_PRUNE_SIZE_LIMIT_DEFAULT * 3, storeType: StoreType.CASTS }),
+        StorageLimit.create({ limit: CASTS_SIZE_LIMIT_DEFAULT * 3, storeType: StoreType.CASTS }),
       );
       expect(newLimits).toContainEqual(
-        StorageLimit.create({ limit: REACTION_PRUNE_SIZE_LIMIT_DEFAULT * 3, storeType: StoreType.REACTIONS }),
+        StorageLimit.create({ limit: REACTIONS_SIZE_LIMIT_DEFAULT * 3, storeType: StoreType.REACTIONS }),
       );
       expect(newLimits).toContainEqual(
-        StorageLimit.create({ limit: LINK_PRUNE_SIZE_LIMIT_DEFAULT * 3, storeType: StoreType.LINKS }),
+        StorageLimit.create({ limit: LINKS_SIZE_LIMIT_DEFAULT * 3, storeType: StoreType.LINKS }),
       );
       expect(newLimits).toContainEqual(
-        StorageLimit.create({ limit: USER_DATA_PRUNE_SIZE_LIMIT_DEFAULT * 3, storeType: StoreType.USER_DATA }),
+        StorageLimit.create({ limit: USER_DATA_SIZE_LIMIT_DEFAULT * 3, storeType: StoreType.USER_DATA }),
       );
       expect(newLimits).toContainEqual(
-        StorageLimit.create({ limit: VERIFICATION_PRUNE_SIZE_LIMIT_DEFAULT * 3, storeType: StoreType.VERIFICATIONS }),
+        StorageLimit.create({ limit: VERIFICATIONS_SIZE_LIMIT_DEFAULT * 3, storeType: StoreType.VERIFICATIONS }),
+      );
+      expect(newLimits).toContainEqual(
+        StorageLimit.create({ limit: USERNAME_PROOFS_SIZE_LIMIT_DEFAULT * 3, storeType: StoreType.USERNAME_PROOFS }),
       );
     });
   });

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -6,6 +6,7 @@ import {
   CastId,
   CastRemoveMessage,
   FarcasterNetwork,
+  getStoreLimits,
   hexStringToBytes,
   HubAsyncResult,
   HubError,
@@ -800,28 +801,7 @@ class Engine {
     }
 
     return ok({
-      limits: [
-        {
-          storeType: StoreType.CASTS,
-          limit: this._castStore.pruneSizeLimit * units.value,
-        },
-        {
-          storeType: StoreType.LINKS,
-          limit: this._linkStore.pruneSizeLimit * units.value,
-        },
-        {
-          storeType: StoreType.REACTIONS,
-          limit: this._reactionStore.pruneSizeLimit * units.value,
-        },
-        {
-          storeType: StoreType.USER_DATA,
-          limit: this._userDataStore.pruneSizeLimit * units.value,
-        },
-        {
-          storeType: StoreType.VERIFICATIONS,
-          limit: this._verificationStore.pruneSizeLimit * units.value,
-        },
-      ],
+      limits: getStoreLimits(units.value),
     });
   }
 

--- a/apps/hubble/src/storage/jobs/pruneMessagesJob.test.ts
+++ b/apps/hubble/src/storage/jobs/pruneMessagesJob.test.ts
@@ -5,6 +5,7 @@ import {
   Message,
   MessageType,
   PruneMessageHubEvent,
+  VERIFICATIONS_SIZE_LIMIT_DEFAULT,
 } from "@farcaster/hub-nodejs";
 import { jestRocksDB } from "../db/jestUtils.js";
 import Engine from "../engine/index.js";
@@ -27,7 +28,7 @@ const seedMessagesFromTimestamp = async (engine: Engine, fid: number, signer: Ed
   );
   const linkAdd = await Factories.LinkAddMessage.create({ data: { fid, timestamp } }, { transient: { signer } });
   const proofs = await Factories.VerificationAddEthAddressMessage.createList(
-    51,
+    VERIFICATIONS_SIZE_LIMIT_DEFAULT + 1,
     { data: { fid, timestamp } },
     { transient: { signer } },
   );
@@ -92,7 +93,7 @@ describe("doJobs", () => {
         expect(links._unsafeUnwrap().messages.length).toEqual(1);
 
         const verifications = await engine.getVerificationsByFid(fid);
-        expect(verifications._unsafeUnwrap().messages.length).toEqual(51);
+        expect(verifications._unsafeUnwrap().messages.length).toEqual(VERIFICATIONS_SIZE_LIMIT_DEFAULT + 1);
       }
 
       const nowOrig = Date.now;
@@ -121,7 +122,7 @@ describe("doJobs", () => {
         expect(verifications._unsafeUnwrap().messages.length).toEqual(25);
       }
 
-      expect(prunedMessages.length).toEqual(52); // 26 verifications * 2 fids
+      expect(prunedMessages.length).toEqual(2); // 1 verification for each of the 2 fids
       expect(prunedMessages.filter((m) => m.data?.type !== MessageType.VERIFICATION_ADD_ETH_ADDRESS)).toEqual([]);
     },
     15 * 1000,

--- a/apps/hubble/src/storage/stores/castStore.ts
+++ b/apps/hubble/src/storage/stores/castStore.ts
@@ -8,6 +8,7 @@ import {
   bytesCompare,
   isCastAddMessage,
   isCastRemoveMessage,
+  CASTS_SIZE_LIMIT_DEFAULT,
 } from "@farcaster/hub-nodejs";
 import { err, ok, ResultAsync } from "neverthrow";
 import {
@@ -22,8 +23,6 @@ import { Transaction } from "../db/rocksdb.js";
 import { RootPrefix, TRUE_VALUE, UserMessagePostfix, UserPostfix } from "../db/types.js";
 import { MessagesPage, PageOptions } from "../stores/types.js";
 import { Store } from "./store.js";
-
-export const CAST_PRUNE_SIZE_LIMIT_DEFAULT = 10_000;
 
 /**
  * Generates unique keys used to store or fetch CastAdd messages in the adds set index
@@ -134,7 +133,7 @@ class CastStore extends Store<CastAddMessage, CastRemoveMessage> {
   override _removeMessageType = MessageType.CAST_REMOVE;
 
   protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return CAST_PRUNE_SIZE_LIMIT_DEFAULT;
+    return CASTS_SIZE_LIMIT_DEFAULT;
   }
 
   protected override get PRUNE_TIME_LIMIT_DEFAULT() {

--- a/apps/hubble/src/storage/stores/linkStore.ts
+++ b/apps/hubble/src/storage/stores/linkStore.ts
@@ -6,6 +6,7 @@ import {
   MessageType,
   isLinkAddMessage,
   isLinkRemoveMessage,
+  LINKS_SIZE_LIMIT_DEFAULT,
 } from "@farcaster/hub-nodejs";
 import {
   getManyMessages,
@@ -20,8 +21,6 @@ import { MessagesPage, PAGE_SIZE_MAX, PageOptions } from "./types.js";
 import { Store } from "./store.js";
 import { ResultAsync, err, ok } from "neverthrow";
 import { Transaction } from "../db/rocksdb.js";
-
-export const LINK_PRUNE_SIZE_LIMIT_DEFAULT = 2_500;
 
 const makeTargetKey = (target: number): Buffer => {
   return makeFidKey(target);
@@ -152,7 +151,7 @@ class LinkStore extends Store<LinkAddMessage, LinkRemoveMessage> {
   override _removeMessageType = MessageType.LINK_REMOVE;
 
   protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return LINK_PRUNE_SIZE_LIMIT_DEFAULT;
+    return LINKS_SIZE_LIMIT_DEFAULT;
   }
 
   override async buildSecondaryIndices(txn: Transaction, message: LinkAddMessage): HubAsyncResult<void> {

--- a/apps/hubble/src/storage/stores/reactionStore.ts
+++ b/apps/hubble/src/storage/stores/reactionStore.ts
@@ -7,6 +7,7 @@ import {
   MessageType,
   ReactionAddMessage,
   ReactionRemoveMessage,
+  REACTIONS_SIZE_LIMIT_DEFAULT,
   ReactionType,
 } from "@farcaster/hub-nodejs";
 import { err, ok, ResultAsync } from "neverthrow";
@@ -24,7 +25,6 @@ import { RootPrefix, TSHASH_LENGTH, UserMessagePostfix, UserPostfix } from "../d
 import { MessagesPage, PAGE_SIZE_MAX, PageOptions } from "../stores/types.js";
 import { Store } from "./store.js";
 
-export const REACTION_PRUNE_SIZE_LIMIT_DEFAULT = 5_000;
 const PRUNE_TIME_LIMIT_DEFAULT = 60 * 60 * 24 * 90; // 90 days
 
 const makeTargetKey = (target: CastId | string): Buffer => {
@@ -147,7 +147,7 @@ class ReactionStore extends Store<ReactionAddMessage, ReactionRemoveMessage> {
   override _removeMessageType = MessageType.REACTION_REMOVE;
 
   protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return REACTION_PRUNE_SIZE_LIMIT_DEFAULT;
+    return REACTIONS_SIZE_LIMIT_DEFAULT;
   }
 
   protected override get PRUNE_TIME_LIMIT_DEFAULT() {

--- a/apps/hubble/src/storage/stores/store.ts
+++ b/apps/hubble/src/storage/stores/store.ts
@@ -330,9 +330,6 @@ export abstract class Store<TAdd extends Message, TRemove extends Message> {
   }
 
   get pruneSizeLimit(): number {
-    if (Date.now() > STORE_SIZE_CORRECTION_TIMESTAMP) {
-      return this._pruneSizeLimit / 2;
-    }
     return this._pruneSizeLimit;
   }
 

--- a/apps/hubble/src/storage/stores/userDataStore.ts
+++ b/apps/hubble/src/storage/stores/userDataStore.ts
@@ -8,6 +8,7 @@ import {
   UserNameProof,
   UserDataAddMessage,
   UserDataType,
+  USER_DATA_SIZE_LIMIT_DEFAULT,
 } from "@farcaster/hub-nodejs";
 import { ok, ResultAsync } from "neverthrow";
 import { makeUserKey } from "../db/message.js";
@@ -24,8 +25,6 @@ import { MessagesPage, PageOptions } from "../stores/types.js";
 import { eventCompare, usernameProofCompare } from "../stores/utils.js";
 import { Store } from "./store.js";
 import { Transaction } from "../db/rocksdb.js";
-
-export const USER_DATA_PRUNE_SIZE_LIMIT_DEFAULT = 100;
 
 /**
  * Generates unique keys used to store or fetch UserDataAdd messages in the UserDataAdd set index
@@ -86,7 +85,7 @@ class UserDataStore extends Store<UserDataAddMessage, never> {
   override _removeMessageType = undefined;
 
   protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return USER_DATA_PRUNE_SIZE_LIMIT_DEFAULT;
+    return USER_DATA_SIZE_LIMIT_DEFAULT;
   }
 
   /**

--- a/apps/hubble/src/storage/stores/usernameProofStore.test.ts
+++ b/apps/hubble/src/storage/stores/usernameProofStore.test.ts
@@ -6,6 +6,7 @@ import {
   HubError,
   MergeUsernameProofHubEvent,
   MessageType,
+  USERNAME_PROOFS_SIZE_LIMIT_DEFAULT,
   UserNameProof,
   UsernameProofMessage,
   UserNameType,
@@ -182,7 +183,7 @@ describe("usernameProofStore", () => {
       const sizePrunedStore = new UsernameProofStore(db, eventHandler, { pruneSizeLimit: 2 });
 
       test("defaults size limit", async () => {
-        expect(set.pruneSizeLimit).toEqual(10);
+        expect(set.pruneSizeLimit).toEqual(USERNAME_PROOFS_SIZE_LIMIT_DEFAULT);
         expect(set.pruneTimeLimit).toBeUndefined();
       });
 

--- a/apps/hubble/src/storage/stores/usernameProofStore.ts
+++ b/apps/hubble/src/storage/stores/usernameProofStore.ts
@@ -4,6 +4,7 @@ import {
   HubEventType,
   isUsernameProofMessage,
   MessageType,
+  USERNAME_PROOFS_SIZE_LIMIT_DEFAULT,
   UserNameProof,
   UsernameProofMessage,
   UserNameType,
@@ -14,8 +15,6 @@ import { Store } from "./store.js";
 import { Transaction } from "../db/rocksdb.js";
 import { makeFidKey, makeTsHash, makeUserKey, readFidKey } from "../db/message.js";
 import { HubEventArgs } from "./storeEventHandler.js";
-
-const PRUNE_SIZE_LIMIT_DEFAULT = 10;
 
 /**
  * Generates a unique key used to store a UsernameProof Message
@@ -57,7 +56,7 @@ class UsernameProofStore extends Store<UsernameProofMessage, never> {
   override _removeMessageType = undefined;
 
   protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return PRUNE_SIZE_LIMIT_DEFAULT;
+    return USERNAME_PROOFS_SIZE_LIMIT_DEFAULT;
   }
 
   /**

--- a/apps/hubble/src/storage/stores/verificationStore.ts
+++ b/apps/hubble/src/storage/stores/verificationStore.ts
@@ -5,14 +5,13 @@ import {
   MessageType,
   VerificationAddEthAddressMessage,
   VerificationRemoveMessage,
+  VERIFICATIONS_SIZE_LIMIT_DEFAULT,
 } from "@farcaster/hub-nodejs";
 import { ok } from "neverthrow";
 import { makeUserKey } from "../db/message.js";
 import { UserMessagePostfix, UserPostfix } from "../db/types.js";
 import { MessagesPage, PageOptions } from "./types.js";
 import { Store } from "./store.js";
-
-export const VERIFICATION_PRUNE_SIZE_LIMIT_DEFAULT = 50;
 
 /**
  * Generates a unique key used to store a VerificationAdds message key in the VerificationsAdds
@@ -94,7 +93,7 @@ class VerificationStore extends Store<VerificationAddEthAddressMessage, Verifica
   override _removeMessageType = MessageType.VERIFICATION_REMOVE;
 
   protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return VERIFICATION_PRUNE_SIZE_LIMIT_DEFAULT;
+    return VERIFICATIONS_SIZE_LIMIT_DEFAULT;
   }
 
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,3 +9,4 @@ export * from "./time";
 export * as validations from "./validations";
 export * from "./verifications";
 export * from "./userNameProof";
+export * from "./limits";

--- a/packages/core/src/limits.ts
+++ b/packages/core/src/limits.ts
@@ -1,0 +1,35 @@
+import { StoreType } from "./protobufs";
+
+export const CASTS_SIZE_LIMIT_DEFAULT = 5_000;
+export const LINKS_SIZE_LIMIT_DEFAULT = 1_250;
+export const REACTIONS_SIZE_LIMIT_DEFAULT = 2_500;
+export const USER_DATA_SIZE_LIMIT_DEFAULT = 50;
+export const USERNAME_PROOFS_SIZE_LIMIT_DEFAULT = 5;
+export const VERIFICATIONS_SIZE_LIMIT_DEFAULT = 25;
+
+export const getStoreLimits = (units: number) => [
+  {
+    storeType: StoreType.CASTS,
+    limit: CASTS_SIZE_LIMIT_DEFAULT * units,
+  },
+  {
+    storeType: StoreType.LINKS,
+    limit: LINKS_SIZE_LIMIT_DEFAULT * units,
+  },
+  {
+    storeType: StoreType.REACTIONS,
+    limit: REACTIONS_SIZE_LIMIT_DEFAULT * units,
+  },
+  {
+    storeType: StoreType.USER_DATA,
+    limit: USER_DATA_SIZE_LIMIT_DEFAULT * units,
+  },
+  {
+    storeType: StoreType.USERNAME_PROOFS,
+    limit: USERNAME_PROOFS_SIZE_LIMIT_DEFAULT * units,
+  },
+  {
+    storeType: StoreType.VERIFICATIONS,
+    limit: VERIFICATIONS_SIZE_LIMIT_DEFAULT * units,
+  },
+];

--- a/packages/core/src/protobufs/generated/request_response.ts
+++ b/packages/core/src/protobufs/generated/request_response.ts
@@ -22,6 +22,7 @@ export enum StoreType {
   REACTIONS = 3,
   USER_DATA = 4,
   VERIFICATIONS = 5,
+  USERNAME_PROOFS = 6,
 }
 
 export function storeTypeFromJSON(object: any): StoreType {
@@ -44,6 +45,9 @@ export function storeTypeFromJSON(object: any): StoreType {
     case 5:
     case "STORE_TYPE_VERIFICATIONS":
       return StoreType.VERIFICATIONS;
+    case 6:
+    case "STORE_TYPE_USERNAME_PROOFS":
+      return StoreType.USERNAME_PROOFS;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum StoreType");
   }
@@ -63,6 +67,8 @@ export function storeTypeToJSON(object: StoreType): string {
       return "STORE_TYPE_USER_DATA";
     case StoreType.VERIFICATIONS:
       return "STORE_TYPE_VERIFICATIONS";
+    case StoreType.USERNAME_PROOFS:
+      return "STORE_TYPE_USERNAME_PROOFS";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum StoreType");
   }

--- a/packages/hub-nodejs/src/generated/request_response.ts
+++ b/packages/hub-nodejs/src/generated/request_response.ts
@@ -22,6 +22,7 @@ export enum StoreType {
   REACTIONS = 3,
   USER_DATA = 4,
   VERIFICATIONS = 5,
+  USERNAME_PROOFS = 6,
 }
 
 export function storeTypeFromJSON(object: any): StoreType {
@@ -44,6 +45,9 @@ export function storeTypeFromJSON(object: any): StoreType {
     case 5:
     case "STORE_TYPE_VERIFICATIONS":
       return StoreType.VERIFICATIONS;
+    case 6:
+    case "STORE_TYPE_USERNAME_PROOFS":
+      return StoreType.USERNAME_PROOFS;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum StoreType");
   }
@@ -63,6 +67,8 @@ export function storeTypeToJSON(object: StoreType): string {
       return "STORE_TYPE_USER_DATA";
     case StoreType.VERIFICATIONS:
       return "STORE_TYPE_VERIFICATIONS";
+    case StoreType.USERNAME_PROOFS:
+      return "STORE_TYPE_USERNAME_PROOFS";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum StoreType");
   }

--- a/packages/hub-web/src/generated/request_response.ts
+++ b/packages/hub-web/src/generated/request_response.ts
@@ -22,6 +22,7 @@ export enum StoreType {
   REACTIONS = 3,
   USER_DATA = 4,
   VERIFICATIONS = 5,
+  USERNAME_PROOFS = 6,
 }
 
 export function storeTypeFromJSON(object: any): StoreType {
@@ -44,6 +45,9 @@ export function storeTypeFromJSON(object: any): StoreType {
     case 5:
     case "STORE_TYPE_VERIFICATIONS":
       return StoreType.VERIFICATIONS;
+    case 6:
+    case "STORE_TYPE_USERNAME_PROOFS":
+      return StoreType.USERNAME_PROOFS;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum StoreType");
   }
@@ -63,6 +67,8 @@ export function storeTypeToJSON(object: StoreType): string {
       return "STORE_TYPE_USER_DATA";
     case StoreType.VERIFICATIONS:
       return "STORE_TYPE_VERIFICATIONS";
+    case StoreType.USERNAME_PROOFS:
+      return "STORE_TYPE_USERNAME_PROOFS";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum StoreType");
   }

--- a/protobufs/schemas/request_response.proto
+++ b/protobufs/schemas/request_response.proto
@@ -176,6 +176,7 @@ enum StoreType {
   STORE_TYPE_REACTIONS = 3;
   STORE_TYPE_USER_DATA = 4;
   STORE_TYPE_VERIFICATIONS = 5;
+  STORE_TYPE_USERNAME_PROOFS = 6;
 }
 
 message StorageLimit {


### PR DESCRIPTION
## Motivation

Move storage limits to core so it's more easily accessible by external consumers without calling the RPC

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding storage limit constants to the core.

### Detailed summary:
- Added storage limit constants for casts, links, reactions, user data, username proofs, and verifications.
- Modified the `Engine` class to return the store limits based on the units value.
- Modified the `UsernameProofStore`, `LinkStore`, `UserDataStore`, `CastStore`, `VerificationStore`, and `ReactionStore` classes to use the new storage limit constants.
- Updated the `storeTypeFromJSON` and `storeTypeToJSON` functions in the generated `request_response.ts` files to include the `USERNAME_PROOFS` store type.
- Added unit tests for the `UsernameProofStore` and `PruneMessagesJob` classes.

> The following files were skipped due to too many changes: `apps/hubble/src/storage/jobs/pruneMessagesJob.test.ts`, `apps/hubble/src/rpc/test/server.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->