### PR TITLE
test: Fix flaky test

### DIFF
--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -36,7 +36,7 @@ import { sleepWhile } from "../../utils/crypto.js";
 import { statsd } from "../../utils/statsd.js";
 import { logger, messageToLog } from "../../utils/logger.js";
 import { OnChainEventPostfix, RootPrefix } from "../../storage/db/types.js";
-import { bytesStartsWith, fromFarcasterTime } from "@farcaster/core";
+import { bytesCompare, bytesStartsWith, fromFarcasterTime } from "@farcaster/core";
 import { L2EventsProvider } from "../../eth/l2EventsProvider.js";
 import { SyncEngineProfiler } from "./syncEngineProfiler.js";
 import os from "os";
@@ -788,7 +788,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     const anyFailed =
       ourMessagesResult.value
         .map((message) => {
-          const peerMessage = messagesResult.value.messages.find((m) => m.hash === message.hash);
+          const peerMessage = messagesResult.value.messages.find((m) => bytesCompare(m.hash, message.hash) === 0);
           if (!peerMessage) {
             log.warn({ message: messageToLog(message), peerId }, "PeerError: Peer is missing message during audit");
             return "failed";


### PR DESCRIPTION

## Change Summary

- Fix flaky test

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the sync engine in the Hubble app. It introduces a new function `bytesCompare` and uses it to compare message hashes during the audit process.

### Detailed summary
- Imported `bytesCompare` function from `@farcaster/core`
- Replaced the comparison of message hashes with `bytesCompare` in the sync engine's audit process

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->