### PR TITLE
fix: hubble.sh - Dont delete before overwriting

### DIFF
--- a/.changeset/large-bananas-marry.md
+++ b/.changeset/large-bananas-marry.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: hubble.sh - Don't delete before overwriting

--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -242,17 +242,6 @@ setup_grafana() {
         fi
     }
 
-    delete_dashboard() {
-        local dashboard_uid
-
-        dashboard_uid=$(curl -s "$grafana_url/api/search?query=Hub Dashboard" -u "$credentials" | \
-            jq -r '.[] | select(.title == "Hub Dashboard") | .uid')
-
-        if [[ "$dashboard_uid" ]]; then
-            curl -s -X "DELETE" "$grafana_url/api/dashboards/uid/$dashboard_uid" -u "$credentials"
-        fi
-    }
-
     # Step 1: Restart statsd and grafana if they are running, otherwise start them
     ensure_grafana
 
@@ -283,10 +272,7 @@ setup_grafana() {
         fi
     fi
 
-    # Step 4: Delete the dashboard if it exists
-    delete_dashboard
-
-    # Step 5: Import the dashboard. The API takes a slighly different format than the JSON import
+    # Step 4: Import the dashboard. The API takes a slighly different format than the JSON import
     # in the UI, so we need to convert the JSON file first.
     jq '{dashboard: (del(.id) | . + {id: null}), folderId: 0, overwrite: true}' "grafana-dashboard.json" > "grafana-dashboard.api.json"
     


### PR DESCRIPTION
Fixes #1395

## Change Summary

- Don't delete before overwriting grafana dashboard in hubble.sh

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an issue with the `hubble.sh` script in the `@farcaster/hubble` package. 

### Detailed summary
- Fixed a bug in `hubble.sh` that caused deletion before overwriting
- Removed the `delete_dashboard` function
- Updated the import of the dashboard in the `setup_grafana` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->