### PR TITLE
feat: Globally unique verifications

### DIFF
--- a/.changeset/pink-tables-appear.md
+++ b/.changeset/pink-tables-appear.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": minor
+---
+
+feat: make verifications globally unique

--- a/apps/hubble/src/storage/db/migrations/4.uniqueVerifications.test.ts
+++ b/apps/hubble/src/storage/db/migrations/4.uniqueVerifications.test.ts
@@ -1,0 +1,97 @@
+import { performDbMigrations } from "./migrations.js";
+import { Factories, isVerificationAddEthAddressMessage } from "@farcaster/hub-nodejs";
+import { jestRocksDB } from "../jestUtils.js";
+import StoreEventHandler from "../../stores/storeEventHandler.js";
+import VerificationStore, {
+  makeVerificationAddsKey,
+  makeVerificationRemovesKey,
+} from "../../stores/verificationStore.js";
+import { VerificationAddEthAddressMessage, VerificationRemoveMessage } from "@farcaster/core";
+import RocksDB from "../rocksdb.js";
+import { makeTsHash, putMessageTransaction } from "../message.js";
+import OnChainEventStore from "../../stores/onChainEventStore.js";
+
+const db = jestRocksDB("clearEvents.migration.test");
+
+describe("uniqueVerifications migration", () => {
+  const putVerificationMessage = async (
+    db: RocksDB,
+    message: VerificationAddEthAddressMessage | VerificationRemoveMessage,
+  ) => {
+    const txn = db.transaction();
+    const tsHash = makeTsHash(message.data?.timestamp, message.hash)._unsafeUnwrap();
+    putMessageTransaction(txn, message);
+    if (isVerificationAddEthAddressMessage(message)) {
+      const addKey = makeVerificationAddsKey(message.data.fid, message.data.verificationAddEthAddressBody.address);
+      txn.put(addKey, Buffer.from(tsHash));
+    } else {
+      const removeKey = makeVerificationRemovesKey(message.data.fid, message.data.verificationRemoveBody.address);
+      txn.put(removeKey, Buffer.from(tsHash));
+    }
+    await db.commit(txn);
+  };
+
+  test("should delete duplicate verifications by address", async () => {
+    const fid = Factories.Fid.build();
+    const ethSigner = Factories.Eip712Signer.build();
+    const ethSignerKey = (await ethSigner.getSignerKey())._unsafeUnwrap();
+    const verificationAdd1 = await Factories.VerificationAddEthAddressMessage.create(
+      {
+        data: { fid, verificationAddEthAddressBody: { address: ethSignerKey } },
+      },
+      { transient: { ethSigner } },
+    );
+    const verificationAdd2 = await Factories.VerificationAddEthAddressMessage.create({
+      data: { fid },
+    });
+
+    const verificationRemove = await Factories.VerificationRemoveMessage.create({
+      data: { fid },
+    });
+    const olderVerificationAddDifferentFid = await Factories.VerificationAddEthAddressMessage.create({
+      data: {
+        ...verificationAdd1.data,
+        timestamp: verificationAdd1.data.timestamp - 100,
+        fid: fid + 1,
+      },
+    });
+    const newerVerificationAddDifferentFid = await Factories.VerificationAddEthAddressMessage.create({
+      data: {
+        ...verificationAdd2.data,
+        timestamp: verificationAdd2.data.timestamp + 2,
+        fid: olderVerificationAddDifferentFid.data.fid,
+      },
+    });
+
+    const onChainEvenStore = new OnChainEventStore(db, new StoreEventHandler(db));
+    await onChainEvenStore.mergeOnChainEvent(Factories.IdRegistryOnChainEvent.build({ fid }));
+    await onChainEvenStore.mergeOnChainEvent(
+      Factories.IdRegistryOnChainEvent.build({ fid: olderVerificationAddDifferentFid.data.fid }),
+    );
+
+    await putVerificationMessage(db, verificationAdd1);
+    await putVerificationMessage(db, verificationAdd2);
+    await putVerificationMessage(db, verificationRemove);
+    await putVerificationMessage(db, olderVerificationAddDifferentFid);
+    await putVerificationMessage(db, newerVerificationAddDifferentFid);
+
+    const store = new VerificationStore(db, new StoreEventHandler(db));
+
+    expect((await store.getAllVerificationMessagesByFid(verificationAdd1.data.fid)).messages).toHaveLength(3);
+    expect(
+      (await store.getAllVerificationMessagesByFid(olderVerificationAddDifferentFid.data.fid)).messages,
+    ).toHaveLength(2);
+
+    const success = await performDbMigrations(db, 3, 4);
+    expect(success).toBe(true);
+
+    expect((await store.getAllVerificationMessagesByFid(verificationAdd1.data.fid)).messages).toHaveLength(2);
+    expect(
+      (await store.getAllVerificationMessagesByFid(olderVerificationAddDifferentFid.data.fid)).messages,
+    ).toHaveLength(1);
+    await expect(store.getVerificationAdd(verificationAdd1.data.fid, ethSignerKey)).resolves.toEqual(verificationAdd1);
+    await expect(store.getVerificationAdd(olderVerificationAddDifferentFid.data.fid, ethSignerKey)).rejects.toThrow(
+      "NotFound",
+    );
+  });
+});

