### PR TITLE
test: Fix bytesCompare flakiness

### DIFF
--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -368,6 +368,7 @@ describe("Multi peer sync engine", () => {
     expect(await syncEngine1.trie.rootHash()).toEqual(await syncEngine2.trie.rootHash());
 
     // Now, delete the messages from engine 1
+    await engine1.getDb().clear();
     const allValues = await syncEngine1.trie.getAllValues(new Uint8Array());
     for (const value of allValues) {
       await syncEngine1.trie.deleteByBytes(value);

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -856,7 +856,7 @@ class Engine extends TypedEmitter<EngineEvents> {
     return ok(event);
   }
 
-  private async validateMessage(message: Message): HubAsyncResult<Message> {
+  async validateMessage(message: Message): HubAsyncResult<Message> {
     // 1. Ensure message data is present
     if (!message || !message.data) {
       return err(new HubError("bad_request.validation_failure", "message data is missing"));

--- a/packages/core/src/bytes.test.ts
+++ b/packages/core/src/bytes.test.ts
@@ -24,8 +24,10 @@ describe("bytesCompare", () => {
     [new Uint8Array([1, 0, 0, 1, 0]), new Uint8Array([1, 0, 0, 2, 0]), -1],
   ];
   for (const [a, b, result] of cases) {
-    test(`returns byte-wise order for two byte arrays: ${a}, ${b}`, () => {
+    test(`returns byte-wise order for two byte arrays: [${a}], [${b}]`, () => {
       expect(bytesCompare(a, b)).toEqual(result);
+      expect(bytesCompare(b, a)).toEqual(result !== 0 ? -result : result);
+      expect(bytesCompare(Buffer.from(a), Buffer.from(b))).toEqual(result);
     });
   }
 });

--- a/packages/core/src/bytes.ts
+++ b/packages/core/src/bytes.ts
@@ -3,24 +3,22 @@ import { bytesToHex, hexToBytes } from "viem";
 import { HubError, HubResult } from "./errors";
 
 export const bytesCompare = (a: Uint8Array, b: Uint8Array): number => {
-  const aValue = a[0];
-  const bValue = b[0];
+  const len = Math.min(a.length, b.length);
 
-  if (typeof aValue !== "number" && typeof bValue !== "number") {
-    return 0;
-  } else if (typeof aValue !== "number") {
-    return -1;
-  } else if (typeof bValue !== "number") {
-    return 1;
+  for (let i = 0; i < len; i++) {
+    if ((a[i] as number) < (b[i] as number)) {
+      return -1;
+    } else if ((a[i] as number) > (b[i] as number)) {
+      return 1;
+    }
   }
 
-  if (aValue < bValue) {
+  if (a.length < b.length) {
     return -1;
-  } else if (aValue > bValue) {
+  } else if (a.length > b.length) {
     return 1;
-  } else {
-    return bytesCompare(a.subarray(1), b.subarray(1));
   }
+  return 0;
 };
 
 export const bytesIncrement = (inputBytes: Uint8Array): HubResult<Uint8Array> => {


### PR DESCRIPTION
## Change Summary

- Make bytesCompare non-recursive
- Fix comparison of Messages during sync audit. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The focus of this PR is to make various changes and improvements in the codebase.
- Notable changes include:
  - Deleting messages from the engine in a test file.
  - Changing the access modifier of a function in the storage engine.
  - Adding additional test cases and improvements in the bytes module.
  - Refactoring and improving the syncEngine module.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->