### PR TITLE
chore: Release 1.6.0

### DIFF
--- a/.changeset/afraid-spies-visit.md
+++ b/.changeset/afraid-spies-visit.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: add migration to clear onchain events and force re-sync

--- a/.changeset/beige-drinks-prove.md
+++ b/.changeset/beige-drinks-prove.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Use DB_SCHEMA version in snapshot path

--- a/.changeset/dry-mayflies-raise.md
+++ b/.changeset/dry-mayflies-raise.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-chore: Upgrade ed25519-dalek in rust

--- a/.changeset/forty-cycles-cough.md
+++ b/.changeset/forty-cycles-cough.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: Add a flag to clear l2 events

--- a/.changeset/great-parents-occur.md
+++ b/.changeset/great-parents-occur.md
@@ -1,6 +1,0 @@
----
-"@farcaster/core": patch
-"@farcaster/hubble": patch
----
-
-upgrade viem to 1.12.2

--- a/.changeset/khaki-dots-cheer.md
+++ b/.changeset/khaki-dots-cheer.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fall back to eth_getLogs in event sync

--- a/.changeset/lucky-donuts-sleep.md
+++ b/.changeset/lucky-donuts-sleep.md
@@ -1,6 +1,0 @@
----
-"@farcaster/hub-web": patch
-"@farcaster/hubble": patch
----
-
-chore: Replace hub-web with HTTP api examples

--- a/.changeset/new-pears-divide.md
+++ b/.changeset/new-pears-divide.md
@@ -1,8 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
-"@farcaster/hub-web": patch
-"@farcaster/core": patch
-"@farcaster/hubble": patch
----
-
-feat: Add peer scoring

--- a/.changeset/pink-tables-appear.md
+++ b/.changeset/pink-tables-appear.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": minor
----
-
-feat: make verifications globally unique

--- a/.changeset/silent-guests-cry.md
+++ b/.changeset/silent-guests-cry.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: Audit peer's messages during sync

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @farcaster/hubble
 
+## 1.6.0
+
+### Minor Changes
+
+- 09b7949c: feat: make verifications globally unique
+
+### Patch Changes
+
+- 8abf1864: feat: add migration to clear onchain events and force re-sync
+- c64400dc: fix: Use DB_SCHEMA version in snapshot path
+- 4dea7e28: chore: Upgrade ed25519-dalek in rust
+- 472e8ae3: feat: Add a flag to clear l2 events
+- ef795c71: upgrade viem to 1.12.2
+- ef795c71: fall back to eth_getLogs in event sync
+- b7c2b0a9: chore: Replace hub-web with HTTP api examples
+- 14f67cf2: feat: Add peer scoring
+- 03cd3333: feat: Audit peer's messages during sync
+- Updated dependencies [14f67cf2]
+  - @farcaster/hub-nodejs@0.10.11
+
 ## 1.5.6
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.5.6",
+  "version": "1.6.0",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -69,7 +69,7 @@
     "@chainsafe/libp2p-gossipsub": "6.1.0",
     "@chainsafe/libp2p-noise": "^11.0.0 ",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.10.10",
+    "@farcaster/hub-nodejs": "^0.10.11",
     "@farcaster/rocksdb": "^5.5.0",
     "@fastify/cors": "^8.4.0",
     "@grpc/grpc-js": "~1.8.21",

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -80,13 +80,14 @@ export const APP_NICKNAME = process.env["HUBBLE_NAME"] ?? "Farcaster Hub";
 export const SNAPSHOT_S3_DEFAULT_BUCKET = "download.farcaster.xyz";
 export const S3_REGION = "us-east-1";
 
-export const FARCASTER_VERSION = "2023.8.23";
+export const FARCASTER_VERSION = "2023.10.4";
 export const FARCASTER_VERSIONS_SCHEDULE: VersionSchedule[] = [
   { version: "2023.3.1", expiresAt: 1682553600000 }, // expires at 4/27/23 00:00 UTC
   { version: "2023.4.19", expiresAt: 1686700800000 }, // expires at 6/14/23 00:00 UTC
   { version: "2023.5.31", expiresAt: 1690329600000 }, // expires at 7/26/23 00:00 UTC
   { version: "2023.7.12", expiresAt: 1693958400000 }, // expires at 9/6/23 00:00 UTC
   { version: "2023.8.23", expiresAt: 1697587200000 }, // expires at 10/18/23 00:00 UTC
+  { version: "2023.10.4", expiresAt: 1701216000000 }, // expires at 11/28/23 00:00 UTC
 ];
 
 export interface HubInterface {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/core
 
+## 0.12.11
+
+### Patch Changes
+
+- ef795c71: upgrade viem to 1.12.2
+- 14f67cf2: feat: Add peer scoring
+
 ## 0.12.10
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.12.10",
+  "version": "0.12.11",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -11,7 +11,9 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "license": "MIT",
   "dependencies": {
     "@noble/curves": "^1.0.0",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @farcaster/hub-nodejs
 
+## 0.10.11
+
+### Patch Changes
+
+- 14f67cf2: feat: Add peer scoring
+- Updated dependencies [ef795c71]
+- Updated dependencies [14f67cf2]
+  - @farcaster/core@0.12.11
+
 ## 0.10.10
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.10.10",
+  "version": "0.10.11",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -11,10 +11,12 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "license": "MIT",
   "dependencies": {
-    "@farcaster/core": "0.12.10",
+    "@farcaster/core": "0.12.11",
     "@grpc/grpc-js": "~1.8.21",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"

--- a/packages/hub-web/CHANGELOG.md
+++ b/packages/hub-web/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @farcaster/hub-web
 
+## 0.6.6
+
+### Patch Changes
+
+- b7c2b0a9: chore: Replace hub-web with HTTP api examples
+- 14f67cf2: feat: Add peer scoring
+- Updated dependencies [ef795c71]
+- Updated dependencies [14f67cf2]
+  - @farcaster/core@0.12.11
+
 ## 0.6.5
 
 ### Patch Changes

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-web",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -11,7 +11,9 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "license": "MIT",
   "scripts": {
     "build": "tsup --config tsup.config.ts",
@@ -27,7 +29,7 @@
     "ts-proto": "^1.146.0"
   },
   "dependencies": {
-    "@farcaster/core": "^0.12.9",
+    "@farcaster/core": "^0.12.11",
     "@improbable-eng/grpc-web": "^0.15.0",
     "rxjs": "^7.8.0"
   }


### PR DESCRIPTION
## Motivation

Release 1.6

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on upgrading dependencies and adding new features. 

### Detailed summary
- Upgraded `viem` to version 1.12.2
- Added peer scoring feature
- Updated dependencies in `hub-nodejs` package to version 0.10.11
- Updated dependencies in `hub-web` package to version 0.6.6
- Updated `@farcaster/core` package to version 0.12.11
- Updated `@farcaster/hub-nodejs` package to version 0.10.11
- Updated `@farcaster/hub-web` package to version 0.6.6
- Upgraded `ed25519-dalek` in Rust
- Added migration to clear onchain events and force re-sync
- Fixed snapshot path to use DB_SCHEMA version
- Added a flag to clear L2 events
- Fall back to `eth_getLogs` in event sync
- Replaced `hub-web` with HTTP API examples
- Audited peer's messages during sync
- Updated `@farcaster/hub-nodejs` dependency in `hubble` app to version 0.10.11
- Updated `@farcaster/core` dependency in `hubble` app to version 0.12.11
- Updated `FARCASTER_VERSION` in `hubble.ts` to "2023.10.4"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->