### PR TITLE
fix: Use hashes to compare hubble.sh upgrade

### DIFF
--- a/.changeset/mighty-fireants-smoke.md
+++ b/.changeset/mighty-fireants-smoke.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Use hashes to compare upgrade 'hubble.sh' versions

--- a/apps/hubble/grafana/grafana-dashboard.json
+++ b/apps/hubble/grafana/grafana-dashboard.json
@@ -526,6 +526,10 @@
               {
                 "color": "red",
                 "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
               }
             ]
           }
@@ -793,6 +797,10 @@
               {
                 "color": "red",
                 "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
               }
             ]
           }

--- a/apps/hubble/src/storage/jobs/pruneMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/pruneMessagesJob.ts
@@ -24,6 +24,11 @@ export class PruneMessagesJobScheduler {
 
   start(cronSchedule?: string) {
     this._cronTask = cron.schedule(cronSchedule ?? DEFAULT_PRUNE_MESSAGES_JOB_CRON, () => this.doJobs());
+
+    // Log the DB Size at startup
+    setTimeout(() => {
+      this.logDbSize();
+    }, 1000);
   }
 
   stop() {
@@ -34,6 +39,15 @@ export class PruneMessagesJobScheduler {
 
   status(): SchedulerStatus {
     return this._cronTask ? "started" : "stopped";
+  }
+
+  async logDbSize() {
+    this._engine
+      .getDb()
+      .approximateSize()
+      .then((size) => {
+        statsd().gauge("rocksdb.approximate_size", size || 0);
+      });
   }
 
   async doJobs(): HubAsyncResult<void> {
@@ -66,14 +80,10 @@ export class PruneMessagesJobScheduler {
     } while (!finished);
 
     log.info({ timeTakenMs: Date.now() - start }, "finished prune messages job");
-    this._engine
-      .getDb()
-      .approximateSize()
-      .then((size) => {
-        statsd().gauge("rocksdb.approximate_size", size || 0);
-      });
-
     this._running = false;
+
+    this.logDbSize();
+
     return ok(undefined);
   }
 }


### PR DESCRIPTION
## Motivation

Use hashes instead of CURRENT_VERSION to check for hubble.sh upgrade 

## Change Summary

- Adjust grafana dashboard threshold colors
- Log approx DB size at startup
- Use hash instead of CURRENT_VERSION

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an issue with the 'hubble.sh' upgrade process. 

### Detailed summary
- Uses hashes to compare upgrade 'hubble.sh' versions
- Adds new colors and values to the 'grafana-dashboard.json' file
- Logs the DB size at startup in 'pruneMessagesJob.ts'
- Updates the version of 'hubble.sh' to 3

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->