### PR TITLE
docs: Linter now checks rpc.proto to ensure HTTP APIs

### DIFF
--- a/.changeset/tidy-dolphins-repeat.md
+++ b/.changeset/tidy-dolphins-repeat.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+docs: Linter now checks the rpc.proto to make sure all methods and implemented in HTTP API

--- a/apps/hubble/src/rpc/httpServer.ts
+++ b/apps/hubble/src/rpc/httpServer.ts
@@ -1,4 +1,5 @@
 import {
+  FidsResponse,
   HubError,
   HubEvent,
   HubInfoResponse,
@@ -430,6 +431,15 @@ export class HttpAPIServer {
       },
     );
 
+    //=================FIDs=================
+    // @doc-tag: /fids
+    this.app.get<{ Querystring: QueryPageParams }>("/v1/fids", (request, reply) => {
+      const pageOptions = getPageOptions(request.query);
+
+      const call = getCallObject("getFids", pageOptions, request);
+      this.grpcImpl.getFids(call, handleResponse(reply, FidsResponse));
+    });
+
     //=================Storage API================
     // @doc-tag: /storageLimitsByFid?fid=...
     this.app.get<{ Querystring: { fid: string } }>("/v1/storageLimitsByFid", (request, reply) => {
@@ -450,8 +460,8 @@ export class HttpAPIServer {
       this.grpcImpl.getUsernameProof(call, handleResponse(reply, UserNameProof));
     });
 
-    // @doc-tag: /usernameproofsByFid?fid=...
-    this.app.get<{ Querystring: { fid: string } }>("/v1/usernameproofsByFid", (request, reply) => {
+    // @doc-tag: /userNameProofsByFid?fid=...
+    this.app.get<{ Querystring: { fid: string } }>("/v1/userNameProofsByFid", (request, reply) => {
       const { fid } = request.query;
 
       const call = getCallObject("getUserNameProofsByFid", { fid: parseInt(fid) }, request);

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -5,7 +5,6 @@ import {
   DbStats,
   FidsResponse,
   getServer,
-  HubAsyncResult,
   HubError,
   HubEvent,
   HubEventType,
@@ -342,11 +341,11 @@ export default class Server {
     this.subscribeIpLimiter.clear();
   }
 
-  getImpl = (): HubServiceServer => {
+  getImpl(): HubServiceServer {
     return this.impl;
-  };
+  }
 
-  makeImpl = (): HubServiceServer => {
+  makeImpl(): HubServiceServer {
     return {
       getInfo: (call, callback) => {
         (async () => {
@@ -1244,5 +1243,5 @@ export default class Server {
         }
       },
     };
-  };
+  }
 }

--- a/apps/hubble/src/rpc/test/httpServer.test.ts
+++ b/apps/hubble/src/rpc/test/httpServer.test.ts
@@ -251,6 +251,17 @@ describe("httpServer", () => {
     });
   });
 
+  describe("FID APIs", () => {
+    test("fid", async () => {
+      // Get a http client for port 2181
+      const url = getFullUrl("/v1/fids");
+      const response = await axiosGet(url);
+
+      expect(response.status).toBe(200);
+      expect(response.data.fids).toEqual([fid]);
+    });
+  });
+
   describe("cast APIs", () => {
     let castAdd: CastAddMessage;
 
@@ -595,7 +606,7 @@ describe("httpServer", () => {
       expect(response.data).toEqual((protoToJSON(proof, Message) as UsernameProofMessage).data.usernameProofBody);
 
       // Get via fid
-      const url2 = getFullUrl(`/v1/usernameproofsByFid?fid=${fid}`);
+      const url2 = getFullUrl(`/v1/userNameProofsByFid?fid=${fid}`);
       const response2 = await axiosGet(url2);
 
       expect(response2.status).toBe(200);

--- a/apps/hubble/www/docs/.vitepress/config.ts
+++ b/apps/hubble/www/docs/.vitepress/config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
               { text: "Reactions API", link: "/docs/httpapi/reactions" },
               { text: "Links API", link: "/docs/httpapi/links" },
               { text: "UserData API", link: "/docs/httpapi/userdata" },
+              { text: "FIDS API", link: "/docs/httpapi/fids" },
               { text: "Storage API", link: "/docs/httpapi/storagelimits" },
               { text: "Username Proofs API", link: "/docs/httpapi/usernameproof" },
               { text: "Verifications API", link: "/docs/httpapi/verification" },

--- a/apps/hubble/www/docs/docs/httpapi/fids.md
+++ b/apps/hubble/www/docs/docs/httpapi/fids.md
@@ -1,0 +1,25 @@
+# FIDs API
+
+
+## fids
+Get a list of all the FIDs
+
+**Query Parameters**
+| Parameter | Description | Example |
+| --------- | ----------- | ------- |
+|  | This endpoint accepts no parameters |  |
+
+
+**Example**
+```bash
+curl http://127.0.0.1:2281/v1/fids
+```
+
+
+**Response**
+```json
+{
+  "fids": [1, 2, 3, 4, 5, 6],
+  "nextPageToken": "AAAnEA=="
+}
+```

--- a/apps/hubble/www/docs/docs/httpapi/usernameproof.md
+++ b/apps/hubble/www/docs/docs/httpapi/usernameproof.md
@@ -30,7 +30,7 @@ curl http://127.0.0.1:2281/v1/userNameProofByName?name=adityapk
 ```
 
 
-## usernameproofsByFid
+## userNameProofsByFid
 Get a list of proofs provided by an FID
 
 **Query Parameters**
@@ -41,7 +41,7 @@ Get a list of proofs provided by an FID
 
 **Example**
 ```bash
-curl http://127.0.0.1:2281/v1/usernameproofsByFid?fid=2
+curl http://127.0.0.1:2281/v1/userNameProofsByFid?fid=2
 ```
 
 

--- a/protobufs/schemas/rpc.proto
+++ b/protobufs/schemas/rpc.proto
@@ -6,66 +6,101 @@ import "request_response.proto";
 import "username_proof.proto";
 import "onchain_event.proto";
 
+// Note about http-api annotations:
+// The `httpServer.ts` class implements a HTTP API wrapper on top of this gRPC API.
+// The annotations below are used to verify that all the HTTP API endpoints are implemented.
+// If you are adding a new RPC method, if there needs to be a corresponding HTTP API endpoint, 
+// add the annotation to the method. @http-api: none means that there is no corresponding HTTP API
+// If there is no annotation, we assume there is a corresponding HTTP API endpoint with the same name as the RPC method
+// Please see `httpServer.ts` for more details
+
 service HubService {
   // Submit Methods
   rpc SubmitMessage(Message) returns (Message);
 
   // Event Methods
+  // @http-api: none
   rpc Subscribe(SubscribeRequest) returns (stream HubEvent);
+  // @http-api: events
   rpc GetEvent(EventRequest) returns (HubEvent);
 
   // Casts
+  // @http-api: castById
   rpc GetCast(CastId) returns (Message);
   rpc GetCastsByFid(FidRequest) returns (MessagesResponse);
   rpc GetCastsByParent(CastsByParentRequest) returns (MessagesResponse);
   rpc GetCastsByMention(FidRequest) returns (MessagesResponse);
 
   // Reactions
+  // @http-api: reactionById
   rpc GetReaction(ReactionRequest) returns (Message);
   rpc GetReactionsByFid(ReactionsByFidRequest) returns (MessagesResponse);
   rpc GetReactionsByCast(ReactionsByTargetRequest) returns (MessagesResponse); // To be deprecated
   rpc GetReactionsByTarget(ReactionsByTargetRequest) returns (MessagesResponse);
 
   // User Data
+  // @http-api: none
   rpc GetUserData(UserDataRequest) returns (Message);
   rpc GetUserDataByFid(FidRequest) returns (MessagesResponse);
 
   // Username Proof
+  // @http-api: userNameProofByName
   rpc GetUsernameProof(UsernameProofRequest) returns (UserNameProof);
   rpc GetUserNameProofsByFid(FidRequest) returns (UsernameProofsResponse);
 
   // Verifications
+  // @http-api: none
   rpc GetVerification(VerificationRequest) returns (Message);
   rpc GetVerificationsByFid(FidRequest) returns (MessagesResponse);
 
   // OnChain Events
+  // @http-api: none
   rpc GetOnChainSigner(SignerRequest) returns (OnChainEvent);
   rpc GetOnChainSignersByFid(FidRequest) returns (OnChainEventResponse);
+  // @http-api: none
   rpc GetOnChainEvents(OnChainEventRequest) returns (OnChainEventResponse);
+  // @http-api: none
   rpc GetIdRegistryOnChainEvent(FidRequest) returns (OnChainEvent);
+  // @http-api: onChainIdRegistryEventByAddress
   rpc GetIdRegistryOnChainEventByAddress(IdRegistryEventByAddressRequest) returns (OnChainEvent);
+  // @http-api: storageLimitsByFid
   rpc GetCurrentStorageLimitsByFid(FidRequest) returns (StorageLimitsResponse);
 
   rpc GetFids(FidsRequest) returns (FidsResponse);
 
   // Links
+  // @http-api: linkById
   rpc GetLink(LinkRequest) returns (Message);
   rpc GetLinksByFid(LinksByFidRequest) returns (MessagesResponse);
+  // @http-api: linksByTargetFid
   rpc GetLinksByTarget(LinksByTargetRequest) returns (MessagesResponse);
 
   // Bulk Methods
+  // The Bulk methods don't have corresponding HTTP API endpoints because the 
+  // regular endpoints can be used to get all the messages
+  // @http-api: none
   rpc GetAllCastMessagesByFid(FidRequest) returns (MessagesResponse);
+  // @http-api: none
   rpc GetAllReactionMessagesByFid(FidRequest) returns (MessagesResponse);
+  // @http-api: none
   rpc GetAllVerificationMessagesByFid(FidRequest) returns (MessagesResponse);
+  // @http-api: none
   rpc GetAllUserDataMessagesByFid(FidRequest) returns (MessagesResponse);
+  // @http-api: none
   rpc GetAllLinkMessagesByFid(FidRequest) returns (MessagesResponse);
 
-  // Sync Methods
+  // Sync Methods  
+  // Outside the "info" RPC, the HTTP API doesn't implement any of the sync methods
   rpc GetInfo(HubInfoRequest) returns (HubInfoResponse);
+  // @http-api: none
   rpc GetSyncStatus(SyncStatusRequest) returns (SyncStatusResponse);
+  // @http-api: none
   rpc GetAllSyncIdsByPrefix(TrieNodePrefix) returns (SyncIds);
+  // @http-api: none
   rpc GetAllMessagesBySyncIds(SyncIds) returns (MessagesResponse);
+  // @http-api: none
   rpc GetSyncMetadataByPrefix(TrieNodePrefix) returns (TrieNodeMetadataResponse);
+  // @http-api: none
   rpc GetSyncSnapshotByPrefix(TrieNodePrefix) returns (TrieNodeSnapshotResponse);
 }
 


### PR DESCRIPTION


## Change Summary

- Ensure all rpc.proto methods (i.e., grpc methods) have corresponding HTTP API implementations

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding and updating HTTP API endpoints in the Hubble application.

### Detailed summary:
- Added a new HTTP API endpoint for retrieving a list of all FIDs.
- Renamed the `usernameproofsByFid` HTTP API endpoint to `userNameProofsByFid`.
- Updated the documentation to reflect the changes in the HTTP API endpoints.
- Added annotations in the `rpc.proto` file to indicate which RPC methods have corresponding HTTP API endpoints.
- Added a script to check if all RPC methods in the `rpc.proto` file have corresponding HTTP API endpoints in the `httpServer.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->