### PR TITLE
feat: set rpc/gossip ports using env variables

### DIFF
--- a/apps/hubble/docker-compose.yml
+++ b/apps/hubble/docker-compose.yml
@@ -12,8 +12,8 @@ services:
     command: [
       "node", "--no-warnings",  "build/cli.js", "start",
       "--ip", "0.0.0.0",
-      "--gossip-port", "2282",
-      "--rpc-port", "2283",      
+      "--gossip-port", "${GOSSIP_PORT:-2282}",
+      "--rpc-port", "${RPC_PORT:-2283}",   
       "--eth-mainnet-rpc-url", "$ETH_MAINNET_RPC_URL",
       "--l2-rpc-url", "$OPTIMISM_L2_RPC_URL",
       "--network", "${FC_NETWORK_ID:-1}",
@@ -23,8 +23,8 @@ services:
       "--hub-operator-fid", "${HUB_OPERATOR_FID:-0}",
     ]
     ports:
-      - '2282:2282' # Gossip
-      - '2283:2283' # RPC
+      - '${GOSSIP_PORT:-2282}:${GOSSIP_PORT:-2282}' # Gossip. You can set GOSSIP_PORT in .env
+      - '${RPC_PORT:-2283}:${RPC_PORT:-2283}' # RPC. You can set RPC_PORT in .env
     volumes:
       - ./.hub:/home/node/app/apps/hubble/.hub
       - ./.rocks:/home/node/app/apps/hubble/.rocks


### PR DESCRIPTION
Env variables $GOSSIP_PORT and $RPC_PORT can be used to set the respective ports. If not set, the default values (2282, 2283) are used.

## Motivation

I'm running Hubble using non-standard ports (not 2282, 2283). To do so, I had to change docker-compose.yml, but the yaml file gets overwritten every time I upgrade to a new version.

## Change Summary

docker-compose.yml uses two env variables, GOSSIP_PORT and RPC_PORT, to set the ports. If not found it defaults to the standard ones.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Contex

Rebased PR #1394 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the configuration flexibility of the Hubble Docker Compose file. 

### Detailed summary
- The `--gossip-port` and `--rpc-port` arguments now use environment variables with default values.
- The port mappings in the `ports` section now use the same environment variables with default values.
- Added a comment indicating that the `GOSSIP_PORT` and `RPC_PORT` can be set in the `.env` file.
- Updated the volume mappings for the `.hub` and `.rocks` directories.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->