### PR TITLE
fix: Cleanup old snapshots from S3

### DIFF
--- a/.changeset/bright-carrots-study.md
+++ b/.changeset/bright-carrots-study.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Cleanup old snapshots from S3

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -65,7 +65,7 @@ import { NetworkConfig, applyNetworkConfig, fetchNetworkConfig } from "./network
 import { UpdateNetworkConfigJobScheduler } from "./storage/jobs/updateNetworkConfigJob.js";
 import { statsd } from "./utils/statsd.js";
 import { LATEST_DB_SCHEMA_VERSION, performDbMigrations } from "./storage/db/migrations/migrations.js";
-import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { S3Client, PutObjectCommand, ListObjectsV2Command, DeleteObjectsCommand } from "@aws-sdk/client-s3";
 import path from "path";
 import { addProgressBar } from "./utils/progressBars.js";
 import * as fs from "fs";
@@ -465,6 +465,9 @@ export class Hub implements HubInterface {
 
           // Delete the tar file, ignore errors
           fs.unlink(tarResult.value, () => {});
+
+          // Cleanup old files from S3
+          this.deleteOldSnapshotsFromS3();
         }, 10);
       } else {
         log.error({ error: tarResult.error }, "failed to create tar backup for S3");
@@ -1344,6 +1347,78 @@ export class Hub implements HubInterface {
       await s3.send(new PutObjectCommand(latestJsonParams));
       log.info({ key, timeTakenMs: Date.now() - start }, "Snapshot uploaded to S3");
       return ok(key);
+    } catch (e: unknown) {
+      return err(new HubError("unavailable.network_failure", (e as Error).message));
+    }
+  }
+
+  async listS3Snapshots(): HubAsyncResult<
+    Array<{ Key: string | undefined; Size: number | undefined; LastModified: Date | undefined }>
+  > {
+    const network = FarcasterNetwork[this.options.network].toString();
+
+    const s3 = new S3Client({
+      region: S3_REGION,
+    });
+
+    const params = {
+      Bucket: this.s3_snapshot_bucket,
+      Prefix: `snapshots/${network}/`,
+    };
+
+    try {
+      const response = await s3.send(new ListObjectsV2Command(params));
+
+      if (response.Contents) {
+        return ok(
+          response.Contents.map((item) => ({
+            Key: item.Key,
+            Size: item.Size,
+            LastModified: item.LastModified,
+          })),
+        );
+      } else {
+        return ok([]);
+      }
+    } catch (e: unknown) {
+      return err(new HubError("unavailable.network_failure", (e as Error).message));
+    }
+  }
+
+  async deleteOldSnapshotsFromS3(): HubAsyncResult<void> {
+    try {
+      const fileListResult = await this.listS3Snapshots();
+
+      if (!fileListResult.isOk()) {
+        return err(new HubError("unavailable.network_failure", fileListResult.error.message));
+      }
+
+      const oneMonthAgo = new Date();
+      oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
+
+      const oldFiles = fileListResult.value
+        .filter((file) => (file.LastModified ? new Date(file.LastModified) < oneMonthAgo : false))
+        .slice(0, 10);
+
+      if (oldFiles.length === 0) {
+        return ok(undefined);
+      }
+
+      log.warn({ oldFiles }, "Deleting old snapshot files from S3");
+
+      const deleteParams = {
+        Bucket: this.s3_snapshot_bucket,
+        Delete: {
+          Objects: oldFiles.map((file) => ({ Key: file.Key })),
+        },
+      };
+
+      const s3 = new S3Client({
+        region: S3_REGION,
+      });
+
+      await s3.send(new DeleteObjectsCommand(deleteParams));
+      return ok(undefined);
     } catch (e: unknown) {
       return err(new HubError("unavailable.network_failure", (e as Error).message));
     }


### PR DESCRIPTION


## Change Summary

- Delete snapshots older than 1 month from S3

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on cleaning up old snapshots from S3. 

### Detailed summary
- Added `deleteOldSnapshotsFromS3` method to delete old snapshot files from S3.
- Added `listS3Snapshots` method to list the existing S3 snapshots.
- Updated `Hub` class to call `deleteOldSnapshotsFromS3` method during backup cleanup.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->