### PR TITLE
Fix: Fix flaky pruneMessagesJob test

### DIFF
--- a/.changeset/four-crabs-reflect.md
+++ b/.changeset/four-crabs-reflect.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Fix flaky pruneMessagesJob test


### PR DESCRIPTION

## Change Summary

- Fix flaky test

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a flaky test in the `pruneMessagesJob` module. 

### Detailed summary
- Added import for `makeTsHash` function from `../../storage/db/message.js`
- Sorted the proofs by `tsHash` in `seedMessagesFromTimestamp` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->