### PR TITLE
fix: Support reading grafana creds from env file

### DIFF
--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -214,8 +214,15 @@ ensure_grafana() {
 ## Configure Grafana
 setup_grafana() {
     local grafana_url="http://127.0.0.1:3000"
-    local credentials="admin:admin"
+    local credentials
     local response dashboard_uid prefs
+
+    if key_exists "GRAFANA_CREDS"; then
+        credentials=$(grep "^GRAFANA_CREDS=" .env | awk -F '=' '{printf $2}')
+        echo "Using grafana creds from .env file"
+    else
+        credentials="admin:admin"
+    fi
 
     add_datasource() {
         response=$(curl -s -o /dev/null -w "%{http_code}" -X "POST" "$grafana_url/api/datasources" \


### PR DESCRIPTION
## Motivation

cc @manan19 

It does not write the creds back to the file after requesting it, but will read it and use that if it's present.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `setup_grafana` function in `scripts/hubble.sh` to use credentials from `.env` file if available. 

### Detailed summary
- Added logic to check if `GRAFANA_CREDS` key exists in `.env` file.
- If key exists, use the credentials from `.env` file.
- If key does not exist, use default credentials "admin:admin".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->