### PR TITLE
fix: remove outdated CLI args

### DIFF
--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -147,7 +147,6 @@ app
   )
   .option("--profile-sync", "Profile a full hub sync and exit. (default: disabled)")
   .option("--rebuild-sync-trie", "Rebuild the sync trie before starting (default: disabled)")
-  .option("--resync-eth-events", "Resync events from the Farcaster contracts before starting (default: disabled)")
   .option("--resync-name-events", "Resync events from the Fname server before starting (default: disabled)")
   .option(
     "--chunk-size <number>",
@@ -515,7 +514,6 @@ app
       resetDB,
       rebuildSyncTrie,
       profileSync,
-      resyncEthEvents: cliOptions.resyncEthEvents ?? hubConfig.resyncEthEvents ?? false,
       resyncNameEvents: cliOptions.resyncNameEvents ?? hubConfig.resyncNameEvents ?? false,
       commitLockTimeout: cliOptions.commitLockTimeout ?? hubConfig.commitLockTimeout,
       commitLockMaxPending: cliOptions.commitLockMaxPending ?? hubConfig.commitLockMaxPending,

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -209,9 +209,6 @@ export interface HubOptions {
   /** Resync l2 events */
   l2ResyncEvents?: boolean;
 
-  /** Resync events */
-  resyncEthEvents?: boolean;
-
   /** Resync fname events */
   resyncNameEvents?: boolean;
 

--- a/apps/hubble/www/docs/docs/cli.md
+++ b/apps/hubble/www/docs/docs/cli.md
@@ -85,8 +85,7 @@ Metrics:
 Debugging Options:
   --gossip-metrics-enabled              Generate tracing and metrics for the gossip network. (default: disabled)
   --profile-sync                        Profile a full hub sync and exit. (default: disabled)
-  --rebuild-sync-trie                   Rebuild the sync trie before starting (default: disabled)
-  --resync-eth-events                   Resync events from the Farcaster contracts before starting (default: disabled)
+  --rebuild-sync-trie                   Rebuild the sync trie before starting (default: disabled)  
   --resync-name-events                  Resync events from the Fname server before starting (default: disabled)
   --chunk-size <number>                 The number of blocks to batch when syncing historical events from Farcaster contracts. (default: 10000)
   --commit-lock-timeout <number>        Rocks DB commit lock timeout in milliseconds (default: 500)


### PR DESCRIPTION


## Change Summary

Remove outdated CLI args

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on renaming and reorganizing event resync options in the Hubble application.

### Detailed summary:
- Renamed `resyncEthEvents` to `resyncNameEvents` in `hubble.ts`.
- Renamed `--resync-eth-events` to `--resync-name-events` in `cli.ts` and `cli.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->