### PR TITLE
docs: Fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This monorepo contains Hubble, an official Farcaster Hub implementation, and oth
 
 1. To run Hubble, see the [Hubble docs](https://www.thehubble.xyz/).
 1. To use Hubble, see the [hub-nodejs docs](./packages/hub-nodejs/docs/README.md).
-1. To use the HTTP API to read Hubble data, see the [HTTP API docs](https://www.thehubble.xyz/docs/httpapi.html)
+1. To use the HTTP API to read Hubble data, see the [HTTP API docs](https://www.thehubble.xyz/docs/httpapi/httpapi.html)
 
 ## Packages
 

--- a/apps/hubble/www/docs/.vitepress/config.ts
+++ b/apps/hubble/www/docs/.vitepress/config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
           { text: "APIs", link: "/docs/api" },
           {
             text: "HTTP APIs",
+            collapsed: true,
             items: [
               { text: "Using HTTP APIs", link: "/docs/httpapi/httpapi" },
               { text: "Casts API", link: "/docs/httpapi/casts" },

--- a/apps/hubble/www/docs/docs/httpapi/submitmessage.md
+++ b/apps/hubble/www/docs/docs/httpapi/submitmessage.md
@@ -52,7 +52,7 @@ curl -X POST "http://127.0.0.1:2281/v1/submitMessage" \
 ```
 
 ### Auth
-If the rpc auth has been enabled on the server (using `--rpc-auth username:password`) then you will also need to pass in the username and password while calling `submitMessage` using HTTP Basic Auth. 
+If the rpc auth has been enabled on the server (using `--rpc-auth username:password`), you will need to also pass in the username and password while calling `submitMessage` using HTTP Basic Auth. 
 
 
 **Example**
@@ -61,7 +61,6 @@ curl -X POST "http://127.0.0.1:2281/v1/submitMessage" \
      -u "username:password" \
      -H "Content-Type: application/octet-stream" \
      --data-binary "@message.encoded.protobuf"
-
 ```
 
 **JS Example**
@@ -83,5 +82,4 @@ try {
 } catch (e) {
     // handle errors...
 }
-
 ```

--- a/packages/hub-nodejs/docs/README.md
+++ b/packages/hub-nodejs/docs/README.md
@@ -8,7 +8,7 @@
 - [Signers](./signers/), which are required by Builders to sign messages.
 - [Utils](./Utils.md), which are helpers to deal with Farcaster idiosyncrasies.
 
-Note: The HTTP API is an alternate way to read/write to the Hub. Please see the [HTTP API docs](https://www.thehubble.xyz/docs/httpapi.html)
+Note: The HTTP API is an alternate way to read/write to the Hub. Please see the [HTTP API docs](https://www.thehubble.xyz/docs/httpapi/httpapi.html)
 
 ## Idiosyncrasies
 


### PR DESCRIPTION


## Change Summary

- Fix broken links

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the links in the codebase to the HTTP API documentation. 

### Detailed summary
- Updated the link to the HTTP API docs in `README.md`
- Updated the link to the HTTP API docs in `packages/hub-nodejs/docs/README.md`
- Updated the link to the HTTP API docs in `apps/hubble/www/docs/docs/httpapi/submitmessage.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->