### PR TITLE
fix: (replicator) match type on reaction remove

### DIFF
--- a/packages/hub-nodejs/examples/replicate-data-postgres/hubReplicator.ts
+++ b/packages/hub-nodejs/examples/replicate-data-postgres/hubReplicator.ts
@@ -600,6 +600,7 @@ export class HubReplicator {
       await this.db
         .updateTable("reactions")
         .where("fid", "=", message.data.fid)
+        .where("reaction_type", "=", message.data.reactionBody.type)
         .where((eb) => {
           // Search based on the type of reaction
           if (message.data.reactionBody.targetUrl) {


### PR DESCRIPTION
## Motivation
Fixes an issue where the replicator marks the recast AND like as removed, if only 1 of them was removed

## Change Summary
match `reaction_type` in the where clause

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR
This PR focuses on updating the `hubReplicator.ts` file in the `replicate-data-postgres` example of the `hub-nodejs` package.

### Detailed summary
- Added a new `where` condition to filter the `reactions` table based on the `reaction_type` property in `message.data.reactionBody`.
- The `where` condition is nested inside another `where` condition that filters based on the `fid` property in `message.data`.
- If `message.data.reactionBody.targetUrl` is truthy, an additional search based on the `type` of reaction is performed.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->