### PR TITLE
[feat] Add migration to clear on chain events and force resync

### DIFF
--- a/.changeset/afraid-spies-visit.md
+++ b/.changeset/afraid-spies-visit.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: add migration to clear onchain events and force re-sync

--- a/apps/hubble/src/eth/l2EventsProvider.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.ts
@@ -165,15 +165,7 @@ export class L2EventsProvider {
     return this._lastBlockNumber;
   }
 
-  public get ready(): boolean {
-    return !!this.idRegistryAddress && !!this.keyRegistryAddress && !!this.storageRegistryAddress;
-  }
-
   public async start() {
-    if (!this.ready) {
-      log.warn("Deferring start until L2 contract addresses are available");
-      return;
-    }
     // Connect to L2 RPC
     await this.connectAndSyncHistoricalEvents();
 

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -292,8 +292,8 @@ export class Hub implements HubInterface {
   private updateNetworkConfigJobScheduler: UpdateNetworkConfigJobScheduler;
 
   engine: Engine;
-  fNameRegistryEventsProvider?: FNameRegistryEventsProvider;
-  l2RegistryProvider?: L2EventsProvider;
+  fNameRegistryEventsProvider: FNameRegistryEventsProvider;
+  l2RegistryProvider: L2EventsProvider;
 
   constructor(options: HubOptions) {
     this.options = options;
@@ -606,12 +606,8 @@ export class Hub implements HubInterface {
       await this.adminServer.start(this.options.adminServerHost ?? "127.0.0.1");
     }
 
-    // Start the L2 registry provider second
-    if (this.l2RegistryProvider) {
-      await this.l2RegistryProvider.start();
-    }
-
-    await this.fNameRegistryEventsProvider?.start();
+    await this.l2RegistryProvider.start();
+    await this.fNameRegistryEventsProvider.start();
 
     // Start the sync engine
     await this.syncEngine.start(this.options.rebuildSyncTrie ?? false);
@@ -676,21 +672,6 @@ export class Hub implements HubInterface {
 
       this.gossipNode.updateDeniedPeerIds(deniedPeerIds);
       this.deniedPeerIds = deniedPeerIds;
-
-      if (!this.l2RegistryProvider?.ready) {
-        if (
-          networkConfig.storageRegistryAddress &&
-          networkConfig.keyRegistryAddress &&
-          networkConfig.idRegistryAddress
-        ) {
-          this.l2RegistryProvider?.setAddresses(
-            networkConfig.storageRegistryAddress,
-            networkConfig.keyRegistryAddress,
-            networkConfig.idRegistryAddress,
-          );
-          this.l2RegistryProvider?.start();
-        }
-      }
 
       log.info({ allowedPeerIds, deniedPeerIds }, "Network config applied");
 
@@ -845,12 +826,8 @@ export class Hub implements HubInterface {
     this.checkIncomingPortsJobScheduler.stop();
     this.updateNetworkConfigJobScheduler.stop();
 
-    // Stop the L2 registry provider
-    if (this.l2RegistryProvider) {
-      await this.l2RegistryProvider.stop();
-    }
-
-    await this.fNameRegistryEventsProvider?.stop();
+    await this.l2RegistryProvider.stop();
+    await this.fNameRegistryEventsProvider.stop();
 
     // Stop the engine
     await this.engine.stop();

--- a/apps/hubble/src/storage/db/migrations/3.clearEvents.test.ts
+++ b/apps/hubble/src/storage/db/migrations/3.clearEvents.test.ts
@@ -1,0 +1,45 @@
+import { performDbMigrations } from "./migrations.js";
+import { Factories } from "@farcaster/hub-nodejs";
+import { jestRocksDB } from "../jestUtils.js";
+import OnChainEventStore from "../../stores/onChainEventStore.js";
+import StoreEventHandler from "../../stores/storeEventHandler.js";
+import * as process from "process";
+
+const db = jestRocksDB("clearEvents.migration.test");
+
+describe("clearEvents migration", () => {
+  test("should clear all events", async () => {
+    const event1 = Factories.IdRegistryOnChainEvent.build();
+    const event2 = Factories.StorageRentOnChainEvent.build();
+    const event3 = Factories.SignerOnChainEvent.build();
+    const store = new OnChainEventStore(db, new StoreEventHandler(db));
+    await expect(store.mergeOnChainEvent(event1)).resolves.toBeTruthy();
+    await expect(store.mergeOnChainEvent(event2)).resolves.toBeTruthy();
+    await expect(store.mergeOnChainEvent(event3)).resolves.toBeTruthy();
+
+    await expect(store.getIdRegisterEventByFid(event1.fid)).resolves.toEqual(event1);
+
+    const success = await performDbMigrations(db, 2, 3);
+    expect(success).toBe(true);
+
+    await expect(store.getIdRegisterEventByFid(event1.fid)).rejects.toThrow("NotFound");
+  });
+
+  test("does not clear events if skip env var is set", async () => {
+    try {
+      process.env["SKIP_CLEAR_EVENTS"] = "true";
+      const event = Factories.IdRegistryOnChainEvent.build();
+      const store = new OnChainEventStore(db, new StoreEventHandler(db));
+      await expect(store.mergeOnChainEvent(event)).resolves.toBeTruthy();
+
+      await expect(store.getIdRegisterEventByFid(event.fid)).resolves.toEqual(event);
+
+      const success = await performDbMigrations(db, 2, 3);
+      expect(success).toBe(true);
+
+      await expect(store.getIdRegisterEventByFid(event.fid)).resolves.toEqual(event);
+    } finally {
+      process.env["SKIP_CLEAR_EVENTS"] = undefined;
+    }
+  });
+});

--- a/apps/hubble/src/storage/db/migrations/3.clearEvents.ts
+++ b/apps/hubble/src/storage/db/migrations/3.clearEvents.ts
@@ -1,0 +1,22 @@
+/**
+ For a period of time, the hubble snapshots had bad on chain event data. So, this migration will clear all onchain
+ events and force a fresh re-sync
+ */
+
+import { logger } from "../../../utils/logger.js";
+import RocksDB from "../rocksdb.js";
+import OnChainEventStore from "../../stores/onChainEventStore.js";
+
+const log = logger.child({ component: "ClearEventsMigration" });
+
+export const clearEventsMigration = async (db: RocksDB): Promise<boolean> => {
+  if (process.env["SKIP_CLEAR_EVENTS"] === "true") {
+    log.info({}, "Skipping clearEvents migration");
+    return true;
+  }
+  log.info({}, "Starting clearEvents migration");
+  const start = Date.now();
+  await OnChainEventStore.clearEvents(db);
+  log.info({ duration: Date.now() - start }, "Finished clearEvents migration");
+  return true;
+};

--- a/apps/hubble/src/storage/db/migrations/migrations.ts
+++ b/apps/hubble/src/storage/db/migrations/migrations.ts
@@ -1,8 +1,9 @@
 import { ResultAsync } from "neverthrow";
 import RocksDB from "../rocksdb.js";
+import { logger } from "../../../utils/logger.js";
 import { usernameProofIndexMigration } from "./1.usernameproof.js";
 import { fnameProofIndexMigration } from "./2.fnameproof.js";
-import { logger } from "../../../utils/logger.js";
+import { clearEventsMigration } from "./3.clearEvents.js";
 
 type MigrationFunctionType = (db: RocksDB) => Promise<boolean>;
 const migrations = new Map<number, MigrationFunctionType>();
@@ -17,6 +18,9 @@ migrations.set(1, async (db: RocksDB) => {
 });
 migrations.set(2, async (db: RocksDB) => {
   return await fnameProofIndexMigration(db);
+});
+migrations.set(3, async (db: RocksDB) => {
+  return await clearEventsMigration(db);
 });
 
 // To Add a new migration

--- a/apps/hubble/src/storage/stores/onChainEventStore.ts
+++ b/apps/hubble/src/storage/stores/onChainEventStore.ts
@@ -270,9 +270,13 @@ class OnChainEventStore {
       {},
       1 * 60 * 60 * 1000,
     );
-    const state = await getHubState(db);
-    state.lastL2Block = 0;
-    await putHubState(db, state);
+    const result = await ResultAsync.fromPromise(getHubState(db), (e) => e as HubError);
+    if (result.isOk()) {
+      result.value.lastL2Block = 0;
+      await putHubState(db, result.value);
+    } else {
+      logger.warn(result.error, "Could not reset hub state when clearing events");
+    }
     return count;
   }
 }

--- a/apps/hubble/src/storage/stores/onChainEventStore.ts
+++ b/apps/hubble/src/storage/stores/onChainEventStore.ts
@@ -34,7 +34,6 @@ import { PageOptions } from "./types.js";
 import { logger } from "../../utils/logger.js";
 
 const SUPPORTED_SIGNER_SCHEMES = [1];
-export const MIGRATION_BLOCK = 108911959;
 
 /**
  * OnChainStore persists On Chain Event messages in RocksDB using a grow only CRDT set
@@ -140,30 +139,6 @@ class OnChainEventStore {
    * Merges a rent ContractEvent into the StorageEventStore
    */
   async _mergeEvent(event: OnChainEvent): Promise<number> {
-    if (event.blockNumber <= MIGRATION_BLOCK) {
-      // Handle events that were merged with the incorrect index (using txIndex instead of logIndex if they exist)
-      const _badEvent = await ResultAsync.fromPromise(
-        getOnChainEvent(this._db, event.type, event.fid, event.blockNumber, event.txIndex),
-        () => undefined,
-      );
-      if (_badEvent.isOk()) {
-        const incorrectPrimaryKey = makeOnChainEventPrimaryKey(event.type, event.fid, event.blockNumber, event.txIndex);
-        const correctPrimaryKey = makeOnChainEventPrimaryKey(event.type, event.fid, event.blockNumber, event.logIndex);
-        const txn = this._db.transaction();
-        txn.del(incorrectPrimaryKey);
-        putOnChainEventTransaction(txn, event);
-
-        if (isSignerOnChainEvent(_badEvent.value)) {
-          txn.put(makeSignerOnChainEventBySignerKey(event.fid, _badEvent.value.signerEventBody.key), correctPrimaryKey);
-        } else if (isIdRegisterOnChainEvent(_badEvent.value)) {
-          txn
-            .put(makeIdRegisterEventByCustodyKey(_badEvent.value.idRegisterEventBody.to), correctPrimaryKey)
-            .put(makeIdRegisterEventByFidKey(event.fid), correctPrimaryKey);
-        }
-        await this._db.commit(txn);
-        throw new HubError("bad_request.duplicate", "onChainEvent already exists (txIndex updated)");
-      }
-    }
     const _existingEvent = await ResultAsync.fromPromise(
       getOnChainEvent(this._db, event.type, event.fid, event.blockNumber, event.logIndex),
       () => undefined,

--- a/apps/hubble/src/storage/stores/onchainEventStore.test.ts
+++ b/apps/hubble/src/storage/stores/onchainEventStore.test.ts
@@ -1,5 +1,5 @@
 import { jestRocksDB } from "../db/jestUtils.js";
-import OnChainEventStore, { MIGRATION_BLOCK } from "./onChainEventStore.js";
+import OnChainEventStore from "./onChainEventStore.js";
 import StoreEventHandler from "./storeEventHandler.js";
 import {
   Factories,
@@ -29,58 +29,6 @@ describe("OnChainEventStore", () => {
       const onChainEvent = Factories.SignerOnChainEvent.build();
       await set.mergeOnChainEvent(onChainEvent);
       await expect(set.mergeOnChainEvent(onChainEvent)).rejects.toThrow("already exists");
-    });
-
-    describe("old events based on txIndex", () => {
-      test("replaces txIndex with logIndex if it exists", async () => {
-        // There was a bug where we were using txIndex instead of logIndex for ordering.
-        // If we re-merge the same event, then we should silently replace the old event with the correct one
-        const txIndex = 2;
-        const logIndex = 10;
-        const badSignerEvent = Factories.SignerOnChainEvent.build({
-          logIndex: txIndex, // Log index was incorrectly set to txIndex
-          txIndex: 0, // Did not have this field
-          blockNumber: MIGRATION_BLOCK - 100,
-        });
-        const badRegisterEvent = Factories.IdRegistryOnChainEvent.build({
-          logIndex: txIndex, // Log index was incorrectly set to txIndex
-          txIndex: 0, // Did not have this field
-          blockNumber: MIGRATION_BLOCK - 10,
-        });
-        await set.mergeOnChainEvent(badSignerEvent);
-        await set.mergeOnChainEvent(badRegisterEvent);
-        badSignerEvent.txIndex = txIndex;
-        badSignerEvent.logIndex = logIndex;
-        badRegisterEvent.txIndex = txIndex;
-        badRegisterEvent.logIndex = txIndex; // Assume log index is the same as tx index
-
-        await expect(set.mergeOnChainEvent(badSignerEvent)).rejects.toThrow("already exists");
-        await expect(set.mergeOnChainEvent(badSignerEvent)).rejects.toThrow("already exists");
-        const signerEvents = await set.getOnChainEvents(OnChainEventType.EVENT_TYPE_SIGNER, badSignerEvent.fid);
-        expect(signerEvents).toHaveLength(1);
-        expect(signerEvents[0]?.txIndex).toEqual(txIndex);
-        expect(signerEvents[0]?.logIndex).toEqual(logIndex);
-
-        const onChainSigner = await set.getActiveSigner(badSignerEvent.fid, badSignerEvent.signerEventBody.key);
-        expect(onChainSigner.signerEventBody.key).toEqual(badSignerEvent.signerEventBody.key);
-
-        await expect(set.mergeOnChainEvent(badRegisterEvent)).rejects.toThrow("already exists");
-        await expect(set.mergeOnChainEvent(badRegisterEvent)).rejects.toThrow("already exists");
-        const registerEvents = await set.getOnChainEvents(
-          OnChainEventType.EVENT_TYPE_ID_REGISTER,
-          badRegisterEvent.fid,
-        );
-        expect(registerEvents).toHaveLength(1);
-        expect(registerEvents[0]?.txIndex).toEqual(txIndex);
-        expect(registerEvents[0]?.logIndex).toEqual(txIndex);
-
-        const idRegisterByFid = await set.getIdRegisterEventByFid(badRegisterEvent.fid);
-        expect(idRegisterByFid).toEqual(badRegisterEvent);
-        const idRegisterByCustody = await set.getIdRegisterEventByCustodyAddress(
-          badRegisterEvent.idRegisterEventBody.to,
-        );
-        expect(idRegisterByCustody).toEqual(badRegisterEvent);
-      });
     });
 
     describe("signers", () => {


### PR DESCRIPTION
## Motivation

Hubble snapshots potentially had some bad onchain event data, so create a migration to clear all onchain events and force a re-sync on all hubs during the next upgrade.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- This PR adds a migration to clear onchain events and force a re-sync.
- It updates the `l2EventsProvider.ts` file by removing the `ready` function and modifying the `start` function.
- It adds a new migration file `3.clearEvents.ts` to clear all onchain events.
- It updates the `hubble.ts` file by modifying the `constructor` and the `start` and `stop` functions.
- It updates the `onChainEventStore.ts` file by removing the `MIGRATION_BLOCK` constant and modifying the `_mergeEvent` and `_clearEvents` functions.
- It adds a new test file `3.clearEvents.test.ts` to test the clearEvents migration.
- It updates the `onChainEventStore.test.ts` file by removing the test for old events based on `txIndex`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->