### PR TITLE
chore: cleanup links store limit default

### DIFF
--- a/.changeset/smooth-dancers-march.md
+++ b/.changeset/smooth-dancers-march.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/core": patch
+---
+
+chore: cleanup default links store size code

--- a/packages/core/src/limits.ts
+++ b/packages/core/src/limits.ts
@@ -1,11 +1,7 @@
 import { StoreType } from "./protobufs";
 
-// Default link store limit should be 2500. Pick a date in the future to update the limit so hubs will
-// stay in sync between versions
-const LINKS_LIMIT_FIX_DATE = new Date("2023-09-20").getTime();
-
 const CASTS_SIZE_LIMIT_DEFAULT = 5_000;
-const LINKS_SIZE_LIMIT_DEFAULT = 1_250;
+const LINKS_SIZE_LIMIT_DEFAULT = 2_500;
 const REACTIONS_SIZE_LIMIT_DEFAULT = 2_500;
 const USER_DATA_SIZE_LIMIT_DEFAULT = 50;
 const USERNAME_PROOFS_SIZE_LIMIT_DEFAULT = 5;
@@ -42,7 +38,7 @@ export const getDefaultStoreLimit = (storeType: StoreType) => {
     case StoreType.CASTS:
       return CASTS_SIZE_LIMIT_DEFAULT;
     case StoreType.LINKS:
-      return Date.now() > LINKS_LIMIT_FIX_DATE ? LINKS_SIZE_LIMIT_DEFAULT * 2 : LINKS_SIZE_LIMIT_DEFAULT;
+      return LINKS_SIZE_LIMIT_DEFAULT;
     case StoreType.REACTIONS:
       return REACTIONS_SIZE_LIMIT_DEFAULT;
     case StoreType.USER_DATA:


### PR DESCRIPTION
## Motivation

Remove backwards compatibility code from https://github.com/farcasterxyz/hub-monorepo/pull/1382

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on cleaning up the default links store size code. 

### Detailed summary
- Updates the default links store size limit to 2,500.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->