### PR TITLE
chore: read --rpc-subscribe-per-ip-limit from the env file

### DIFF
--- a/apps/hubble/docker-compose.yml
+++ b/apps/hubble/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       "--eth-mainnet-rpc-url", "$ETH_MAINNET_RPC_URL",
       "--l2-rpc-url", "$OPTIMISM_L2_RPC_URL",
       "--network", "${FC_NETWORK_ID:-1}",
+      "--rpc-subscribe-per-ip-limit", "${RPC_SUBSCRIBE_PER_IP_LIMIT:-4}",
       "-b", "${BOOTSTRAP_NODE:-/dns/nemes.farcaster.xyz/tcp/2282}",
       "--statsd-metrics-server", "$STATSD_METRICS_SERVER",
       "--hub-operator-fid", "${HUB_OPERATOR_FID:-0}",


### PR DESCRIPTION
## Motivation
Configure per IP subscription limit without running a custom docker command

## Change Summary
Adds a parameter to docker-compose.yml

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on updating the `docker-compose.yml` file in the `apps/hubble` directory.

### Detailed summary:
- Added a new flag `--rpc-subscribe-per-ip-limit` with a default value of `4`.
- Removed the `-b` flag and its corresponding value `${BOOTSTRAP_NODE:-/dns/nemes.farcaster.xyz/tcp/2282}`.
- Updated the value of `--network` to `${FC_NETWORK_ID:-1}`.
- Updated the value of `--hub-operator-fid` to `${HUB_OPERATOR_FID:-0}`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->