### PR TITLE
fix: Set pull_policy to always to ensure hubs always upgrade on restart

### DIFF
--- a/apps/hubble/docker-compose.yml
+++ b/apps/hubble/docker-compose.yml
@@ -8,6 +8,7 @@ version: '3.9'
 services:
   hubble:
     image: farcasterxyz/hubble:latest
+    pull_policy: always
     restart: unless-stopped
     command: [
       "node", "--no-warnings",  "build/cli.js", "start",


### PR DESCRIPTION
## Motivation

Set `pull_policy` to `always` so hubs will always upgrade on docker compose up. Right now, this is not guaranteed to happen since we use the `latest` tag.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a `pull_policy` parameter to the `hubble` service in the `docker-compose.yml` file.

### Detailed summary
- Added `pull_policy: always` parameter to the `hubble` service in `docker-compose.yml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->