### PR TITLE
feat: Support onchain events and fnames in sync trie

### DIFF
--- a/.changeset/cold-snakes-join.md
+++ b/.changeset/cold-snakes-join.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+feat: support onchain events and fnames in sync trie

--- a/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
+++ b/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
@@ -2,6 +2,7 @@ import {
   FNameRegistryClientInterface,
   FNameRegistryEventsProvider,
   FNameTransfer,
+  FNameTransferRequest,
 } from "./fnameRegistryEventsProvider.js";
 import { jestRocksDB } from "../storage/db/jestUtils.js";
 import Engine from "../storage/engine/index.js";
@@ -11,6 +12,7 @@ import { getUserNameProof } from "../storage/db/nameRegistryEvent.js";
 import { utf8ToBytes } from "@noble/curves/abstract/utils";
 import { generatePrivateKey, privateKeyToAccount, PrivateKeyAccount, Address } from "viem/accounts";
 import { bytesToHex } from "viem";
+import { HubState } from "@farcaster/hub-nodejs";
 
 class MockFnameRegistryClient implements FNameRegistryClientInterface {
   private transfersToReturn: FNameTransfer[][] = [];
@@ -57,12 +59,12 @@ class MockFnameRegistryClient implements FNameRegistryClientInterface {
     this.timesToThrow = 1;
   }
 
-  async getTransfers(since: 0): Promise<FNameTransfer[]> {
+  async getTransfers(params: FNameTransferRequest): Promise<FNameTransfer[]> {
     if (this.timesToThrow > 0) {
       this.timesToThrow--;
       throw new Error("connection failed");
     }
-    expect(since).toBeGreaterThanOrEqual(this.minimumSince);
+    expect(params.fromId).toBeGreaterThanOrEqual(this.minimumSince);
     const transfers = this.transfersToReturn.shift();
     if (!transfers) {
       return Promise.resolve([]);
@@ -146,7 +148,7 @@ describe("fnameRegistryEventsProvider", () => {
     });
 
     it("fetches events from where it left off", async () => {
-      await hub.putHubState({ lastFnameProof: transferEvents[0]?.id ?? 0, lastEthBlock: 0, lastL2Block: 0 });
+      await hub.putHubState(HubState.create({ lastFnameProof: transferEvents[0]?.id ?? 0 }));
       mockFnameRegistryClient.setMinimumSince(transferEvents[0]?.id ?? 0);
       await provider.start();
       expect(await getUserNameProof(db, utf8ToBytes("test2"))).toBeTruthy();

--- a/apps/hubble/src/eth/fnameRegistryEventsProvider.ts
+++ b/apps/hubble/src/eth/fnameRegistryEventsProvider.ts
@@ -29,8 +29,13 @@ export type FNameTransfer = {
   to: number;
 };
 
+export type FNameTransferRequest = {
+  fromId?: number;
+  name?: string;
+};
+
 export interface FNameRegistryClientInterface {
-  getTransfers(fromId: number): Promise<FNameTransfer[]>;
+  getTransfers(params: FNameTransferRequest): Promise<FNameTransfer[]>;
   getSigner(): Promise<string>;
 }
 
@@ -40,8 +45,9 @@ export class FNameRegistryClient implements FNameRegistryClientInterface {
     this.url = url;
   }
 
-  public async getTransfers(fromId = 0): Promise<FNameTransfer[]> {
-    const response = await axios.get(`${this.url}/transfers?from_id=${fromId}`, {
+  public async getTransfers(params: FNameTransferRequest): Promise<FNameTransfer[]> {
+    const response = await axios.get(`${this.url}/transfers`, {
+      params,
       timeout: DEFAULT_READ_TIMEOUT_IN_MS,
     });
     return response.data.transfers;
@@ -114,7 +120,7 @@ export class FNameRegistryEventsProvider {
     }
 
     this.lastTransferId = fromId;
-    let transfers = await this.safeGetTransfers(fromId);
+    let transfers = await this.safeGetTransfers({ fromId });
     let transfersCount = 0;
     while (transfers.length > 0 && !this.shouldStop) {
       transfersCount += transfers.length;
@@ -124,7 +130,7 @@ export class FNameRegistryEventsProvider {
         break;
       }
       this.lastTransferId = lastTransfer.id;
-      transfers = await this.safeGetTransfers(this.lastTransferId);
+      transfers = await this.safeGetTransfers({ fromId: this.lastTransferId });
     }
     log.info(`Fetched ${transfersCount} fname events upto ${this.lastTransferId}`);
     const result = await this.hub.getHubState();
@@ -136,11 +142,18 @@ export class FNameRegistryEventsProvider {
     }
   }
 
-  private async safeGetTransfers(fromId: number) {
+  public async retryTransferByName(name: Uint8Array) {
+    const nameStr = Buffer.from(name).toString("utf-8");
+    const transfers = await this.safeGetTransfers({ name: nameStr });
+    await this.mergeTransfers(transfers);
+    log.info(`Retried ${transfers.length} fname events for ${nameStr}`);
+  }
+
+  private async safeGetTransfers(params: FNameTransferRequest) {
     try {
-      return await this.client.getTransfers(fromId);
+      return await this.client.getTransfers(params);
     } catch (err) {
-      log.error(err, `Failed to get transfers from ${fromId}`);
+      log.error(err, `Failed to get transfers ${params}`);
       return [];
     }
   }

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -344,7 +344,13 @@ export class Hub implements HubInterface {
     this.engine = new Engine(this.rocksDB, options.network, eventHandler, mainnetClient);
 
     const profileSync = options.profileSync ?? false;
-    this.syncEngine = new SyncEngine(this, this.rocksDB, this.l2RegistryProvider, profileSync);
+    this.syncEngine = new SyncEngine(
+      this,
+      this.rocksDB,
+      this.l2RegistryProvider,
+      this.fNameRegistryEventsProvider,
+      profileSync,
+    );
 
     // If profileSync is true, exit after sync is complete
     if (profileSync) {
@@ -838,7 +844,7 @@ export class Hub implements HubInterface {
     const result = await ResultAsync.fromPromise(getHubState(this.rocksDB), (e) => e as HubError);
     if (result.isErr() && result.error.errCode === "not_found") {
       log.info("hub state not found, resetting state");
-      const hubState = HubState.create({ lastEthBlock: 0, lastFnameProof: 0 });
+      const hubState = HubState.create({ lastEthBlock: 0, lastFnameProof: 0, syncEvents: false });
       await putHubState(this.rocksDB, hubState);
       return ok(hubState);
     }

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -9,6 +9,7 @@ import {
   HubInfoRequest,
   getFarcasterTime,
   OnChainEvent,
+  UserNameProof,
 } from "@farcaster/hub-nodejs";
 import { APP_NICKNAME, APP_VERSION, HubInterface } from "../../hubble.js";
 import SyncEngine from "./syncEngine.js";
@@ -38,15 +39,35 @@ let custodyEvent: OnChainEvent;
 let signerEvent: OnChainEvent;
 let storageEvent: OnChainEvent;
 let castAdd: Message;
+let fname: UserNameProof;
+
+const eventsByBlock = new Map<number, OnChainEvent>();
+// biome-ignore lint/suspicious/noExplicitAny: mock used only in tests
+const l2EventsProvider = jest.fn() as any;
+l2EventsProvider.retryEventsFromBlock = jest.fn();
+const retryEventsMock = l2EventsProvider.retryEventsFromBlock;
+
+// biome-ignore lint/suspicious/noExplicitAny: mock used only in tests
+const fnameEventsProvider = jest.fn() as any;
+fnameEventsProvider.retryTransferByName = jest.fn();
+const retryTransferByName = fnameEventsProvider.retryTransferByName;
 
 beforeAll(async () => {
   const custodySignerKey = (await custodySigner.getSignerKey())._unsafeUnwrap();
   const signerKey = (await signer.getSignerKey())._unsafeUnwrap();
   custodyEvent = Factories.IdRegistryOnChainEvent.build({ fid }, { transient: { to: custodySignerKey } });
 
-  signerEvent = Factories.SignerOnChainEvent.build({ fid }, { transient: { signer: signerKey } });
-  storageEvent = Factories.StorageRentOnChainEvent.build({ fid });
+  signerEvent = Factories.SignerOnChainEvent.build(
+    { fid, blockNumber: custodyEvent.blockNumber + 1 },
+    { transient: { signer: signerKey } },
+  );
+  storageEvent = Factories.StorageRentOnChainEvent.build({ fid, blockNumber: custodyEvent.blockNumber + 2 });
   castAdd = await Factories.CastAddMessage.create({ data: { fid, network } }, { transient: { signer } });
+  fname = Factories.UserNameProof.build({ fid });
+
+  eventsByBlock.set(custodyEvent.blockNumber, custodyEvent);
+  eventsByBlock.set(signerEvent.blockNumber, signerEvent);
+  eventsByBlock.set(storageEvent.blockNumber, storageEvent);
 });
 
 describe("Multi peer sync engine", () => {
@@ -101,15 +122,37 @@ describe("Multi peer sync engine", () => {
   let port1;
   let clientForServer1: HubRpcClient;
 
+  let engine2: Engine;
+  let hub2: HubInterface;
+  let syncEngine2: SyncEngine;
+
   beforeEach(async () => {
+    jest.clearAllMocks();
     // Engine 1 is where we add events, and see if engine 2 will sync them
     engine1 = new Engine(testDb1, network);
     hub1 = new MockHub(testDb1, engine1);
     syncEngine1 = new SyncEngine(hub1, testDb1);
-    syncEngine1.start();
+    await syncEngine1.start();
+    await syncEngine1.enableEventsSync();
     server1 = new Server(hub1, engine1, syncEngine1);
     port1 = await server1.start();
     clientForServer1 = getInsecureHubRpcClient(`127.0.0.1:${port1}`);
+
+    retryEventsMock.mockImplementation(async (blockNumber: number) => {
+      const event = eventsByBlock.get(blockNumber);
+      if (event) {
+        return engine2.mergeOnChainEvent(event);
+      } else {
+        throw new Error(`Block ${blockNumber} not found`);
+      }
+    });
+    retryTransferByName.mockImplementation(async (name: Uint8Array) => {
+      expect(name).toEqual(fname.name);
+      await engine2.mergeUserNameProof(fname);
+    });
+    engine2 = new Engine(testDb2, network);
+    hub2 = new MockHub(testDb2, engine2);
+    syncEngine2 = new SyncEngine(hub2, testDb2, l2EventsProvider, fnameEventsProvider);
   }, TEST_TIMEOUT_SHORT);
 
   afterEach(async () => {
@@ -118,6 +161,9 @@ describe("Multi peer sync engine", () => {
     await server1.stop();
     await syncEngine1.stop();
     await engine1.stop();
+
+    await syncEngine2.stop();
+    await engine2.stop();
   }, TEST_TIMEOUT_SHORT);
 
   test("toBytes test", async () => {
@@ -159,21 +205,13 @@ describe("Multi peer sync engine", () => {
       await expect(engine1.mergeOnChainEvent(custodyEvent)).resolves.toBeDefined();
       await expect(engine1.mergeOnChainEvent(signerEvent)).resolves.toBeDefined();
       await expect(engine1.mergeOnChainEvent(storageEvent)).resolves.toBeDefined();
+      await expect(engine1.mergeUserNameProof(fname)).resolves.toBeDefined();
 
       // Add messages to engine 1
       await addMessagesWithTimeDelta(engine1, [167, 169, 172]);
       await sleepWhile(() => syncEngine1.syncTrieQSize > 0, SLEEPWHILE_TIMEOUT);
 
-      const engine2 = new Engine(testDb2, network);
-      const hub2 = new MockHub(testDb2, engine2);
-      const syncEngine2 = new SyncEngine(hub2, testDb2);
-
-      // Add the signer custody event to engine 2
-      await engine2.mergeOnChainEvent(custodyEvent);
-      await engine2.mergeOnChainEvent(signerEvent);
-      await engine2.mergeOnChainEvent(storageEvent);
-
-      // Engine 2 should sync with engine1
+      // Engine 2 should sync with engine1 (inlcuding onchain events and fnames)
       expect(
         (await syncEngine2.syncStatus("engine2", (await syncEngine1.getSnapshot())._unsafeUnwrap()))._unsafeUnwrap()
           .shouldSync,
@@ -215,8 +253,8 @@ describe("Multi peer sync engine", () => {
       // Make sure root hash matches
       expect(await syncEngine1.trie.rootHash()).toEqual(await syncEngine2.trie.rootHash());
 
-      await syncEngine2.stop();
-      await engine2.stop();
+      expect(syncEngine2.trie.exists(SyncId.fromFName(fname))).toBeTruthy();
+      expect(syncEngine2.trie.exists(SyncId.fromOnChainEvent(storageEvent))).toBeTruthy();
     },
     TEST_TIMEOUT_LONG,
   );
@@ -230,15 +268,6 @@ describe("Multi peer sync engine", () => {
     // Add a cast to engine1
     const castAdd = (await addMessagesWithTimeDelta(engine1, [167]))[0] as Message;
     await sleepWhile(() => syncEngine1.syncTrieQSize > 0, SLEEPWHILE_TIMEOUT);
-
-    const engine2 = new Engine(testDb2, network);
-    const hub2 = new MockHub(testDb2, engine2);
-    const syncEngine2 = new SyncEngine(hub2, testDb2);
-
-    // Add the signer custody event to engine 2
-    await engine2.mergeOnChainEvent(custodyEvent);
-    await engine2.mergeOnChainEvent(signerEvent);
-    await engine2.mergeOnChainEvent(storageEvent);
 
     // Sync engine 2 with engine 1
     await syncEngine2.performSync("engine1", (await syncEngine1.getSnapshot())._unsafeUnwrap(), clientForServer1);
@@ -308,22 +337,16 @@ describe("Multi peer sync engine", () => {
     await sleepWhile(() => syncEngine2.syncTrieQSize > 0, SLEEPWHILE_TIMEOUT);
 
     expect(await syncEngine2.trie.rootHash()).toEqual(beforeRootHash);
-
-    await syncEngine2.stop();
-    await engine2.stop();
   });
 
   test("shouldn't fetch messages that already exist", async () => {
-    // Engine1 has 1 message
+    // Engine1 has no messages
     await engine1.mergeOnChainEvent(custodyEvent);
     await engine1.mergeOnChainEvent(signerEvent);
     await engine1.mergeOnChainEvent(storageEvent);
 
-    const engine2 = new Engine(testDb2, network);
-    const hub2 = new MockHub(testDb2, engine2);
-    const syncEngine2 = new SyncEngine(hub2, testDb2);
-
     // Engine2 has 2 messages
+    await syncEngine2.enableEventsSync();
     await engine2.mergeOnChainEvent(custodyEvent);
     await engine2.mergeOnChainEvent(signerEvent);
     await engine2.mergeOnChainEvent(storageEvent);
@@ -337,27 +360,16 @@ describe("Multi peer sync engine", () => {
 
       expect(fetchMessagesSpy).not.toHaveBeenCalled();
     }
-
-    await syncEngine2.stop();
-    await engine2.stop();
   });
 
   test("should fetch only the exact missing message", async () => {
-    // Engine1 has 2 message
+    // Engine1 has 1 message
     await engine1.mergeOnChainEvent(custodyEvent);
     await engine1.mergeOnChainEvent(signerEvent);
     await engine1.mergeOnChainEvent(storageEvent);
     const msgs = await addMessagesWithTimeDelta(engine1, [167]);
 
-    const engine2 = new Engine(testDb2, network);
-    const hub2 = new MockHub(testDb2, engine2);
-    const syncEngine2 = new SyncEngine(hub2, testDb2);
-
-    // Engine2 has 1 messages
-    await engine2.mergeOnChainEvent(custodyEvent);
-    await engine2.mergeOnChainEvent(signerEvent);
-    await engine2.mergeOnChainEvent(storageEvent);
-
+    // Engine2 has no messages
     // Syncing engine2 --> engine1 should fetch only the missing message
     {
       const fetchMessagesSpy = jest.spyOn(syncEngine1, "getAllMessagesBySyncIds");
@@ -369,27 +381,20 @@ describe("Multi peer sync engine", () => {
       // Also assert the root hashes are the same
       expect(await syncEngine2.trie.rootHash()).toEqual(await syncEngine1.trie.rootHash());
     }
-
-    await syncEngine2.stop();
-    await engine2.stop();
   });
 
   describe("after migration", () => {
     let engine2: Engine;
     let syncEngine2: SyncEngine;
-    let retryEventsMock: L2EventsProvider;
     let custodyEvent: OnChainEvent;
     let signerEvent: OnChainEvent;
 
     beforeEach(async () => {
       engine2 = new Engine(testDb2, network);
       const hub2 = new MockHub(testDb2, engine2);
-      // biome-ignore lint/suspicious/noExplicitAny: mock used only in tests
-      const l2EventsProvider = jest.fn() as any;
-      l2EventsProvider.retryEventsFromBlock = jest.fn();
-      retryEventsMock = l2EventsProvider.retryEventsFromBlock;
 
       syncEngine2 = new SyncEngine(hub2, testDb2, l2EventsProvider);
+      await syncEngine2.enableEventsSync();
 
       // Set up engine1
       custodyEvent = Factories.IdRegistryOnChainEvent.build({ fid });
@@ -429,9 +434,10 @@ describe("Multi peer sync engine", () => {
       expect(retryEventsMock).toHaveBeenCalledWith(signerEvent.blockNumber);
     });
 
-    test("does not retry any block if both events are present", async () => {
+    test("does not retry any block if all events are present", async () => {
       await engine2.mergeOnChainEvent(custodyEvent);
       await engine2.mergeOnChainEvent(signerEvent);
+      await engine2.mergeOnChainEvent(storageEvent);
       await syncEngine2.performSync("engine1", (await syncEngine1.getSnapshot())._unsafeUnwrap(), clientForServer1);
 
       // Because do it without awaiting, we need to wait for the promise to resolve
@@ -441,13 +447,9 @@ describe("Multi peer sync engine", () => {
   });
 
   test("recovers if there are missing messages in the engine", async () => {
-    const engine2 = new Engine(testDb2, network);
-    const hub2 = new MockHub(testDb2, engine2);
-    const syncEngine2 = new SyncEngine(hub2, testDb2);
-    await syncEngine2.start();
-
+    await syncEngine2.enableEventsSync();
     // Add a message to engine1 synctrie, but not to the engine itself.
-    syncEngine1.trie.insert(SyncId.fromMessage(castAdd));
+    await syncEngine1.trie.insert(SyncId.fromMessage(castAdd));
 
     // Attempt to sync engine2 <-- engine1.
     await syncEngine2.performSync("engine1", (await syncEngine1.getSnapshot())._unsafeUnwrap(), clientForServer1);
@@ -463,17 +465,10 @@ describe("Multi peer sync engine", () => {
     // The root hashes should be the same, since nothing actually happened
     expect(await syncEngine1.trie.items()).toEqual(await syncEngine2.trie.items());
     expect(await syncEngine1.trie.rootHash()).toEqual(EMPTY_HASH);
-
-    await syncEngine2.stop();
-    await engine2.stop();
   });
 
   test("recovers if there are missing messages in the engine during sync", async () => {
-    const engine2 = new Engine(testDb2, network);
-    const hub2 = new MockHub(testDb2, engine2);
-    const syncEngine2 = new SyncEngine(hub2, testDb2);
-    await syncEngine2.start();
-
+    await syncEngine2.enableEventsSync();
     await engine2.mergeOnChainEvent(custodyEvent);
     await engine1.mergeOnChainEvent(custodyEvent);
 
@@ -483,6 +478,8 @@ describe("Multi peer sync engine", () => {
     await engine1.mergeOnChainEvent(storageEvent);
     await engine2.mergeOnChainEvent(storageEvent);
 
+    const initialEngine1Count = await syncEngine1.trie.items();
+    const initialEngine2Count = await syncEngine1.trie.items();
     // We'll get 2 CastAdds
     const castAdd1 = await Factories.CastAddMessage.create({ data: { fid, network } }, { transient: { signer } });
     const castAdd2 = await Factories.CastAddMessage.create({ data: { fid, network } }, { transient: { signer } });
@@ -495,8 +492,8 @@ describe("Multi peer sync engine", () => {
     await syncEngine2.trie.insert(SyncId.fromMessage(castAdd2));
 
     // Wait for the sync trie to be updated
-    await sleepWhile(async () => (await syncEngine2.trie.items()) !== 2, SLEEPWHILE_TIMEOUT);
-    await sleepWhile(async () => (await syncEngine1.trie.items()) !== 1, SLEEPWHILE_TIMEOUT);
+    await sleepWhile(async () => (await syncEngine2.trie.items()) !== initialEngine2Count + 2, SLEEPWHILE_TIMEOUT);
+    await sleepWhile(async () => (await syncEngine1.trie.items()) !== initialEngine1Count + 1, SLEEPWHILE_TIMEOUT);
 
     // Attempt to sync engine2 <-- engine1. Engine1 has only singerAdd
     await syncEngine2.performSync("engine1", (await syncEngine1.getSnapshot())._unsafeUnwrap(), clientForServer1);
@@ -508,9 +505,6 @@ describe("Multi peer sync engine", () => {
 
     // but the castAdd1 should still be there
     expect(await syncEngine2.trie.exists(SyncId.fromMessage(castAdd1))).toBeTruthy();
-
-    await syncEngine2.stop();
-    await engine2.stop();
   });
 
   test("recovers if messages are missing from the sync trie", async () => {
@@ -518,25 +512,22 @@ describe("Multi peer sync engine", () => {
     await engine1.mergeOnChainEvent(signerEvent);
     await engine1.mergeOnChainEvent(storageEvent);
 
-    const engine2 = new Engine(testDb2, network);
-    const hub2 = new MockHub(testDb2, engine2);
-    const syncEngine2 = new SyncEngine(hub2, testDb2);
-    await syncEngine2.start();
-
     // We add it to the engine2 synctrie as normal...
+    await syncEngine2.enableEventsSync();
     await engine2.mergeOnChainEvent(custodyEvent);
     await engine2.mergeOnChainEvent(signerEvent);
     await engine2.mergeOnChainEvent(storageEvent);
 
+    const initialEngine2Count = await syncEngine2.trie.items();
+
     await engine1.mergeMessage(castAdd);
     await engine2.mergeMessage(castAdd);
 
-    // ...but we'll corrupt the sync trie by pretending that the signerAdd message is missing
-    syncEngine2.trie.deleteBySyncId(SyncId.fromMessage(castAdd));
+    // ...but we'll corrupt the sync trie by pretending that the castAdd message is missing
+    await syncEngine2.trie.deleteBySyncId(SyncId.fromMessage(castAdd));
 
     // syncengine2 should be empty
-    expect(await syncEngine2.trie.items()).toEqual(0);
-    expect(await syncEngine2.trie.rootHash()).toEqual(EMPTY_HASH);
+    expect(await syncEngine2.trie.items()).toEqual(initialEngine2Count);
 
     // Attempt to sync engine2 <-- engine1.
     // It will appear to engine2 that the message is missing, so it will request it from engine1.
@@ -553,23 +544,20 @@ describe("Multi peer sync engine", () => {
     // The root hashes should now be the same
     expect(await syncEngine1.trie.items()).toEqual(await syncEngine2.trie.items());
     expect(await syncEngine1.trie.rootHash()).toEqual(await syncEngine2.trie.rootHash());
-
-    await syncEngine2.stop();
-    await engine2.stop();
   });
 
   test("syncEngine syncs with same numMessages but different hashes", async () => {
+    await syncEngine2.enableEventsSync();
     await engine1.mergeOnChainEvent(custodyEvent);
     await engine1.mergeOnChainEvent(signerEvent);
     await engine1.mergeOnChainEvent(storageEvent);
 
-    const engine2 = new Engine(testDb2, network);
-    const hub2 = new MockHub(testDb2, engine2);
-    const syncEngine2 = new SyncEngine(hub2, testDb2);
-
     await engine2.mergeOnChainEvent(custodyEvent);
     await engine2.mergeOnChainEvent(signerEvent);
     await engine2.mergeOnChainEvent(storageEvent);
+
+    const initialEngine1Count = await syncEngine1.trie.items();
+    const initialEngine2Count = await syncEngine2.trie.items();
 
     expect(await syncEngine1.trie.items()).toEqual(await syncEngine2.trie.items());
     expect(await syncEngine1.trie.rootHash()).toEqual(await syncEngine2.trie.rootHash());
@@ -578,14 +566,14 @@ describe("Multi peer sync engine", () => {
     await addMessagesWithTimeDelta(engine1, [167]);
     await addMessagesWithTimeDelta(engine2, [169]);
 
-    await sleepWhile(async () => (await syncEngine1.trie.items()) !== 1, SLEEPWHILE_TIMEOUT);
-    await sleepWhile(async () => (await syncEngine2.trie.items()) !== 1, SLEEPWHILE_TIMEOUT);
+    await sleepWhile(async () => (await syncEngine1.trie.items()) !== initialEngine1Count + 1, SLEEPWHILE_TIMEOUT);
+    await sleepWhile(async () => (await syncEngine2.trie.items()) !== initialEngine2Count + 1, SLEEPWHILE_TIMEOUT);
 
     // Do a sync
     await syncEngine2.performSync("engine1", (await syncEngine1.getSnapshot())._unsafeUnwrap(), clientForServer1);
-    await sleepWhile(async () => (await syncEngine2.trie.items()) !== 2, SLEEPWHILE_TIMEOUT);
+    await sleepWhile(async () => (await syncEngine2.trie.items()) !== initialEngine2Count + 2, SLEEPWHILE_TIMEOUT);
 
-    expect(await syncEngine2.trie.items()).toEqual(2);
+    expect(await syncEngine2.trie.items()).toEqual(initialEngine2Count + 2);
 
     // Do a sync the other way
     {
@@ -594,7 +582,7 @@ describe("Multi peer sync engine", () => {
       const clientForServer2 = getInsecureHubRpcClient(`127.0.0.1:${port2}`);
 
       await syncEngine1.performSync("engine2", (await syncEngine2.getSnapshot())._unsafeUnwrap(), clientForServer2);
-      await sleepWhile(async () => (await syncEngine1.trie.items()) !== 2, 1000);
+      await sleepWhile(async () => (await syncEngine1.trie.items()) !== initialEngine2Count + 2, 1000);
 
       // Now both engines should have the same number of messages and the same root hash
       expect(await syncEngine1.trie.items()).toEqual(await syncEngine2.trie.items());
@@ -603,19 +591,13 @@ describe("Multi peer sync engine", () => {
       clientForServer2.$.close();
       await server2.stop();
     }
-
-    await syncEngine2.stop();
-    await engine2.stop();
   });
 
   test("syncEngine syncs with more numMessages and different hashes", async () => {
+    await syncEngine2.enableEventsSync();
     await engine1.mergeOnChainEvent(custodyEvent);
     await engine1.mergeOnChainEvent(signerEvent);
     await engine1.mergeOnChainEvent(storageEvent);
-
-    const engine2 = new Engine(testDb2, network);
-    const hub2 = new MockHub(testDb2, engine2);
-    const syncEngine2 = new SyncEngine(hub2, testDb2);
 
     await engine2.mergeOnChainEvent(custodyEvent);
     await engine2.mergeOnChainEvent(signerEvent);
@@ -635,7 +617,7 @@ describe("Multi peer sync engine", () => {
     await syncEngine2.performSync("engine1", (await syncEngine1.getSnapshot())._unsafeUnwrap(), clientForServer1);
     await sleepWhile(() => syncEngine2.syncTrieQSize > 0, SLEEPWHILE_TIMEOUT);
 
-    expect(await syncEngine2.trie.items()).toEqual(3);
+    expect(await syncEngine2.trie.items()).toEqual(6); // Includes on chain events
 
     // Do a sync the other way
     {
@@ -653,9 +635,6 @@ describe("Multi peer sync engine", () => {
       clientForServer2.$.close();
       await server2.stop();
     }
-
-    await syncEngine2.stop();
-    await engine2.stop();
   });
 
   xtest(

--- a/apps/hubble/src/network/sync/syncId.test.ts
+++ b/apps/hubble/src/network/sync/syncId.test.ts
@@ -25,8 +25,9 @@ describe("SyncId", () => {
         { data: { fid, network } },
         { transient: { signer } },
       );
-      const syncId = SyncId.fromMessage(castAddMessage).syncId();
-      const unpackedSyncId = SyncId.unpack(syncId) as MessageSyncId;
+      const syncId = SyncId.fromMessage(castAddMessage);
+      expect(syncId.type()).toEqual(SyncIdType.Message);
+      const unpackedSyncId = syncId.unpack() as MessageSyncId;
       expect(unpackedSyncId.type).toEqual(SyncIdType.Message);
       expect(unpackedSyncId.fid).toEqual(fid);
       expect(unpackedSyncId.hash).toEqual(castAddMessage.hash);
@@ -37,8 +38,9 @@ describe("SyncId", () => {
   describe("FName syncIds", () => {
     test("creates and unpacks correctly from message", async () => {
       const fnameProof = Factories.UserNameProof.build();
-      const syncId = SyncId.fromFName(fnameProof).syncId();
-      const unpackedSyncId = SyncId.unpack(syncId) as FNameSyncId;
+      const syncId = SyncId.fromFName(fnameProof);
+      expect(syncId.type()).toEqual(SyncIdType.FName);
+      const unpackedSyncId = syncId.unpack() as FNameSyncId;
       expect(unpackedSyncId.type).toEqual(SyncIdType.FName);
       expect(unpackedSyncId.fid).toEqual(fnameProof.fid);
       expect(unpackedSyncId.name).toEqual(fnameProof.name);
@@ -48,8 +50,9 @@ describe("SyncId", () => {
   describe("OnChainEvent syncIds", () => {
     test("creates and unpacks correctly from message", async () => {
       const onChainEvent = Factories.IdRegistryOnChainEvent.build();
-      const syncId = SyncId.fromOnChainEvent(onChainEvent).syncId();
-      const unpackedSyncId = SyncId.unpack(syncId) as OnChainEventSyncId;
+      const syncId = SyncId.fromOnChainEvent(onChainEvent);
+      expect(syncId.type()).toEqual(SyncIdType.OnChainEvent);
+      const unpackedSyncId = syncId.unpack() as OnChainEventSyncId;
       expect(unpackedSyncId.type).toEqual(SyncIdType.OnChainEvent);
       expect(unpackedSyncId.fid).toEqual(onChainEvent.fid);
       expect(unpackedSyncId.blockNumber).toEqual(onChainEvent.blockNumber);
@@ -62,7 +65,9 @@ describe("SyncId", () => {
       bytes.set([RootPrefix.HubEvents], TIMESTAMP_LENGTH);
       const fid = Factories.Fid.build();
       bytes.set(makeFidKey(fid), TIMESTAMP_LENGTH + 1);
-      const unpackedSyncId = SyncId.unpack(bytes);
+      const syncId = SyncId.fromBytes(bytes);
+      expect(syncId.type()).toEqual(SyncIdType.Unknown);
+      const unpackedSyncId = syncId.unpack();
       expect(unpackedSyncId.type).toEqual(SyncIdType.Unknown);
       expect(unpackedSyncId.fid).toEqual(0);
     });

--- a/packages/core/src/protobufs/generated/hub_state.ts
+++ b/packages/core/src/protobufs/generated/hub_state.ts
@@ -6,10 +6,11 @@ export interface HubState {
   lastEthBlock: number;
   lastFnameProof: number;
   lastL2Block: number;
+  syncEvents: boolean;
 }
 
 function createBaseHubState(): HubState {
-  return { lastEthBlock: 0, lastFnameProof: 0, lastL2Block: 0 };
+  return { lastEthBlock: 0, lastFnameProof: 0, lastL2Block: 0, syncEvents: false };
 }
 
 export const HubState = {
@@ -22,6 +23,9 @@ export const HubState = {
     }
     if (message.lastL2Block !== 0) {
       writer.uint32(24).uint64(message.lastL2Block);
+    }
+    if (message.syncEvents === true) {
+      writer.uint32(32).bool(message.syncEvents);
     }
     return writer;
   },
@@ -54,6 +58,13 @@ export const HubState = {
 
           message.lastL2Block = longToNumber(reader.uint64() as Long);
           continue;
+        case 4:
+          if (tag != 32) {
+            break;
+          }
+
+          message.syncEvents = reader.bool();
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -68,6 +79,7 @@ export const HubState = {
       lastEthBlock: isSet(object.lastEthBlock) ? Number(object.lastEthBlock) : 0,
       lastFnameProof: isSet(object.lastFnameProof) ? Number(object.lastFnameProof) : 0,
       lastL2Block: isSet(object.lastL2Block) ? Number(object.lastL2Block) : 0,
+      syncEvents: isSet(object.syncEvents) ? Boolean(object.syncEvents) : false,
     };
   },
 
@@ -76,6 +88,7 @@ export const HubState = {
     message.lastEthBlock !== undefined && (obj.lastEthBlock = Math.round(message.lastEthBlock));
     message.lastFnameProof !== undefined && (obj.lastFnameProof = Math.round(message.lastFnameProof));
     message.lastL2Block !== undefined && (obj.lastL2Block = Math.round(message.lastL2Block));
+    message.syncEvents !== undefined && (obj.syncEvents = message.syncEvents);
     return obj;
   },
 
@@ -88,6 +101,7 @@ export const HubState = {
     message.lastEthBlock = object.lastEthBlock ?? 0;
     message.lastFnameProof = object.lastFnameProof ?? 0;
     message.lastL2Block = object.lastL2Block ?? 0;
+    message.syncEvents = object.syncEvents ?? false;
     return message;
   },
 };

--- a/protobufs/schemas/hub_state.proto
+++ b/protobufs/schemas/hub_state.proto
@@ -4,4 +4,5 @@ message HubState {
   uint32 last_eth_block = 1;
   uint64 last_fname_proof = 2;
   uint64 last_l2_block = 3;
+  bool syncEvents = 4;
 }


### PR DESCRIPTION
## Motivation

Fixes https://github.com/farcasterxyz/hub-monorepo/issues/1045

Supports detecting and repairing missing onchain events and fnames from other hubs on the network. Starts disabled but hubs will automatically turn the feature on the first time they encounter another hubs with the new sync ids.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
