### PR TITLE
fix: Bugfix grafana dashboard didn't show incoming sync

### DIFF
--- a/.changeset/bright-ducks-invent.md
+++ b/.changeset/bright-ducks-invent.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Grafana issue where incoming sync count was not correct

--- a/apps/hubble/grafana/grafana-dashboard.json
+++ b/apps/hubble/grafana/grafana-dashboard.json
@@ -20,6 +20,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
+  "id": 1,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -340,7 +341,7 @@
     },
     {
       "datasource": "Graphite",
-      "description": "The Hubble version and the Farcaster Protocol version.",
+      "description": "The Farcaster Protocol version.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -353,10 +354,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }
@@ -365,7 +362,7 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 8,
+        "w": 4,
         "x": 0,
         "y": 5
       },
@@ -381,21 +378,77 @@
           "values": false
         },
         "text": {
-          "titleSize": 26,
-          "valueSize": 1
+          "titleSize": 8,
+          "valueSize": 32
         },
-        "textMode": "auto"
+        "textMode": "value"
       },
       "pluginVersion": "10.0.3",
       "targets": [
         {
           "datasource": "Graphite",
           "refId": "A",
-          "target": "aliasByNode(stats.gauges.hubble.farcaster.*.*.*.*, 5, 6, 7)",
+          "target": "aliasByNode(stats.gauges.hubble.farcaster.fcversion.*, 5)",
           "textEditor": true
         }
       ],
-      "title": "Hubble Version",
+      "title": "Protocol Version",
+      "type": "stat"
+    },
+    {
+      "datasource": "Graphite",
+      "description": "The Hubble App version ",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 5
+      },
+      "id": 31,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "titleSize": 8,
+          "valueSize": 32
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "10.0.3",
+      "targets": [
+        {
+          "datasource": "Graphite",
+          "refId": "A",
+          "target": "aliasByNode(stats.gauges.hubble.farcaster.appversion.*, 5)",
+          "textEditor": true
+        }
+      ],
+      "title": "App Version",
       "type": "stat"
     },
     {
@@ -1120,8 +1173,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1206,8 +1258,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1306,8 +1357,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1415,8 +1465,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1537,8 +1586,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1621,8 +1669,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1719,8 +1766,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",

--- a/apps/hubble/grafana/grafana-dashboard.json
+++ b/apps/hubble/grafana/grafana-dashboard.json
@@ -817,7 +817,7 @@
       "options": {
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": ["sum"],
           "fields": "",
           "values": false
         },

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -38,6 +38,7 @@ import { SyncEngineProfiler } from "./syncEngineProfiler.js";
 import os from "os";
 import { addProgressBar, finishAllProgressBars } from "../../utils/progressBars.js";
 import { SingleBar } from "cli-progress";
+import { SemVer } from "semver";
 
 // Number of seconds to wait for the network to "settle" before syncing. We will only
 // attempt to sync messages that are older than this time.
@@ -327,8 +328,15 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     this.emit("syncStart");
 
     // Log the version number for the dashboard
-    statsd().gauge(`farcaster.version.${FARCASTER_VERSION}`, 1);
-    statsd().gauge(`farcaster.hubversion.${APP_VERSION}`, 1);
+    const fcversion = new SemVer(FARCASTER_VERSION);
+    statsd().gauge("farcaster.fcversion.major", fcversion.major);
+    statsd().gauge("farcaster.fcversion.minor", fcversion.minor);
+    statsd().gauge("farcaster.fcversion.patch", fcversion.patch);
+
+    const appversion = new SemVer(APP_VERSION);
+    statsd().gauge("farcaster.appversion.major", appversion.major);
+    statsd().gauge("farcaster.appversion.minor", appversion.minor);
+    statsd().gauge("farcaster.appversion.patch", appversion.patch);
 
     if (this.currentHubPeerContacts.size === 0) {
       log.warn("Diffsync: No peer contacts, skipping sync");


### PR DESCRIPTION
## Change Summary

- Fix issue with grafana total incoming syncs meter

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a Grafana issue related to the incorrect incoming sync count. 

### Detailed summary:
- Added `SemVer` import from `semver`
- Updated the version number for the dashboard in the `SyncEngine` class
- Updated the description in the Grafana dashboard for the Farcaster Protocol version
- Added a new panel for displaying the Hubble App version in the Grafana dashboard

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->