### PR TITLE
fix: Use DB_SCHEMA version in snapshot path

### DIFF
--- a/.changeset/beige-drinks-prove.md
+++ b/.changeset/beige-drinks-prove.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Use DB_SCHEMA version in snapshot path

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1355,6 +1355,8 @@ export class Hub implements HubInterface {
       region: S3_REGION,
     });
 
+    // Note: We get the snapshots across all DB_SCHEMA versions
+    // when determining which snapshots to delete, we only delete snapshots from the current DB_SCHEMA version
     const params = {
       Bucket: this.s3_snapshot_bucket,
       Prefix: `snapshots/${network}/`,

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -698,8 +698,7 @@ export class Hub implements HubInterface {
           if (dbFiles.isErr() || dbFiles.value.length === 0) {
             log.info({ dbLocation }, "DB is empty, fetching snapshot from S3");
 
-            const network = FarcasterNetwork[this.options.network].toString();
-            const response = await axios.get(`https://download.farcaster.xyz/snapshots/${network}/latest.json`);
+            const response = await axios.get(`https://download.farcaster.xyz/${this.getSnapshotFolder()}/latest.json`);
             const { key } = response.data;
 
             if (!key) {
@@ -1300,6 +1299,11 @@ export class Hub implements HubInterface {
     return true;
   }
 
+  private getSnapshotFolder(): string {
+    const network = FarcasterNetwork[this.options.network].toString();
+    return `snapshots/${network}/DB_SCHEMA_${LATEST_DB_SCHEMA_VERSION}`;
+  }
+
   async uploadToS3(filePath: string): HubAsyncResult<string> {
     const network = FarcasterNetwork[this.options.network].toString();
 
@@ -1308,7 +1312,7 @@ export class Hub implements HubInterface {
     });
 
     // The AWS key is "snapshots/{network}/snapshot-{yyyy-mm-dd}-{timestamp}.tar.gz"
-    const key = `snapshots/${network}/snapshot-${new Date().toISOString().split("T")[0]}-${Math.floor(
+    const key = `${this.getSnapshotFolder()}/snapshot-${new Date().toISOString().split("T")[0]}-${Math.floor(
       Date.now() / 1000,
     )}.tar.gz`;
 
@@ -1328,7 +1332,7 @@ export class Hub implements HubInterface {
 
     const latestJsonParams = {
       Bucket: this.s3_snapshot_bucket,
-      Key: `snapshots/${network}/latest.json`,
+      Key: `${this.getSnapshotFolder()}/latest.json`,
       Body: JSON.stringify({ key, timestamp: Date.now(), serverDate: new Date().toISOString() }),
     };
 


### PR DESCRIPTION


## Change Summary

- Use DB_SCHEMA version number in snapshot path so that hubs download the snapshot image that is compatible with their code DB_SCHEMA

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Fixing an issue with the snapshot path in the Hubble application.

### Detailed summary:
- Updated the snapshot path in the Hubble application to include the DB_SCHEMA version.
- Added a new method `getSnapshotFolder()` to retrieve the snapshot folder path.
- Updated the S3 key for uploading and retrieving snapshots to include the DB_SCHEMA version.
- Added a note about deleting snapshots only from the current DB_SCHEMA version.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->