### PR TITLE
feat: Add "up" and "down" commands to hubble.sh

### DIFF
--- a/.changeset/red-moons-sip.md
+++ b/.changeset/red-moons-sip.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: Add "up" and "down" commands to hubble.sh

--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -478,12 +478,14 @@ if [ "$1" == "logs" ]; then
     exit 0
 fi
 
-# If run without args, show a help
-if [ $# -eq 0 ]; then
+# If run without args OR with "help", show a help
+if [ $# -eq 0 ] || [ "$1" == "help" ]; then
     echo "hubble.sh - Install or upgrade Hubble"
-    echo "Usage: hubble.sh [command]"
-    echo "  upgrade: Upgrade an existing installation of Hubble"
-    echo "  logs: Show the logs of the Hubble service"
-    echo "  help: Show this help"
+    echo "Usage:     hubble.sh [command]"
+    echo "  upgrade  Upgrade an existing installation of Hubble"
+    echo "  logs     Show the logs of the Hubble service"
+    echo "  up       Start Hubble and Grafana dashboard"
+    echo "  down     Stop Hubble and Grafana dashboard"
+    echo "  help     Show this help"
     exit 0
 fi

--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -396,6 +396,35 @@ reexec_as_root_if_needed() {
 # Call the function at the beginning of your script
 reexec_as_root_if_needed "$@"
 
+# Check for the "up" command-line argument
+if [ "$1" == "up" ]; then
+   # Setup the docker-compose command
+    set_compose_command
+
+    # Run docker compose up -d hubble
+    $COMPOSE_CMD up -d hubble statsd grafana
+
+    echo "✅ Hubble is running."
+
+    # Finally, start showing the logs
+    $COMPOSE_CMD logs --tail 100 -f hubble
+
+    exit 0
+fi
+
+# "down" command-line argument
+if [ "$1" == "down" ]; then
+    # Setup the docker-compose command
+    set_compose_command
+
+    # Run docker compose down
+    $COMPOSE_CMD down
+
+    echo "✅ Hubble is stopped."
+
+    exit 0
+fi
+
 # Check the command-line argument for 'upgrade'
 if [ "$1" == "upgrade" ]; then    
     # Ensure the ~/hubble directory exists


### PR DESCRIPTION
## Change Summary

- Add hubble.sh "up" and "down" commands that start / stop the containers without upgrading

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding "up" and "down" commands to `hubble.sh` script.

### Detailed summary
- Added "up" command to start Hubble and Grafana dashboard.
- Added "down" command to stop Hubble and Grafana dashboard.
- Updated the help message to include new commands.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->