### PR TITLE
fix: Update links store size to be 2500 in the future

### DIFF
--- a/.changeset/clean-buckets-kiss.md
+++ b/.changeset/clean-buckets-kiss.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+fix: Update links store size to be 2500 in the future

--- a/apps/hubble/src/rpc/test/server.test.ts
+++ b/apps/hubble/src/rpc/test/server.test.ts
@@ -15,12 +15,7 @@ import {
   StorageLimit,
   StorageLimitsResponse,
   StoreType,
-  CASTS_SIZE_LIMIT_DEFAULT,
-  REACTIONS_SIZE_LIMIT_DEFAULT,
-  LINKS_SIZE_LIMIT_DEFAULT,
-  USER_DATA_SIZE_LIMIT_DEFAULT,
-  VERIFICATIONS_SIZE_LIMIT_DEFAULT,
-  USERNAME_PROOFS_SIZE_LIMIT_DEFAULT,
+  getDefaultStoreLimit,
 } from "@farcaster/hub-nodejs";
 import Engine from "../../storage/engine/index.js";
 import { MockHub } from "../../test/mocks.js";
@@ -111,12 +106,12 @@ describe("server rpc tests", () => {
       const result = await client.getCurrentStorageLimitsByFid(FidRequest.create({ fid }));
       // Default storage limits
       expect(result._unsafeUnwrap().limits.map((l) => l.limit)).toEqual([
-        CASTS_SIZE_LIMIT_DEFAULT,
-        LINKS_SIZE_LIMIT_DEFAULT,
-        REACTIONS_SIZE_LIMIT_DEFAULT,
-        USER_DATA_SIZE_LIMIT_DEFAULT,
-        USERNAME_PROOFS_SIZE_LIMIT_DEFAULT,
-        VERIFICATIONS_SIZE_LIMIT_DEFAULT,
+        getDefaultStoreLimit(StoreType.CASTS),
+        getDefaultStoreLimit(StoreType.LINKS),
+        getDefaultStoreLimit(StoreType.REACTIONS),
+        getDefaultStoreLimit(StoreType.USER_DATA),
+        getDefaultStoreLimit(StoreType.USERNAME_PROOFS),
+        getDefaultStoreLimit(StoreType.VERIFICATIONS),
       ]);
     });
 