--- a/apps/hubble/src/storage/db/migrations/4.uniqueVerifications.ts
+++ b/apps/hubble/src/storage/db/migrations/4.uniqueVerifications.ts
@@ -1,0 +1,28 @@
+/**
+ Make verification addresses globally unique
+ */
+
+import { logger } from "../../../utils/logger.js";
+import RocksDB from "../rocksdb.js";
+import StoreEventHandler from "../../stores/storeEventHandler.js";
+import VerificationStore from "../../stores/verificationStore.js";
+
+const log = logger.child({ component: "UniqueVerifications" });
+
+export const uniqueVerificationsMigration = async (db: RocksDB): Promise<boolean> => {
+  log.info({}, "Starting uniqueVerifications migration");
+  const start = Date.now();
+  const verificationsStore = new VerificationStore(db, new StoreEventHandler(db));
+
+  const res = await verificationsStore.migrateVerifications();
+  if (res.isOk()) {
+    log.info(
+      { duration: Date.now() - start },
+      `Finished uniqueVerifications migration. Total: ${res.value.total}, duplicates: ${res.value.duplicates}`,
+    );
+    return true;
+  } else {
+    log.error({ errCode: res.error.errCode, err: res.error }, "Error migrating verifications");
+    return false;
+  }
+};

--- a/apps/hubble/src/storage/db/migrations/migrations.ts
+++ b/apps/hubble/src/storage/db/migrations/migrations.ts
@@ -4,6 +4,7 @@ import { logger } from "../../../utils/logger.js";
 import { usernameProofIndexMigration } from "./1.usernameproof.js";
 import { fnameProofIndexMigration } from "./2.fnameproof.js";
 import { clearEventsMigration } from "./3.clearEvents.js";
+import { uniqueVerificationsMigration } from "./4.uniqueVerifications.js";
 
 type MigrationFunctionType = (db: RocksDB) => Promise<boolean>;
 const migrations = new Map<number, MigrationFunctionType>();
@@ -21,6 +22,9 @@ migrations.set(2, async (db: RocksDB) => {
 });
 migrations.set(3, async (db: RocksDB) => {
   return await clearEventsMigration(db);
+});
+migrations.set(4, async (db: RocksDB) => {
+  return await uniqueVerificationsMigration(db);
 });
 
 // To Add a new migration

