### PR TITLE
feat: Add audits during sync

### DIFF
--- a/.changeset/silent-guests-cry.md
+++ b/.changeset/silent-guests-cry.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: Audit peer's messages during sync

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -254,6 +254,19 @@ describe("Multi peer sync engine", () => {
 
       expect(syncEngine2.trie.exists(SyncId.fromFName(fname))).toBeTruthy();
       expect(syncEngine2.trie.exists(SyncId.fromOnChainEvent(storageEvent))).toBeTruthy();
+
+      // Sync again, and this time the audit should increase the peer score
+      // First, get the existing peer score
+      const peerScoreBefore = syncEngine2.getPeerScore("engine1");
+
+      // Now sync again
+      await syncEngine2.performSync("engine1", newSnapshot, clientForServer1, true);
+
+      // Make sure root hash matches and peer score has increased
+      expect(await syncEngine1.trie.rootHash()).toEqual(await syncEngine2.trie.rootHash());
+      const peerScoreAfter = syncEngine2.getPeerScore("engine1");
+      expect(peerScoreAfter).toBeDefined();
+      expect(peerScoreAfter?.score).toBeGreaterThan(peerScoreBefore?.score ?? Infinity);
     },
     TEST_TIMEOUT_LONG,
   );

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -246,18 +246,11 @@ describe("Multi peer sync engine", () => {
       // Should sync should now be true
       expect((await syncEngine2.syncStatus("engine1", newSnapshot))._unsafeUnwrap().shouldSync).toBeTruthy();
 
-      const startScore = syncEngine2.getPeerScore("engine1")?.score ?? 0;
-
       // Do the sync again, this time enabling audit
       await syncEngine2.performSync("engine1", newSnapshot, clientForServer1, true);
 
       // Make sure root hash matches
       expect(await syncEngine1.trie.rootHash()).toEqual(await syncEngine2.trie.rootHash());
-
-      // Check the peer score to make sure it increased
-      const peerScore = syncEngine2.getPeerScore("engine1");
-      expect(peerScore).toBeDefined();
-      expect(peerScore?.score).toBeGreaterThan(startScore);
 
       expect(syncEngine2.trie.exists(SyncId.fromFName(fname))).toBeTruthy();
       expect(syncEngine2.trie.exists(SyncId.fromOnChainEvent(storageEvent))).toBeTruthy();

--- a/apps/hubble/src/network/sync/peerScore.ts
+++ b/apps/hubble/src/network/sync/peerScore.ts
@@ -12,14 +12,25 @@ const log = logger.child({
 export class PeerScore {
   score: number;
   blocked: boolean;
-  blockedAt?: number;
-  lastSyncTime?: number;
-  lastBadSyncTime?: number;
-  lastSyncResult?: MergeResult;
+  blockedAt: number | undefined;
+  lastSyncTime: number | undefined;
+  lastBadSyncTime: number | undefined;
+  lastSyncResult: MergeResult | undefined;
 
   constructor() {
     this.score = 0;
     this.blocked = false;
+  }
+
+  clone(): PeerScore {
+    const score = new PeerScore();
+    score.score = this.score;
+    score.blocked = this.blocked;
+    score.blockedAt = this.blockedAt;
+    score.lastSyncTime = this.lastSyncTime;
+    score.lastBadSyncTime = this.lastBadSyncTime;
+    score.lastSyncResult = this.lastSyncResult;
+    return score;
   }
 }
 

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -376,7 +376,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
   }
 
   public getPeerScore(peerId: string): PeerScore | undefined {
-    return this._peerScorer.getScore(peerId);
+    return this._peerScorer.getScore(peerId)?.clone();
   }
 
   public getSyncProfile(): SyncEngineProfiler | undefined {
@@ -802,8 +802,10 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
 
     // If peer passed the audit, score them up
     if (!anyFailed) {
+      const before = this._peerScorer.getScore(peerId)?.score ?? 0;
       this._peerScorer.incrementScore(peerId);
-      log.info({ peerId, numMessages: syncIds.length }, "Peer passed audit");
+      const after = this._peerScorer.getScore(peerId)?.score ?? 0;
+      log.info({ peerId, numMessages: syncIds.length, before, after }, "Peer passed audit");
     } else {
       this._peerScorer.decrementScore(peerId, 10);
       log.warn({ peerId, numMessages: syncIds.length }, "Peer failed audit");


### PR DESCRIPTION
## Motivation

Add audits during sync to ensure that the peer is not withholding messages

## Change Summary

- During sync, make sure that the peer is not witholding messages
- Fetch known messages, checking with node's own messages 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding an audit feature for peer messages during sync in the Hubble application. 

### Detailed summary
- Added `clone()` method to `PeerScore` class
- Modified `performSync()` method in `SyncEngine` class to support audit feature
- Added `auditPeer()` method in `SyncEngine` class to perform message audit during sync

> The following files were skipped due to too many changes: `apps/hubble/src/network/sync/syncEngine.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->