### PR TITLE
fix: Fix tests due to LINK storage change

### DIFF
--- a/.changeset/modern-emus-behave.md
+++ b/.changeset/modern-emus-behave.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+test: Fix broken test due to Link storage limits change

--- a/apps/hubble/src/rpc/test/server.test.ts
+++ b/apps/hubble/src/rpc/test/server.test.ts
@@ -136,7 +136,7 @@ describe("server rpc tests", () => {
       const newLimits = StorageLimitsResponse.fromJSON(result2._unsafeUnwrap()).limits;
       expect(newLimits).toContainEqual(StorageLimit.create({ limit: 5000 * 3, storeType: StoreType.CASTS }));
       expect(newLimits).toContainEqual(StorageLimit.create({ limit: 2500 * 3, storeType: StoreType.REACTIONS }));
-      expect(newLimits).toContainEqual(StorageLimit.create({ limit: 1250 * 3, storeType: StoreType.LINKS }));
+      expect(newLimits).toContainEqual(StorageLimit.create({ limit: 2500 * 3, storeType: StoreType.LINKS }));
       expect(newLimits).toContainEqual(StorageLimit.create({ limit: 50 * 3, storeType: StoreType.USER_DATA }));
       expect(newLimits).toContainEqual(StorageLimit.create({ limit: 25 * 3, storeType: StoreType.VERIFICATIONS }));
       expect(newLimits).toContainEqual(StorageLimit.create({ limit: 5 * 3, storeType: StoreType.USERNAME_PROOFS }));

--- a/apps/hubble/src/storage/stores/linkStore.test.ts
+++ b/apps/hubble/src/storage/stores/linkStore.test.ts
@@ -822,14 +822,7 @@ describe("pruneMessages", () => {
     const sizePrunedStore = new LinkStore(db, eventHandler, { pruneSizeLimit: 3 });
 
     test("size limit changes in the future", () => {
-      expect(getDefaultStoreLimit(StoreType.LINKS)).toEqual(1250);
-      const nowOrig = Date.now;
-      try {
-        Date.now = () => new Date("2023-10-01").getTime();
-        expect(getDefaultStoreLimit(StoreType.LINKS)).toEqual(2500);
-      } finally {
-        Date.now = nowOrig;
-      }
+      expect(getDefaultStoreLimit(StoreType.LINKS)).toEqual(2500);
     });
 
     test("no-ops when no messages have been merged", async () => {


### PR DESCRIPTION

## Change Summary

- Fix broken tests

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing broken tests and updating storage limits for the `LINKS` store type.

### Detailed summary
- Fixed a broken test in `linkStore.test.ts` due to changes in Link storage limits.
- Updated the default store limit for `LINKS` from 1250 to 2500 in `linkStore.test.ts`.
- Updated the storage limit for `LINKS` from 1250 to 2500 in `server.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->