### PR TITLE
fix: Add HTTP API port in docker compose

### DIFF
--- a/.changeset/proud-toes-tickle.md
+++ b/.changeset/proud-toes-tickle.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: HTTP API port in docker-compose

--- a/apps/hubble/docker-compose.yml
+++ b/apps/hubble/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       "--hub-operator-fid", "${HUB_OPERATOR_FID:-0}",
     ]
     ports:
+      - '${HTTPAPI_PORT:-2281}:${HTTPAPI_PORT:-2281}' # HTTP API. You can set HTTP_PORT in .env
       - '${GOSSIP_PORT:-2282}:${GOSSIP_PORT:-2282}' # Gossip. You can set GOSSIP_PORT in .env
       - '${RPC_PORT:-2283}:${RPC_PORT:-2283}' # RPC. You can set RPC_PORT in .env
     volumes:

--- a/apps/hubble/www/docs/intro/hubble.md
+++ b/apps/hubble/www/docs/intro/hubble.md
@@ -13,6 +13,7 @@ The Farcaster team runs some instances of Hubble for use by the public. These in
 
 ```bash
 url: nemes.farcaster.xyz
+httpapi_port: 2281
 gossipsub_port: 2282
 grpc_port: 2283
 ```


### PR DESCRIPTION


## Change Summary

- Add HTTP API port to docker compose

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the HTTP API port in the docker-compose file for the "@farcaster/hubble" package.

### Detailed summary
- The HTTP API port in the hubble.md file is updated to 2281.
- The docker-compose.yml file is updated to use the HTTPAPI_PORT environment variable for the HTTP API port.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->