### PR TITLE
feat: add autouprade to hubble.sh

### DIFF
--- a/apps/hubble/src/rpc/test/server.test.ts
+++ b/apps/hubble/src/rpc/test/server.test.ts
@@ -136,7 +136,7 @@ describe("server rpc tests", () => {
       const newLimits = StorageLimitsResponse.fromJSON(result2._unsafeUnwrap()).limits;
       expect(newLimits).toContainEqual(StorageLimit.create({ limit: 5000 * 3, storeType: StoreType.CASTS }));
       expect(newLimits).toContainEqual(StorageLimit.create({ limit: 2500 * 3, storeType: StoreType.REACTIONS }));
-      expect(newLimits).toContainEqual(StorageLimit.create({ limit: 1250 * 3, storeType: StoreType.LINKS }));
+      expect(newLimits).toContainEqual(StorageLimit.create({ limit: 2500 * 3, storeType: StoreType.LINKS }));
       expect(newLimits).toContainEqual(StorageLimit.create({ limit: 50 * 3, storeType: StoreType.USER_DATA }));
       expect(newLimits).toContainEqual(StorageLimit.create({ limit: 25 * 3, storeType: StoreType.VERIFICATIONS }));
       expect(newLimits).toContainEqual(StorageLimit.create({ limit: 5 * 3, storeType: StoreType.USERNAME_PROOFS }));

--- a/apps/hubble/src/storage/stores/linkStore.test.ts
+++ b/apps/hubble/src/storage/stores/linkStore.test.ts
@@ -821,17 +821,6 @@ describe("pruneMessages", () => {
   describe("with size limit", () => {
     const sizePrunedStore = new LinkStore(db, eventHandler, { pruneSizeLimit: 3 });
 
-    test("size limit changes in the future", () => {
-      expect(getDefaultStoreLimit(StoreType.LINKS)).toEqual(1250);
-      const nowOrig = Date.now;
-      try {
-        Date.now = () => new Date("2023-10-01").getTime();
-        expect(getDefaultStoreLimit(StoreType.LINKS)).toEqual(2500);
-      } finally {
-        Date.now = nowOrig;
-      }
-    });
-
     test("no-ops when no messages have been merged", async () => {
       const result = await sizePrunedStore.pruneMessages(fid);
       expect(result._unsafeUnwrap()).toEqual([]);


### PR DESCRIPTION
## Motivation

Fixes https://github.com/farcasterxyz/hub-monorepo/issues/1379

Add a crontab entry for a random day of week (based on operator fid or peerid) and random hour to automatically upgrade the hub when using the hubble.sh script

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on upgrading the hubble.sh script and making improvements to the auto-upgrade functionality.

### Detailed summary
- Upgraded the version of the hubble.sh script from "3" to "4".
- Added functionality to determine the appropriate hash command to use.
- Improved the auto-upgrade feature by adding a crontab entry for automatic upgrades.
- Added a new function `ensure_grafana()` to handle the restart or startup of the Grafana container.
- Added a new function `setup_identity()` to create or check the existence of the Peer Identity.
- Updated the `start_hubble()` function to include the setup of the Peer Identity and crontab entry.
- Added a new function `setup_crontab()` to handle the installation of the crontab entry for auto-upgrades.
- Added a new command `autoupgrade` to trigger the auto-upgrade process.
- Added error handling and improved logging for the auto-upgrade process.
- Updated the help message to include information about the hubble.sh script.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->