### PR TITLE
fix: Use "from_id" for fname server params

### DIFF
--- a/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
+++ b/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
@@ -64,7 +64,7 @@ class MockFnameRegistryClient implements FNameRegistryClientInterface {
       this.timesToThrow--;
       throw new Error("connection failed");
     }
-    expect(params.fromId).toBeGreaterThanOrEqual(this.minimumSince);
+    expect(params.from_id).toBeGreaterThanOrEqual(this.minimumSince);
     const transfers = this.transfersToReturn.shift();
     if (!transfers) {
       return Promise.resolve([]);

--- a/apps/hubble/src/eth/fnameRegistryEventsProvider.ts
+++ b/apps/hubble/src/eth/fnameRegistryEventsProvider.ts
@@ -30,7 +30,7 @@ export type FNameTransfer = {
 };
 
 export type FNameTransferRequest = {
-  fromId?: number;
+  from_id?: number;
   name?: string;
 };
 
@@ -120,7 +120,7 @@ export class FNameRegistryEventsProvider {
     }
 
     this.lastTransferId = fromId;
-    let transfers = await this.safeGetTransfers({ fromId });
+    let transfers = await this.safeGetTransfers({ from_id: fromId });
     let transfersCount = 0;
     while (transfers.length > 0 && !this.shouldStop) {
       transfersCount += transfers.length;
@@ -130,7 +130,7 @@ export class FNameRegistryEventsProvider {
         break;
       }
       this.lastTransferId = lastTransfer.id;
-      transfers = await this.safeGetTransfers({ fromId: this.lastTransferId });
+      transfers = await this.safeGetTransfers({ from_id: this.lastTransferId });
     }
     log.info(`Fetched ${transfersCount} fname events upto ${this.lastTransferId}`);
     const result = await this.hub.getHubState();


### PR DESCRIPTION


## Change Summary

- use "from_id" instead of "fromId" for fname server param

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the parameter name `fromId` to `from_id` in the `FNameTransferRequest` type and the corresponding usage in the `FNameRegistryEventsProvider` class.

### Detailed summary:
- Updated the parameter name `fromId` to `from_id` in the `FNameTransferRequest` type.
- Updated the parameter name in the `safeGetTransfers` method calls in the `FNameRegistryEventsProvider` class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->