### PR TITLE
feat: Repair sync trie when events and fnames are already present

### DIFF
--- a/.changeset/green-ducks-sip.md
+++ b/.changeset/green-ducks-sip.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: Repair sync trie when events and fnames are already present

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -273,6 +273,22 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
         }
       }
     });
+    this._hub.engine.on("duplicateUserNameProofEvent", async (event: UserNameProof) => {
+      if (this._syncEvents && event.type === UserNameType.USERNAME_TYPE_FNAME) {
+        const syncId = SyncId.fromFName(event);
+        if (!(await this.trie.exists(syncId))) {
+          await this._trie.insert(syncId);
+        }
+      }
+    });
+    this._hub.engine.on("duplicateOnChainEvent", async (event: OnChainEvent) => {
+      if (this._syncEvents) {
+        const syncId = SyncId.fromOnChainEvent(event);
+        if (!(await this.trie.exists(syncId))) {
+          await this._trie.insert(syncId);
+        }
+      }
+    });
   }
 
   public get syncTrieQSize(): number {

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -318,7 +318,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
   /** Rebuild the entire Sync Trie */
   public async rebuildSyncTrie() {
     log.info("Rebuilding sync trie...");
-    await this._trie.rebuild();
+    await this._trie.rebuild(this._syncEvents);
     log.info("Rebuilding sync trie complete");
   }
 

--- a/apps/hubble/src/storage/stores/userDataStore.test.ts
+++ b/apps/hubble/src/storage/stores/userDataStore.test.ts
@@ -69,6 +69,14 @@ describe("mergeUserNameProof", () => {
     await expect(set.getUserNameProofByFid(proof.fid)).resolves.toEqual(proof);
   });
 
+  test("does not merge duplicates", async () => {
+    const proof = await Factories.UserNameProof.build();
+    await set.mergeUserNameProof(proof);
+    await expect(set.getUserNameProof(proof.name)).resolves.toEqual(proof);
+
+    await expect(set.mergeUserNameProof(proof)).rejects.toThrow("already exists");
+  });
+
   test("replaces existing proof with proof of greater timestamp", async () => {
     const existingProof = await Factories.UserNameProof.build();
     await set.mergeUserNameProof(existingProof);

--- a/apps/hubble/src/storage/stores/userDataStore.ts
+++ b/apps/hubble/src/storage/stores/userDataStore.ts
@@ -113,7 +113,9 @@ class UserDataStore extends Store<UserDataAddMessage, never> {
 
   async mergeUserNameProof(usernameProof: UserNameProof): Promise<number> {
     const existingProof = await ResultAsync.fromPromise(this.getUserNameProof(usernameProof.name), () => undefined);
-    if (existingProof.isOk() && usernameProofCompare(existingProof.value, usernameProof) >= 0) {
+    if (existingProof.isOk() && usernameProofCompare(existingProof.value, usernameProof) === 0) {
+      throw new HubError("bad_request.duplicate", "proof already exists");
+    } else if (existingProof.isOk() && usernameProofCompare(existingProof.value, usernameProof) > 0) {
       throw new HubError("bad_request.conflict", "event conflicts with a more recent UserNameProof");
     }
 

--- a/apps/hubble/src/storage/stores/utils.ts
+++ b/apps/hubble/src/storage/stores/utils.ts
@@ -1,14 +1,16 @@
-import { UserNameProof, HubError, bytesIncrement } from "@farcaster/hub-nodejs";
+import { UserNameProof, bytesIncrement } from "@farcaster/hub-nodejs";
+import { bytesCompare } from "@farcaster/core";
 
 export const usernameProofCompare = (a: UserNameProof, b: UserNameProof): number => {
-  // Compare timestamps
+  // Compare timestamps (assumes name and proof type have already been checked by the caller)
   if (a.timestamp < b.timestamp) {
     return -1;
   } else if (a.timestamp > b.timestamp) {
     return 1;
   }
 
-  throw new HubError("bad_request.validation_failure", "proofs have the same timestamp");
+  // If timestamps match, order by signature bytes so we can deterministically choose the same proof everywhere
+  return bytesCompare(a.signature, b.signature);
 };
 
 export const makeEndPrefix = (prefix: Buffer): Buffer | undefined => {


### PR DESCRIPTION
## Motivation

 - Rebuild sync trie now also rebuilds fnames and events
 - Add sync id to trie if fnames and events are already present from the db but missing in the trie

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on repairing the sync trie when events and fnames are already present. 

### Detailed summary
- Added a test to ensure that duplicates are not merged.
- Modified the `mergeUserNameProof` function to throw a `HubError` with the code "bad_request.duplicate" if a duplicate proof is detected.
- Added a new import statement for `UserNameProof` and `bytesCompare` in the `utils.ts` file.
- Added event listeners for "duplicateUserNameProofEvent" and "duplicateOnChainEvent" in the `Engine` class.
- Modified the `rebuildSyncTrie` function in the `MerkleTrie` class to include events and fnames when rebuilding the trie.
- Added a test to verify that sync ids are added to the trie when not present and the engine rejects them as duplicates.
- Added a test to verify that the trie is reconstructed from the database when calling the `rebuildSyncTrie` function.

> The following files were skipped due to too many changes: `apps/hubble/src/network/sync/syncEngine.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->