### PR TITLE
feat: FIP-8 verifications for contract wallets

### DIFF
--- a/.changeset/orange-crabs-double.md
+++ b/.changeset/orange-crabs-double.md
@@ -1,0 +1,8 @@
+---
+"@farcaster/hub-nodejs": patch
+"@farcaster/hub-web": patch
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+FIP-8 contract verifications

--- a/apps/hubble/src/storage/engine/index.test.ts
+++ b/apps/hubble/src/storage/engine/index.test.ts
@@ -206,6 +206,69 @@ describe("mergeMessage", () => {
         // Signature will not match because we're attempting to recover the address based on the wrong network
         expect(result).toEqual(err(new HubError("bad_request.validation_failure", "invalid ethSignature")));
       });
+
+      describe("validateOrRevokeMessage", () => {
+        let mergedMessage: Message;
+        let verifications: VerificationAddEthAddressMessage[] = [];
+
+        const getVerifications = async () => {
+          const verificationsResult = await engine.getVerificationsByFid(fid);
+          if (verificationsResult.isOk()) {
+            verifications = verificationsResult.value.messages;
+          }
+        };
+
+        const createVerification = async () => {
+          return await Factories.VerificationAddEthAddressMessage.create(
+            {
+              data: {
+                fid,
+                verificationAddEthAddressBody: Factories.VerificationAddEthAddressBody.build({
+                  chainId: 1,
+                  verificationType: 1,
+                }),
+              },
+            },
+            { transient: { signer } },
+          );
+        };
+
+        beforeEach(async () => {
+          jest.replaceProperty(publicClient.chain, "id", 1);
+          jest.spyOn(publicClient, "verifyTypedData").mockResolvedValue(true);
+          mergedMessage = await createVerification();
+          const result = await engine.mergeMessage(mergedMessage);
+          expect(result.isOk()).toBeTruthy();
+          await getVerifications();
+          expect(verifications.length).toBe(1);
+        });
+
+        afterEach(async () => {
+          jest.restoreAllMocks();
+        });
+
+        test("revokes a contract verification when signature is no longer valid", async () => {
+          jest.spyOn(publicClient, "verifyTypedData").mockResolvedValue(false);
+          const result = await engine.validateOrRevokeMessage(mergedMessage);
+          expect(result.isOk()).toBeTruthy();
+
+          const verificationsResult = await engine.getVerificationsByFid(fid);
+          expect(verificationsResult.isOk()).toBeTruthy();
+
+          await getVerifications();
+          expect(verifications.length).toBe(0);
+        });
+
+        test("does not revoke contract verifications when RPC call fails", async () => {
+          jest.spyOn(publicClient, "verifyTypedData").mockRejectedValue(new Error("verify failed"));
+          const result = await engine.validateOrRevokeMessage(mergedMessage);
+          expect(result._unsafeUnwrapErr().errCode).toEqual("unavailable.network_failure");
+          expect(result._unsafeUnwrapErr().message).toMatch("verify failed");
+
+          await getVerifications();
+          expect(verifications.length).toBe(1);
+        });
+      });
     });
 
     describe("UserDataAdd", () => {

--- a/apps/hubble/src/storage/engine/index.test.ts
+++ b/apps/hubble/src/storage/engine/index.test.ts
@@ -204,9 +204,7 @@ describe("mergeMessage", () => {
         );
         const result = await engine.mergeMessage(testnetVerificationAdd);
         // Signature will not match because we're attempting to recover the address based on the wrong network
-        expect(result).toEqual(
-          err(new HubError("bad_request.validation_failure", "ethSignature does not match address")),
-        );
+        expect(result).toEqual(err(new HubError("bad_request.validation_failure", "invalid ethSignature")));
       });
     });
 

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -63,6 +63,7 @@ import { isRateLimitedByKey, consumeRateLimitByKey, getRateLimiterForTotalMessag
 import { nativeValidationMethods } from "../../rustfunctions.js";
 import { RateLimiterAbstract } from "rate-limiter-flexible";
 import { TypedEmitter } from "tiny-typed-emitter";
+import { ValidationWorkerData } from "./validation.worker.js";
 
 const log = logger.child({
   component: "Engine",
@@ -1102,7 +1103,7 @@ class Engine extends TypedEmitter<EngineEvents> {
     return ok(undefined);
   }
 
-  private getPublicClients() {
+  private getPublicClients(): { [chainId: number]: PublicClient } | undefined {
     const clients: { [chainId: number]: PublicClient } = {};
     if (this._publicClient?.chain) {
       clients[this._publicClient.chain.id] = this._publicClient;
@@ -1113,7 +1114,7 @@ class Engine extends TypedEmitter<EngineEvents> {
     return Object.keys(clients).length > 0 ? clients : undefined;
   }
 
-  private getWorkerData() {
+  private getWorkerData(): ValidationWorkerData {
     const l1Transports: string[] = [];
     this._publicClient?.transport["transports"].forEach((transport: { value?: { url: string } }) => {
       if (transport?.value) {

--- a/apps/hubble/src/storage/engine/validation.worker.ts
+++ b/apps/hubble/src/storage/engine/validation.worker.ts
@@ -1,12 +1,39 @@
 import { validations } from "@farcaster/hub-nodejs";
 import { nativeValidationMethods } from "../../rustfunctions.js";
-import { parentPort } from "worker_threads";
+import { workerData, parentPort } from "worker_threads";
+import { http, createPublicClient, fallback } from "viem";
+import { optimism, mainnet } from "viem/chains";
+
+interface WorkerData {
+  l2RpcUrl: string;
+  ethMainnetRpcUrl: string;
+}
+
+const config = workerData as WorkerData;
+const opMainnetRpcUrls = config.l2RpcUrl.split(",");
+const opTransports = opMainnetRpcUrls.map((url) => http(url, { retryCount: 2 }));
+const opClient = createPublicClient({
+  chain: optimism,
+  transport: fallback(opTransports, { rank: false }),
+});
+
+const ethMainnetRpcUrls = config.ethMainnetRpcUrl.split(",");
+const transports = ethMainnetRpcUrls.map((url) => http(url, { retryCount: 2 }));
+const mainnetClient = createPublicClient({
+  chain: mainnet,
+  transport: fallback(transports, { rank: false }),
+});
+
+const publicClients = {
+  [optimism.id]: opClient,
+  [mainnet.id]: mainnetClient,
+};
 
 // Wait for messages from the main thread and validate them, posting the result back
 parentPort?.on("message", (data) => {
   (async () => {
     const { id, message } = data;
-    const result = await validations.validateMessage(message, nativeValidationMethods);
+    const result = await validations.validateMessage(message, nativeValidationMethods, publicClients);
 
     if (result.isErr()) {
       parentPort?.postMessage({ id, errCode: result.error.errCode, errMessage: result.error.message });

--- a/apps/hubble/src/storage/engine/validation.worker.ts
+++ b/apps/hubble/src/storage/engine/validation.worker.ts
@@ -4,12 +4,12 @@ import { workerData, parentPort } from "worker_threads";
 import { http, createPublicClient, fallback } from "viem";
 import { optimism, mainnet } from "viem/chains";
 
-interface WorkerData {
+export interface ValidationWorkerData {
   l2RpcUrl: string;
   ethMainnetRpcUrl: string;
 }
 
-const config = workerData as WorkerData;
+const config = workerData as ValidationWorkerData;
 const opMainnetRpcUrls = config.l2RpcUrl.split(",");
 const opTransports = opMainnetRpcUrls.map((url) => http(url, { retryCount: 2 }));
 const opClient = createPublicClient({

--- a/apps/hubble/src/test/utils.ts
+++ b/apps/hubble/src/test/utils.ts
@@ -17,7 +17,7 @@ export const anvilChain = {
       http: [localHttpUrl],
     },
   },
-} as const satisfies Chain;
+} satisfies Chain;
 
 const provider = {
   // biome-ignore lint/suspicious/noExplicitAny: legacy code, avoid using ignore for new code

--- a/packages/core/src/crypto/eip712.ts
+++ b/packages/core/src/crypto/eip712.ts
@@ -3,6 +3,8 @@ import { ResultAsync } from "neverthrow";
 import { HubAsyncResult, HubError } from "../errors";
 import { VerificationEthAddressClaim } from "../verifications";
 import { UserNameProofClaim } from "../userNameProof";
+import { PublicClients, defaultPublicClients } from "../eth/clients";
+import { CHAIN_IDS } from "../eth/chains";
 
 export const EIP_712_FARCASTER_DOMAIN = {
   name: "Farcaster Verify Ethereum Address",
@@ -30,6 +32,8 @@ export const EIP_712_FARCASTER_VERIFICATION_CLAIM = [
   },
 ] as const;
 
+export const EIP_712_FARCASTER_VERIFICATION_CLAIM_CHAIN_IDS = [...CHAIN_IDS, 0];
+
 export const EIP_712_FARCASTER_MESSAGE_DATA = [
   {
     name: "hash",
@@ -50,11 +54,18 @@ export const EIP_712_USERNAME_PROOF = [
   { name: "owner", type: "address" },
 ] as const;
 
-export const verifyVerificationEthAddressClaimSignature = async (
+const verifyVerificationClaimEOASignature = async (
   claim: VerificationEthAddressClaim,
   signature: Uint8Array,
   address: Uint8Array,
+  chainId: number,
 ): HubAsyncResult<boolean> => {
+  if (chainId !== 0) {
+    return ResultAsync.fromPromise(
+      Promise.reject(),
+      () => new HubError("bad_request.invalid_param", "Invalid chain ID"),
+    );
+  }
   const valid = await ResultAsync.fromPromise(
     verifyTypedData({
       address: bytesToHex(address),
@@ -66,8 +77,62 @@ export const verifyVerificationEthAddressClaimSignature = async (
     }),
     (e) => new HubError("unknown", e as Error),
   );
-
   return valid;
+};
+
+const verifyVerificationClaimContractSignature = async (
+  claim: VerificationEthAddressClaim,
+  signature: Uint8Array,
+  address: Uint8Array,
+  chainId: number,
+  publicClients: PublicClients = defaultPublicClients,
+): HubAsyncResult<boolean> => {
+  const client = publicClients[chainId];
+  if (!client) {
+    return ResultAsync.fromPromise(
+      Promise.reject(),
+      () => new HubError("bad_request.invalid_param", "Invalid chain ID"),
+    );
+  }
+  const valid = await ResultAsync.fromPromise(
+    client.verifyTypedData({
+      address: bytesToHex(address),
+      domain: { ...EIP_712_FARCASTER_DOMAIN, chainId },
+      types: { VerificationClaim: EIP_712_FARCASTER_VERIFICATION_CLAIM },
+      primaryType: "VerificationClaim",
+      message: claim,
+      signature,
+    }),
+    (e) => new HubError("unknown", e as Error),
+  );
+  return valid;
+};
+
+export const verifyVerificationEthAddressClaimSignature = async (
+  claim: VerificationEthAddressClaim,
+  signature: Uint8Array,
+  address: Uint8Array,
+  verificationType: number,
+  chainId: number,
+  publicClients: PublicClients = defaultPublicClients,
+): HubAsyncResult<boolean> => {
+  if (!EIP_712_FARCASTER_VERIFICATION_CLAIM_CHAIN_IDS.includes(chainId)) {
+    return ResultAsync.fromPromise(
+      Promise.reject(),
+      () => new HubError("bad_request.invalid_param", "Invalid chain ID"),
+    );
+  }
+
+  if (verificationType === 0) {
+    return verifyVerificationClaimEOASignature(claim, signature, address, chainId);
+  } else if (verificationType === 1) {
+    return verifyVerificationClaimContractSignature(claim, signature, address, chainId, publicClients);
+  } else {
+    return ResultAsync.fromPromise(
+      Promise.reject(),
+      () => new HubError("bad_request.invalid_param", "Invalid verification type"),
+    );
+  }
 };
 
 export const verifyUserNameProofClaim = async (

--- a/packages/core/src/crypto/eip712.ts
+++ b/packages/core/src/crypto/eip712.ts
@@ -91,7 +91,7 @@ const verifyVerificationClaimContractSignature = async (
   if (!client) {
     return ResultAsync.fromPromise(
       Promise.reject(),
-      () => new HubError("bad_request.invalid_param", "Invalid chain ID"),
+      () => new HubError("bad_request.invalid_param", `RPC client not provided for chainId ${chainId}`),
     );
   }
   const valid = await ResultAsync.fromPromise(
@@ -103,7 +103,7 @@ const verifyVerificationClaimContractSignature = async (
       message: claim,
       signature,
     }),
-    (e) => new HubError("unknown", e as Error),
+    (e) => new HubError("unavailable.network_failure", e as Error),
   );
   return valid;
 };

--- a/packages/core/src/eth/chains.ts
+++ b/packages/core/src/eth/chains.ts
@@ -1,0 +1,3 @@
+import { mainnet, goerli, optimism, optimismGoerli } from "viem/chains";
+
+export const CHAIN_IDS = [mainnet.id, goerli.id, optimism.id, optimismGoerli.id] as const;

--- a/packages/core/src/eth/clients.ts
+++ b/packages/core/src/eth/clients.ts
@@ -1,0 +1,33 @@
+import { PublicClient, createPublicClient, http } from "viem";
+import { mainnet, goerli, optimism, optimismGoerli } from "viem/chains";
+
+export type PublicClients = {
+  [chainId: number]: PublicClient;
+};
+
+export const defaultL1PublicClient: PublicClient = createPublicClient({
+  chain: mainnet,
+  transport: http(),
+});
+
+export const defaultL2PublicClient: PublicClient = createPublicClient({
+  chain: optimism,
+  transport: http(),
+});
+
+export const defaultL1PublicTestClient: PublicClient = createPublicClient({
+  chain: goerli,
+  transport: http(),
+});
+
+export const defaultL2PublicTestClient: PublicClient = createPublicClient({
+  chain: optimismGoerli,
+  transport: http(),
+});
+
+export const defaultPublicClients: PublicClients = {
+  [mainnet.id]: defaultL1PublicClient,
+  [optimism.id]: defaultL2PublicClient,
+  [goerli.id]: defaultL1PublicTestClient,
+  [optimismGoerli.id]: defaultL2PublicTestClient,
+};

--- a/packages/core/src/eth/index.ts
+++ b/packages/core/src/eth/index.ts
@@ -1,0 +1,2 @@
+export * as chains from "./chains";
+export * as clients from "./clients";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export * from "./builders";
 export * from "./bytes";
 export * from "./crypto";
 export * from "./errors";
+export * from "./eth";
 export * from "./factories";
 export * from "./signers";
 export * from "./time";

--- a/packages/core/src/protobufs/generated/message.ts
+++ b/packages/core/src/protobufs/generated/message.ts
@@ -431,6 +431,10 @@ export interface VerificationAddEthAddressBody {
   ethSignature: Uint8Array;
   /** Hash of the latest Ethereum block when the signature was produced */
   blockHash: Uint8Array;
+  /** Type of verification. 0 = EOA, 1 = contract */
+  verificationType: number;
+  /** 0 for EOA verifications, 1 or 10 for contract verifications */
+  chainId: number;
 }
 
 /** Removes a Verification of any type */
@@ -1382,7 +1386,13 @@ export const ReactionBody = {
 };
 
 function createBaseVerificationAddEthAddressBody(): VerificationAddEthAddressBody {
-  return { address: new Uint8Array(), ethSignature: new Uint8Array(), blockHash: new Uint8Array() };
+  return {
+    address: new Uint8Array(),
+    ethSignature: new Uint8Array(),
+    blockHash: new Uint8Array(),
+    verificationType: 0,
+    chainId: 0,
+  };
 }
 
 export const VerificationAddEthAddressBody = {
@@ -1395,6 +1405,12 @@ export const VerificationAddEthAddressBody = {
     }
     if (message.blockHash.length !== 0) {
       writer.uint32(26).bytes(message.blockHash);
+    }
+    if (message.verificationType !== 0) {
+      writer.uint32(32).uint32(message.verificationType);
+    }
+    if (message.chainId !== 0) {
+      writer.uint32(40).uint32(message.chainId);
     }
     return writer;
   },
@@ -1427,6 +1443,20 @@ export const VerificationAddEthAddressBody = {
 
           message.blockHash = reader.bytes();
           continue;
+        case 4:
+          if (tag != 32) {
+            break;
+          }
+
+          message.verificationType = reader.uint32();
+          continue;
+        case 5:
+          if (tag != 40) {
+            break;
+          }
+
+          message.chainId = reader.uint32();
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -1441,6 +1471,8 @@ export const VerificationAddEthAddressBody = {
       address: isSet(object.address) ? bytesFromBase64(object.address) : new Uint8Array(),
       ethSignature: isSet(object.ethSignature) ? bytesFromBase64(object.ethSignature) : new Uint8Array(),
       blockHash: isSet(object.blockHash) ? bytesFromBase64(object.blockHash) : new Uint8Array(),
+      verificationType: isSet(object.verificationType) ? Number(object.verificationType) : 0,
+      chainId: isSet(object.chainId) ? Number(object.chainId) : 0,
     };
   },
 
@@ -1454,6 +1486,8 @@ export const VerificationAddEthAddressBody = {
       ));
     message.blockHash !== undefined &&
       (obj.blockHash = base64FromBytes(message.blockHash !== undefined ? message.blockHash : new Uint8Array()));
+    message.verificationType !== undefined && (obj.verificationType = Math.round(message.verificationType));
+    message.chainId !== undefined && (obj.chainId = Math.round(message.chainId));
     return obj;
   },
 
@@ -1468,6 +1502,8 @@ export const VerificationAddEthAddressBody = {
     message.address = object.address ?? new Uint8Array();
     message.ethSignature = object.ethSignature ?? new Uint8Array();
     message.blockHash = object.blockHash ?? new Uint8Array();
+    message.verificationType = object.verificationType ?? 0;
+    message.chainId = object.chainId ?? 0;
     return message;
   },
 };

--- a/packages/core/src/signers/eip712Signer.ts
+++ b/packages/core/src/signers/eip712Signer.ts
@@ -16,6 +16,9 @@ export abstract class Eip712Signer implements Signer {
    */
   public abstract getSignerKey(): HubAsyncResult<Uint8Array>;
   public abstract signMessageHash(hash: Uint8Array): HubAsyncResult<Uint8Array>;
-  public abstract signVerificationEthAddressClaim(claim: VerificationEthAddressClaim): HubAsyncResult<Uint8Array>;
+  public abstract signVerificationEthAddressClaim(
+    claim: VerificationEthAddressClaim,
+    chainId?: number,
+  ): HubAsyncResult<Uint8Array>;
   public abstract signUserNameProofClaim(claim: UserNameProofClaim): HubAsyncResult<Uint8Array>;
 }

--- a/packages/core/src/signers/ethersEip712Signer.ts
+++ b/packages/core/src/signers/ethersEip712Signer.ts
@@ -43,13 +43,13 @@ export class EthersEip712Signer extends Eip712Signer {
     return hexSignature.andThen((hex) => hexStringToBytes(hex));
   }
 
-  public async signVerificationEthAddressClaim(claim: VerificationEthAddressClaim): HubAsyncResult<Uint8Array> {
+  public async signVerificationEthAddressClaim(
+    claim: VerificationEthAddressClaim,
+    chainId = 0,
+  ): HubAsyncResult<Uint8Array> {
+    const domain = chainId === 0 ? EIP_712_FARCASTER_DOMAIN : { ...EIP_712_FARCASTER_DOMAIN, chainId };
     const hexSignature = await ResultAsync.fromPromise(
-      this._ethersSigner.signTypedData(
-        EIP_712_FARCASTER_DOMAIN,
-        { VerificationClaim: [...EIP_712_FARCASTER_VERIFICATION_CLAIM] },
-        claim,
-      ),
+      this._ethersSigner.signTypedData(domain, { VerificationClaim: [...EIP_712_FARCASTER_VERIFICATION_CLAIM] }, claim),
       (e) => new HubError("bad_request.invalid_param", e as Error),
     );
 

--- a/packages/core/src/signers/ethersV5Eip712Signer.ts
+++ b/packages/core/src/signers/ethersV5Eip712Signer.ts
@@ -39,10 +39,14 @@ export class EthersV5Eip712Signer extends Eip712Signer {
     return hexSignature.andThen((hex) => hexStringToBytes(hex));
   }
 
-  public async signVerificationEthAddressClaim(claim: VerificationEthAddressClaim): HubAsyncResult<Uint8Array> {
+  public async signVerificationEthAddressClaim(
+    claim: VerificationEthAddressClaim,
+    chainId = 0,
+  ): HubAsyncResult<Uint8Array> {
+    const domain = chainId === 0 ? eip712.EIP_712_FARCASTER_DOMAIN : { ...eip712.EIP_712_FARCASTER_DOMAIN, chainId };
     const hexSignature = await ResultAsync.fromPromise(
       this._typedDataSigner._signTypedData(
-        eip712.EIP_712_FARCASTER_DOMAIN,
+        domain,
         { VerificationClaim: [...eip712.EIP_712_FARCASTER_VERIFICATION_CLAIM] },
         claim,
       ),

--- a/packages/core/src/signers/testUtils.ts
+++ b/packages/core/src/signers/testUtils.ts
@@ -44,7 +44,7 @@ export const testEip712Signer = async (signer: Eip712Signer) => {
     });
 
     test("succeeds", async () => {
-      const valid = await eip712.verifyVerificationEthAddressClaimSignature(claim, signature, signerKey);
+      const valid = await eip712.verifyVerificationEthAddressClaimSignature(claim, signature, signerKey, 0, 0);
       expect(valid).toEqual(ok(true));
     });
 

--- a/packages/core/src/signers/viemLocalEip712Signer.ts
+++ b/packages/core/src/signers/viemLocalEip712Signer.ts
@@ -44,10 +44,14 @@ export class ViemLocalEip712Signer extends Eip712Signer {
     return hexSignature.andThen((hex) => hexStringToBytes(hex));
   }
 
-  public async signVerificationEthAddressClaim(claim: VerificationEthAddressClaim): HubAsyncResult<Uint8Array> {
+  public async signVerificationEthAddressClaim(
+    claim: VerificationEthAddressClaim,
+    chainId = 0,
+  ): HubAsyncResult<Uint8Array> {
+    const domain = chainId === 0 ? EIP_712_FARCASTER_DOMAIN : { ...EIP_712_FARCASTER_DOMAIN, chainId };
     const hexSignature = await ResultAsync.fromPromise(
       this._viemLocalAccount.signTypedData({
-        domain: EIP_712_FARCASTER_DOMAIN,
+        domain,
         types: { VerificationClaim: EIP_712_FARCASTER_VERIFICATION_CLAIM },
         primaryType: "VerificationClaim",
         message: claim,

--- a/packages/core/src/validations.test.ts
+++ b/packages/core/src/validations.test.ts
@@ -689,6 +689,14 @@ describe("validateVerificationAddEthAddressSignature", () => {
     expect(result).toEqual(err(new HubError("bad_request.invalid_param", "Invalid chain ID")));
   });
 
+  test("fails if ethSignature is > 256 bytes", async () => {
+    const body = await Factories.VerificationAddEthAddressBody.create({
+      ethSignature: Factories.Bytes.build({}, { transient: { length: 257 } }),
+    });
+    const result = await validations.validateVerificationAddEthAddressSignature(body, fid, network, {});
+    expect(result).toEqual(err(new HubError("bad_request.validation_failure", "ethSignature > 256 bytes")));
+  });
+
   test("succeeds for contract signatures", async () => {
     const body = await Factories.VerificationAddEthAddressBody.create(
       {
@@ -712,7 +720,7 @@ describe("validateVerificationAddEthAddressSignature", () => {
       { transient: { fid, network, contractSignature: true } },
     );
     const result = await validations.validateVerificationAddEthAddressSignature(body, fid, network);
-    expect(result).toEqual(err(new HubError("bad_request.invalid_param", "ethSignature does not match address")));
+    expect(result).toEqual(err(new HubError("bad_request.validation_failure", "invalid ethSignature")));
   });
 
   test("fails with eth signature from different address", async () => {
@@ -726,7 +734,7 @@ describe("validateVerificationAddEthAddressSignature", () => {
       address: Factories.EthAddress.build(),
     });
     const result = await validations.validateVerificationAddEthAddressSignature(body, fid, network);
-    expect(result).toEqual(err(new HubError("bad_request.validation_failure", "ethSignature does not match address")));
+    expect(result).toEqual(err(new HubError("bad_request.validation_failure", "invalid ethSignature")));
   });
 });
 

--- a/packages/core/src/validations.test.ts
+++ b/packages/core/src/validations.test.ts
@@ -686,14 +686,14 @@ describe("validateVerificationAddEthAddressSignature", () => {
     expect(result).toEqual(err(new HubError("bad_request.invalid_param", "Invalid chain ID")));
   });
 
-  test("fails if chainId not supported by client", async () => {
+  test("fails if client not provided for chainId", async () => {
     const body = await Factories.VerificationAddEthAddressBody.create({
       ethSignature: Factories.Bytes.build({}, { transient: { length: 1 } }),
       chainId: 1,
       verificationType: 1,
     });
     const result = await validations.validateVerificationAddEthAddressSignature(body, fid, network, {});
-    expect(result).toEqual(err(new HubError("bad_request.invalid_param", "Invalid chain ID")));
+    expect(result).toEqual(err(new HubError("bad_request.invalid_param", "RPC client not provided for chainId 1")));
   });
 
   test("fails if ethSignature is > 256 bytes", async () => {

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -254,6 +254,10 @@ export const validateVerificationAddEthAddressSignature = async (
   network: protobufs.FarcasterNetwork,
   publicClients: PublicClients = defaultPublicClients,
 ): HubAsyncResult<Uint8Array> => {
+  if (body.ethSignature.length > 256) {
+    return err(new HubError("bad_request.validation_failure", "ethSignature > 256 bytes"));
+  }
+
   const reconstructedClaim = makeVerificationEthAddressClaim(fid, body.address, network, body.blockHash);
   if (reconstructedClaim.isErr()) {
     return err(reconstructedClaim.error);
@@ -273,7 +277,7 @@ export const validateVerificationAddEthAddressSignature = async (
   }
 
   if (!verificationResult.value) {
-    return err(new HubError("bad_request.validation_failure", "ethSignature does not match address"));
+    return err(new HubError("bad_request.validation_failure", "invalid ethSignature"));
   }
 
   return ok(body.ethSignature);

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -8,6 +8,7 @@ import { getFarcasterTime, toFarcasterTime } from "./time";
 import { makeVerificationEthAddressClaim } from "./verifications";
 import { UserNameType } from "./protobufs";
 import { normalize } from "viem/ens";
+import { defaultPublicClients, PublicClients } from "./eth/clients";
 
 /** Number of seconds (10 minutes) that is appropriate for clock skew */
 export const ALLOWED_CLOCK_SKEW_SECONDS = 10 * 60;
@@ -113,13 +114,14 @@ export const validateEd25519PublicKey = (publicKey?: Uint8Array | null): HubResu
 export const validateMessage = async (
   message: protobufs.Message,
   validationMethods: ValidationMethods = pureJSValidationMethods,
+  publicClients: PublicClients = defaultPublicClients,
 ): HubAsyncResult<protobufs.Message> => {
   // 1. Check the message data
   const data = message.data;
   if (!data) {
     return err(new HubError("bad_request.validation_failure", "data is missing"));
   }
-  const validData = await validateMessageData(data);
+  const validData = await validateMessageData(data, publicClients);
   if (validData.isErr()) {
     return err(validData.error);
   }
@@ -166,7 +168,10 @@ export const validateMessage = async (
   return ok(message);
 };
 
-export const validateMessageData = async <T extends protobufs.MessageData>(data: T): HubAsyncResult<T> => {
+export const validateMessageData = async <T extends protobufs.MessageData>(
+  data: T,
+  publicClients: PublicClients = defaultPublicClients,
+): HubAsyncResult<T> => {
   // 1. Validate fid
   const validFid = validateFid(data.fid);
   if (validFid.isErr()) {
@@ -226,6 +231,7 @@ export const validateMessageData = async <T extends protobufs.MessageData>(data:
       data.verificationAddEthAddressBody,
       validFid.value,
       validNetwork.value,
+      publicClients,
     );
   } else if (validType.value === protobufs.MessageType.VERIFICATION_REMOVE && !!data.verificationRemoveBody) {
     bodyResult = validateVerificationRemoveBody(data.verificationRemoveBody);
@@ -246,6 +252,7 @@ export const validateVerificationAddEthAddressSignature = async (
   body: protobufs.VerificationAddEthAddressBody,
   fid: number,
   network: protobufs.FarcasterNetwork,
+  publicClients: PublicClients = defaultPublicClients,
 ): HubAsyncResult<Uint8Array> => {
   const reconstructedClaim = makeVerificationEthAddressClaim(fid, body.address, network, body.blockHash);
   if (reconstructedClaim.isErr()) {
@@ -256,6 +263,9 @@ export const validateVerificationAddEthAddressSignature = async (
     reconstructedClaim.value,
     body.ethSignature,
     body.address,
+    body.verificationType,
+    body.chainId,
+    publicClients,
   );
 
   if (verificationResult.isErr()) {
@@ -501,6 +511,7 @@ export const validateVerificationAddEthAddressBody = async (
   body: protobufs.VerificationAddEthAddressBody,
   fid: number,
   network: protobufs.FarcasterNetwork,
+  publicClients: PublicClients,
 ): HubAsyncResult<protobufs.VerificationAddEthAddressBody> => {
   const validAddress = validateEthAddress(body.address);
   if (validAddress.isErr()) {
@@ -512,7 +523,7 @@ export const validateVerificationAddEthAddressBody = async (
     return err(validBlockHash.error);
   }
 
-  const validSignature = await validateVerificationAddEthAddressSignature(body, fid, network);
+  const validSignature = await validateVerificationAddEthAddressSignature(body, fid, network, publicClients);
   if (validSignature.isErr()) {
     return err(validSignature.error);
   }

--- a/packages/hub-nodejs/src/generated/message.ts
+++ b/packages/hub-nodejs/src/generated/message.ts
@@ -431,6 +431,10 @@ export interface VerificationAddEthAddressBody {
   ethSignature: Uint8Array;
   /** Hash of the latest Ethereum block when the signature was produced */
   blockHash: Uint8Array;
+  /** Type of verification. 0 = EOA, 1 = contract */
+  verificationType: number;
+  /** 0 for EOA verifications, 1 or 10 for contract verifications */
+  chainId: number;
 }
 
 /** Removes a Verification of any type */
@@ -1382,7 +1386,13 @@ export const ReactionBody = {
 };
 
 function createBaseVerificationAddEthAddressBody(): VerificationAddEthAddressBody {
-  return { address: new Uint8Array(), ethSignature: new Uint8Array(), blockHash: new Uint8Array() };
+  return {
+    address: new Uint8Array(),
+    ethSignature: new Uint8Array(),
+    blockHash: new Uint8Array(),
+    verificationType: 0,
+    chainId: 0,
+  };
 }
 
 export const VerificationAddEthAddressBody = {
@@ -1395,6 +1405,12 @@ export const VerificationAddEthAddressBody = {
     }
     if (message.blockHash.length !== 0) {
       writer.uint32(26).bytes(message.blockHash);
+    }
+    if (message.verificationType !== 0) {
+      writer.uint32(32).uint32(message.verificationType);
+    }
+    if (message.chainId !== 0) {
+      writer.uint32(40).uint32(message.chainId);
     }
     return writer;
   },
@@ -1427,6 +1443,20 @@ export const VerificationAddEthAddressBody = {
 
           message.blockHash = reader.bytes();
           continue;
+        case 4:
+          if (tag != 32) {
+            break;
+          }
+
+          message.verificationType = reader.uint32();
+          continue;
+        case 5:
+          if (tag != 40) {
+            break;
+          }
+
+          message.chainId = reader.uint32();
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -1441,6 +1471,8 @@ export const VerificationAddEthAddressBody = {
       address: isSet(object.address) ? bytesFromBase64(object.address) : new Uint8Array(),
       ethSignature: isSet(object.ethSignature) ? bytesFromBase64(object.ethSignature) : new Uint8Array(),
       blockHash: isSet(object.blockHash) ? bytesFromBase64(object.blockHash) : new Uint8Array(),
+      verificationType: isSet(object.verificationType) ? Number(object.verificationType) : 0,
+      chainId: isSet(object.chainId) ? Number(object.chainId) : 0,
     };
   },
 
@@ -1454,6 +1486,8 @@ export const VerificationAddEthAddressBody = {
       ));
     message.blockHash !== undefined &&
       (obj.blockHash = base64FromBytes(message.blockHash !== undefined ? message.blockHash : new Uint8Array()));
+    message.verificationType !== undefined && (obj.verificationType = Math.round(message.verificationType));
+    message.chainId !== undefined && (obj.chainId = Math.round(message.chainId));
     return obj;
   },
 
@@ -1468,6 +1502,8 @@ export const VerificationAddEthAddressBody = {
     message.address = object.address ?? new Uint8Array();
     message.ethSignature = object.ethSignature ?? new Uint8Array();
     message.blockHash = object.blockHash ?? new Uint8Array();
+    message.verificationType = object.verificationType ?? 0;
+    message.chainId = object.chainId ?? 0;
     return message;
   },
 };

--- a/packages/hub-web/src/generated/message.ts
+++ b/packages/hub-web/src/generated/message.ts
@@ -431,6 +431,10 @@ export interface VerificationAddEthAddressBody {
   ethSignature: Uint8Array;
   /** Hash of the latest Ethereum block when the signature was produced */
   blockHash: Uint8Array;
+  /** Type of verification. 0 = EOA, 1 = contract */
+  verificationType: number;
+  /** 0 for EOA verifications, 1 or 10 for contract verifications */
+  chainId: number;
 }
 
 /** Removes a Verification of any type */
@@ -1382,7 +1386,13 @@ export const ReactionBody = {
 };
 
 function createBaseVerificationAddEthAddressBody(): VerificationAddEthAddressBody {
-  return { address: new Uint8Array(), ethSignature: new Uint8Array(), blockHash: new Uint8Array() };
+  return {
+    address: new Uint8Array(),
+    ethSignature: new Uint8Array(),
+    blockHash: new Uint8Array(),
+    verificationType: 0,
+    chainId: 0,
+  };
 }
 
 export const VerificationAddEthAddressBody = {
@@ -1395,6 +1405,12 @@ export const VerificationAddEthAddressBody = {
     }
     if (message.blockHash.length !== 0) {
       writer.uint32(26).bytes(message.blockHash);
+    }
+    if (message.verificationType !== 0) {
+      writer.uint32(32).uint32(message.verificationType);
+    }
+    if (message.chainId !== 0) {
+      writer.uint32(40).uint32(message.chainId);
     }
     return writer;
   },
@@ -1427,6 +1443,20 @@ export const VerificationAddEthAddressBody = {
 
           message.blockHash = reader.bytes();
           continue;
+        case 4:
+          if (tag != 32) {
+            break;
+          }
+
+          message.verificationType = reader.uint32();
+          continue;
+        case 5:
+          if (tag != 40) {
+            break;
+          }
+
+          message.chainId = reader.uint32();
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -1441,6 +1471,8 @@ export const VerificationAddEthAddressBody = {
       address: isSet(object.address) ? bytesFromBase64(object.address) : new Uint8Array(),
       ethSignature: isSet(object.ethSignature) ? bytesFromBase64(object.ethSignature) : new Uint8Array(),
       blockHash: isSet(object.blockHash) ? bytesFromBase64(object.blockHash) : new Uint8Array(),
+      verificationType: isSet(object.verificationType) ? Number(object.verificationType) : 0,
+      chainId: isSet(object.chainId) ? Number(object.chainId) : 0,
     };
   },
 
@@ -1454,6 +1486,8 @@ export const VerificationAddEthAddressBody = {
       ));
     message.blockHash !== undefined &&
       (obj.blockHash = base64FromBytes(message.blockHash !== undefined ? message.blockHash : new Uint8Array()));
+    message.verificationType !== undefined && (obj.verificationType = Math.round(message.verificationType));
+    message.chainId !== undefined && (obj.chainId = Math.round(message.chainId));
     return obj;
   },
 
@@ -1468,6 +1502,8 @@ export const VerificationAddEthAddressBody = {
     message.address = object.address ?? new Uint8Array();
     message.ethSignature = object.ethSignature ?? new Uint8Array();
     message.blockHash = object.blockHash ?? new Uint8Array();
+    message.verificationType = object.verificationType ?? 0;
+    message.chainId = object.chainId ?? 0;
     return message;
   },
 };

--- a/packages/hub-web/src/generated/rpc.ts
+++ b/packages/hub-web/src/generated/rpc.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { grpc } from "@improbable-eng/grpc-web";
+import grpcWeb from "@improbable-eng/grpc-web";
 import { BrowserHeaders } from "browser-headers";
 import { Observable } from "rxjs";
 import { share } from "rxjs/operators";
@@ -43,75 +43,75 @@ import { UserNameProof } from "./username_proof";
 
 export interface HubService {
   /** Submit Methods */
-  submitMessage(request: DeepPartial<Message>, metadata?: grpc.Metadata): Promise<Message>;
+  submitMessage(request: DeepPartial<Message>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
   /** Event Methods */
-  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpc.Metadata): Observable<HubEvent>;
-  getEvent(request: DeepPartial<EventRequest>, metadata?: grpc.Metadata): Promise<HubEvent>;
+  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpcWeb.grpc.Metadata): Observable<HubEvent>;
+  getEvent(request: DeepPartial<EventRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubEvent>;
   /** Casts */
-  getCast(request: DeepPartial<CastId>, metadata?: grpc.Metadata): Promise<Message>;
-  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
-  getCastsByParent(request: DeepPartial<CastsByParentRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
-  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getCast(request: DeepPartial<CastId>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
+  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getCastsByParent(request: DeepPartial<CastsByParentRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
   /** Reactions */
-  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpc.Metadata): Promise<Message>;
-  getReactionsByFid(request: DeepPartial<ReactionsByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
+  getReactionsByFid(request: DeepPartial<ReactionsByFidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
   /** To be deprecated */
   getReactionsByCast(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpc.Metadata,
+    metadata?: grpcWeb.grpc.Metadata,
   ): Promise<MessagesResponse>;
   getReactionsByTarget(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpc.Metadata,
+    metadata?: grpcWeb.grpc.Metadata,
   ): Promise<MessagesResponse>;
   /** User Data */
-  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpc.Metadata): Promise<Message>;
-  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
+  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
   /** Username Proof */
-  getUsernameProof(request: DeepPartial<UsernameProofRequest>, metadata?: grpc.Metadata): Promise<UserNameProof>;
-  getUserNameProofsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<UsernameProofsResponse>;
+  getUsernameProof(request: DeepPartial<UsernameProofRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<UserNameProof>;
+  getUserNameProofsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<UsernameProofsResponse>;
   /** Verifications */
-  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpc.Metadata): Promise<Message>;
-  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
+  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
   /** OnChain Events */
-  getOnChainSigner(request: DeepPartial<SignerRequest>, metadata?: grpc.Metadata): Promise<OnChainEvent>;
-  getOnChainSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<OnChainEventResponse>;
-  getOnChainEvents(request: DeepPartial<OnChainEventRequest>, metadata?: grpc.Metadata): Promise<OnChainEventResponse>;
-  getIdRegistryOnChainEvent(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<OnChainEvent>;
+  getOnChainSigner(request: DeepPartial<SignerRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEvent>;
+  getOnChainSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEventResponse>;
+  getOnChainEvents(request: DeepPartial<OnChainEventRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEventResponse>;
+  getIdRegistryOnChainEvent(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEvent>;
   getIdRegistryOnChainEventByAddress(
     request: DeepPartial<IdRegistryEventByAddressRequest>,
-    metadata?: grpc.Metadata,
+    metadata?: grpcWeb.grpc.Metadata,
   ): Promise<OnChainEvent>;
   getCurrentStorageLimitsByFid(
     request: DeepPartial<FidRequest>,
-    metadata?: grpc.Metadata,
+    metadata?: grpcWeb.grpc.Metadata,
   ): Promise<StorageLimitsResponse>;
-  getFids(request: DeepPartial<FidsRequest>, metadata?: grpc.Metadata): Promise<FidsResponse>;
+  getFids(request: DeepPartial<FidsRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<FidsResponse>;
   /** Links */
-  getLink(request: DeepPartial<LinkRequest>, metadata?: grpc.Metadata): Promise<Message>;
-  getLinksByFid(request: DeepPartial<LinksByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
-  getLinksByTarget(request: DeepPartial<LinksByTargetRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getLink(request: DeepPartial<LinkRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
+  getLinksByFid(request: DeepPartial<LinksByFidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getLinksByTarget(request: DeepPartial<LinksByTargetRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
   /** Bulk Methods */
-  getAllCastMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
-  getAllReactionMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getAllCastMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getAllReactionMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
   getAllVerificationMessagesByFid(
     request: DeepPartial<FidRequest>,
-    metadata?: grpc.Metadata,
+    metadata?: grpcWeb.grpc.Metadata,
   ): Promise<MessagesResponse>;
-  getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
-  getAllLinkMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getAllLinkMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
   /** Sync Methods */
-  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpc.Metadata): Promise<HubInfoResponse>;
-  getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpc.Metadata): Promise<SyncStatusResponse>;
-  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpc.Metadata): Promise<SyncIds>;
-  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubInfoResponse>;
+  getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncStatusResponse>;
+  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncIds>;
+  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
   getSyncMetadataByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpc.Metadata,
+    metadata?: grpcWeb.grpc.Metadata,
   ): Promise<TrieNodeMetadataResponse>;
   getSyncSnapshotByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpc.Metadata,
+    metadata?: grpcWeb.grpc.Metadata,
   ): Promise<TrieNodeSnapshotResponse>;
 }
 
@@ -160,99 +160,99 @@ export class HubServiceClientImpl implements HubService {
     this.getSyncSnapshotByPrefix = this.getSyncSnapshotByPrefix.bind(this);
   }
 
-  submitMessage(request: DeepPartial<Message>, metadata?: grpc.Metadata): Promise<Message> {
+  submitMessage(request: DeepPartial<Message>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceSubmitMessageDesc, Message.fromPartial(request), metadata);
   }
 
-  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpc.Metadata): Observable<HubEvent> {
+  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpcWeb.grpc.Metadata): Observable<HubEvent> {
     return this.rpc.invoke(HubServiceSubscribeDesc, SubscribeRequest.fromPartial(request), metadata);
   }
 
-  getEvent(request: DeepPartial<EventRequest>, metadata?: grpc.Metadata): Promise<HubEvent> {
+  getEvent(request: DeepPartial<EventRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubEvent> {
     return this.rpc.unary(HubServiceGetEventDesc, EventRequest.fromPartial(request), metadata);
   }
 
-  getCast(request: DeepPartial<CastId>, metadata?: grpc.Metadata): Promise<Message> {
+  getCast(request: DeepPartial<CastId>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetCastDesc, CastId.fromPartial(request), metadata);
   }
 
-  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetCastsByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getCastsByParent(request: DeepPartial<CastsByParentRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getCastsByParent(request: DeepPartial<CastsByParentRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetCastsByParentDesc, CastsByParentRequest.fromPartial(request), metadata);
   }
 
-  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetCastsByMentionDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpc.Metadata): Promise<Message> {
+  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetReactionDesc, ReactionRequest.fromPartial(request), metadata);
   }
 
-  getReactionsByFid(request: DeepPartial<ReactionsByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getReactionsByFid(request: DeepPartial<ReactionsByFidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetReactionsByFidDesc, ReactionsByFidRequest.fromPartial(request), metadata);
   }
 
   getReactionsByCast(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpc.Metadata,
+    metadata?: grpcWeb.grpc.Metadata,
   ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetReactionsByCastDesc, ReactionsByTargetRequest.fromPartial(request), metadata);
   }
 
   getReactionsByTarget(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpc.Metadata,
+    metadata?: grpcWeb.grpc.Metadata,
   ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetReactionsByTargetDesc, ReactionsByTargetRequest.fromPartial(request), metadata);
   }
 
-  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpc.Metadata): Promise<Message> {
+  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetUserDataDesc, UserDataRequest.fromPartial(request), metadata);
   }
 
-  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetUserDataByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getUsernameProof(request: DeepPartial<UsernameProofRequest>, metadata?: grpc.Metadata): Promise<UserNameProof> {
+  getUsernameProof(request: DeepPartial<UsernameProofRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<UserNameProof> {
     return this.rpc.unary(HubServiceGetUsernameProofDesc, UsernameProofRequest.fromPartial(request), metadata);
   }
 
-  getUserNameProofsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<UsernameProofsResponse> {
+  getUserNameProofsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<UsernameProofsResponse> {
     return this.rpc.unary(HubServiceGetUserNameProofsByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpc.Metadata): Promise<Message> {
+  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetVerificationDesc, VerificationRequest.fromPartial(request), metadata);
   }
 
-  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetVerificationsByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getOnChainSigner(request: DeepPartial<SignerRequest>, metadata?: grpc.Metadata): Promise<OnChainEvent> {
+  getOnChainSigner(request: DeepPartial<SignerRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEvent> {
     return this.rpc.unary(HubServiceGetOnChainSignerDesc, SignerRequest.fromPartial(request), metadata);
   }
 
-  getOnChainSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<OnChainEventResponse> {
+  getOnChainSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEventResponse> {
     return this.rpc.unary(HubServiceGetOnChainSignersByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getOnChainEvents(request: DeepPartial<OnChainEventRequest>, metadata?: grpc.Metadata): Promise<OnChainEventResponse> {
+  getOnChainEvents(request: DeepPartial<OnChainEventRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEventResponse> {
     return this.rpc.unary(HubServiceGetOnChainEventsDesc, OnChainEventRequest.fromPartial(request), metadata);
   }
 
-  getIdRegistryOnChainEvent(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<OnChainEvent> {
+  getIdRegistryOnChainEvent(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEvent> {
     return this.rpc.unary(HubServiceGetIdRegistryOnChainEventDesc, FidRequest.fromPartial(request), metadata);
   }
 
   getIdRegistryOnChainEventByAddress(
     request: DeepPartial<IdRegistryEventByAddressRequest>,
-    metadata?: grpc.Metadata,
+    metadata?: grpcWeb.grpc.Metadata,
   ): Promise<OnChainEvent> {
     return this.rpc.unary(
       HubServiceGetIdRegistryOnChainEventByAddressDesc,
@@ -263,76 +263,76 @@ export class HubServiceClientImpl implements HubService {
 
   getCurrentStorageLimitsByFid(
     request: DeepPartial<FidRequest>,
-    metadata?: grpc.Metadata,
+    metadata?: grpcWeb.grpc.Metadata,
   ): Promise<StorageLimitsResponse> {
     return this.rpc.unary(HubServiceGetCurrentStorageLimitsByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getFids(request: DeepPartial<FidsRequest>, metadata?: grpc.Metadata): Promise<FidsResponse> {
+  getFids(request: DeepPartial<FidsRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<FidsResponse> {
     return this.rpc.unary(HubServiceGetFidsDesc, FidsRequest.fromPartial(request), metadata);
   }
 
-  getLink(request: DeepPartial<LinkRequest>, metadata?: grpc.Metadata): Promise<Message> {
+  getLink(request: DeepPartial<LinkRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetLinkDesc, LinkRequest.fromPartial(request), metadata);
   }
 
-  getLinksByFid(request: DeepPartial<LinksByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getLinksByFid(request: DeepPartial<LinksByFidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetLinksByFidDesc, LinksByFidRequest.fromPartial(request), metadata);
   }
 
-  getLinksByTarget(request: DeepPartial<LinksByTargetRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getLinksByTarget(request: DeepPartial<LinksByTargetRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetLinksByTargetDesc, LinksByTargetRequest.fromPartial(request), metadata);
   }
 
-  getAllCastMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getAllCastMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllCastMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getAllReactionMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getAllReactionMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllReactionMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
   getAllVerificationMessagesByFid(
     request: DeepPartial<FidRequest>,
-    metadata?: grpc.Metadata,
+    metadata?: grpcWeb.grpc.Metadata,
   ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllVerificationMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllUserDataMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getAllLinkMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getAllLinkMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllLinkMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpc.Metadata): Promise<HubInfoResponse> {
+  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubInfoResponse> {
     return this.rpc.unary(HubServiceGetInfoDesc, HubInfoRequest.fromPartial(request), metadata);
   }
 
-  getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpc.Metadata): Promise<SyncStatusResponse> {
+  getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncStatusResponse> {
     return this.rpc.unary(HubServiceGetSyncStatusDesc, SyncStatusRequest.fromPartial(request), metadata);
   }
 
-  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpc.Metadata): Promise<SyncIds> {
+  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncIds> {
     return this.rpc.unary(HubServiceGetAllSyncIdsByPrefixDesc, TrieNodePrefix.fromPartial(request), metadata);
   }
 
-  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
+  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllMessagesBySyncIdsDesc, SyncIds.fromPartial(request), metadata);
   }
 
   getSyncMetadataByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpc.Metadata,
+    metadata?: grpcWeb.grpc.Metadata,
   ): Promise<TrieNodeMetadataResponse> {
     return this.rpc.unary(HubServiceGetSyncMetadataByPrefixDesc, TrieNodePrefix.fromPartial(request), metadata);
   }
 
   getSyncSnapshotByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpc.Metadata,
+    metadata?: grpcWeb.grpc.Metadata,
   ): Promise<TrieNodeSnapshotResponse> {
     return this.rpc.unary(HubServiceGetSyncSnapshotByPrefixDesc, TrieNodePrefix.fromPartial(request), metadata);
   }
@@ -1215,9 +1215,9 @@ export const HubServiceGetSyncSnapshotByPrefixDesc: UnaryMethodDefinitionish = {
 };
 
 export interface AdminService {
-  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty>;
-  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty>;
-  submitOnChainEvent(request: DeepPartial<OnChainEvent>, metadata?: grpc.Metadata): Promise<OnChainEvent>;
+  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty>;
+  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty>;
+  submitOnChainEvent(request: DeepPartial<OnChainEvent>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEvent>;
 }
 
 export class AdminServiceClientImpl implements AdminService {
@@ -1230,15 +1230,15 @@ export class AdminServiceClientImpl implements AdminService {
     this.submitOnChainEvent = this.submitOnChainEvent.bind(this);
   }
 
-  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty> {
+  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty> {
     return this.rpc.unary(AdminServiceRebuildSyncTrieDesc, Empty.fromPartial(request), metadata);
   }
 
-  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty> {
+  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty> {
     return this.rpc.unary(AdminServiceDeleteAllMessagesFromDbDesc, Empty.fromPartial(request), metadata);
   }
 
-  submitOnChainEvent(request: DeepPartial<OnChainEvent>, metadata?: grpc.Metadata): Promise<OnChainEvent> {
+  submitOnChainEvent(request: DeepPartial<OnChainEvent>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEvent> {
     return this.rpc.unary(AdminServiceSubmitOnChainEventDesc, OnChainEvent.fromPartial(request), metadata);
   }
 }
@@ -1314,7 +1314,7 @@ export const AdminServiceSubmitOnChainEventDesc: UnaryMethodDefinitionish = {
   } as any,
 };
 
-interface UnaryMethodDefinitionishR extends grpc.UnaryMethodDefinition<any, any> {
+interface UnaryMethodDefinitionishR extends grpcWeb.grpc.UnaryMethodDefinition<any, any> {
   requestStream: any;
   responseStream: any;
 }
@@ -1325,32 +1325,32 @@ interface Rpc {
   unary<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     request: any,
-    metadata: grpc.Metadata | undefined,
+    metadata: grpcWeb.grpc.Metadata | undefined,
   ): Promise<any>;
   invoke<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     request: any,
-    metadata: grpc.Metadata | undefined,
+    metadata: grpcWeb.grpc.Metadata | undefined,
   ): Observable<any>;
 }
 
 export class GrpcWebImpl {
   private host: string;
   private options: {
-    transport?: grpc.TransportFactory;
-    streamingTransport?: grpc.TransportFactory;
+    transport?: grpcWeb.grpc.TransportFactory;
+    streamingTransport?: grpcWeb.grpc.TransportFactory;
     debug?: boolean;
-    metadata?: grpc.Metadata;
+    metadata?: grpcWeb.grpc.Metadata;
     upStreamRetryCodes?: number[];
   };
 
   constructor(
     host: string,
     options: {
-      transport?: grpc.TransportFactory;
-      streamingTransport?: grpc.TransportFactory;
+      transport?: grpcWeb.grpc.TransportFactory;
+      streamingTransport?: grpcWeb.grpc.TransportFactory;
       debug?: boolean;
-      metadata?: grpc.Metadata;
+      metadata?: grpcWeb.grpc.Metadata;
       upStreamRetryCodes?: number[];
     },
   ) {
@@ -1361,21 +1361,21 @@ export class GrpcWebImpl {
   unary<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     _request: any,
-    metadata: grpc.Metadata | undefined,
+    metadata: grpcWeb.grpc.Metadata | undefined,
   ): Promise<any> {
     const request = { ..._request, ...methodDesc.requestType };
     const maybeCombinedMetadata = metadata && this.options.metadata
       ? new BrowserHeaders({ ...this.options?.metadata.headersMap, ...metadata?.headersMap })
       : metadata || this.options.metadata;
     return new Promise((resolve, reject) => {
-      grpc.unary(methodDesc, {
+      grpcWeb.grpc.unary(methodDesc, {
         request,
         host: this.host,
         metadata: maybeCombinedMetadata,
         transport: this.options.transport,
         debug: this.options.debug,
         onEnd: function (response) {
-          if (response.status === grpc.Code.OK) {
+          if (response.status === grpcWeb.grpc.Code.OK) {
             resolve(response.message!.toObject());
           } else {
             const err = new GrpcWebError(response.statusMessage, response.status, response.trailers);
@@ -1389,7 +1389,7 @@ export class GrpcWebImpl {
   invoke<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     _request: any,
-    metadata: grpc.Metadata | undefined,
+    metadata: grpcWeb.grpc.Metadata | undefined,
   ): Observable<any> {
     const upStreamCodes = this.options.upStreamRetryCodes || [];
     const DEFAULT_TIMEOUT_TIME: number = 3_000;
@@ -1399,14 +1399,14 @@ export class GrpcWebImpl {
       : metadata || this.options.metadata;
     return new Observable((observer) => {
       const upStream = (() => {
-        const client = grpc.invoke(methodDesc, {
+        const client = grpcWeb.grpc.invoke(methodDesc, {
           host: this.host,
           request,
           transport: this.options.streamingTransport || this.options.transport,
           metadata: maybeCombinedMetadata,
           debug: this.options.debug,
           onMessage: (next) => observer.next(next),
-          onEnd: (code: grpc.Code, message: string, trailers: grpc.Metadata) => {
+          onEnd: (code: grpcWeb.grpc.Code, message: string, trailers: grpcWeb.grpc.Metadata) => {
             if (code === 0) {
               observer.complete();
             } else if (upStreamCodes.includes(code)) {
@@ -1457,7 +1457,7 @@ type DeepPartial<T> = T extends Builtin ? T
   : Partial<T>;
 
 export class GrpcWebError extends tsProtoGlobalThis.Error {
-  constructor(message: string, public code: grpc.Code, public metadata: grpc.Metadata) {
+  constructor(message: string, public code: grpcWeb.grpc.Code, public metadata: grpcWeb.grpc.Metadata) {
     super(message);
   }
 }

--- a/protobufs/schemas/message.proto
+++ b/protobufs/schemas/message.proto
@@ -1,9 +1,9 @@
 syntax = "proto3";
 import "username_proof.proto";
 
-/** 
-  * A Message is a delta operation on the Farcaster network. The message protobuf is an envelope 
-  * that wraps a MessageData object and contains a hash and signature which can verify its authenticity. 
+/**
+  * A Message is a delta operation on the Farcaster network. The message protobuf is an envelope
+  * that wraps a MessageData object and contains a hash and signature which can verify its authenticity.
   */
 message Message {
   MessageData data = 1; // Contents of the message
@@ -14,12 +14,12 @@ message Message {
   bytes signer = 6; // Public key or address of the key pair that produced the signature
 }
 
-  /** 
- * A MessageData object contains properties common to all messages and wraps a body object which 
+  /**
+ * A MessageData object contains properties common to all messages and wraps a body object which
  * contains properties specific to the MessageType.
  */
 message MessageData {
-  MessageType type = 1; // Type of message contained in the body 
+  MessageType type = 1; // Type of message contained in the body
   uint64 fid = 2; // Farcaster ID of the user producing the message
   uint32 timestamp = 3; // Farcaster epoch timestamp in seconds
   FarcasterNetwork network = 4; // Farcaster network the message is intended for
@@ -47,7 +47,7 @@ enum HashScheme {
 enum SignatureScheme {
   SIGNATURE_SCHEME_NONE = 0;
   SIGNATURE_SCHEME_ED25519 = 1; // Ed25519 signature (default)
-  SIGNATURE_SCHEME_EIP712 = 2; // ECDSA signature using EIP-712 scheme 
+  SIGNATURE_SCHEME_EIP712 = 2; // ECDSA signature using EIP-712 scheme
 }
 
 /** Type of the MessageBody */
@@ -144,6 +144,8 @@ message VerificationAddEthAddressBody {
   bytes address = 1; // Ethereum address being verified
   bytes eth_signature = 2; // Signature produced by the user's Ethereum address
   bytes block_hash = 3; // Hash of the latest Ethereum block when the signature was produced
+  uint32 verification_type = 4; // Type of verification. 0 = EOA, 1 = contract
+  uint32 chain_id = 5; // 0 for EOA verifications, 1 or 10 for contract verifications
 }
 
 /** Removes a Verification of any type */


### PR DESCRIPTION
## Motivation

Support verifications signed by smart contracts. See [FIP-8](https://github.com/farcasterxyz/protocol/discussions/109) for more details.

## Change Summary

Update validations to verify smart contract signatures provided in verification messages using [`publicClient.verifyTypedData`](https://viem.sh/docs/actions/public/verifyTypedData.html). This function makes an RPC call to verify smart contract signatures, trying EIP-6492, EIP-1271, and ECDSA recovery in order. 

Create and pass default public clients to validation functions that may need them.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

Related protocol docs PR: https://github.com/farcasterxyz/protocol/pull/129

**Hubble**
- **Hub:** Create an Optimism `publicClient` at hub creation time.
- **Storage Engine:** Add `l2PublicClient`. Pass public clients through to validation functions.
- **Storage Engine Worker:** Pass serialized RPC config to worker thread, create and pass public clients to validation functions.

**Core**
- **New:** Add `eth/clients` and `eth/chains` modules, providing default mainnet/testnet public clients. 
- **Validations:** Pass provided or default public clients through validations to signature verifier. Validations that do not explicitly provide `PublicClients` will inherit the defaults.
- **Crypto:** Add smart contract signature verification using [`publicClient.verifyTypedData`](https://viem.sh/docs/actions/public/verifyTypedData.html). This function makes an RPC call to verify smart contract signatures, trying EIP-6492, EIP-1271, and ECDSA recovery in order. Note that we don't use this for EOA recovery to avoid making an unnecessary RPC call. Instead we call the "offline" [`verifyTypedData`](https://viem.sh/docs/utilities/verifyTypedData.html) util (i.e. the existing EOA signature verification behavior).
- **Protobufs:** Update `VerificationAddEthAddressBody` protobuf to add `chainId` and `verificationType`.
- **Signers:** Add optional `chainId` argument to `signVerificationEthAddressClaim`
- **Factories:** Add transient `contractSignature` parameter to verification factory.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding FIP-8 contract verifications to the Farcaster codebase. 

### Detailed summary
- Added FIP-8 contract verifications to the `eth` module
- Updated the `signVerificationEthAddressClaim` method in various signers to include the `chainId` parameter
- Added `defaultPublicClients` and `defaultL1PublicTestClient` to the `clients` module
- Updated the `VerificationAddEthAddressBodyFactory` in the `factories` module to include the `contractSignature` parameter
- Updated the `Hub` and `ValidationWorkerData` classes in the `hubble` module to include support for optimism chains
- Updated the `Message` and `MessageData` protobufs in the `schemas` module to include `verification_type` and `chain_id` fields

> The following files were skipped due to too many changes: `apps/hubble/src/storage/engine/index.test.ts`, `packages/hub-web/src/generated/message.ts`, `packages/hub-nodejs/src/generated/message.ts`, `packages/core/src/protobufs/generated/message.ts`, `packages/core/src/crypto/eip712.ts`, `packages/core/src/validations.ts`, `apps/hubble/src/storage/engine/index.ts`, `packages/core/src/validations.test.ts`, `packages/hub-web/src/generated/rpc.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->