### PR TITLE
fix: Bound generated timestamps for tests

### DIFF
--- a/.changeset/calm-olives-begin.md
+++ b/.changeset/calm-olives-begin.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/core": patch
+---
+
+fix: Bound generated timestamps for tests

--- a/packages/core/src/factories.ts
+++ b/packages/core/src/factories.ts
@@ -577,7 +577,7 @@ const OnChainEventFactory = Factory.define<protobufs.OnChainEvent>(() => {
     fid: FidFactory.build(),
     blockNumber: faker.datatype.number({ min: 1, max: 100_000 }),
     blockHash: BlockHashFactory.build(),
-    blockTimestamp: Math.floor(faker.datatype.datetime({ min: FARCASTER_EPOCH }).getTime() / 1000),
+    blockTimestamp: Math.floor(faker.datatype.datetime({ min: FARCASTER_EPOCH, max: Date.now() }).getTime() / 1000),
     transactionHash: TransactionHashFactory.build(),
     logIndex: faker.datatype.number({ min: 0, max: 1_000 }),
   });


### PR DESCRIPTION
## Change Summary

- Fix generated timestamps to prevent flaky tests

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the bound generated timestamps for tests in the `factories.ts` file.

### Detailed summary
- Updated the `blockTimestamp` generation in the `factories.ts` file to use the current timestamp as the maximum value.
- This ensures that the generated `blockTimestamp` falls within a valid range for tests.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->