--- a/apps/hubble/src/storage/db/types.ts
+++ b/apps/hubble/src/storage/db/types.ts
@@ -72,6 +72,9 @@ export enum RootPrefix {
 
   /* Used to index fname username proofs by fid */
   FNameUserNameProofByFid = 25,
+
+  /* Used to index verifications by address */
+  VerificationByAddress = 25,
 }
 
 /**

--- a/apps/hubble/src/storage/stores/verificationStore.test.ts
+++ b/apps/hubble/src/storage/stores/verificationStore.test.ts
@@ -129,14 +129,14 @@ describe("merge", () => {
 
   const assertVerificationExists = async (message: VerificationAddEthAddressMessage | VerificationRemoveMessage) => {
     const tsHash = makeTsHash(message.data.timestamp, message.hash)._unsafeUnwrap();
-    await expect(getMessage(db, fid, UserPostfix.VerificationMessage, tsHash)).resolves.toEqual(message);
+    await expect(getMessage(db, message.data.fid, UserPostfix.VerificationMessage, tsHash)).resolves.toEqual(message);
   };
 
   const assertVerificationDoesNotExist = async (
     message: VerificationAddEthAddressMessage | VerificationRemoveMessage,
   ) => {
     const tsHash = makeTsHash(message.data.timestamp, message.hash)._unsafeUnwrap();
-    await expect(getMessage(db, fid, UserPostfix.VerificationMessage, tsHash)).rejects.toThrow(HubError);
+    await expect(getMessage(db, message.data.fid, UserPostfix.VerificationMessage, tsHash)).rejects.toThrow(HubError);
   };
 
   const assertVerificationAddWins = async (message: VerificationAddEthAddressMessage) => {
@@ -414,6 +414,57 @@ describe("merge", () => {
           [verificationRemove, [verificationAddSameTime]],
         ]);
       });
+    });
+  });
+
+  describe("with conflicting verification for different fid", () => {
+    test("message with newer timestamp is merged", async () => {
+      const verificationAddDifferentFid = await Factories.VerificationAddEthAddressMessage.create({
+        data: {
+          ...verificationAdd.data,
+          timestamp: verificationAdd.data.timestamp + 1,
+          fid: Factories.Fid.build(),
+        },
+      });
+
+      // First merge the original add
+      await expect(set.merge(verificationAdd)).resolves.toBeTruthy();
+
+      // Then merge a newer add for the same address but a different fid
+      await expect(set.merge(verificationAddDifferentFid)).resolves.toBeTruthy();
+
+      // This replaces the original verification
+      await assertVerificationDoesNotExist(verificationAdd);
+      await assertVerificationExists(verificationAddDifferentFid);
+
+      // Re-adding the older verification fails
+      await expect(set.merge(verificationAdd)).rejects.toEqual(
+        new HubError("bad_request.conflict", "message conflicts with a more recent add"),
+      );
+      // Verification remove for the old fid merges successfully, but does not impact the current verification
+      await expect(set.merge(verificationRemove)).resolves.toBeTruthy();
+      await assertVerificationExists(verificationRemove);
+      await assertVerificationExists(verificationAddDifferentFid);
+
+      expect(mergeEvents).toEqual([
+        [verificationAdd, []],
+        [verificationAddDifferentFid, [verificationAdd]],
+        [verificationRemove, []],
+      ]);
+    });
+
+    test("message with older timestamp is rejected", async () => {
+      const verificationEarlierAddDifferentFid = await Factories.VerificationAddEthAddressMessage.create({
+        data: {
+          ...verificationAdd.data,
+          timestamp: verificationAdd.data.timestamp - 100,
+          fid: Factories.Fid.build(),
+        },
+      });
+      await expect(set.merge(verificationAdd)).resolves.toBeTruthy();
+      await expect(set.merge(verificationEarlierAddDifferentFid)).rejects.toEqual(
+        new HubError("bad_request.conflict", "message conflicts with a more recent add"),
+      );
     });
   });
 });


### PR DESCRIPTION
## Motivation

https://github.com/farcasterxyz/protocol/discussions/114

Makes verification addresses unique across fids. 


## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on making verifications globally unique. 

### Detailed summary:
- Added a new migration to make verification addresses globally unique.
- Created a new migration file for unique verifications.
- Added a new function to the verification store for migrating verifications.
- Updated the verification store test to test the unique verification migration.
- Added a new function to generate a unique key for verification adds.
- Added a new function to generate a unique key for verification removes.
- Added a new function to generate a unique key for verification by address.

> The following files were skipped due to too many changes: `apps/hubble/src/storage/stores/verificationStore.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->