### PR TITLE
fix: Fix onchain event dedup bug

### DIFF
--- a/.changeset/breezy-ghosts-buy.md
+++ b/.changeset/breezy-ghosts-buy.md
@@ -1,0 +1,8 @@
+---
+"@farcaster/hub-nodejs": patch
+"@farcaster/hub-web": patch
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+fix: Add txIndex to onchain events fix wrong index being used in the primary key

--- a/apps/hubble/src/eth/l2EventsProvider.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.ts
@@ -202,10 +202,16 @@ export class L2EventsProvider {
     logs: OnLogsParameter<any, true, string>,
   ) {
     for (const event of logs) {
-      const { blockNumber, blockHash, transactionHash, transactionIndex } = event;
+      const { blockNumber, blockHash, transactionHash, transactionIndex, logIndex } = event;
 
       // Do nothing if the block is pending
-      if (blockHash === null || blockNumber === null || transactionHash === null || transactionIndex === null) {
+      if (
+        blockHash === null ||
+        blockNumber === null ||
+        transactionHash === null ||
+        transactionIndex === null ||
+        logIndex === null
+      ) {
         continue;
       }
 
@@ -239,6 +245,7 @@ export class L2EventsProvider {
             blockHash,
             transactionHash,
             transactionIndex,
+            logIndex,
             undefined,
             undefined,
             undefined,
@@ -257,10 +264,16 @@ export class L2EventsProvider {
     logs: OnLogsParameter<any, true, string>,
   ) {
     for (const event of logs) {
-      const { blockNumber, blockHash, transactionHash, transactionIndex } = event;
+      const { blockNumber, blockHash, transactionHash, transactionIndex, logIndex } = event;
 
       // Do nothing if the block is pending
-      if (blockHash === null || blockNumber === null || transactionHash === null || transactionIndex === null) {
+      if (
+        blockHash === null ||
+        blockNumber === null ||
+        transactionHash === null ||
+        transactionIndex === null ||
+        logIndex === null
+      ) {
         continue;
       }
 
@@ -288,6 +301,7 @@ export class L2EventsProvider {
             blockHash,
             transactionHash,
             transactionIndex,
+            logIndex,
             signerEventBody,
           );
         } else if (event.eventName === "Remove") {
@@ -309,6 +323,7 @@ export class L2EventsProvider {
             blockHash,
             transactionHash,
             transactionIndex,
+            logIndex,
             signerEventBody,
           );
         } else if (event.eventName === "AdminReset") {
@@ -330,6 +345,7 @@ export class L2EventsProvider {
             blockHash,
             transactionHash,
             transactionIndex,
+            logIndex,
             signerEventBody,
           );
         } else if (event.eventName === "Migrated") {
@@ -347,6 +363,7 @@ export class L2EventsProvider {
             blockHash,
             transactionHash,
             transactionIndex,
+            logIndex,
             undefined,
             SignerMigratedEventBody.create({ migratedAt: Number(migratedEvent.args.keysMigratedAt) }),
           );
@@ -363,10 +380,16 @@ export class L2EventsProvider {
     logs: OnLogsParameter<any, true, string>,
   ) {
     for (const event of logs) {
-      const { blockNumber, blockHash, transactionHash, transactionIndex } = event;
+      const { blockNumber, blockHash, transactionHash, transactionIndex, logIndex } = event;
 
       // Do nothing if the block is pending
-      if (blockHash === null || blockNumber === null || transactionHash === null || transactionIndex === null) {
+      if (
+        blockHash === null ||
+        blockNumber === null ||
+        transactionHash === null ||
+        transactionIndex === null ||
+        logIndex === null
+      ) {
         continue;
       }
 
@@ -392,6 +415,7 @@ export class L2EventsProvider {
             blockHash,
             transactionHash,
             transactionIndex,
+            logIndex,
             undefined,
             undefined,
             idRegisterEventBody,
@@ -416,6 +440,7 @@ export class L2EventsProvider {
             blockHash,
             transactionHash,
             transactionIndex,
+            logIndex,
             undefined,
             undefined,
             idRegisterEventBody,
@@ -439,6 +464,7 @@ export class L2EventsProvider {
             blockHash,
             transactionHash,
             transactionIndex,
+            logIndex,
             undefined,
             undefined,
             idRegisterEventBody,
@@ -731,7 +757,8 @@ export class L2EventsProvider {
     blockNumBigInt: bigint,
     blockHash: string,
     transactionHash: string,
-    index: number,
+    txIndex: number,
+    logIndex: number,
     signerEventBody?: SignerEventBody,
     signerMigratedEventBody?: SignerMigratedEventBody,
     idRegisterEventBody?: IdRegisterEventBody,
@@ -759,7 +786,8 @@ export class L2EventsProvider {
       blockHash: blockHashBytes,
       blockTimestamp: timestamp,
       transactionHash: transactionHashBytes,
-      logIndex: index,
+      txIndex: txIndex,
+      logIndex: logIndex,
       signerEventBody: signerEventBody,
       signerMigratedEventBody: signerMigratedEventBody,
       idRegisterEventBody: idRegisterEventBody,

--- a/apps/hubble/src/storage/stores/onchainEventStore.test.ts
+++ b/apps/hubble/src/storage/stores/onchainEventStore.test.ts
@@ -1,5 +1,5 @@
 import { jestRocksDB } from "../db/jestUtils.js";
-import OnChainEventStore from "./onChainEventStore.js";
+import OnChainEventStore, { MIGRATION_BLOCK } from "./onChainEventStore.js";
 import StoreEventHandler from "./storeEventHandler.js";
 import {
   Factories,
@@ -40,10 +40,12 @@ describe("OnChainEventStore", () => {
         const badSignerEvent = Factories.SignerOnChainEvent.build({
           logIndex: txIndex, // Log index was incorrectly set to txIndex
           txIndex: 0, // Did not have this field
+          blockNumber: MIGRATION_BLOCK - 100,
         });
         const badRegisterEvent = Factories.IdRegistryOnChainEvent.build({
           logIndex: txIndex, // Log index was incorrectly set to txIndex
           txIndex: 0, // Did not have this field
+          blockNumber: MIGRATION_BLOCK - 10,
         });
         await set.mergeOnChainEvent(badSignerEvent);
         await set.mergeOnChainEvent(badRegisterEvent);

--- a/packages/core/src/protobufs/generated/onchain_event.ts
+++ b/packages/core/src/protobufs/generated/onchain_event.ts
@@ -144,6 +144,7 @@ export interface OnChainEvent {
   signerMigratedEventBody?: SignerMigratedEventBody | undefined;
   idRegisterEventBody?: IdRegisterEventBody | undefined;
   storageRentEventBody?: StorageRentEventBody | undefined;
+  txIndex: number;
 }
 
 export interface SignerEventBody {
@@ -185,6 +186,7 @@ function createBaseOnChainEvent(): OnChainEvent {
     signerMigratedEventBody: undefined,
     idRegisterEventBody: undefined,
     storageRentEventBody: undefined,
+    txIndex: 0,
   };
 }
 
@@ -225,6 +227,9 @@ export const OnChainEvent = {
     }
     if (message.storageRentEventBody !== undefined) {
       StorageRentEventBody.encode(message.storageRentEventBody, writer.uint32(98).fork()).ldelim();
+    }
+    if (message.txIndex !== 0) {
+      writer.uint32(104).uint32(message.txIndex);
     }
     return writer;
   },
@@ -320,6 +325,13 @@ export const OnChainEvent = {
 
           message.storageRentEventBody = StorageRentEventBody.decode(reader, reader.uint32());
           continue;
+        case 13:
+          if (tag != 104) {
+            break;
+          }
+
+          message.txIndex = reader.uint32();
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -349,6 +361,7 @@ export const OnChainEvent = {
       storageRentEventBody: isSet(object.storageRentEventBody)
         ? StorageRentEventBody.fromJSON(object.storageRentEventBody)
         : undefined,
+      txIndex: isSet(object.txIndex) ? Number(object.txIndex) : 0,
     };
   },
 
@@ -377,6 +390,7 @@ export const OnChainEvent = {
     message.storageRentEventBody !== undefined && (obj.storageRentEventBody = message.storageRentEventBody
       ? StorageRentEventBody.toJSON(message.storageRentEventBody)
       : undefined);
+    message.txIndex !== undefined && (obj.txIndex = Math.round(message.txIndex));
     return obj;
   },
 
@@ -407,6 +421,7 @@ export const OnChainEvent = {
     message.storageRentEventBody = (object.storageRentEventBody !== undefined && object.storageRentEventBody !== null)
       ? StorageRentEventBody.fromPartial(object.storageRentEventBody)
       : undefined;
+    message.txIndex = object.txIndex ?? 0;
     return message;
   },
 };

--- a/packages/hub-nodejs/src/generated/onchain_event.ts
+++ b/packages/hub-nodejs/src/generated/onchain_event.ts
@@ -144,6 +144,7 @@ export interface OnChainEvent {
   signerMigratedEventBody?: SignerMigratedEventBody | undefined;
   idRegisterEventBody?: IdRegisterEventBody | undefined;
   storageRentEventBody?: StorageRentEventBody | undefined;
+  txIndex: number;
 }
 
 export interface SignerEventBody {
@@ -185,6 +186,7 @@ function createBaseOnChainEvent(): OnChainEvent {
     signerMigratedEventBody: undefined,
     idRegisterEventBody: undefined,
     storageRentEventBody: undefined,
+    txIndex: 0,
   };
 }
 
@@ -225,6 +227,9 @@ export const OnChainEvent = {
     }
     if (message.storageRentEventBody !== undefined) {
       StorageRentEventBody.encode(message.storageRentEventBody, writer.uint32(98).fork()).ldelim();
+    }
+    if (message.txIndex !== 0) {
+      writer.uint32(104).uint32(message.txIndex);
     }
     return writer;
   },
@@ -320,6 +325,13 @@ export const OnChainEvent = {
 
           message.storageRentEventBody = StorageRentEventBody.decode(reader, reader.uint32());
           continue;
+        case 13:
+          if (tag != 104) {
+            break;
+          }
+
+          message.txIndex = reader.uint32();
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -349,6 +361,7 @@ export const OnChainEvent = {
       storageRentEventBody: isSet(object.storageRentEventBody)
         ? StorageRentEventBody.fromJSON(object.storageRentEventBody)
         : undefined,
+      txIndex: isSet(object.txIndex) ? Number(object.txIndex) : 0,
     };
   },
 
@@ -377,6 +390,7 @@ export const OnChainEvent = {
     message.storageRentEventBody !== undefined && (obj.storageRentEventBody = message.storageRentEventBody
       ? StorageRentEventBody.toJSON(message.storageRentEventBody)
       : undefined);
+    message.txIndex !== undefined && (obj.txIndex = Math.round(message.txIndex));
     return obj;
   },
 
@@ -407,6 +421,7 @@ export const OnChainEvent = {
     message.storageRentEventBody = (object.storageRentEventBody !== undefined && object.storageRentEventBody !== null)
       ? StorageRentEventBody.fromPartial(object.storageRentEventBody)
       : undefined;
+    message.txIndex = object.txIndex ?? 0;
     return message;
   },
 };

--- a/packages/hub-web/src/generated/onchain_event.ts
+++ b/packages/hub-web/src/generated/onchain_event.ts
@@ -144,6 +144,7 @@ export interface OnChainEvent {
   signerMigratedEventBody?: SignerMigratedEventBody | undefined;
   idRegisterEventBody?: IdRegisterEventBody | undefined;
   storageRentEventBody?: StorageRentEventBody | undefined;
+  txIndex: number;
 }
 
 export interface SignerEventBody {
@@ -185,6 +186,7 @@ function createBaseOnChainEvent(): OnChainEvent {
     signerMigratedEventBody: undefined,
     idRegisterEventBody: undefined,
     storageRentEventBody: undefined,
+    txIndex: 0,
   };
 }
 
@@ -225,6 +227,9 @@ export const OnChainEvent = {
     }
     if (message.storageRentEventBody !== undefined) {
       StorageRentEventBody.encode(message.storageRentEventBody, writer.uint32(98).fork()).ldelim();
+    }
+    if (message.txIndex !== 0) {
+      writer.uint32(104).uint32(message.txIndex);
     }
     return writer;
   },
@@ -320,6 +325,13 @@ export const OnChainEvent = {
 
           message.storageRentEventBody = StorageRentEventBody.decode(reader, reader.uint32());
           continue;
+        case 13:
+          if (tag != 104) {
+            break;
+          }
+
+          message.txIndex = reader.uint32();
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -349,6 +361,7 @@ export const OnChainEvent = {
       storageRentEventBody: isSet(object.storageRentEventBody)
         ? StorageRentEventBody.fromJSON(object.storageRentEventBody)
         : undefined,
+      txIndex: isSet(object.txIndex) ? Number(object.txIndex) : 0,
     };
   },
 
@@ -377,6 +390,7 @@ export const OnChainEvent = {
     message.storageRentEventBody !== undefined && (obj.storageRentEventBody = message.storageRentEventBody
       ? StorageRentEventBody.toJSON(message.storageRentEventBody)
       : undefined);
+    message.txIndex !== undefined && (obj.txIndex = Math.round(message.txIndex));
     return obj;
   },
 
@@ -407,6 +421,7 @@ export const OnChainEvent = {
     message.storageRentEventBody = (object.storageRentEventBody !== undefined && object.storageRentEventBody !== null)
       ? StorageRentEventBody.fromPartial(object.storageRentEventBody)
       : undefined;
+    message.txIndex = object.txIndex ?? 0;
     return message;
   },
 };

--- a/protobufs/schemas/onchain_event.proto
+++ b/protobufs/schemas/onchain_event.proto
@@ -23,6 +23,7 @@ message OnChainEvent {
     IdRegisterEventBody id_register_event_body = 11;
     StorageRentEventBody storage_rent_event_body = 12;
   }
+  uint32 tx_index = 13;
 }
 
 enum SignerEventType {


### PR DESCRIPTION
## Motivation

Fixes https://github.com/farcasterxyz/hub-monorepo/issues/1308 and corrects existing data on events re-sync.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a bug related to the indexing of onchain events. It introduces the `txIndex` field and replaces incorrect usage of `txIndex` with `logIndex` for ordering events. 

### Detailed summary
- Added `txIndex` field to `OnChainEvent` protobuf message
- Fixed incorrect usage of `txIndex` instead of `logIndex` for ordering events
- Replaced incorrect events with correct ones based on `logIndex`

> The following files were skipped due to too many changes: `apps/hubble/src/eth/l2EventsProvider.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->