### PR TITLE
[feat] Add a flag to clear L2 events

### DIFF
--- a/.changeset/forty-cycles-cough.md
+++ b/.changeset/forty-cycles-cough.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: Add a flag to clear l2 events

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -82,6 +82,7 @@ app
   .option("--l2-key-registry-address <address>", "The address of the L2 Farcaster Key Registry contract")
   .option("--l2-storage-registry-address <address>", "The address of the L2 Farcaster Storage Registry contract")
   .option("--l2-resync-events", "Resync events from the L2 Farcaster contracts before starting (default: disabled)")
+  .option("--l2-clear-events", "Deletes all events from the L2 Farcaster contracts before starting (default: disabled)")
   .option(
     "--l2-first-block <number>",
     "The block number to begin syncing events from L2 Farcaster contracts",
@@ -490,6 +491,7 @@ app
       l2ChunkSize: cliOptions.l2ChunkSize ?? hubConfig.l2ChunkSize,
       l2ChainId: cliOptions.l2ChainId ?? hubConfig.l2ChainId,
       l2ResyncEvents: cliOptions.l2ResyncEvents ?? hubConfig.l2ResyncEvents ?? false,
+      l2ClearEvents: cliOptions.l2ClearEvents ?? hubConfig.l2ClearEvents ?? false,
       l2RentExpiryOverride: cliOptions.l2RentExpiryOverride ?? hubConfig.l2RentExpiryOverride,
       bootstrapAddrs,
       allowedPeers: cliOptions.allowedPeers ?? hubConfig.allowedPeers,

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -72,6 +72,7 @@ import axios from "axios";
 import { HttpAPIServer } from "./rpc/httpServer.js";
 import { SingleBar } from "cli-progress";
 import { exportToProtobuf } from "@libp2p/peer-id-factory";
+import OnChainEventStore from "./storage/stores/onChainEventStore.js";
 
 export type HubSubmitSource = "gossip" | "rpc" | "eth-provider" | "l2-provider" | "sync" | "fname-registry";
 
@@ -191,6 +192,9 @@ export interface HubOptions {
 
   /** Resync l2 events */
   l2ResyncEvents?: boolean;
+
+  /** Clears all l2 events */
+  l2ClearEvents?: boolean;
 
   /** Resync fname events */
   resyncNameEvents?: boolean;
@@ -532,6 +536,12 @@ export class Hub implements HubInterface {
           "Hub was NOT shutdown cleanly. Sync might re-fetch messages. Please re-run with --rebuild-sync-trie to rebuild the trie if needed.",
         );
       }
+    }
+
+    if (this.options.l2ClearEvents === true) {
+      log.info("clearing l2 events");
+      await OnChainEventStore.clearEvents(this.rocksDB);
+      log.info("l2 events cleared");
     }
 
     // Get the Network ID from the DB

--- a/apps/hubble/www/docs/docs/cli.md
+++ b/apps/hubble/www/docs/docs/cli.md
@@ -46,6 +46,7 @@ L2 Options:
   --l2-key-registry-address <address>   The address of the L2 Farcaster Key Registry contract
   --l2-storage-registry-address <address>  The address of the L2 Farcaster Storage Registry contract
   --l2-resync-events                    Resync events from the L2 Farcaster contracts before starting (default: disabled)
+  --l2-clear-events                     Deletes all L2 events before starting (default: disabled)
   --l2-first-block <number>             The block number to begin syncing events from L2 Farcaster contracts
   --l2-chunk-size <number>              The number of events to fetch from L2 Farcaster contracts at a time
   --l2-chain-id <number>                The chain ID of the L2 Farcaster contracts are deployed to


### PR DESCRIPTION
## Motivation

Will helps fix hubs with bad data for https://github.com/farcasterxyz/hub-monorepo/issues/1425

Adds a flag to fully delete l2 events so it can be re-fetched.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a flag to clear L2 events in the Hubble app. 

### Detailed summary
- Added `--l2-clear-events` flag to delete all L2 events before starting
- Imported `OnChainEventStore` from `./storage/stores/onChainEventStore.js`
- Updated `HubOptions` interface with `l2ClearEvents` property
- Added conditional logic to clear L2 events in the `Hub` class
- Updated CLI options in `cli.ts` to include `--l2-clear-events`
- Updated `HubConfig` with `l2ClearEvents` property

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->