### PR TITLE
fix: Fix edge case where txIndex is the same as logIndex

### DIFF
--- a/apps/hubble/src/storage/stores/onchainEventStore.test.ts
+++ b/apps/hubble/src/storage/stores/onchainEventStore.test.ts
@@ -52,8 +52,9 @@ describe("OnChainEventStore", () => {
         badSignerEvent.txIndex = txIndex;
         badSignerEvent.logIndex = logIndex;
         badRegisterEvent.txIndex = txIndex;
-        badRegisterEvent.logIndex = logIndex;
+        badRegisterEvent.logIndex = txIndex; // Assume log index is the same as tx index
 
+        await expect(set.mergeOnChainEvent(badSignerEvent)).rejects.toThrow("already exists");
         await expect(set.mergeOnChainEvent(badSignerEvent)).rejects.toThrow("already exists");
         const signerEvents = await set.getOnChainEvents(OnChainEventType.EVENT_TYPE_SIGNER, badSignerEvent.fid);
         expect(signerEvents).toHaveLength(1);
@@ -64,13 +65,14 @@ describe("OnChainEventStore", () => {
         expect(onChainSigner.signerEventBody.key).toEqual(badSignerEvent.signerEventBody.key);
 
         await expect(set.mergeOnChainEvent(badRegisterEvent)).rejects.toThrow("already exists");
+        await expect(set.mergeOnChainEvent(badRegisterEvent)).rejects.toThrow("already exists");
         const registerEvents = await set.getOnChainEvents(
           OnChainEventType.EVENT_TYPE_ID_REGISTER,
           badRegisterEvent.fid,
         );
         expect(registerEvents).toHaveLength(1);
         expect(registerEvents[0]?.txIndex).toEqual(txIndex);
-        expect(registerEvents[0]?.logIndex).toEqual(logIndex);
+        expect(registerEvents[0]?.logIndex).toEqual(txIndex);
 
         const idRegisterByFid = await set.getIdRegisterEventByFid(badRegisterEvent.fid);
         expect(idRegisterByFid).toEqual(badRegisterEvent);


### PR DESCRIPTION
## Motivation

We were accidentally deleting the primary key in cases when --l2-resync-events was run multiple times, and the txIndex matched the logIndex (~120 events). This fixes it perform the delete first, so the "corrected" event would add it back.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the on-chain event store by making several changes. 

### Detailed summary
- Import `logger` from `../../utils/logger.js` in `onChainEventStore.ts`
- Replace `const txn = putOnChainEventTransaction(this._db.transaction(), event);` with `const txn = this._db.transaction();` in `OnChainEventStore` class
- Move `putOnChainEventTransaction(txn, event);` after `txn.del(incorrectPrimaryKey);` in `OnChainEventStore` class
- Replace `throw new HubError("unavailable.storage_failure", `secondary index corrupted for ${secondaryKey}`);` with `logger.warn(`secondary index corrupted for ${secondaryKey.toString("hex")}`);` in `OnChainEventStore` class
- Change the value of `badRegisterEvent.logIndex` to `txIndex` in `onchainEventStore.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->