### PR TITLE
feat: add a dockerfile for the replicator

### DIFF
--- a/packages/hub-nodejs/examples/replicate-data-postgres/Dockerfile.replicator
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/Dockerfile.replicator
@@ -1,0 +1,14 @@
+FROM node:20.2-alpine
+
+RUN apk add --no-cache libc6-compat python3 make g++ linux-headers
+
+WORKDIR /home/node/app
+
+COPY package.json .
+COPY yarn.lock .
+
+RUN yarn install
+
+COPY . .
+
+CMD ["yarn", "start"]

--- a/packages/hub-nodejs/examples/replicate-data-postgres/docker-compose.yml
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/docker-compose.yml
@@ -4,13 +4,9 @@ services:
   app:
     build:
       context: .
-      # Need to install python3 due to ffi requirements in core. Once we release a new version of core removing the dep,
-      # we can remove this.
-      dockerfile_inline: |
-        FROM node:20.2-alpine
-        RUN apk add --no-cache libc6-compat python3 make g++ linux-headers
+      dockerfile: Dockerfile.replicator
     restart: unless-stopped
-    command: ["sh", "-c", "yarn install && exec yarn start"]
+    command: ["sh", "-c", "exec yarn start"]
     init: true
     environment:
       - NODE_OPTIONS=--max-old-space-size=512 # Limit memory usage


### PR DESCRIPTION
## Motivation

Makes it easier to build and deploy as a standalone app

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the Docker setup for the `replicate-data-postgres` example in the `hub-nodejs` package.

### Detailed summary
- Updated Dockerfile to use `node:20.2-alpine` as the base image.
- Added necessary dependencies (`libc6-compat`, `python3`, `make`, `g++`, `linux-headers`) to the Dockerfile.
- Set the working directory to `/home/node/app` in the Dockerfile.
- Added copying of `package.json`, `yarn.lock`, and all other files to the working directory in the Dockerfile.
- Changed the command in the `docker-compose.yml` file to `["sh", "-c", "exec yarn start"]`.
- Removed the inline Dockerfile and replaced it with a reference to `Dockerfile.replicator`.
- Set `init` to `true` in the `docker-compose.yml` file.
- Set `NODE_OPTIONS` to `--max-old-space-size=512` in the `environment` section of the `docker-compose.yml` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->