### PR TITLE
test: Add 2 hubble sync+gossip test

### DIFF
--- a/.changeset/fair-peas-check.md
+++ b/.changeset/fair-peas-check.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+test: Add 2 hubble sync+gossip test

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -427,6 +427,10 @@ export class Hub implements HubInterface {
     return this.gossipNode.peerId.toString();
   }
 
+  async syncWithPeerId(peerId: string): Promise<void> {
+    await this.syncEngine.diffSyncIfRequired(this, peerId);
+  }
+
   /* Start the GossipNode and RPC server  */
   async start() {
     // See if we have to fetch the IP address

--- a/apps/hubble/src/test/e2e/hubbleNetwork.test.ts
+++ b/apps/hubble/src/test/e2e/hubbleNetwork.test.ts
@@ -1,0 +1,136 @@
+import { Factories, FarcasterNetwork, Message, bytesToHexString } from "@farcaster/hub-nodejs";
+import { deployStorageRegistry, testClient } from "../utils.js";
+import { Hub, HubOptions, randomDbName } from "../../hubble.js";
+import { localHttpUrl } from "../constants.js";
+import { sleep, sleepWhile } from "../../utils/crypto.js";
+import { DB_DIRECTORY } from "../../storage/db/rocksdb.js";
+import fs from "fs";
+import { TestFNameRegistryServer } from "./testFnameRegistryServer.js";
+import { Multiaddr } from "@multiformats/multiaddr";
+
+const TEST_TIMEOUT_SHORT = 10_000;
+
+let storageRegistryAddress: `0x${string}`;
+let keyRegistryAddress: `0x${string}`;
+let idRegistryAddress: `0x${string}`;
+
+let fnameServerUrl: string;
+let fnameServer: TestFNameRegistryServer;
+let rocksDBName1: string;
+let rocksDBName2: string;
+
+let hubOptions: HubOptions;
+
+describe("hubble gossip and sync tests", () => {
+  beforeEach(async () => {
+    const { contractAddress: storageAddr } = await deployStorageRegistry();
+    if (!storageAddr) throw new Error("Failed to deploy StorageRegistry contract");
+    storageRegistryAddress = storageAddr;
+
+    idRegistryAddress = bytesToHexString(Factories.EthAddress.build())._unsafeUnwrap();
+    keyRegistryAddress = bytesToHexString(Factories.EthAddress.build())._unsafeUnwrap();
+
+    fnameServer = new TestFNameRegistryServer();
+    fnameServerUrl = await fnameServer.start();
+
+    rocksDBName1 = randomDbName();
+    rocksDBName2 = randomDbName();
+
+    hubOptions = {
+      network: FarcasterNetwork.DEVNET,
+      l2StorageRegistryAddress: storageRegistryAddress,
+      l2IdRegistryAddress: idRegistryAddress,
+      l2KeyRegistryAddress: keyRegistryAddress,
+      l2RpcUrl: localHttpUrl,
+      ethMainnetRpcUrl: localHttpUrl,
+      fnameServerUrl,
+      announceIp: "127.0.0.1",
+      disableSnapshotSync: true,
+    };
+  });
+
+  afterAll(async () => {
+    await fnameServer.stop();
+
+    // rm -rf the rocksdb directory
+    fs.rm(`${DB_DIRECTORY}/${rocksDBName1}`, { recursive: true }, (err) => {});
+    fs.rm(`${DB_DIRECTORY}/${rocksDBName2}`, { recursive: true }, (err) => {});
+  });
+
+  test(
+    "Two hubbles gossip + sync",
+    async () => {
+      let hub1: Hub | undefined = undefined;
+      let hub2: Hub | undefined = undefined;
+
+      try {
+        hub1 = new Hub({ ...hubOptions, rocksDBName: rocksDBName1 });
+        hub2 = new Hub({ ...hubOptions, rocksDBName: rocksDBName2 });
+
+        await Promise.all([hub1.start(), hub2.start()]);
+
+        // check that the two hubs are synced
+        const hub1Info = await hub1.getHubState();
+        const hub2Info = await hub2.getHubState();
+        expect(hub1Info).toEqual(hub2Info);
+
+        // Connect the 2 hubs over gossip
+        await hub1.connectAddress(hub2.gossipAddresses[0] as Multiaddr);
+        await sleep(1000);
+
+        const fid = Factories.Fid.build();
+
+        const signer = Factories.Ed25519Signer.build();
+        const custodySigner = Factories.Eip712Signer.build();
+
+        const signerKey = (await signer.getSignerKey())._unsafeUnwrap();
+        const custodySignerKey = (await custodySigner.getSignerKey())._unsafeUnwrap();
+        const custodyEvent = Factories.IdRegistryOnChainEvent.build({ fid }, { transient: { to: custodySignerKey } });
+        const signerEvent = Factories.SignerOnChainEvent.build({ fid }, { transient: { signer: signerKey } });
+        const storageEvent = Factories.StorageRentOnChainEvent.build({ fid });
+
+        expect(await hub1.engine.mergeOnChainEvent(custodyEvent)).toBeTruthy();
+        expect(await hub1.engine.mergeOnChainEvent(signerEvent)).toBeTruthy();
+        expect(await hub1.engine.mergeOnChainEvent(storageEvent)).toBeTruthy();
+
+        expect(await hub2.engine.mergeOnChainEvent(custodyEvent)).toBeTruthy();
+        expect(await hub2.engine.mergeOnChainEvent(signerEvent)).toBeTruthy();
+        expect(await hub2.engine.mergeOnChainEvent(storageEvent)).toBeTruthy();
+
+        // Create a cast message and merge it into hub1
+        const castAdd = await Factories.CastAddMessage.create(
+          { data: { fid, network: FarcasterNetwork.DEVNET } },
+          { transient: { signer } },
+        );
+
+        // Submit the message to hub1 via rpc, so it is gossip'd to hub2
+        expect(await hub1.submitMessage(castAdd, "rpc")).toBeTruthy();
+
+        // This should trigger a gossip message to hub2, where it should be merged
+        await sleepWhile(async () => (await (hub2 as Hub).engine.getCast(fid, castAdd.hash)).isErr(), 2000);
+
+        const result = await hub2.engine.getCast(fid, castAdd.hash);
+        expect(result.isOk()).toBeTruthy();
+        expect(Message.toJSON(result._unsafeUnwrap())).toEqual(Message.toJSON(castAdd));
+
+        // Create a second cast message, and merge it into hub2 via "sync", so it doesn't trigger a gossip message
+        const castAdd2 = await Factories.CastAddMessage.create(
+          { data: { fid, network: FarcasterNetwork.DEVNET } },
+          { transient: { signer } },
+        );
+        expect(await hub2.submitMessage(castAdd2, "sync")).toBeTruthy();
+
+        // Get hub2 to sync with Hub1
+        await hub2.syncWithPeerId(hub1.identity);
+
+        // Check that the cast message was merged into hub2
+        const result2 = await hub2.engine.getCast(fid, castAdd2.hash);
+        expect(result2.isOk()).toBeTruthy();
+      } finally {
+        await hub1?.stop();
+        await hub2?.stop();
+      }
+    },
+    100 * TEST_TIMEOUT_SHORT,
+  );
+});

--- a/apps/hubble/src/test/e2e/testFnameRegistryServer.ts
+++ b/apps/hubble/src/test/e2e/testFnameRegistryServer.ts
@@ -1,0 +1,37 @@
+import { Factories, bytesToHexString } from "@farcaster/hub-nodejs";
+import fastify, { FastifyInstance } from "fastify";
+
+export class TestFNameRegistryServer {
+  private server?: FastifyInstance;
+  private port = 0;
+
+  public async start(): Promise<string> {
+    this.server = fastify();
+
+    this.server.get("/transfers", async (request, reply) => {
+      reply.send({ transfers: [] });
+    });
+
+    this.server.get("/signer", async (request, reply) => {
+      reply.send({ signer: bytesToHexString(Factories.EthAddress.build())._unsafeUnwrap() });
+    });
+
+    try {
+      await this.server.listen({ port: this.port, host: "localhost" });
+      const address = this.server.server.address();
+      const port = typeof address === "string" ? 0 : address?.port;
+      return `http://localhost:${port}`;
+    } catch (err) {
+      console.log(err);
+      throw err;
+    }
+  }
+
+  public async stop(): Promise<void> {
+    try {
+      await this.server?.close();
+    } catch (err) {
+      console.log(err);
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

A full end-to-end test that starts up 2 hubble instances and makes sure they can sync and gossip



## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `syncWithPeerId` method to the `Hubble` class in `hubble.ts`.
- Added `TestFNameRegistryServer` class with `start` and `stop` methods in `testFnameRegistryServer.ts`.
- Updated imports and removed duplicate code in `hubbleStartup.test.ts` and `hubbleNetwork.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->