### PR TITLE
fix: Improve logging on unhandled errors

### DIFF
--- a/.changeset/five-olives-drum.md
+++ b/.changeset/five-olives-drum.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Improve logging on unhandled errors

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Logs
 yarn-debug.log*
 yarn-error.log*
+hub.log
 
 .DS_Store
 **/.DS_Store

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -631,15 +631,13 @@ app
     });
 
     process.on("uncaughtException", (err) => {
-      logger.error({ reason: "Uncaught exception" }, "shutting down hub");
-      logger.fatal(err);
+      logger.error({ reason: "Uncaught exception", err }, "shutting down hub");
 
       handleShutdownSignal("uncaughtException");
     });
 
     process.on("unhandledRejection", (err) => {
-      logger.error({ reason: "Unhandled Rejection" }, "shutting down hub");
-      logger.fatal(err);
+      logger.error({ reason: "Unhandled Rejection", err }, "shutting down hub");
 
       handleShutdownSignal("unhandledRejection");
     });
@@ -822,35 +820,6 @@ app
 
     logger.info({ rocksDBName }, "Database cleared.");
     exit(0);
-  });
-
-/*//////////////////////////////////////////////////////////////
-                          EVENTSRESET COMMAND
-//////////////////////////////////////////////////////////////*/
-
-app
-  .command("events-reset")
-  .description("Clear L2 contract events from the database")
-  .option("--db-name <name>", "The name of the RocksDB instance")
-  .option("-c, --config <filepath>", "Path to a config file with options")
-  .action(async (cliOptions) => {
-    const hubConfig = cliOptions.config ? (await import(resolve(cliOptions.config))).Config : DefaultConfig;
-    const rocksDBName = cliOptions.dbName ?? hubConfig.dbName ?? "";
-
-    if (!rocksDBName) throw new Error("No RocksDB name provided.");
-
-    const rocksDB = new RocksDB(rocksDBName);
-
-    const dbResult = await ResultAsync.fromPromise(rocksDB.open(), (e) => e as Error);
-    if (dbResult.isErr()) {
-      logger.warn({ rocksDBName }, "Failed to open RocksDB");
-      exit(1);
-    } else {
-      const count = await OnChainEventStore.clearEvents(rocksDB);
-      await rocksDB.close();
-      logger.info({ rocksDBName, count }, "Events cleared");
-      exit(0);
-    }
   });
 
 /*//////////////////////////////////////////////////////////////

--- a/apps/hubble/www/docs/docs/cli.md
+++ b/apps/hubble/www/docs/docs/cli.md
@@ -6,9 +6,8 @@ Documentation for the Hubble CLI.
 2. `identity` - generate or validate hub identities
 3. `status` - status reports on sync, storage and other systems.
 4. `dbreset` - clear the database. 
-4. `events-reset` - clear l2 events data from the db. 
-4. `profile` - profile the storage usage of the db. 
-5. `console` - start an interactive repl console for debugging.
+5. `profile` - profile the storage usage of the db.
+6. `console` - start an interactive repl console for debugging.
 
 Commands must invoked with yarn by running: 
 
@@ -124,19 +123,6 @@ Commands:
 Usage: yarn dbreset [options]
 
 Completely remove the database
-
-Options:
-  --db-name <name>         The name of the RocksDB instance
-  -c, --config <filepath>  Path to a config file with options
-  -h, --help               display help for command
-```
-
-### events-reset
-
-```
-Usage: yarn events-reset [options]
-
-Clears all data about L2 events from the database.
 
 Options:
   --db-name <name>         The name of the RocksDB instance


### PR DESCRIPTION
## Motivation

https://github.com/farcasterxyz/hub-monorepo/issues/1393.

For some reason, the logger.fatal is not capturing the error. So add it to logger.error and remove the fatal.

Also deleted events-reset since we have an `--l2-clear-events` flag now.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving logging on unhandled errors in the Hubble application. 

### Detailed summary
- Added `hub.log` to `.gitignore`
- Updated the CLI documentation to reflect changes in command numbering
- Updated error logging in `cli.ts` to include the error object
- Removed the `events-reset` command from the CLI

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->