### PR TITLE
text: Fix flaky L2 blocks test

### DIFF
--- a/apps/hubble/src/eth/l2EventsProvider.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.ts
@@ -84,9 +84,8 @@ export class L2EventsProvider {
   private _isHandlingBlock = false;
 
   // Number of blocks to wait before processing an event. This is hardcoded to
-  // 6 for now, because that's the threshold beyond which blocks are unlikely
-  // to reorg anymore. 6 blocks represents ~72 seconds on Goerli, so the delay
-  // is not too long.
+  // 2 for now, because that's the threshold beyond which blocks are unlikely
+  // to reorg anymore. Note that these are blocks on the L2 chain, not the L1.
   static numConfirmations = 2;
 
   // Events are only processed after `numConfirmations` blocks have been confirmed; poll less


### PR DESCRIPTION


## Change Summary

- Fix the flaky test for l2 handle blocks

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on reducing the number of blocks to wait before processing an event in the `l2EventsProvider.ts` file. 

### Detailed summary
- Changed the `numConfirmations` value from 6 to 2 in `l2EventsProvider.ts`
- Updated the test case in `l2EventsProvider.test.ts` to use the new `numConfirmations` value

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->