### PR TITLE
fix: Remove "id" and set to null when installing grafana dashboard

### DIFF
--- a/apps/hubble/grafana/grafana-dashboard.json
+++ b/apps/hubble/grafana/grafana-dashboard.json
@@ -20,7 +20,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 1,
+  "id": null,
   "links": [],
   "liveNow": false,
   "panels": [

--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -286,7 +286,7 @@ setup_grafana() {
 
     # Step 5: Import the dashboard. The API takes a slighly different format than the JSON import
     # in the UI, so we need to convert the JSON file first.
-    jq 'if .dashboard then . else {dashboard: ., folderId: 0, overwrite: true} end' "grafana-dashboard.json" > "grafana-dashboard.api.json"
+    jq '{dashboard: (del(.id) | . + {id: null}), folderId: 0, overwrite: true}' "grafana-dashboard.json" > "grafana-dashboard.api.json"
     
     response=$(curl -s -X "POST" "$grafana_url/api/dashboards/db" \
         -u "$credentials" \


### PR DESCRIPTION
## Motivation

Grafana doesn't install dashboard if the id is not null. Fix it during install. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Fixing an issue with the Grafana dashboard import process.

### Detailed summary:
- Changed the value of `id` in `grafana-dashboard.json` from `1` to `null`.
- Updated the conversion step in `hubble.sh` to handle the new value of `id` in `grafana-dashboard.json`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->