### PR TITLE
chore: Add docker to release instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -287,6 +287,7 @@ are at all unsure about how to proceed, please reach out to Varun ([Github](http
 9. Push all tags to the remote repo: `git push origin @latest --force && git push origin HEAD --tags`
 10. Create a GitHub Release for Hubble, marking it as the latest.
 11. If this is a non-patch change, create an NFT for the release.
+12. Make sure that the Docker image for the latest release gets built and published to [Docker hub](https://hub.docker.com/r/farcasterxyz/hubble/tags).
 
 ### 3.7 Working in Rust
 

--- a/apps/hubble/www/docs/intro/install.md
+++ b/apps/hubble/www/docs/intro/install.md
@@ -57,6 +57,7 @@ ETH_MAINNET_RPC_URL=your-ETH-mainnet-RPC-URL
 # Set this to your L2 Optimism Mainnet RPC URL
 OPTIMISM_L2_RPC_URL=your-L2-optimism-RPC-URL
 
+# Set this to your Farcaster FID
 HUB_OPERATOR_FID=your-fid
 ```
 


### PR DESCRIPTION
## Motivation

Add docker publishing to release instructions

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a Docker image build and publish step for the latest release of Hubble. 

### Detailed summary
- Added step to build and publish Docker image for latest release of Hubble.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->