### PR TITLE
feat: Add Peer scoring

### DIFF
--- a/.changeset/new-pears-divide.md
+++ b/.changeset/new-pears-divide.md
@@ -1,0 +1,8 @@
+---
+"@farcaster/hub-nodejs": patch
+"@farcaster/hub-web": patch
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+feat: Add peer scoring

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,6 @@ First, ensure that the following are installed globally on your machine:
 - [Foundry](https://book.getfoundry.sh/getting-started/installation#using-foundryup)
 - [Rust](https://www.rust-lang.org/tools/install)
 
-To regenerae the protobufs, you will need `protoc` 
-- [Protoc 3.15.3](https://github.com/protocolbuffers/protobuf/releases/tag/v3.15.3)
-
 Then, from the root folder run:
 
 - `yarn install` to install dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,9 @@ First, ensure that the following are installed globally on your machine:
 - [Foundry](https://book.getfoundry.sh/getting-started/installation#using-foundryup)
 - [Rust](https://www.rust-lang.org/tools/install)
 
+To regenerae the protobufs, you will need `protoc` 
+- [Protoc 3.15.3](https://github.com/protocolbuffers/protobuf/releases/tag/v3.15.3)
+
 Then, from the root folder run:
 
 - `yarn install` to install dependencies

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -13,8 +13,6 @@ import {
   getSSLHubRpcClient,
   getInsecureHubRpcClient,
   UserNameProof,
-  AckMessageBody,
-  NetworkLatencyMessage,
   OnChainEvent,
   onChainEventTypeToJSON,
   ClientOptions,
@@ -361,6 +359,12 @@ export class Hub implements HubInterface {
       this.fNameRegistryEventsProvider,
       profileSync,
     );
+
+    // On syncComplete, we update the denied peer ids list with the bad peers.
+    // This is not active yet.
+    // this.syncEngine.on("syncComplete", async (success) => {
+    //   this.gossipNode.updateDeniedPeerIds(this.syncEngine.getBadPeerIds());
+    // });
 
     // If profileSync is true, exit after sync is complete
     if (profileSync) {

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -25,7 +25,6 @@ import { PeerScoreThresholds } from "@chainsafe/libp2p-gossipsub/score";
 import { statsd } from "../../utils/statsd.js";
 import { createFromProtobuf, exportToProtobuf } from "@libp2p/peer-id-factory";
 import EventEmitter from "events";
-const MultiaddrLocalHost = "/ip4/127.0.0.1";
 
 /** The maximum number of pending merge messages before we drop new incoming gossip or sync messages. */
 export const MAX_MESSAGE_QUEUE_SIZE = 100_000;

--- a/apps/hubble/src/network/sync/peerScore.test.ts
+++ b/apps/hubble/src/network/sync/peerScore.test.ts
@@ -1,0 +1,44 @@
+import { PeerScorer } from "./peerScore.js";
+import { MergeResult } from "./syncEngine.js";
+
+describe("peerScore", () => {
+  let peerScorer: PeerScorer;
+
+  beforeEach(() => {
+    peerScorer = new PeerScorer();
+  });
+
+  test("not blocked by default", () => {
+    peerScorer.incrementScore("peerId");
+    expect(peerScorer.getScore("peerId")?.blocked).toBe(false);
+  });
+
+  test("blocks peer after 10 bad syncs", () => {
+    for (let i = 0; i < 10; i++) {
+      const result = new MergeResult(1000, 0, 0);
+      peerScorer.updateLastSync("peerId", result);
+    }
+
+    expect(peerScorer.getScore("peerId")?.score).toBe(-100);
+    expect(peerScorer.getBadPeerIds()).toEqual(["peerId"]);
+    expect(peerScorer.getScore("peerId")?.blocked).toBe(true);
+  });
+
+  test("Good sync increases score", () => {
+    const result = new MergeResult(1000, 1000, 0);
+    peerScorer.updateLastSync("peerId", result);
+
+    expect(peerScorer.getScore("peerId")?.score).toBe(1);
+    expect(peerScorer.getBadPeerIds()).toEqual([]);
+    expect(peerScorer.getScore("peerId")?.blocked).toBe(false);
+  });
+
+  test("No messages differed increases score", () => {
+    const result = new MergeResult(0, 0, 0);
+    peerScorer.updateLastSync("peerId", result);
+
+    expect(peerScorer.getScore("peerId")?.score).toBe(1);
+    expect(peerScorer.getBadPeerIds()).toEqual([]);
+    expect(peerScorer.getScore("peerId")?.blocked).toBe(false);
+  });
+});

--- a/apps/hubble/src/network/sync/peerScore.ts
+++ b/apps/hubble/src/network/sync/peerScore.ts
@@ -1,0 +1,103 @@
+import { logger } from "../../utils/logger.js";
+import { statsd } from "../../utils/statsd.js";
+import { MergeResult } from "./syncEngine.js";
+
+const BAD_PEER_MESSAGE_THRESHOLD = 1000; // Number of messages we can't merge before we consider a peer "bad"
+const BLOCKED_PEER_SCORE_THRESHOLD = -100; // A score below this threshold means a peer is blocked
+
+const log = logger.child({
+  component: "PeerScorer",
+});
+
+export class PeerScore {
+  score: number;
+  blocked: boolean;
+  blockedAt?: number;
+  lastSyncTime?: number;
+  lastBadSyncTime?: number;
+  lastSyncResult?: MergeResult;
+
+  constructor() {
+    this.score = 0;
+    this.blocked = false;
+  }
+}
+
+/**
+ * Keeps track of the score of each peer.
+ */
+export class PeerScorer {
+  // PeerID (string) -> Score
+  private scores: Map<string, PeerScore> = new Map();
+
+  incrementScore(peerID?: string, by = 1) {
+    if (!peerID) {
+      return;
+    }
+
+    if (!this.scores.has(peerID)) {
+      this.scores.set(peerID, new PeerScore());
+    }
+
+    const score = this.scores.get(peerID) as PeerScore;
+    score.score += by;
+
+    statsd().gauge(`peer.${peerID}.score`, score.score);
+  }
+
+  decrementScore(peerID?: string, by = 1) {
+    this.incrementScore(peerID, -by);
+  }
+
+  updateLastSync(peerId: string, result: MergeResult) {
+    if (!this.scores.has(peerId)) {
+      this.scores.set(peerId, new PeerScore());
+    }
+    const score = this.scores.get(peerId) as PeerScore;
+
+    // If we did not merge any messages and didn't defer any. Then this peer only had old messages.
+    if (result.total >= BAD_PEER_MESSAGE_THRESHOLD && result.successCount === 0 && result.deferredCount === 0) {
+      log.warn({ peerId }, "Perform sync: No messages were successfully fetched. Peer will be blocked for a while.");
+      score.lastBadSyncTime = Date.now();
+      this.decrementScore(peerId, 10);
+    }
+
+    // If on the other hand, we merged >80% of the messages, then we consider this peer good.
+    if (result.total > 0 && result.successCount / result.total > 0.8) {
+      log.debug({ peerId }, "Perform sync: 80%+ success. Peer is good.");
+      this.incrementScore(peerId);
+    }
+
+    // If we didn't merge any messages (i.e., the hashes matched), then we consider this peer good.
+    if (result.total === 0 && result.successCount === 0) {
+      log.debug({ peerId }, "Perform sync: No messages differed. Peer is good.");
+      this.incrementScore(peerId);
+    }
+
+    score.lastSyncTime = Date.now();
+    score.lastSyncResult = result;
+  }
+
+  getScore(peerId: string): PeerScore | undefined {
+    return this.scores.get(peerId);
+  }
+
+  /**
+   * A PeerID with a score < 100 is considered a bad peer.
+   */
+  getBadPeerIds(): string[] {
+    const blocked = [];
+    for (const [peerId, score] of this.scores.entries()) {
+      if (score.score <= BLOCKED_PEER_SCORE_THRESHOLD) {
+        if (!score.blocked) {
+          log.warn({ peerId }, "Peer blocked");
+          score.blocked = true;
+          score.blockedAt = Date.now();
+        }
+        blocked.push(peerId);
+      }
+    }
+
+    return blocked;
+  }
+}

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -417,6 +417,7 @@ export default class Server {
                     divergenceSecondsAgo: status.divergenceSecondsAgo,
                     ourMessages: status.ourSnapshot.numMessages,
                     theirMessages: status.theirSnapshot.numMessages,
+                    score: status.score,
                   }),
                 );
               }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,9 +11,7 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "MIT",
   "dependencies": {
     "@noble/curves": "^1.0.0",
@@ -26,7 +24,7 @@
   "scripts": {
     "build": "tsup --config tsup.config.ts",
     "clean": "rimraf ./dist",
-    "protoc": "protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=./src/protobufs/generated/ --ts_proto_opt=esModuleInterop=true,exportCommonSymbols=false,outputServices=false,useOptionals=none,unrecognizedEnum=false,removeEnumPrefix=true --proto_path=../../protobufs/schemas  ../../protobufs/schemas/*",
+    "protoc": "docker run --rm -v $(pwd)/../../node_modules:/node_modules -v $(pwd)/../../protobufs/schemas:/defs -v $(pwd)/src/protobufs/generated:/out namely/protoc:1.50_1 --plugin=/node_modules/ts-proto/protoc-gen-ts_proto --ts_proto_out=/out --ts_proto_opt=esModuleInterop=true,exportCommonSymbols=false,outputServices=false,useOptionals=none,unrecognizedEnum=false,removeEnumPrefix=true --proto_path=/defs $(ls ../../protobufs/schemas/*.proto | xargs -n 1 basename | xargs -I{} echo '/defs/{}' | tr '\n' ' ')",
     "lint": "biome format src/ --write && biome check src/ --apply",
     "lint:ci": "biome ci src/",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",

--- a/packages/core/src/protobufs/generated/request_response.ts
+++ b/packages/core/src/protobufs/generated/request_response.ts
@@ -126,6 +126,7 @@ export interface SyncStatus {
   theirMessages: number;
   ourMessages: number;
   lastBadSync: number;
+  score: number;
 }
 
 export interface TrieNodeMetadataResponse {
@@ -910,6 +911,7 @@ function createBaseSyncStatus(): SyncStatus {
     theirMessages: 0,
     ourMessages: 0,
     lastBadSync: 0,
+    score: 0,
   };
 }
 
@@ -938,6 +940,9 @@ export const SyncStatus = {
     }
     if (message.lastBadSync !== 0) {
       writer.uint32(64).int64(message.lastBadSync);
+    }
+    if (message.score !== 0) {
+      writer.uint32(72).int64(message.score);
     }
     return writer;
   },
@@ -1005,6 +1010,13 @@ export const SyncStatus = {
 
           message.lastBadSync = longToNumber(reader.int64() as Long);
           continue;
+        case 9:
+          if (tag != 72) {
+            break;
+          }
+
+          message.score = longToNumber(reader.int64() as Long);
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -1024,6 +1036,7 @@ export const SyncStatus = {
       theirMessages: isSet(object.theirMessages) ? Number(object.theirMessages) : 0,
       ourMessages: isSet(object.ourMessages) ? Number(object.ourMessages) : 0,
       lastBadSync: isSet(object.lastBadSync) ? Number(object.lastBadSync) : 0,
+      score: isSet(object.score) ? Number(object.score) : 0,
     };
   },
 
@@ -1037,6 +1050,7 @@ export const SyncStatus = {
     message.theirMessages !== undefined && (obj.theirMessages = Math.round(message.theirMessages));
     message.ourMessages !== undefined && (obj.ourMessages = Math.round(message.ourMessages));
     message.lastBadSync !== undefined && (obj.lastBadSync = Math.round(message.lastBadSync));
+    message.score !== undefined && (obj.score = Math.round(message.score));
     return obj;
   },
 
@@ -1054,6 +1068,7 @@ export const SyncStatus = {
     message.theirMessages = object.theirMessages ?? 0;
     message.ourMessages = object.ourMessages ?? 0;
     message.lastBadSync = object.lastBadSync ?? 0;
+    message.score = object.score ?? 0;
     return message;
   },
 };

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -11,9 +11,7 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "MIT",
   "dependencies": {
     "@farcaster/core": "0.12.10",
@@ -24,7 +22,7 @@
   "scripts": {
     "build": "tsup --config tsup.config.ts",
     "clean": "rimraf ./dist",
-    "protoc": "protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto  --ts_proto_out=./src/generated/ --ts_proto_opt=esModuleInterop=true,exportCommonSymbols=false,outputServices=grpc-js,useOptionals=none,unrecognizedEnum=false,removeEnumPrefix=true --proto_path=../../protobufs/schemas ../../protobufs/schemas/rpc.proto",
+    "protoc": "docker run --rm -v $(pwd)/../../node_modules:/node_modules -v $(pwd)/../../protobufs/schemas:/defs -v $(pwd)/src/generated:/out namely/protoc:1.50_1 --plugin=/node_modules/ts-proto/protoc-gen-ts_proto --ts_proto_out=/out --ts_proto_opt=esModuleInterop=true,exportCommonSymbols=false,outputServices=grpc-js,useOptionals=none,unrecognizedEnum=false,removeEnumPrefix=true --proto_path=/defs /defs/rpc.proto",
     "lint": "biome format src/ examples/ --write && biome check src/ examples --apply",
     "lint:ci": "biome ci src/ examples/",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",

--- a/packages/hub-nodejs/src/generated/request_response.ts
+++ b/packages/hub-nodejs/src/generated/request_response.ts
@@ -126,6 +126,7 @@ export interface SyncStatus {
   theirMessages: number;
   ourMessages: number;
   lastBadSync: number;
+  score: number;
 }
 
 export interface TrieNodeMetadataResponse {
@@ -910,6 +911,7 @@ function createBaseSyncStatus(): SyncStatus {
     theirMessages: 0,
     ourMessages: 0,
     lastBadSync: 0,
+    score: 0,
   };
 }
 
@@ -938,6 +940,9 @@ export const SyncStatus = {
     }
     if (message.lastBadSync !== 0) {
       writer.uint32(64).int64(message.lastBadSync);
+    }
+    if (message.score !== 0) {
+      writer.uint32(72).int64(message.score);
     }
     return writer;
   },
@@ -1005,6 +1010,13 @@ export const SyncStatus = {
 
           message.lastBadSync = longToNumber(reader.int64() as Long);
           continue;
+        case 9:
+          if (tag != 72) {
+            break;
+          }
+
+          message.score = longToNumber(reader.int64() as Long);
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -1024,6 +1036,7 @@ export const SyncStatus = {
       theirMessages: isSet(object.theirMessages) ? Number(object.theirMessages) : 0,
       ourMessages: isSet(object.ourMessages) ? Number(object.ourMessages) : 0,
       lastBadSync: isSet(object.lastBadSync) ? Number(object.lastBadSync) : 0,
+      score: isSet(object.score) ? Number(object.score) : 0,
     };
   },
 
@@ -1037,6 +1050,7 @@ export const SyncStatus = {
     message.theirMessages !== undefined && (obj.theirMessages = Math.round(message.theirMessages));
     message.ourMessages !== undefined && (obj.ourMessages = Math.round(message.ourMessages));
     message.lastBadSync !== undefined && (obj.lastBadSync = Math.round(message.lastBadSync));
+    message.score !== undefined && (obj.score = Math.round(message.score));
     return obj;
   },
 
@@ -1054,6 +1068,7 @@ export const SyncStatus = {
     message.theirMessages = object.theirMessages ?? 0;
     message.ourMessages = object.ourMessages ?? 0;
     message.lastBadSync = object.lastBadSync ?? 0;
+    message.score = object.score ?? 0;
     return message;
   },
 };

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -11,14 +11,12 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "MIT",
   "scripts": {
     "build": "tsup --config tsup.config.ts",
     "clean": "rimraf ./dist",
-    "protoc": "protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto  --ts_proto_out=./src/generated/ --ts_proto_opt=esModuleInterop=true,exportCommonSymbols=false,outputClientImpl=grpc-web,useOptionals=none,unrecognizedEnum=false,removeEnumPrefix=true,lowerCaseServiceMethods=true --proto_path=../../protobufs//schemas ../../protobufs/schemas/rpc.proto",
+    "protoc": "docker run --rm -v $(pwd)/../../node_modules:/node_modules -v $(pwd)/../../protobufs/schemas:/defs -v $(pwd)/src/generated:/out namely/protoc:1.50_1 --plugin=/node_modules/ts-proto/protoc-gen-ts_proto --ts_proto_out=/out --ts_proto_opt=esModuleInterop=true,exportCommonSymbols=false,outputClientImpl=grpc-web,useOptionals=none,unrecognizedEnum=false,removeEnumPrefix=true,lowerCaseServiceMethods=true --proto_path=/defs /defs/rpc.proto",
     "lint": "biome format src/ examples/ --write && biome check src/ examples/ --apply",
     "lint:ci": "biome ci src/ examples/",
     "prepublishOnly": "yarn run build"

--- a/packages/hub-web/src/generated/request_response.ts
+++ b/packages/hub-web/src/generated/request_response.ts
@@ -126,6 +126,7 @@ export interface SyncStatus {
   theirMessages: number;
   ourMessages: number;
   lastBadSync: number;
+  score: number;
 }
 
 export interface TrieNodeMetadataResponse {
@@ -910,6 +911,7 @@ function createBaseSyncStatus(): SyncStatus {
     theirMessages: 0,
     ourMessages: 0,
     lastBadSync: 0,
+    score: 0,
   };
 }
 
@@ -938,6 +940,9 @@ export const SyncStatus = {
     }
     if (message.lastBadSync !== 0) {
       writer.uint32(64).int64(message.lastBadSync);
+    }
+    if (message.score !== 0) {
+      writer.uint32(72).int64(message.score);
     }
     return writer;
   },
@@ -1005,6 +1010,13 @@ export const SyncStatus = {
 
           message.lastBadSync = longToNumber(reader.int64() as Long);
           continue;
+        case 9:
+          if (tag != 72) {
+            break;
+          }
+
+          message.score = longToNumber(reader.int64() as Long);
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -1024,6 +1036,7 @@ export const SyncStatus = {
       theirMessages: isSet(object.theirMessages) ? Number(object.theirMessages) : 0,
       ourMessages: isSet(object.ourMessages) ? Number(object.ourMessages) : 0,
       lastBadSync: isSet(object.lastBadSync) ? Number(object.lastBadSync) : 0,
+      score: isSet(object.score) ? Number(object.score) : 0,
     };
   },
 
@@ -1037,6 +1050,7 @@ export const SyncStatus = {
     message.theirMessages !== undefined && (obj.theirMessages = Math.round(message.theirMessages));
     message.ourMessages !== undefined && (obj.ourMessages = Math.round(message.ourMessages));
     message.lastBadSync !== undefined && (obj.lastBadSync = Math.round(message.lastBadSync));
+    message.score !== undefined && (obj.score = Math.round(message.score));
     return obj;
   },
 
@@ -1054,6 +1068,7 @@ export const SyncStatus = {
     message.theirMessages = object.theirMessages ?? 0;
     message.ourMessages = object.ourMessages ?? 0;
     message.lastBadSync = object.lastBadSync ?? 0;
+    message.score = object.score ?? 0;
     return message;
   },
 };

--- a/packages/hub-web/src/generated/rpc.ts
+++ b/packages/hub-web/src/generated/rpc.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import grpcWeb from "@improbable-eng/grpc-web";
+import { grpc } from "@improbable-eng/grpc-web";
 import { BrowserHeaders } from "browser-headers";
 import { Observable } from "rxjs";
 import { share } from "rxjs/operators";
@@ -43,75 +43,75 @@ import { UserNameProof } from "./username_proof";
 
 export interface HubService {
   /** Submit Methods */
-  submitMessage(request: DeepPartial<Message>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
+  submitMessage(request: DeepPartial<Message>, metadata?: grpc.Metadata): Promise<Message>;
   /** Event Methods */
-  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpcWeb.grpc.Metadata): Observable<HubEvent>;
-  getEvent(request: DeepPartial<EventRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubEvent>;
+  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpc.Metadata): Observable<HubEvent>;
+  getEvent(request: DeepPartial<EventRequest>, metadata?: grpc.Metadata): Promise<HubEvent>;
   /** Casts */
-  getCast(request: DeepPartial<CastId>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
-  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
-  getCastsByParent(request: DeepPartial<CastsByParentRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
-  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getCast(request: DeepPartial<CastId>, metadata?: grpc.Metadata): Promise<Message>;
+  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getCastsByParent(request: DeepPartial<CastsByParentRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /** Reactions */
-  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
-  getReactionsByFid(request: DeepPartial<ReactionsByFidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpc.Metadata): Promise<Message>;
+  getReactionsByFid(request: DeepPartial<ReactionsByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /** To be deprecated */
   getReactionsByCast(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<MessagesResponse>;
   getReactionsByTarget(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<MessagesResponse>;
   /** User Data */
-  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
-  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpc.Metadata): Promise<Message>;
+  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /** Username Proof */
-  getUsernameProof(request: DeepPartial<UsernameProofRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<UserNameProof>;
-  getUserNameProofsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<UsernameProofsResponse>;
+  getUsernameProof(request: DeepPartial<UsernameProofRequest>, metadata?: grpc.Metadata): Promise<UserNameProof>;
+  getUserNameProofsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<UsernameProofsResponse>;
   /** Verifications */
-  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
-  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpc.Metadata): Promise<Message>;
+  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /** OnChain Events */
-  getOnChainSigner(request: DeepPartial<SignerRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEvent>;
-  getOnChainSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEventResponse>;
-  getOnChainEvents(request: DeepPartial<OnChainEventRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEventResponse>;
-  getIdRegistryOnChainEvent(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEvent>;
+  getOnChainSigner(request: DeepPartial<SignerRequest>, metadata?: grpc.Metadata): Promise<OnChainEvent>;
+  getOnChainSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<OnChainEventResponse>;
+  getOnChainEvents(request: DeepPartial<OnChainEventRequest>, metadata?: grpc.Metadata): Promise<OnChainEventResponse>;
+  getIdRegistryOnChainEvent(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<OnChainEvent>;
   getIdRegistryOnChainEventByAddress(
     request: DeepPartial<IdRegistryEventByAddressRequest>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<OnChainEvent>;
   getCurrentStorageLimitsByFid(
     request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<StorageLimitsResponse>;
-  getFids(request: DeepPartial<FidsRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<FidsResponse>;
+  getFids(request: DeepPartial<FidsRequest>, metadata?: grpc.Metadata): Promise<FidsResponse>;
   /** Links */
-  getLink(request: DeepPartial<LinkRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
-  getLinksByFid(request: DeepPartial<LinksByFidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
-  getLinksByTarget(request: DeepPartial<LinksByTargetRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getLink(request: DeepPartial<LinkRequest>, metadata?: grpc.Metadata): Promise<Message>;
+  getLinksByFid(request: DeepPartial<LinksByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getLinksByTarget(request: DeepPartial<LinksByTargetRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /** Bulk Methods */
-  getAllCastMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
-  getAllReactionMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getAllCastMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getAllReactionMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   getAllVerificationMessagesByFid(
     request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<MessagesResponse>;
-  getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
-  getAllLinkMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getAllLinkMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /** Sync Methods */
-  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubInfoResponse>;
-  getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncStatusResponse>;
-  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncIds>;
-  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpc.Metadata): Promise<HubInfoResponse>;
+  getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpc.Metadata): Promise<SyncStatusResponse>;
+  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpc.Metadata): Promise<SyncIds>;
+  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   getSyncMetadataByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<TrieNodeMetadataResponse>;
   getSyncSnapshotByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<TrieNodeSnapshotResponse>;
 }
 
@@ -160,99 +160,99 @@ export class HubServiceClientImpl implements HubService {
     this.getSyncSnapshotByPrefix = this.getSyncSnapshotByPrefix.bind(this);
   }
 
-  submitMessage(request: DeepPartial<Message>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  submitMessage(request: DeepPartial<Message>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceSubmitMessageDesc, Message.fromPartial(request), metadata);
   }
 
-  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpcWeb.grpc.Metadata): Observable<HubEvent> {
+  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpc.Metadata): Observable<HubEvent> {
     return this.rpc.invoke(HubServiceSubscribeDesc, SubscribeRequest.fromPartial(request), metadata);
   }
 
-  getEvent(request: DeepPartial<EventRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubEvent> {
+  getEvent(request: DeepPartial<EventRequest>, metadata?: grpc.Metadata): Promise<HubEvent> {
     return this.rpc.unary(HubServiceGetEventDesc, EventRequest.fromPartial(request), metadata);
   }
 
-  getCast(request: DeepPartial<CastId>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  getCast(request: DeepPartial<CastId>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetCastDesc, CastId.fromPartial(request), metadata);
   }
 
-  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetCastsByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getCastsByParent(request: DeepPartial<CastsByParentRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getCastsByParent(request: DeepPartial<CastsByParentRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetCastsByParentDesc, CastsByParentRequest.fromPartial(request), metadata);
   }
 
-  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetCastsByMentionDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetReactionDesc, ReactionRequest.fromPartial(request), metadata);
   }
 
-  getReactionsByFid(request: DeepPartial<ReactionsByFidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getReactionsByFid(request: DeepPartial<ReactionsByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetReactionsByFidDesc, ReactionsByFidRequest.fromPartial(request), metadata);
   }
 
   getReactionsByCast(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetReactionsByCastDesc, ReactionsByTargetRequest.fromPartial(request), metadata);
   }
 
   getReactionsByTarget(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetReactionsByTargetDesc, ReactionsByTargetRequest.fromPartial(request), metadata);
   }
 
-  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetUserDataDesc, UserDataRequest.fromPartial(request), metadata);
   }
 
-  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetUserDataByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getUsernameProof(request: DeepPartial<UsernameProofRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<UserNameProof> {
+  getUsernameProof(request: DeepPartial<UsernameProofRequest>, metadata?: grpc.Metadata): Promise<UserNameProof> {
     return this.rpc.unary(HubServiceGetUsernameProofDesc, UsernameProofRequest.fromPartial(request), metadata);
   }
 
-  getUserNameProofsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<UsernameProofsResponse> {
+  getUserNameProofsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<UsernameProofsResponse> {
     return this.rpc.unary(HubServiceGetUserNameProofsByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetVerificationDesc, VerificationRequest.fromPartial(request), metadata);
   }
 
-  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetVerificationsByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getOnChainSigner(request: DeepPartial<SignerRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEvent> {
+  getOnChainSigner(request: DeepPartial<SignerRequest>, metadata?: grpc.Metadata): Promise<OnChainEvent> {
     return this.rpc.unary(HubServiceGetOnChainSignerDesc, SignerRequest.fromPartial(request), metadata);
   }
 
-  getOnChainSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEventResponse> {
+  getOnChainSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<OnChainEventResponse> {
     return this.rpc.unary(HubServiceGetOnChainSignersByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getOnChainEvents(request: DeepPartial<OnChainEventRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEventResponse> {
+  getOnChainEvents(request: DeepPartial<OnChainEventRequest>, metadata?: grpc.Metadata): Promise<OnChainEventResponse> {
     return this.rpc.unary(HubServiceGetOnChainEventsDesc, OnChainEventRequest.fromPartial(request), metadata);
   }
 
-  getIdRegistryOnChainEvent(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEvent> {
+  getIdRegistryOnChainEvent(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<OnChainEvent> {
     return this.rpc.unary(HubServiceGetIdRegistryOnChainEventDesc, FidRequest.fromPartial(request), metadata);
   }
 
   getIdRegistryOnChainEventByAddress(
     request: DeepPartial<IdRegistryEventByAddressRequest>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<OnChainEvent> {
     return this.rpc.unary(
       HubServiceGetIdRegistryOnChainEventByAddressDesc,
@@ -263,76 +263,76 @@ export class HubServiceClientImpl implements HubService {
 
   getCurrentStorageLimitsByFid(
     request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<StorageLimitsResponse> {
     return this.rpc.unary(HubServiceGetCurrentStorageLimitsByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getFids(request: DeepPartial<FidsRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<FidsResponse> {
+  getFids(request: DeepPartial<FidsRequest>, metadata?: grpc.Metadata): Promise<FidsResponse> {
     return this.rpc.unary(HubServiceGetFidsDesc, FidsRequest.fromPartial(request), metadata);
   }
 
-  getLink(request: DeepPartial<LinkRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  getLink(request: DeepPartial<LinkRequest>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetLinkDesc, LinkRequest.fromPartial(request), metadata);
   }
 
-  getLinksByFid(request: DeepPartial<LinksByFidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getLinksByFid(request: DeepPartial<LinksByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetLinksByFidDesc, LinksByFidRequest.fromPartial(request), metadata);
   }
 
-  getLinksByTarget(request: DeepPartial<LinksByTargetRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getLinksByTarget(request: DeepPartial<LinksByTargetRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetLinksByTargetDesc, LinksByTargetRequest.fromPartial(request), metadata);
   }
 
-  getAllCastMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getAllCastMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllCastMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getAllReactionMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getAllReactionMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllReactionMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
   getAllVerificationMessagesByFid(
     request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllVerificationMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllUserDataMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getAllLinkMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getAllLinkMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllLinkMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubInfoResponse> {
+  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpc.Metadata): Promise<HubInfoResponse> {
     return this.rpc.unary(HubServiceGetInfoDesc, HubInfoRequest.fromPartial(request), metadata);
   }
 
-  getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncStatusResponse> {
+  getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpc.Metadata): Promise<SyncStatusResponse> {
     return this.rpc.unary(HubServiceGetSyncStatusDesc, SyncStatusRequest.fromPartial(request), metadata);
   }
 
-  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncIds> {
+  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpc.Metadata): Promise<SyncIds> {
     return this.rpc.unary(HubServiceGetAllSyncIdsByPrefixDesc, TrieNodePrefix.fromPartial(request), metadata);
   }
 
-  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllMessagesBySyncIdsDesc, SyncIds.fromPartial(request), metadata);
   }
 
   getSyncMetadataByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<TrieNodeMetadataResponse> {
     return this.rpc.unary(HubServiceGetSyncMetadataByPrefixDesc, TrieNodePrefix.fromPartial(request), metadata);
   }
 
   getSyncSnapshotByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<TrieNodeSnapshotResponse> {
     return this.rpc.unary(HubServiceGetSyncSnapshotByPrefixDesc, TrieNodePrefix.fromPartial(request), metadata);
   }
@@ -1215,9 +1215,9 @@ export const HubServiceGetSyncSnapshotByPrefixDesc: UnaryMethodDefinitionish = {
 };
 
 export interface AdminService {
-  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty>;
-  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty>;
-  submitOnChainEvent(request: DeepPartial<OnChainEvent>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEvent>;
+  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty>;
+  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty>;
+  submitOnChainEvent(request: DeepPartial<OnChainEvent>, metadata?: grpc.Metadata): Promise<OnChainEvent>;
 }
 
 export class AdminServiceClientImpl implements AdminService {
@@ -1230,15 +1230,15 @@ export class AdminServiceClientImpl implements AdminService {
     this.submitOnChainEvent = this.submitOnChainEvent.bind(this);
   }
 
-  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty> {
+  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty> {
     return this.rpc.unary(AdminServiceRebuildSyncTrieDesc, Empty.fromPartial(request), metadata);
   }
 
-  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty> {
+  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty> {
     return this.rpc.unary(AdminServiceDeleteAllMessagesFromDbDesc, Empty.fromPartial(request), metadata);
   }
 
-  submitOnChainEvent(request: DeepPartial<OnChainEvent>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEvent> {
+  submitOnChainEvent(request: DeepPartial<OnChainEvent>, metadata?: grpc.Metadata): Promise<OnChainEvent> {
     return this.rpc.unary(AdminServiceSubmitOnChainEventDesc, OnChainEvent.fromPartial(request), metadata);
   }
 }
@@ -1314,7 +1314,7 @@ export const AdminServiceSubmitOnChainEventDesc: UnaryMethodDefinitionish = {
   } as any,
 };
 
-interface UnaryMethodDefinitionishR extends grpcWeb.grpc.UnaryMethodDefinition<any, any> {
+interface UnaryMethodDefinitionishR extends grpc.UnaryMethodDefinition<any, any> {
   requestStream: any;
   responseStream: any;
 }
@@ -1325,32 +1325,32 @@ interface Rpc {
   unary<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     request: any,
-    metadata: grpcWeb.grpc.Metadata | undefined,
+    metadata: grpc.Metadata | undefined,
   ): Promise<any>;
   invoke<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     request: any,
-    metadata: grpcWeb.grpc.Metadata | undefined,
+    metadata: grpc.Metadata | undefined,
   ): Observable<any>;
 }
 
 export class GrpcWebImpl {
   private host: string;
   private options: {
-    transport?: grpcWeb.grpc.TransportFactory;
-    streamingTransport?: grpcWeb.grpc.TransportFactory;
+    transport?: grpc.TransportFactory;
+    streamingTransport?: grpc.TransportFactory;
     debug?: boolean;
-    metadata?: grpcWeb.grpc.Metadata;
+    metadata?: grpc.Metadata;
     upStreamRetryCodes?: number[];
   };
 
   constructor(
     host: string,
     options: {
-      transport?: grpcWeb.grpc.TransportFactory;
-      streamingTransport?: grpcWeb.grpc.TransportFactory;
+      transport?: grpc.TransportFactory;
+      streamingTransport?: grpc.TransportFactory;
       debug?: boolean;
-      metadata?: grpcWeb.grpc.Metadata;
+      metadata?: grpc.Metadata;
       upStreamRetryCodes?: number[];
     },
   ) {
@@ -1361,21 +1361,21 @@ export class GrpcWebImpl {
   unary<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     _request: any,
-    metadata: grpcWeb.grpc.Metadata | undefined,
+    metadata: grpc.Metadata | undefined,
   ): Promise<any> {
     const request = { ..._request, ...methodDesc.requestType };
     const maybeCombinedMetadata = metadata && this.options.metadata
       ? new BrowserHeaders({ ...this.options?.metadata.headersMap, ...metadata?.headersMap })
       : metadata || this.options.metadata;
     return new Promise((resolve, reject) => {
-      grpcWeb.grpc.unary(methodDesc, {
+      grpc.unary(methodDesc, {
         request,
         host: this.host,
         metadata: maybeCombinedMetadata,
         transport: this.options.transport,
         debug: this.options.debug,
         onEnd: function (response) {
-          if (response.status === grpcWeb.grpc.Code.OK) {
+          if (response.status === grpc.Code.OK) {
             resolve(response.message!.toObject());
           } else {
             const err = new GrpcWebError(response.statusMessage, response.status, response.trailers);
@@ -1389,7 +1389,7 @@ export class GrpcWebImpl {
   invoke<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     _request: any,
-    metadata: grpcWeb.grpc.Metadata | undefined,
+    metadata: grpc.Metadata | undefined,
   ): Observable<any> {
     const upStreamCodes = this.options.upStreamRetryCodes || [];
     const DEFAULT_TIMEOUT_TIME: number = 3_000;
@@ -1399,14 +1399,14 @@ export class GrpcWebImpl {
       : metadata || this.options.metadata;
     return new Observable((observer) => {
       const upStream = (() => {
-        const client = grpcWeb.grpc.invoke(methodDesc, {
+        const client = grpc.invoke(methodDesc, {
           host: this.host,
           request,
           transport: this.options.streamingTransport || this.options.transport,
           metadata: maybeCombinedMetadata,
           debug: this.options.debug,
           onMessage: (next) => observer.next(next),
-          onEnd: (code: grpcWeb.grpc.Code, message: string, trailers: grpcWeb.grpc.Metadata) => {
+          onEnd: (code: grpc.Code, message: string, trailers: grpc.Metadata) => {
             if (code === 0) {
               observer.complete();
             } else if (upStreamCodes.includes(code)) {
@@ -1457,7 +1457,7 @@ type DeepPartial<T> = T extends Builtin ? T
   : Partial<T>;
 
 export class GrpcWebError extends tsProtoGlobalThis.Error {
-  constructor(message: string, public code: grpcWeb.grpc.Code, public metadata: grpcWeb.grpc.Metadata) {
+  constructor(message: string, public code: grpc.Code, public metadata: grpc.Metadata) {
     super(message);
   }
 }

--- a/protobufs/README.md
+++ b/protobufs/README.md
@@ -13,6 +13,14 @@ Specifications for API's and data formats used in Hubble, including both Farcast
 
 ## Getting Started
 
+### Compiling Protobufs
+If you make changes to the protobufs, you will need to run `yarn protoc` in the following directories to compile and generate the JS files
+- `packages/core`
+- `packages/hub-nodejs`
+- `packages/hub-web`
+
+You will need [protoc version `3.15.3`](https://github.com/protocolbuffers/protobuf/releases/tag/v3.15.3) to compile the protobufs. 
+
 ### Generate Bindings
 
 Coming soon

--- a/protobufs/schemas/request_response.proto
+++ b/protobufs/schemas/request_response.proto
@@ -56,6 +56,7 @@ message SyncStatus {
   uint64 theirMessages = 6;
   uint64 ourMessages = 7;
   int64 lastBadSync = 8;
+  int64 score = 9;
 }
 
 message TrieNodeMetadataResponse {


### PR DESCRIPTION
## Motivation

Add peer scoring to keep track if peers are being honest

## Change Summary

- Add peer scoring
- Log bad peers, but don't ban them yet

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Add peer scoring

### Detailed summary:
- Added a new field `score` to the `SyncStatus` protobuf message in `request_response.proto`
- Updated the `TrieNodeMetadataResponse` protobuf message in `request_response.proto` to include the `score` field
- Added a new file `peerScore.ts` in the `hubble/src/network/sync` directory to implement peer scoring logic
- Updated the `Hub` class in `hubble.ts` to update the denied peer ids list with bad peers after sync is complete
- Updated the `SyncStatus` protobuf message in `request_response.ts` and `request_response.ts` to include the `score` field
- Updated the `createBaseSyncStatus` function in `request_response.ts` to set the `score` field to 0
- Updated the `SyncStatus` protobuf message in `request_response.ts` and `request_response.ts` to handle the `score` field during serialization and deserialization

> The following files were skipped due to too many changes: `packages/core/src/protobufs/generated/request_response.ts`, `apps/hubble/src/network/sync/peerScore.ts`, `apps/hubble/src/network/sync/syncEngine.ts`, `packages/hub-web/src/generated/rpc.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->