### PR TITLE
chore: v1.5.6 release

### DIFF
--- a/.changeset/brave-coins-yell.md
+++ b/.changeset/brave-coins-yell.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: Enable HTTP API server

--- a/.changeset/calm-olives-begin.md
+++ b/.changeset/calm-olives-begin.md
@@ -1,5 +1,0 @@
----
-"@farcaster/core": patch
----
-
-fix: Bound generated timestamps for tests

--- a/.changeset/cold-snakes-join.md
+++ b/.changeset/cold-snakes-join.md
@@ -1,6 +1,0 @@
----
-"@farcaster/core": patch
-"@farcaster/hubble": patch
----
-
-feat: support onchain events and fnames in sync trie

--- a/.changeset/eight-cups-cry.md
+++ b/.changeset/eight-cups-cry.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: Allow settings CORS for http api

--- a/.changeset/green-ducks-sip.md
+++ b/.changeset/green-ducks-sip.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: Repair sync trie when events and fnames are already present

--- a/.changeset/large-bananas-marry.md
+++ b/.changeset/large-bananas-marry.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: hubble.sh - Don't delete before overwriting

--- a/.changeset/large-spiders-cheat.md
+++ b/.changeset/large-spiders-cheat.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: HTTP API add getInfo and other doc fixes

--- a/.changeset/pretty-dolphins-agree.md
+++ b/.changeset/pretty-dolphins-agree.md
@@ -1,7 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
-"@farcaster/core": patch
-"@farcaster/hubble": patch
----
-
-docs: Refactor HTTP API docs

--- a/.changeset/proud-toes-tickle.md
+++ b/.changeset/proud-toes-tickle.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: HTTP API port in docker-compose

--- a/.changeset/selfish-pillows-impress.md
+++ b/.changeset/selfish-pillows-impress.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-chore: Remove "yarn status" command

--- a/.changeset/silly-beers-fail.md
+++ b/.changeset/silly-beers-fail.md
@@ -1,6 +1,0 @@
----
-"@farcaster/core": patch
-"@farcaster/hubble": patch
----
-
-feat: support fname and onchain event syncids

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @farcaster/hubble
 
+## 1.5.6
+
+### Patch Changes
+
+- aa6553b1: feat: Enable HTTP API server
+- fb1f5c61: feat: Support onchain events and fnames in sync trie
+- f743a430: feat: Allow settings CORS for http api
+- f0ad204e: feat: Repair sync trie when events and fnames are already present
+- 833d9651: fix: hubble.sh - Don't delete before overwriting
+- bc4a1366: fix: HTTP API add getInfo and other doc fixes
+- aeab5a4c: docs: Refactor HTTP API docs
+- 4809c9c8: fix: HTTP API port in docker-compose
+- f163fa3d: chore: Remove "yarn status" command
+- 4b99eddb: feat: Support fname and onchain event syncids
+- Updated dependencies [aeab5a4c]
+  - @farcaster/hub-nodejs@0.10.10
+
 ## 1.5.5
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -69,7 +69,7 @@
     "@chainsafe/libp2p-gossipsub": "6.1.0",
     "@chainsafe/libp2p-noise": "^11.0.0 ",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.10.9",
+    "@farcaster/hub-nodejs": "^0.10.10",
     "@farcaster/rocksdb": "^5.5.0",
     "@fastify/cors": "^8.4.0",
     "@grpc/grpc-js": "~1.8.21",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @farcaster/core
 
+## 0.12.10
+
+### Patch Changes
+
+- 31641c17: fix: Bound generated timestamps for tests
+- fb1f5c61: feat: Support onchain events and fnames in sync trie
+- aeab5a4c: docs: Refactor HTTP API docs
+- 4b99eddb: feat: Support fname and onchain event syncids
+
 ## 0.12.9
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @farcaster/hub-nodejs
 
+## 0.10.10
+
+### Patch Changes
+
+- aeab5a4c: docs: Refactor HTTP API docs
+- Updated dependencies [31641c17]
+- Updated dependencies [fb1f5c61]
+- Updated dependencies [aeab5a4c]
+- Updated dependencies [4b99eddb]
+  - @farcaster/core@0.12.10
+
 ## 0.10.9
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@farcaster/core": "0.12.9",
+    "@farcaster/core": "0.12.10",
     "@grpc/grpc-js": "~1.8.21",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"


### PR DESCRIPTION
## Motivation

v1.5.6 release with the HTTP API


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating dependencies and making patch changes to the code. 

### Detailed summary
- Updated dependencies for @farcaster/core and @farcaster/hub-nodejs
- Refactored HTTP API docs
- Fixed bound generated timestamps for tests
- Supported onchain events and fnames in sync trie
- Added support for fname and onchain event syncids
- Enabled HTTP API server
- Allowed setting CORS for HTTP API
- Repaired sync trie when events and fnames are already present
- Fixed issues with hubble.sh and HTTP API
- Removed "yarn status" command
- Updated HTTP API port in docker-compose

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->