### PR TITLE
fix: Grafana sync times are blank for longer time ranges

### DIFF
--- a/.changeset/nasty-paws-hope.md
+++ b/.changeset/nasty-paws-hope.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Grafana: Sync times are blank for longer timeranges

--- a/apps/hubble/grafana/grafana-dashboard.json
+++ b/apps/hubble/grafana/grafana-dashboard.json
@@ -755,7 +755,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "stepBefore",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -814,7 +814,7 @@
         {
           "refCount": 0,
           "refId": "A",
-          "target": "stats.timers.hubble.syncengine.sync_time_ms.mean"
+          "target": "stats.timers.hubble.syncengine.sync_time_ms.sum"
         }
       ],
       "title": "Sync Duration",


### PR DESCRIPTION


## Change Summary

- Fix grafana formula

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an issue in Grafana where sync times are blank for longer timeranges.

### Detailed summary:
- Changed `lineInterpolation` from `"stepBefore"` to `"smooth"`
- Changed `target` value from `"stats.timers.hubble.syncengine.sync_time_ms.mean"` to `"stats.timers.hubble.syncengine.sync_time_ms.sum"`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->