### PR TITLE
fix: Consume FID rate limit only after merge

### DIFF
--- a/.changeset/wise-buttons-sing.md
+++ b/.changeset/wise-buttons-sing.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Consume the FID rate limit only after a successful merge

--- a/apps/hubble/src/utils/rateLimits.ts
+++ b/apps/hubble/src/utils/rateLimits.ts
@@ -1,5 +1,5 @@
 import { HubAsyncResult, HubError } from "@farcaster/hub-nodejs";
-import { err, ok } from "neverthrow";
+import { ResultAsync, err, ok } from "neverthrow";
 import { RateLimiterAbstract, RateLimiterMemory } from "rate-limiter-flexible";
 
 // Number of submit messages (total) that can be merged per 60 seconds
@@ -41,4 +41,19 @@ export const rateLimitByKey = async (key: string, limiter: RateLimiterAbstract):
   } catch (e) {
     return err(new HubError("unavailable", `Too many requests for ${key}`));
   }
+};
+
+/** Is the rate limit hit for the key? */
+export const isRateLimitedByKey = async (key: string, limiter: RateLimiterAbstract): Promise<boolean> => {
+  const res = await limiter.get(key);
+  if (res && res.consumedPoints >= limiter.points) {
+    return true;
+  } else {
+    return false;
+  }
+};
+
+/** Consume 1 point of rate limit for the key key */
+export const consumeRateLimitByKey = async (key: string, limiter: RateLimiterAbstract): Promise<void> => {
+  await ResultAsync.fromPromise(limiter.consume(key), (e) => e);
 };


### PR DESCRIPTION
## Motivation

Consume the per-FID rate limit only after the message passes validations and is successfully merged. 

## Change Summary

- Add `isRateLimited` and `consumeRateLimit`
- Consume rate limits only after successful merges. Unsuccessful merges don't affect storage anyway. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Added `isRateLimitedByKey` function to check if the rate limit is hit for a specific key.
- Added `consumeRateLimitByKey` function to consume 1 point of rate limit for a specific key.
- Modified `rateLimitByKey` function to consume the rate limit only after a successful merge.
- Updated imports in `rateLimits.test.ts` and `index.ts` to include the new functions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->