### PR TITLE
fix: Handle potentially missed cached events

### DIFF
--- a/apps/hubble/src/eth/l2EventsProvider.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.ts
@@ -504,7 +504,8 @@ export class L2EventsProvider {
 
     const hubState = await this._hub.getHubState();
     if (hubState.isOk() && hubState.value.lastL2Block) {
-      lastSyncedBlock = hubState.value.lastL2Block;
+      // Look back 2 blocks just in case hub was shut down before it received enough confirmations to persist the cached events
+      lastSyncedBlock = hubState.value.lastL2Block - L2EventsProvider.numConfirmations;
     }
 
     if (this._resyncEvents) {


### PR DESCRIPTION
## Motivation

lastSyncedBlock needs to account for numConfirmations because it's possible for the hub to lose the cached events on restart.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- The code is modified to look back 2 blocks when setting the `lastSyncedBlock` variable in the `eth/l2EventsProvider.ts` file.
- This change is made as a precaution in case the hub was shut down before receiving enough confirmations to persist the cached events.
- The `L2EventsProvider.numConfirmations` value is subtracted from `lastL2Block` to determine the new `lastSyncedBlock` value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->