@@ -129,22 +124,28 @@ describe("server rpc tests", () => {
       const result = await client.getCurrentStorageLimitsByFid(FidRequest.create({ fid }));
       const storageLimits = StorageLimitsResponse.fromJSON(result._unsafeUnwrap()).limits;
       expect(storageLimits).toContainEqual(
-        StorageLimit.create({ limit: CASTS_SIZE_LIMIT_DEFAULT, storeType: StoreType.CASTS }),
+        StorageLimit.create({ limit: getDefaultStoreLimit(StoreType.CASTS), storeType: StoreType.CASTS }),
       );
       expect(storageLimits).toContainEqual(
-        StorageLimit.create({ limit: REACTIONS_SIZE_LIMIT_DEFAULT, storeType: StoreType.REACTIONS }),
+        StorageLimit.create({ limit: getDefaultStoreLimit(StoreType.REACTIONS), storeType: StoreType.REACTIONS }),
       );
       expect(storageLimits).toContainEqual(
-        StorageLimit.create({ limit: LINKS_SIZE_LIMIT_DEFAULT, storeType: StoreType.LINKS }),
+        StorageLimit.create({ limit: getDefaultStoreLimit(StoreType.LINKS), storeType: StoreType.LINKS }),
       );
       expect(storageLimits).toContainEqual(
-        StorageLimit.create({ limit: USER_DATA_SIZE_LIMIT_DEFAULT, storeType: StoreType.USER_DATA }),
+        StorageLimit.create({ limit: getDefaultStoreLimit(StoreType.USER_DATA), storeType: StoreType.USER_DATA }),
       );
       expect(storageLimits).toContainEqual(
-        StorageLimit.create({ limit: VERIFICATIONS_SIZE_LIMIT_DEFAULT, storeType: StoreType.VERIFICATIONS }),
+        StorageLimit.create({
+          limit: getDefaultStoreLimit(StoreType.VERIFICATIONS),
+          storeType: StoreType.VERIFICATIONS,
+        }),
       );
       expect(storageLimits).toContainEqual(
-        StorageLimit.create({ limit: USERNAME_PROOFS_SIZE_LIMIT_DEFAULT, storeType: StoreType.USERNAME_PROOFS }),
+        StorageLimit.create({
+          limit: getDefaultStoreLimit(StoreType.USERNAME_PROOFS),
+          storeType: StoreType.USERNAME_PROOFS,
+        }),
       );
 
       // add 2 more units
@@ -155,24 +156,12 @@ describe("server rpc tests", () => {
       await engine.mergeOnChainEvent(rentEvent2);
       const result2 = await client.getCurrentStorageLimitsByFid(FidRequest.create({ fid }));
       const newLimits = StorageLimitsResponse.fromJSON(result2._unsafeUnwrap()).limits;
-      expect(newLimits).toContainEqual(
-        StorageLimit.create({ limit: CASTS_SIZE_LIMIT_DEFAULT * 3, storeType: StoreType.CASTS }),
-      );
-      expect(newLimits).toContainEqual(
-        StorageLimit.create({ limit: REACTIONS_SIZE_LIMIT_DEFAULT * 3, storeType: StoreType.REACTIONS }),
-      );
-      expect(newLimits).toContainEqual(
-        StorageLimit.create({ limit: LINKS_SIZE_LIMIT_DEFAULT * 3, storeType: StoreType.LINKS }),
-      );
-      expect(newLimits).toContainEqual(
-        StorageLimit.create({ limit: USER_DATA_SIZE_LIMIT_DEFAULT * 3, storeType: StoreType.USER_DATA }),
-      );
-      expect(newLimits).toContainEqual(
-        StorageLimit.create({ limit: VERIFICATIONS_SIZE_LIMIT_DEFAULT * 3, storeType: StoreType.VERIFICATIONS }),
-      );
-      expect(newLimits).toContainEqual(
-        StorageLimit.create({ limit: USERNAME_PROOFS_SIZE_LIMIT_DEFAULT * 3, storeType: StoreType.USERNAME_PROOFS }),
-      );
+      expect(newLimits).toContainEqual(StorageLimit.create({ limit: 5000 * 3, storeType: StoreType.CASTS }));
+      expect(newLimits).toContainEqual(StorageLimit.create({ limit: 2500 * 3, storeType: StoreType.REACTIONS }));
+      expect(newLimits).toContainEqual(StorageLimit.create({ limit: 1250 * 3, storeType: StoreType.LINKS }));
+      expect(newLimits).toContainEqual(StorageLimit.create({ limit: 50 * 3, storeType: StoreType.USER_DATA }));
+      expect(newLimits).toContainEqual(StorageLimit.create({ limit: 25 * 3, storeType: StoreType.VERIFICATIONS }));
+      expect(newLimits).toContainEqual(StorageLimit.create({ limit: 5 * 3, storeType: StoreType.USERNAME_PROOFS }));
     });
   });
 });

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -70,7 +70,6 @@ import { RevokeMessagesBySignerJobQueue, RevokeMessagesBySignerJobWorker } from 
 import { ensureAboveTargetFarcasterVersion } from "../../utils/versions.js";
 import { PublicClient } from "viem";
 import { normalize } from "viem/ens";
-import os from "os";
 import UsernameProofStore from "../stores/usernameProofStore.js";
 import OnChainEventStore from "../stores/onChainEventStore.js";
 import { isRateLimitedByKey, consumeRateLimitByKey, getRateLimiterForTotalMessages } from "../../utils/rateLimits.js";

