### PR TITLE
chore: Remove yarn status

### DIFF
--- a/.changeset/selfish-pillows-impress.md
+++ b/.changeset/selfish-pillows-impress.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+chore: Remove "yarn status" command

--- a/apps/hubble/www/docs/docs/cli.md
+++ b/apps/hubble/www/docs/docs/cli.md
@@ -115,21 +115,6 @@ Commands:
   help [command]    display help for command
 ```
 
-### status
-
-```
-Usage: yarn status [options]
-
-Reports the db and sync status of the hub
-WARNING: This command has been deprecated, and will be removed in a future release. Please use Grafana monitoring. See https://www.thehubble.xyz/intro/monitoring.html
-
-Options:
-  -s, --server <url>     Farcaster RPC server address:port to connect to (eg. 127.0.0.1:2283) (default: "127.0.0.1:2283")
-  --insecure             Allow insecure connections to the RPC server (default: false)
-  --watch                Keep running and periodically report status (default: false)
-  -p, --peerId <peerId>  Peer id of the hub to compare with (defaults to bootstrap peers)
-  -h, --help             display help for command
-```
 
 ### dbreset
 

--- a/apps/hubble/www/docs/docs/httpapi/casts.md
+++ b/apps/hubble/www/docs/docs/httpapi/casts.md
@@ -13,7 +13,7 @@ Get a cast by its FID and Hash.
 
 **Example**
 ```bash
-curl http://127.0.0.1:2281/v1/castById?id=2&hash=0xd2b1ddc6c88e865a33cb1a565e0058d757042974
+curl http://127.0.0.1:2281/v1/castById?fid=2&hash=0xd2b1ddc6c88e865a33cb1a565e0058d757042974
 ```
 
 


### PR DESCRIPTION

## Change Summary

- Remove `yarn status` command, which has been replaced by the grafana dashboard. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Removed the deprecated `yarn status` command from the CLI.
- Updated the example in `casts.md` to use `fid` instead of `id`.
- Updated the `cli.ts` file to display a deprecation warning for the `status` command and provide a link to use Grafana monitoring instead.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->