### PR TITLE
fix: Fetch ipv4 first for public IP

### DIFF
--- a/.changeset/nervous-teachers-greet.md
+++ b/.changeset/nervous-teachers-greet.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Simplify IP addr fetching, prefering ipv4


### PR DESCRIPTION

## Change Summary

Fix ipv4 address (over ipv6) if `announce-ip` is not provided

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying IP address fetching in the `getPublicIp` function by using the `axios` library instead of the `http` module. 

### Detailed summary
- Replaced the `http` module with `axios` for making HTTP requests.
- Updated the `getPublicIp` function to use `axios` to fetch the public IP address.
- Removed the `lastIpFetch` variable and its usage.
- Updated error handling in the `getPublicIp` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->