--- a/apps/hubble/src/storage/jobs/pruneMessagesJob.test.ts
+++ b/apps/hubble/src/storage/jobs/pruneMessagesJob.test.ts
@@ -2,10 +2,11 @@ import {
   Ed25519Signer,
   Factories,
   FarcasterNetwork,
+  getDefaultStoreLimit,
   Message,
   MessageType,
   PruneMessageHubEvent,
-  VERIFICATIONS_SIZE_LIMIT_DEFAULT,
+  StoreType,
 } from "@farcaster/hub-nodejs";
 import { jestRocksDB } from "../db/jestUtils.js";
 import Engine from "../engine/index.js";
@@ -28,7 +29,7 @@ const seedMessagesFromTimestamp = async (engine: Engine, fid: number, signer: Ed
   );
   const linkAdd = await Factories.LinkAddMessage.create({ data: { fid, timestamp } }, { transient: { signer } });
   const proofs = await Factories.VerificationAddEthAddressMessage.createList(
-    VERIFICATIONS_SIZE_LIMIT_DEFAULT + 1,
+    getDefaultStoreLimit(StoreType.VERIFICATIONS) + 1,
     { data: { fid, timestamp } },
     { transient: { signer } },
   );
@@ -93,7 +94,9 @@ describe("doJobs", () => {
         expect(links._unsafeUnwrap().messages.length).toEqual(1);
 
         const verifications = await engine.getVerificationsByFid(fid);
-        expect(verifications._unsafeUnwrap().messages.length).toEqual(VERIFICATIONS_SIZE_LIMIT_DEFAULT + 1);
+        expect(verifications._unsafeUnwrap().messages.length).toEqual(
+          getDefaultStoreLimit(StoreType.VERIFICATIONS) + 1,
+        );
       }
 
       const nowOrig = Date.now;

--- a/apps/hubble/src/storage/stores/castStore.ts
+++ b/apps/hubble/src/storage/stores/castStore.ts
@@ -8,7 +8,8 @@ import {
   bytesCompare,
   isCastAddMessage,
   isCastRemoveMessage,
-  CASTS_SIZE_LIMIT_DEFAULT,
+  getDefaultStoreLimit,
+  StoreType,
 } from "@farcaster/hub-nodejs";
 import { err, ok, ResultAsync } from "neverthrow";
 import {
@@ -133,7 +134,7 @@ class CastStore extends Store<CastAddMessage, CastRemoveMessage> {
   override _removeMessageType = MessageType.CAST_REMOVE;
 
   protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return CASTS_SIZE_LIMIT_DEFAULT;
+    return getDefaultStoreLimit(StoreType.CASTS);
   }
 
   protected override get PRUNE_TIME_LIMIT_DEFAULT() {

--- a/apps/hubble/src/storage/stores/linkStore.test.ts
+++ b/apps/hubble/src/storage/stores/linkStore.test.ts
@@ -1,17 +1,19 @@
 import {
-  Factories,
-  HubError,
   bytesDecrement,
   bytesIncrement,
+  Factories,
+  getDefaultStoreLimit,
   getFarcasterTime,
+  HubError,
   LinkAddMessage,
+  LinkBody,
+  LinkRemoveMessage,
   MergeMessageHubEvent,
   Message,
   MessageType,
   PruneMessageHubEvent,
-  LinkBody,
-  LinkRemoveMessage,
   RevokeMessageHubEvent,
+  StoreType,
 } from "@farcaster/hub-nodejs";
 import { err, ok } from "neverthrow";
 import { jestRocksDB } from "../db/jestUtils.js";
@@ -815,6 +817,17 @@ describe("pruneMessages", () => {
 
   describe("with size limit", () => {
     const sizePrunedStore = new LinkStore(db, eventHandler, { pruneSizeLimit: 3 });
+
+    test("size limit changes in the future", () => {
+      expect(getDefaultStoreLimit(StoreType.LINKS)).toEqual(1250);
+      const nowOrig = Date.now;
+      try {
+        Date.now = () => new Date("2023-10-01").getTime();
+        expect(getDefaultStoreLimit(StoreType.LINKS)).toEqual(2500);
+      } finally {
+        Date.now = nowOrig;
+      }
+    });
 
     test("no-ops when no messages have been merged", async () => {
       const result = await sizePrunedStore.pruneMessages(fid);

--- a/apps/hubble/src/storage/stores/linkStore.ts
+++ b/apps/hubble/src/storage/stores/linkStore.ts
@@ -1,12 +1,13 @@
 import {
+  getDefaultStoreLimit,
   HubAsyncResult,
   HubError,
+  isLinkAddMessage,
+  isLinkRemoveMessage,
   LinkAddMessage,
   LinkRemoveMessage,
   MessageType,
-  isLinkAddMessage,
-  isLinkRemoveMessage,
-  LINKS_SIZE_LIMIT_DEFAULT,
+  StoreType,
 } from "@farcaster/hub-nodejs";
 import {
   getManyMessages,
@@ -19,7 +20,7 @@ import {
 import { RootPrefix, TSHASH_LENGTH, UserMessagePostfix, UserPostfix } from "../db/types.js";
 import { MessagesPage, PAGE_SIZE_MAX, PageOptions } from "./types.js";
 import { Store } from "./store.js";
-import { ResultAsync, err, ok } from "neverthrow";
+import { err, ok, ResultAsync } from "neverthrow";
 import { Transaction } from "../db/rocksdb.js";
 
 const makeTargetKey = (target: number): Buffer => {
@@ -151,7 +152,7 @@ class LinkStore extends Store<LinkAddMessage, LinkRemoveMessage> {
   override _removeMessageType = MessageType.LINK_REMOVE;
 
   protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return LINKS_SIZE_LIMIT_DEFAULT;
+    return getDefaultStoreLimit(StoreType.LINKS);
   }
 
   override async buildSecondaryIndices(txn: Transaction, message: LinkAddMessage): HubAsyncResult<void> {

--- a/apps/hubble/src/storage/stores/reactionStore.ts
+++ b/apps/hubble/src/storage/stores/reactionStore.ts
@@ -1,5 +1,6 @@
 import {
   CastId,
+  getDefaultStoreLimit,
   HubAsyncResult,
   HubError,
   isReactionAddMessage,
@@ -7,8 +8,8 @@ import {
   MessageType,
   ReactionAddMessage,
   ReactionRemoveMessage,
-  REACTIONS_SIZE_LIMIT_DEFAULT,
   ReactionType,
+  StoreType,
 } from "@farcaster/hub-nodejs";
 import { err, ok, ResultAsync } from "neverthrow";
 import {
@@ -147,7 +148,7 @@ class ReactionStore extends Store<ReactionAddMessage, ReactionRemoveMessage> {
   override _removeMessageType = MessageType.REACTION_REMOVE;
 
   protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return REACTIONS_SIZE_LIMIT_DEFAULT;
+    return getDefaultStoreLimit(StoreType.REACTIONS);
   }
 
   protected override get PRUNE_TIME_LIMIT_DEFAULT() {

--- a/apps/hubble/src/storage/stores/store.ts
+++ b/apps/hubble/src/storage/stores/store.ts
@@ -49,10 +49,6 @@ const deepPartialEquals = <T>(partial: DeepPartial<T>, whole: T) => {
   return true;
 };
 
-// Store size was meant to be halved and existing users were given 2 units of storage, but we did not reduce the size
-// So existing users currently have 2x more storage than intended. Pick a date in the future and reduce the size by half
-const STORE_SIZE_CORRECTION_TIMESTAMP = new Date("2023-09-06").getTime();
-
 export abstract class Store<TAdd extends Message, TRemove extends Message> {
   protected _db: RocksDB;
   protected _eventHandler: StoreEventHandler;

--- a/apps/hubble/src/storage/stores/userDataStore.ts
+++ b/apps/hubble/src/storage/stores/userDataStore.ts
@@ -8,7 +8,8 @@ import {
   UserNameProof,
   UserDataAddMessage,
   UserDataType,
-  USER_DATA_SIZE_LIMIT_DEFAULT,
+  getDefaultStoreLimit,
+  StoreType,
 } from "@farcaster/hub-nodejs";
 import { ok, ResultAsync } from "neverthrow";
 import { makeUserKey } from "../db/message.js";
@@ -85,7 +86,7 @@ class UserDataStore extends Store<UserDataAddMessage, never> {
   override _removeMessageType = undefined;
 
   protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return USER_DATA_SIZE_LIMIT_DEFAULT;
+    return getDefaultStoreLimit(StoreType.USER_DATA);
   }
 
   /**

--- a/apps/hubble/src/storage/stores/usernameProofStore.test.ts
+++ b/apps/hubble/src/storage/stores/usernameProofStore.test.ts
@@ -2,11 +2,12 @@ import { jestRocksDB } from "../db/jestUtils.js";
 import StoreEventHandler from "./storeEventHandler.js";
 import {
   Factories,
+  getDefaultStoreLimit,
   getFarcasterTime,
   HubError,
   MergeUsernameProofHubEvent,
   MessageType,
-  USERNAME_PROOFS_SIZE_LIMIT_DEFAULT,
+  StoreType,
   UserNameProof,
   UsernameProofMessage,
   UserNameType,
@@ -183,7 +184,7 @@ describe("usernameProofStore", () => {
       const sizePrunedStore = new UsernameProofStore(db, eventHandler, { pruneSizeLimit: 2 });
 
       test("defaults size limit", async () => {
-        expect(set.pruneSizeLimit).toEqual(USERNAME_PROOFS_SIZE_LIMIT_DEFAULT);
+        expect(set.pruneSizeLimit).toEqual(getDefaultStoreLimit(StoreType.USERNAME_PROOFS));
         expect(set.pruneTimeLimit).toBeUndefined();
       });
 

--- a/apps/hubble/src/storage/stores/usernameProofStore.ts
+++ b/apps/hubble/src/storage/stores/usernameProofStore.ts
@@ -1,10 +1,11 @@
 import {
+  getDefaultStoreLimit,
   HubAsyncResult,
   HubError,
   HubEventType,
   isUsernameProofMessage,
   MessageType,
-  USERNAME_PROOFS_SIZE_LIMIT_DEFAULT,
+  StoreType,
   UserNameProof,
   UsernameProofMessage,
   UserNameType,
@@ -56,7 +57,7 @@ class UsernameProofStore extends Store<UsernameProofMessage, never> {
   override _removeMessageType = undefined;
 
   protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return USERNAME_PROOFS_SIZE_LIMIT_DEFAULT;
+    return getDefaultStoreLimit(StoreType.USERNAME_PROOFS);
   }
 
   /**

--- a/apps/hubble/src/storage/stores/verificationStore.ts
+++ b/apps/hubble/src/storage/stores/verificationStore.ts
@@ -1,11 +1,12 @@
 import {
+  getDefaultStoreLimit,
   HubAsyncResult,
   isVerificationAddEthAddressMessage,
   isVerificationRemoveMessage,
   MessageType,
+  StoreType,
   VerificationAddEthAddressMessage,
   VerificationRemoveMessage,
-  VERIFICATIONS_SIZE_LIMIT_DEFAULT,
 } from "@farcaster/hub-nodejs";
 import { ok } from "neverthrow";
 import { makeUserKey } from "../db/message.js";
@@ -93,7 +94,7 @@ class VerificationStore extends Store<VerificationAddEthAddressMessage, Verifica
   override _removeMessageType = MessageType.VERIFICATION_REMOVE;
 
   protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return VERIFICATIONS_SIZE_LIMIT_DEFAULT;
+    return getDefaultStoreLimit(StoreType.VERIFICATIONS);
   }
 
   /**

--- a/packages/core/src/limits.ts
+++ b/packages/core/src/limits.ts
@@ -1,35 +1,57 @@
 import { StoreType } from "./protobufs";
 
-export const CASTS_SIZE_LIMIT_DEFAULT = 5_000;
-export const LINKS_SIZE_LIMIT_DEFAULT = 1_250;
-export const REACTIONS_SIZE_LIMIT_DEFAULT = 2_500;
-export const USER_DATA_SIZE_LIMIT_DEFAULT = 50;
-export const USERNAME_PROOFS_SIZE_LIMIT_DEFAULT = 5;
-export const VERIFICATIONS_SIZE_LIMIT_DEFAULT = 25;
+// Default link store limit should be 2500. Pick a date in the future to update the limit so hubs will
+// stay in sync between versions
+const LINKS_LIMIT_FIX_DATE = new Date("2023-09-20").getTime();
+
+const CASTS_SIZE_LIMIT_DEFAULT = 5_000;
+const LINKS_SIZE_LIMIT_DEFAULT = 1_250;
+const REACTIONS_SIZE_LIMIT_DEFAULT = 2_500;
+const USER_DATA_SIZE_LIMIT_DEFAULT = 50;
+const USERNAME_PROOFS_SIZE_LIMIT_DEFAULT = 5;
+const VERIFICATIONS_SIZE_LIMIT_DEFAULT = 25;
 
 export const getStoreLimits = (units: number) => [
   {
     storeType: StoreType.CASTS,
-    limit: CASTS_SIZE_LIMIT_DEFAULT * units,
+    limit: getDefaultStoreLimit(StoreType.CASTS) * units,
   },
   {
     storeType: StoreType.LINKS,
-    limit: LINKS_SIZE_LIMIT_DEFAULT * units,
+    limit: getDefaultStoreLimit(StoreType.LINKS) * units,
   },
   {
     storeType: StoreType.REACTIONS,
-    limit: REACTIONS_SIZE_LIMIT_DEFAULT * units,
+    limit: getDefaultStoreLimit(StoreType.REACTIONS) * units,
   },
   {
     storeType: StoreType.USER_DATA,
-    limit: USER_DATA_SIZE_LIMIT_DEFAULT * units,
+    limit: getDefaultStoreLimit(StoreType.USER_DATA) * units,
   },
   {
     storeType: StoreType.USERNAME_PROOFS,
-    limit: USERNAME_PROOFS_SIZE_LIMIT_DEFAULT * units,
+    limit: getDefaultStoreLimit(StoreType.USERNAME_PROOFS) * units,
   },
   {
     storeType: StoreType.VERIFICATIONS,
-    limit: VERIFICATIONS_SIZE_LIMIT_DEFAULT * units,
+    limit: getDefaultStoreLimit(StoreType.VERIFICATIONS) * units,
   },
 ];
+export const getDefaultStoreLimit = (storeType: StoreType) => {
+  switch (storeType) {
+    case StoreType.CASTS:
+      return CASTS_SIZE_LIMIT_DEFAULT;
+    case StoreType.LINKS:
+      return Date.now() > LINKS_LIMIT_FIX_DATE ? LINKS_SIZE_LIMIT_DEFAULT * 2 : LINKS_SIZE_LIMIT_DEFAULT;
+    case StoreType.REACTIONS:
+      return REACTIONS_SIZE_LIMIT_DEFAULT;
+    case StoreType.USER_DATA:
+      return USER_DATA_SIZE_LIMIT_DEFAULT;
+    case StoreType.USERNAME_PROOFS:
+      return USERNAME_PROOFS_SIZE_LIMIT_DEFAULT;
+    case StoreType.VERIFICATIONS:
+      return VERIFICATIONS_SIZE_LIMIT_DEFAULT;
+    default:
+      throw new Error(`Unknown store type: ${storeType}`);
+  }
+};


### PR DESCRIPTION
## Motivation

When store sizes were halved in https://github.com/farcasterxyz/hub-monorepo/pull/1306, the links store size was already correct. So, bump it back up to 2500, the proper value.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the storage limits for different store types in the code. 

### Detailed summary
- Updated the default storage limits for different store types.
- Added a function to get the default store limit based on the store type.
- Updated the size limit for the `LinkStore` in the future.

> The following files were skipped due to too many changes: `apps/hubble/src/rpc/test/server.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->