### PR TITLE
fix: Fetch envoy config during hubble.sh

### DIFF
--- a/.changeset/thick-ears-end.md
+++ b/.changeset/thick-ears-end.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Fetch envoy config during hubble.sh

--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -15,6 +15,7 @@ DOCKER_COMPOSE_FILE_PATH="apps/hubble/docker-compose.yml"
 SCRIPT_FILE_PATH="scripts/hubble.sh"
 GRAFANA_DASHBOARD_JSON_PATH="apps/hubble/grafana/grafana-dashboard.json"
 GRAFANA_INI_PATH="apps/hubble/grafana/grafana.ini"
+ENVOY_CONFIG_PATH="apps/hubble/envoy/envoy.yaml"
 
 install_jq() {
     if command -v jq >/dev/null 2>&1; then
@@ -122,6 +123,9 @@ fetch_latest_docker_compose_and_dashboard() {
     mkdir -p grafana
     chmod 777 grafana
     fetch_file_from_repo "$GRAFANA_INI_PATH" "grafana/grafana.ini"
+    mkdir -p envoy
+    chmod 777 envoy
+    fetch_file_from_repo "$ENVOY_CONFIG_PATH" "envoy/envoy.yaml"
 }
 
 validate_and_store() {


### PR DESCRIPTION


## Change Summary

- Fetch envoy config during hubble.sh

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context
Fixes #1362 



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the issue of fetching the envoy config during the execution of `hubble.sh` script. 

### Detailed summary
- Added a fix to fetch the envoy config file (`envoy.yaml`) during the execution of `hubble.sh` script.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->