### PR TITLE
[feat] Support fname and onChainEvent SyncIds

### DIFF
--- a/.changeset/silly-beers-fail.md
+++ b/.changeset/silly-beers-fail.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+feat: support fname and onchain event syncids

--- a/apps/hubble/src/network/sync/merkleTrie.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.ts
@@ -220,7 +220,7 @@ class MerkleTrie {
             (e) => e as HubError,
           )();
           if (message.isOk() && message.value.hash.length === HASH_LENGTH) {
-            await this.insert(new SyncId(message.value));
+            await this.insert(SyncId.fromMessage(message.value));
             count += 1;
             if (count % 10_000 === 0) {
               log.info({ count }, "Rebuilding Merkle Trie");

--- a/apps/hubble/src/network/sync/mock.ts
+++ b/apps/hubble/src/network/sync/mock.ts
@@ -5,6 +5,7 @@ import { HubResult, MessagesResponse, SyncIds, TrieNodeMetadataResponse, TrieNod
 import Engine from "../../storage/engine/index.js";
 import { NodeMetadata } from "./merkleTrie.js";
 import SyncEngine from "./syncEngine.js";
+import { SyncId } from "./syncId.js";
 
 export class MockRpcClient {
   engine: Engine;
@@ -71,7 +72,9 @@ export class MockRpcClient {
 
   async getAllMessagesBySyncIds(request: SyncIds): Promise<HubResult<MessagesResponse>> {
     this.getAllMessagesBySyncIdsCalls.push(request);
-    const messagesResult = await this.syncEngine.getAllMessagesBySyncIds(request.syncIds);
+    const messagesResult = await this.syncEngine.getAllMessagesBySyncIds(
+      request.syncIds.map((s) => SyncId.fromBytes(s)),
+    );
     return messagesResult.map((messages) => {
       this.getAllMessagesBySyncIdsReturns += messages.length;
       return MessagesResponse.create({ messages: messages ?? [] });

--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -110,7 +110,7 @@ describe("SyncEngine", () => {
 
     // Two messages (signerEvent + castAdd) was added to the trie
     expect((await syncEngine.trie.items()) - existingItems).toEqual(1);
-    expect(await syncEngine.trie.exists(new SyncId(castAdd))).toBeTruthy();
+    expect(await syncEngine.trie.exists(SyncId.fromMessage(castAdd))).toBeTruthy();
   });
 
   test("trie is not updated on merge failure", async () => {
@@ -125,7 +125,7 @@ describe("SyncEngine", () => {
     await sleepWhile(() => syncEngine.syncTrieQSize > 0, SLEEPWHILE_TIMEOUT);
 
     expect(await syncEngine.trie.items()).toEqual(0);
-    expect(await syncEngine.trie.exists(new SyncId(castAdd))).toBeFalsy();
+    expect(await syncEngine.trie.exists(SyncId.fromMessage(castAdd))).toBeFalsy();
   });
 
   test("trie is updated when a message is removed", async () => {
@@ -150,10 +150,10 @@ describe("SyncEngine", () => {
     // Wait for the trie to be updated
     await sleepWhile(() => syncEngine.syncTrieQSize > 0, SLEEPWHILE_TIMEOUT);
 
-    const id = new SyncId(castRemove);
+    const id = SyncId.fromMessage(castRemove);
     expect(await syncEngine.trie.exists(id)).toBeTruthy();
 
-    const allMessages = await syncEngine.getAllMessagesBySyncIds([id.syncId()]);
+    const allMessages = await syncEngine.getAllMessagesBySyncIds([id]);
     expect(allMessages.isOk()).toBeTruthy();
     expect(allMessages._unsafeUnwrap()[0]?.data?.type).toEqual(MessageType.CAST_REMOVE);
 
@@ -161,7 +161,7 @@ describe("SyncEngine", () => {
     expect(await syncEngine.trie.exists(id)).toBeTruthy();
 
     // The trie should not contain the castAdd anymore
-    expect(await syncEngine.trie.exists(new SyncId(castAdd))).toBeFalsy();
+    expect(await syncEngine.trie.exists(SyncId.fromMessage(castAdd))).toBeFalsy();
   });
 
   test("trie is updated for username proof messages", async () => {
@@ -200,12 +200,12 @@ describe("SyncEngine", () => {
 
     // SignerAdd and Username proof is added to the trie
     expect((await syncEngine.trie.items()) - existingItems).toEqual(1);
-    expect(await syncEngine.trie.exists(new SyncId(proof))).toBeTruthy();
+    expect(await syncEngine.trie.exists(SyncId.fromMessage(proof))).toBeTruthy();
   });
 
   test("getAllMessages returns empty with invalid syncId", async () => {
     expect(await syncEngine.trie.items()).toEqual(0);
-    const result = await syncEngine.getAllMessagesBySyncIds([new SyncId(castAdd).syncId()]);
+    const result = await syncEngine.getAllMessagesBySyncIds([SyncId.fromMessage(castAdd)]);
     expect(result.isOk()).toBeTruthy();
     expect(result._unsafeUnwrap()[0]?.data).toBeUndefined();
     expect(result._unsafeUnwrap()[0]?.hash.length).toEqual(0);
@@ -410,9 +410,9 @@ describe("SyncEngine", () => {
     // Make sure all messages exist
     expect(await syncEngine2.trie.items()).toEqual(3);
     expect(await syncEngine2.trie.rootHash()).toEqual(await syncEngine.trie.rootHash());
-    expect(await syncEngine2.trie.exists(new SyncId(messages[0] as Message))).toBeTruthy();
-    expect(await syncEngine2.trie.exists(new SyncId(messages[1] as Message))).toBeTruthy();
-    expect(await syncEngine2.trie.exists(new SyncId(messages[2] as Message))).toBeTruthy();
+    expect(await syncEngine2.trie.exists(SyncId.fromMessage(messages[0] as Message))).toBeTruthy();
+    expect(await syncEngine2.trie.exists(SyncId.fromMessage(messages[1] as Message))).toBeTruthy();
+    expect(await syncEngine2.trie.exists(SyncId.fromMessage(messages[2] as Message))).toBeTruthy();
 
     await syncEngine2.stop();
   });
@@ -434,9 +434,9 @@ describe("SyncEngine", () => {
       // Make sure all messages exist
       expect(await syncEngine2.trie.items()).toEqual(3);
       expect(await syncEngine2.trie.rootHash()).toEqual(await syncEngine.trie.rootHash());
-      expect(await syncEngine2.trie.exists(new SyncId(messages[0] as Message))).toBeTruthy();
-      expect(await syncEngine2.trie.exists(new SyncId(messages[1] as Message))).toBeTruthy();
-      expect(await syncEngine2.trie.exists(new SyncId(messages[2] as Message))).toBeTruthy();
+      expect(await syncEngine2.trie.exists(SyncId.fromMessage(messages[0] as Message))).toBeTruthy();
+      expect(await syncEngine2.trie.exists(SyncId.fromMessage(messages[1] as Message))).toBeTruthy();
+      expect(await syncEngine2.trie.exists(SyncId.fromMessage(messages[2] as Message))).toBeTruthy();
 
       await syncEngine2.stop();
     },

--- a/apps/hubble/src/network/sync/syncId.test.ts
+++ b/apps/hubble/src/network/sync/syncId.test.ts
@@ -1,6 +1,7 @@
 import { Factories, FarcasterNetwork, Message } from "@farcaster/hub-nodejs";
-import { SyncId } from "./syncId.js";
-import { makeMessagePrimaryKeyFromMessage } from "../../storage/db/message.js";
+import { FNameSyncId, MessageSyncId, OnChainEventSyncId, SyncId, SyncIdType, TIMESTAMP_LENGTH } from "./syncId.js";
+import { makeFidKey, makeMessagePrimaryKeyFromMessage } from "../../storage/db/message.js";
+import { FID_BYTES, RootPrefix } from "../../storage/db/types.js";
 
 let message: Message;
 
@@ -14,13 +15,56 @@ beforeAll(async () => {
 
 describe("SyncId", () => {
   test("succeeds", async () => {
-    const syncId = new SyncId(message).syncId();
+    const syncId = SyncId.fromMessage(message).syncId();
     expect(syncId).toBeDefined();
   });
 
-  test("Test pkFromSyncId", async () => {
-    // Create a new castAdd
-    const castAdd1 = await Factories.CastAddMessage.create({ data: { fid, network } }, { transient: { signer } });
-    expect(makeMessagePrimaryKeyFromMessage(castAdd1)).toEqual(SyncId.pkFromSyncId(new SyncId(castAdd1).syncId()));
+  describe("Message syncIds", () => {
+    test("creates and unpacks correctly from message", async () => {
+      const castAddMessage = await Factories.CastAddMessage.create(
+        { data: { fid, network } },
+        { transient: { signer } },
+      );
+      const syncId = SyncId.fromMessage(castAddMessage).syncId();
+      const unpackedSyncId = SyncId.unpack(syncId) as MessageSyncId;
+      expect(unpackedSyncId.type).toEqual(SyncIdType.Message);
+      expect(unpackedSyncId.fid).toEqual(fid);
+      expect(unpackedSyncId.hash).toEqual(castAddMessage.hash);
+      expect(unpackedSyncId.primaryKey).toEqual(makeMessagePrimaryKeyFromMessage(castAddMessage));
+    });
+  });
+
+  describe("FName syncIds", () => {
+    test("creates and unpacks correctly from message", async () => {
+      const fnameProof = Factories.UserNameProof.build();
+      const syncId = SyncId.fromFName(fnameProof).syncId();
+      const unpackedSyncId = SyncId.unpack(syncId) as FNameSyncId;
+      expect(unpackedSyncId.type).toEqual(SyncIdType.FName);
+      expect(unpackedSyncId.fid).toEqual(fnameProof.fid);
+      expect(unpackedSyncId.name).toEqual(fnameProof.name);
+    });
+  });
+
+  describe("OnChainEvent syncIds", () => {
+    test("creates and unpacks correctly from message", async () => {
+      const onChainEvent = Factories.IdRegistryOnChainEvent.build();
+      const syncId = SyncId.fromOnChainEvent(onChainEvent).syncId();
+      const unpackedSyncId = SyncId.unpack(syncId) as OnChainEventSyncId;
+      expect(unpackedSyncId.type).toEqual(SyncIdType.OnChainEvent);
+      expect(unpackedSyncId.fid).toEqual(onChainEvent.fid);
+      expect(unpackedSyncId.blockNumber).toEqual(onChainEvent.blockNumber);
+    });
+  });
+
+  describe("unknown syncIds", () => {
+    test("always returns 0 fid", async () => {
+      const bytes = new Uint8Array(TIMESTAMP_LENGTH + 1 + FID_BYTES + 1);
+      bytes.set([RootPrefix.HubEvents], TIMESTAMP_LENGTH);
+      const fid = Factories.Fid.build();
+      bytes.set(makeFidKey(fid), TIMESTAMP_LENGTH + 1);
+      const unpackedSyncId = SyncId.unpack(bytes);
+      expect(unpackedSyncId.type).toEqual(SyncIdType.Unknown);
+      expect(unpackedSyncId.fid).toEqual(0);
+    });
   });
 });

--- a/apps/hubble/src/network/utils/factories.ts
+++ b/apps/hubble/src/network/utils/factories.ts
@@ -60,7 +60,7 @@ const SyncIdFactory = Factory.define<undefined, { date: Date; hash: string; fid:
         data: { fid: fid || Factories.Fid.build(), timestamp: (date || faker.date.recent()).getTime() / 1000 },
       });
 
-      return new SyncId(castAddMessage);
+      return SyncId.fromMessage(castAddMessage);
     });
 
     return undefined;

--- a/apps/hubble/src/test/bench/helpers.ts
+++ b/apps/hubble/src/test/bench/helpers.ts
@@ -40,7 +40,7 @@ export const generateSyncIds = (n: number, numFids = 1, maxTimeShift = 1): SyncI
  */
 export const fastSyncId = (fid: number, hash: Uint8Array, timestamp: number, type: number) => {
   // Ducktyping message model to avoid creating the whole message.
-  return new SyncId({
+  return SyncId.fromMessage({
     data: {
       fid,
       timestamp,

--- a/packages/core/src/factories.ts
+++ b/packages/core/src/factories.ts
@@ -21,7 +21,7 @@ import {
 } from "./protobufs";
 import { bytesToHexString, utf8StringToBytes } from "./bytes";
 import { Ed25519Signer, Eip712Signer, NobleEd25519Signer, Signer, ViemLocalEip712Signer } from "./signers";
-import { getFarcasterTime, toFarcasterTime } from "./time";
+import { FARCASTER_EPOCH, getFarcasterTime, toFarcasterTime } from "./time";
 import { VerificationEthAddressClaim } from "./verifications";
 import { LocalAccount } from "viem";
 
@@ -577,7 +577,7 @@ const OnChainEventFactory = Factory.define<protobufs.OnChainEvent>(() => {
     fid: FidFactory.build(),
     blockNumber: faker.datatype.number({ min: 1, max: 100_000 }),
     blockHash: BlockHashFactory.build(),
-    blockTimestamp: faker.datatype.datetime().getTime(),
+    blockTimestamp: Math.floor(faker.datatype.datetime({ min: FARCASTER_EPOCH }).getTime() / 1000),
     transactionHash: TransactionHashFactory.build(),
     logIndex: faker.datatype.number({ min: 0, max: 1_000 }),
   });


### PR DESCRIPTION
## Motivation

https://github.com/farcasterxyz/hub-monorepo/issues/1045

In preparation for adding them to the sync trie

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding support for `fname` and `onchain` event syncids. 

### Detailed summary
- Added support for `fname` and `onchain` event syncids
- Updated the `factories.ts` file to include `FARCASTER_EPOCH` constant
- Updated the `syncId.test.ts` file to include tests for different types of syncids
- Updated the `syncEngine.test.ts` file to include tests for syncid creation and retrieval

> The following files were skipped due to too many changes: `apps/hubble/src/network/sync/syncEngine.ts`, `apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts`, `apps/hubble/src/network/sync/syncId.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->