### PR TITLE
[feat]: Enable events sync by default

### DIFF
--- a/.changeset/thirty-seals-laugh.md
+++ b/.changeset/thirty-seals-laugh.md
@@ -1,0 +1,8 @@
+---
+"@farcaster/hub-nodejs": patch
+"@farcaster/hub-web": patch
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+feat: Enable events sync by default

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -855,7 +855,7 @@ export class Hub implements HubInterface {
     const result = await ResultAsync.fromPromise(getHubState(this.rocksDB), (e) => e as HubError);
     if (result.isErr() && result.error.errCode === "not_found") {
       log.info("hub state not found, resetting state");
-      const hubState = HubState.create({ lastEthBlock: 0, lastFnameProof: 0, syncEvents: false });
+      const hubState = HubState.create({ lastL2Block: 0, lastFnameProof: 0 });
       await putHubState(this.rocksDB, hubState);
       return ok(hubState);
     }

--- a/apps/hubble/src/network/sync/merkleTrie.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.ts
@@ -211,7 +211,7 @@ class MerkleTrie {
     return this.callMethod("initialize");
   }
 
-  public async rebuild(eventsEnabled = false): Promise<void> {
+  public async rebuild(): Promise<void> {
     // First, delete the root node
     const dbStatus = await ResultAsync.fromPromise(
       this._db.del(TrieNode.makePrimaryKey(new Uint8Array())),
@@ -250,9 +250,6 @@ class MerkleTrie {
       1 * 60 * 60 * 1000,
     );
     log.info({ count }, "Rebuilt messages trie");
-    if (!eventsEnabled) {
-      return;
-    }
     // On chain events
     await this._db.forEachIteratorByPrefix(
       Buffer.from([RootPrefix.OnChainEvent]),

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -132,7 +132,6 @@ describe("Multi peer sync engine", () => {
     hub1 = new MockHub(testDb1, engine1);
     syncEngine1 = new SyncEngine(hub1, testDb1);
     await syncEngine1.start();
-    await syncEngine1.enableEventsSync();
     server1 = new Server(hub1, engine1, syncEngine1);
     port1 = await server1.start();
     clientForServer1 = getInsecureHubRpcClient(`127.0.0.1:${port1}`);
@@ -395,7 +394,6 @@ describe("Multi peer sync engine", () => {
     await engine1.mergeOnChainEvent(storageEvent);
 
     // Engine2 has 2 messages
-    await syncEngine2.enableEventsSync();
     await engine2.mergeOnChainEvent(custodyEvent);
     await engine2.mergeOnChainEvent(signerEvent);
     await engine2.mergeOnChainEvent(storageEvent);
@@ -458,7 +456,6 @@ describe("Multi peer sync engine", () => {
   });
 
   test("recovers if there are missing messages in the engine", async () => {
-    await syncEngine2.enableEventsSync();
     // Add a message to engine1 synctrie, but not to the engine itself.
     await syncEngine1.trie.insert(SyncId.fromMessage(castAdd));
 
@@ -479,7 +476,6 @@ describe("Multi peer sync engine", () => {
   });
 
   test("recovers if there are missing messages in the engine during sync", async () => {
-    await syncEngine2.enableEventsSync();
     await engine2.mergeOnChainEvent(custodyEvent);
     await engine1.mergeOnChainEvent(custodyEvent);
 
@@ -525,7 +521,6 @@ describe("Multi peer sync engine", () => {
     await engine1.mergeUserNameProof(fname);
 
     // We add it to the engine2 synctrie as normal...
-    await syncEngine2.enableEventsSync();
     await engine2.mergeOnChainEvent(custodyEvent);
     await engine2.mergeOnChainEvent(signerEvent);
     await engine2.mergeOnChainEvent(storageEvent);
@@ -560,7 +555,6 @@ describe("Multi peer sync engine", () => {
   });
 
   test("syncEngine syncs with same numMessages but different hashes", async () => {
-    await syncEngine2.enableEventsSync();
     await engine1.mergeOnChainEvent(custodyEvent);
     await engine1.mergeOnChainEvent(signerEvent);
     await engine1.mergeOnChainEvent(storageEvent);
@@ -607,7 +601,6 @@ describe("Multi peer sync engine", () => {
   });
 
   test("syncEngine syncs with more numMessages and different hashes", async () => {
-    await syncEngine2.enableEventsSync();
     await engine1.mergeOnChainEvent(custodyEvent);
     await engine1.mergeOnChainEvent(signerEvent);
     await engine1.mergeOnChainEvent(storageEvent);

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -367,7 +367,7 @@ export default class Server {
           if (call.request.dbStats && this.syncEngine) {
             const stats = await this.syncEngine.getDbStats();
             info.dbStats = DbStats.create({
-              numMessages: stats?.numMessages,
+              numMessages: stats?.numItems,
               numFidEvents: stats?.numFids,
               numFnameEvents: stats?.numFnames,
             });

--- a/apps/hubble/src/rpc/test/syncService.test.ts
+++ b/apps/hubble/src/rpc/test/syncService.test.ts
@@ -72,7 +72,7 @@ describe("getInfo", () => {
 
     const result = await client.getInfo(HubInfoRequest.create({ dbStats: true }));
     expect(result.isOk()).toBeTruthy();
-    expect(result._unsafeUnwrap().dbStats?.numMessages).toEqual(2);
+    expect(result._unsafeUnwrap().dbStats?.numMessages).toEqual(5); // Currently returns all items in the trie (3 events + 2 messages)
     expect(result._unsafeUnwrap().dbStats?.numFidEvents).toEqual(1);
     expect(result._unsafeUnwrap().dbStats?.numFnameEvents).toEqual(0);
   });

--- a/apps/hubble/src/test/mocks.ts
+++ b/apps/hubble/src/test/mocks.ts
@@ -53,7 +53,7 @@ export class MockHub implements HubInterface {
   async getHubState(): HubAsyncResult<HubState> {
     const result = await ResultAsync.fromPromise(getHubState(this.db), (e) => e as HubError);
     if (result.isErr() && result.error.errCode === "not_found") {
-      const hubState = HubState.create({ lastEthBlock: 0, lastFnameProof: 0 });
+      const hubState = HubState.create({ lastL2Block: 0, lastFnameProof: 0 });
       await putHubState(this.db, hubState);
       return ok(hubState);
     }

--- a/packages/core/src/protobufs/generated/hub_state.ts
+++ b/packages/core/src/protobufs/generated/hub_state.ts
@@ -3,29 +3,23 @@ import Long from "long";
 import _m0 from "protobufjs/minimal";
 
 export interface HubState {
-  lastEthBlock: number;
+  /** uint32 last_eth_block = 1; // Deprecated */
   lastFnameProof: number;
+  /** bool syncEvents = 4; // Deprecated */
   lastL2Block: number;
-  syncEvents: boolean;
 }
 
 function createBaseHubState(): HubState {
-  return { lastEthBlock: 0, lastFnameProof: 0, lastL2Block: 0, syncEvents: false };
+  return { lastFnameProof: 0, lastL2Block: 0 };
 }
 
 export const HubState = {
   encode(message: HubState, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.lastEthBlock !== 0) {
-      writer.uint32(8).uint32(message.lastEthBlock);
-    }
     if (message.lastFnameProof !== 0) {
       writer.uint32(16).uint64(message.lastFnameProof);
     }
     if (message.lastL2Block !== 0) {
       writer.uint32(24).uint64(message.lastL2Block);
-    }
-    if (message.syncEvents === true) {
-      writer.uint32(32).bool(message.syncEvents);
     }
     return writer;
   },
@@ -37,13 +31,6 @@ export const HubState = {
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
-        case 1:
-          if (tag != 8) {
-            break;
-          }
-
-          message.lastEthBlock = reader.uint32();
-          continue;
         case 2:
           if (tag != 16) {
             break;
@@ -58,13 +45,6 @@ export const HubState = {
 
           message.lastL2Block = longToNumber(reader.uint64() as Long);
           continue;
-        case 4:
-          if (tag != 32) {
-            break;
-          }
-
-          message.syncEvents = reader.bool();
-          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -76,19 +56,15 @@ export const HubState = {
 
   fromJSON(object: any): HubState {
     return {
-      lastEthBlock: isSet(object.lastEthBlock) ? Number(object.lastEthBlock) : 0,
       lastFnameProof: isSet(object.lastFnameProof) ? Number(object.lastFnameProof) : 0,
       lastL2Block: isSet(object.lastL2Block) ? Number(object.lastL2Block) : 0,
-      syncEvents: isSet(object.syncEvents) ? Boolean(object.syncEvents) : false,
     };
   },
 
   toJSON(message: HubState): unknown {
     const obj: any = {};
-    message.lastEthBlock !== undefined && (obj.lastEthBlock = Math.round(message.lastEthBlock));
     message.lastFnameProof !== undefined && (obj.lastFnameProof = Math.round(message.lastFnameProof));
     message.lastL2Block !== undefined && (obj.lastL2Block = Math.round(message.lastL2Block));
-    message.syncEvents !== undefined && (obj.syncEvents = message.syncEvents);
     return obj;
   },
 
@@ -98,10 +74,8 @@ export const HubState = {
 
   fromPartial<I extends Exact<DeepPartial<HubState>, I>>(object: I): HubState {
     const message = createBaseHubState();
-    message.lastEthBlock = object.lastEthBlock ?? 0;
     message.lastFnameProof = object.lastFnameProof ?? 0;
     message.lastL2Block = object.lastL2Block ?? 0;
-    message.syncEvents = object.syncEvents ?? false;
     return message;
   },
 };

--- a/packages/hub-nodejs/src/generated/rpc.ts
+++ b/packages/hub-nodejs/src/generated/rpc.ts
@@ -63,7 +63,10 @@ export const HubServiceService = {
     responseSerialize: (value: Message) => Buffer.from(Message.encode(value).finish()),
     responseDeserialize: (value: Buffer) => Message.decode(value),
   },
-  /** Event Methods */
+  /**
+   * Event Methods
+   * @http-api: none
+   */
   subscribe: {
     path: "/HubService/Subscribe",
     requestStream: false,
@@ -73,6 +76,7 @@ export const HubServiceService = {
     responseSerialize: (value: HubEvent) => Buffer.from(HubEvent.encode(value).finish()),
     responseDeserialize: (value: Buffer) => HubEvent.decode(value),
   },
+  /** @http-api: events */
   getEvent: {
     path: "/HubService/GetEvent",
     requestStream: false,
@@ -82,7 +86,10 @@ export const HubServiceService = {
     responseSerialize: (value: HubEvent) => Buffer.from(HubEvent.encode(value).finish()),
     responseDeserialize: (value: Buffer) => HubEvent.decode(value),
   },
-  /** Casts */
+  /**
+   * Casts
+   * @http-api: castById
+   */
   getCast: {
     path: "/HubService/GetCast",
     requestStream: false,
@@ -119,7 +126,10 @@ export const HubServiceService = {
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
-  /** Reactions */
+  /**
+   * Reactions
+   * @http-api: reactionById
+   */
   getReaction: {
     path: "/HubService/GetReaction",
     requestStream: false,
@@ -157,7 +167,10 @@ export const HubServiceService = {
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
-  /** User Data */
+  /**
+   * User Data
+   * @http-api: none
+   */
   getUserData: {
     path: "/HubService/GetUserData",
     requestStream: false,
@@ -176,7 +189,10 @@ export const HubServiceService = {
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
-  /** Username Proof */
+  /**
+   * Username Proof
+   * @http-api: userNameProofByName
+   */
   getUsernameProof: {
     path: "/HubService/GetUsernameProof",
     requestStream: false,
@@ -195,7 +211,10 @@ export const HubServiceService = {
     responseSerialize: (value: UsernameProofsResponse) => Buffer.from(UsernameProofsResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => UsernameProofsResponse.decode(value),
   },
-  /** Verifications */
+  /**
+   * Verifications
+   * @http-api: none
+   */
   getVerification: {
     path: "/HubService/GetVerification",
     requestStream: false,
@@ -214,7 +233,10 @@ export const HubServiceService = {
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
-  /** OnChain Events */
+  /**
+   * OnChain Events
+   * @http-api: none
+   */
   getOnChainSigner: {
     path: "/HubService/GetOnChainSigner",
     requestStream: false,
@@ -233,6 +255,7 @@ export const HubServiceService = {
     responseSerialize: (value: OnChainEventResponse) => Buffer.from(OnChainEventResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => OnChainEventResponse.decode(value),
   },
+  /** @http-api: none */
   getOnChainEvents: {
     path: "/HubService/GetOnChainEvents",
     requestStream: false,
@@ -242,6 +265,7 @@ export const HubServiceService = {
     responseSerialize: (value: OnChainEventResponse) => Buffer.from(OnChainEventResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => OnChainEventResponse.decode(value),
   },
+  /** @http-api: none */
   getIdRegistryOnChainEvent: {
     path: "/HubService/GetIdRegistryOnChainEvent",
     requestStream: false,
@@ -251,6 +275,7 @@ export const HubServiceService = {
     responseSerialize: (value: OnChainEvent) => Buffer.from(OnChainEvent.encode(value).finish()),
     responseDeserialize: (value: Buffer) => OnChainEvent.decode(value),
   },
+  /** @http-api: onChainIdRegistryEventByAddress */
   getIdRegistryOnChainEventByAddress: {
     path: "/HubService/GetIdRegistryOnChainEventByAddress",
     requestStream: false,
@@ -261,6 +286,7 @@ export const HubServiceService = {
     responseSerialize: (value: OnChainEvent) => Buffer.from(OnChainEvent.encode(value).finish()),
     responseDeserialize: (value: Buffer) => OnChainEvent.decode(value),
   },
+  /** @http-api: storageLimitsByFid */
   getCurrentStorageLimitsByFid: {
     path: "/HubService/GetCurrentStorageLimitsByFid",
     requestStream: false,
@@ -279,7 +305,10 @@ export const HubServiceService = {
     responseSerialize: (value: FidsResponse) => Buffer.from(FidsResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => FidsResponse.decode(value),
   },
-  /** Links */
+  /**
+   * Links
+   * @http-api: linkById
+   */
   getLink: {
     path: "/HubService/GetLink",
     requestStream: false,
@@ -298,6 +327,7 @@ export const HubServiceService = {
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
+  /** @http-api: linksByTargetFid */
   getLinksByTarget: {
     path: "/HubService/GetLinksByTarget",
     requestStream: false,
@@ -307,7 +337,12 @@ export const HubServiceService = {
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
-  /** Bulk Methods */
+  /**
+   * Bulk Methods
+   * The Bulk methods don't have corresponding HTTP API endpoints because the
+   * regular endpoints can be used to get all the messages
+   * @http-api: none
+   */
   getAllCastMessagesByFid: {
     path: "/HubService/GetAllCastMessagesByFid",
     requestStream: false,
@@ -317,6 +352,7 @@ export const HubServiceService = {
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
+  /** @http-api: none */
   getAllReactionMessagesByFid: {
     path: "/HubService/GetAllReactionMessagesByFid",
     requestStream: false,
@@ -326,6 +362,7 @@ export const HubServiceService = {
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
+  /** @http-api: none */
   getAllVerificationMessagesByFid: {
     path: "/HubService/GetAllVerificationMessagesByFid",
     requestStream: false,
@@ -335,6 +372,7 @@ export const HubServiceService = {
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
+  /** @http-api: none */
   getAllUserDataMessagesByFid: {
     path: "/HubService/GetAllUserDataMessagesByFid",
     requestStream: false,
@@ -344,6 +382,7 @@ export const HubServiceService = {
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
+  /** @http-api: none */
   getAllLinkMessagesByFid: {
     path: "/HubService/GetAllLinkMessagesByFid",
     requestStream: false,
@@ -353,7 +392,10 @@ export const HubServiceService = {
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
-  /** Sync Methods */
+  /**
+   * Sync Methods
+   * Outside the "info" RPC, the HTTP API doesn't implement any of the sync methods
+   */
   getInfo: {
     path: "/HubService/GetInfo",
     requestStream: false,
@@ -363,6 +405,7 @@ export const HubServiceService = {
     responseSerialize: (value: HubInfoResponse) => Buffer.from(HubInfoResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => HubInfoResponse.decode(value),
   },
+  /** @http-api: none */
   getSyncStatus: {
     path: "/HubService/GetSyncStatus",
     requestStream: false,
@@ -372,6 +415,7 @@ export const HubServiceService = {
     responseSerialize: (value: SyncStatusResponse) => Buffer.from(SyncStatusResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => SyncStatusResponse.decode(value),
   },
+  /** @http-api: none */
   getAllSyncIdsByPrefix: {
     path: "/HubService/GetAllSyncIdsByPrefix",
     requestStream: false,
@@ -381,6 +425,7 @@ export const HubServiceService = {
     responseSerialize: (value: SyncIds) => Buffer.from(SyncIds.encode(value).finish()),
     responseDeserialize: (value: Buffer) => SyncIds.decode(value),
   },
+  /** @http-api: none */
   getAllMessagesBySyncIds: {
     path: "/HubService/GetAllMessagesBySyncIds",
     requestStream: false,
@@ -390,6 +435,7 @@ export const HubServiceService = {
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
+  /** @http-api: none */
   getSyncMetadataByPrefix: {
     path: "/HubService/GetSyncMetadataByPrefix",
     requestStream: false,
@@ -400,6 +446,7 @@ export const HubServiceService = {
       Buffer.from(TrieNodeMetadataResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => TrieNodeMetadataResponse.decode(value),
   },
+  /** @http-api: none */
   getSyncSnapshotByPrefix: {
     path: "/HubService/GetSyncSnapshotByPrefix",
     requestStream: false,
@@ -415,53 +462,100 @@ export const HubServiceService = {
 export interface HubServiceServer extends UntypedServiceImplementation {
   /** Submit Methods */
   submitMessage: handleUnaryCall<Message, Message>;
-  /** Event Methods */
+  /**
+   * Event Methods
+   * @http-api: none
+   */
   subscribe: handleServerStreamingCall<SubscribeRequest, HubEvent>;
+  /** @http-api: events */
   getEvent: handleUnaryCall<EventRequest, HubEvent>;
-  /** Casts */
+  /**
+   * Casts
+   * @http-api: castById
+   */
   getCast: handleUnaryCall<CastId, Message>;
   getCastsByFid: handleUnaryCall<FidRequest, MessagesResponse>;
   getCastsByParent: handleUnaryCall<CastsByParentRequest, MessagesResponse>;
   getCastsByMention: handleUnaryCall<FidRequest, MessagesResponse>;
-  /** Reactions */
+  /**
+   * Reactions
+   * @http-api: reactionById
+   */
   getReaction: handleUnaryCall<ReactionRequest, Message>;
   getReactionsByFid: handleUnaryCall<ReactionsByFidRequest, MessagesResponse>;
   /** To be deprecated */
   getReactionsByCast: handleUnaryCall<ReactionsByTargetRequest, MessagesResponse>;
   getReactionsByTarget: handleUnaryCall<ReactionsByTargetRequest, MessagesResponse>;
-  /** User Data */
+  /**
+   * User Data
+   * @http-api: none
+   */
   getUserData: handleUnaryCall<UserDataRequest, Message>;
   getUserDataByFid: handleUnaryCall<FidRequest, MessagesResponse>;
-  /** Username Proof */
+  /**
+   * Username Proof
+   * @http-api: userNameProofByName
+   */
   getUsernameProof: handleUnaryCall<UsernameProofRequest, UserNameProof>;
   getUserNameProofsByFid: handleUnaryCall<FidRequest, UsernameProofsResponse>;
-  /** Verifications */
+  /**
+   * Verifications
+   * @http-api: none
+   */
   getVerification: handleUnaryCall<VerificationRequest, Message>;
   getVerificationsByFid: handleUnaryCall<FidRequest, MessagesResponse>;
-  /** OnChain Events */
+  /**
+   * OnChain Events
+   * @http-api: none
+   */
   getOnChainSigner: handleUnaryCall<SignerRequest, OnChainEvent>;
   getOnChainSignersByFid: handleUnaryCall<FidRequest, OnChainEventResponse>;
+  /** @http-api: none */
   getOnChainEvents: handleUnaryCall<OnChainEventRequest, OnChainEventResponse>;
+  /** @http-api: none */
   getIdRegistryOnChainEvent: handleUnaryCall<FidRequest, OnChainEvent>;
+  /** @http-api: onChainIdRegistryEventByAddress */
   getIdRegistryOnChainEventByAddress: handleUnaryCall<IdRegistryEventByAddressRequest, OnChainEvent>;
+  /** @http-api: storageLimitsByFid */
   getCurrentStorageLimitsByFid: handleUnaryCall<FidRequest, StorageLimitsResponse>;
   getFids: handleUnaryCall<FidsRequest, FidsResponse>;
-  /** Links */
+  /**
+   * Links
+   * @http-api: linkById
+   */
   getLink: handleUnaryCall<LinkRequest, Message>;
   getLinksByFid: handleUnaryCall<LinksByFidRequest, MessagesResponse>;
+  /** @http-api: linksByTargetFid */
   getLinksByTarget: handleUnaryCall<LinksByTargetRequest, MessagesResponse>;
-  /** Bulk Methods */
+  /**
+   * Bulk Methods
+   * The Bulk methods don't have corresponding HTTP API endpoints because the
+   * regular endpoints can be used to get all the messages
+   * @http-api: none
+   */
   getAllCastMessagesByFid: handleUnaryCall<FidRequest, MessagesResponse>;
+  /** @http-api: none */
   getAllReactionMessagesByFid: handleUnaryCall<FidRequest, MessagesResponse>;
+  /** @http-api: none */
   getAllVerificationMessagesByFid: handleUnaryCall<FidRequest, MessagesResponse>;
+  /** @http-api: none */
   getAllUserDataMessagesByFid: handleUnaryCall<FidRequest, MessagesResponse>;
+  /** @http-api: none */
   getAllLinkMessagesByFid: handleUnaryCall<FidRequest, MessagesResponse>;
-  /** Sync Methods */
+  /**
+   * Sync Methods
+   * Outside the "info" RPC, the HTTP API doesn't implement any of the sync methods
+   */
   getInfo: handleUnaryCall<HubInfoRequest, HubInfoResponse>;
+  /** @http-api: none */
   getSyncStatus: handleUnaryCall<SyncStatusRequest, SyncStatusResponse>;
+  /** @http-api: none */
   getAllSyncIdsByPrefix: handleUnaryCall<TrieNodePrefix, SyncIds>;
+  /** @http-api: none */
   getAllMessagesBySyncIds: handleUnaryCall<SyncIds, MessagesResponse>;
+  /** @http-api: none */
   getSyncMetadataByPrefix: handleUnaryCall<TrieNodePrefix, TrieNodeMetadataResponse>;
+  /** @http-api: none */
   getSyncSnapshotByPrefix: handleUnaryCall<TrieNodePrefix, TrieNodeSnapshotResponse>;
 }
 
@@ -479,13 +573,17 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: Message) => void,
   ): ClientUnaryCall;
-  /** Event Methods */
+  /**
+   * Event Methods
+   * @http-api: none
+   */
   subscribe(request: SubscribeRequest, options?: Partial<CallOptions>): ClientReadableStream<HubEvent>;
   subscribe(
     request: SubscribeRequest,
     metadata?: Metadata,
     options?: Partial<CallOptions>,
   ): ClientReadableStream<HubEvent>;
+  /** @http-api: events */
   getEvent(request: EventRequest, callback: (error: ServiceError | null, response: HubEvent) => void): ClientUnaryCall;
   getEvent(
     request: EventRequest,
@@ -498,7 +596,10 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: HubEvent) => void,
   ): ClientUnaryCall;
-  /** Casts */
+  /**
+   * Casts
+   * @http-api: castById
+   */
   getCast(request: CastId, callback: (error: ServiceError | null, response: Message) => void): ClientUnaryCall;
   getCast(
     request: CastId,
@@ -556,7 +657,10 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
-  /** Reactions */
+  /**
+   * Reactions
+   * @http-api: reactionById
+   */
   getReaction(
     request: ReactionRequest,
     callback: (error: ServiceError | null, response: Message) => void,
@@ -618,7 +722,10 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
-  /** User Data */
+  /**
+   * User Data
+   * @http-api: none
+   */
   getUserData(
     request: UserDataRequest,
     callback: (error: ServiceError | null, response: Message) => void,
@@ -649,7 +756,10 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
-  /** Username Proof */
+  /**
+   * Username Proof
+   * @http-api: userNameProofByName
+   */
   getUsernameProof(
     request: UsernameProofRequest,
     callback: (error: ServiceError | null, response: UserNameProof) => void,
@@ -680,7 +790,10 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: UsernameProofsResponse) => void,
   ): ClientUnaryCall;
-  /** Verifications */
+  /**
+   * Verifications
+   * @http-api: none
+   */
   getVerification(
     request: VerificationRequest,
     callback: (error: ServiceError | null, response: Message) => void,
@@ -711,7 +824,10 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
-  /** OnChain Events */
+  /**
+   * OnChain Events
+   * @http-api: none
+   */
   getOnChainSigner(
     request: SignerRequest,
     callback: (error: ServiceError | null, response: OnChainEvent) => void,
@@ -742,6 +858,7 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: OnChainEventResponse) => void,
   ): ClientUnaryCall;
+  /** @http-api: none */
   getOnChainEvents(
     request: OnChainEventRequest,
     callback: (error: ServiceError | null, response: OnChainEventResponse) => void,
@@ -757,6 +874,7 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: OnChainEventResponse) => void,
   ): ClientUnaryCall;
+  /** @http-api: none */
   getIdRegistryOnChainEvent(
     request: FidRequest,
     callback: (error: ServiceError | null, response: OnChainEvent) => void,
@@ -772,6 +890,7 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: OnChainEvent) => void,
   ): ClientUnaryCall;
+  /** @http-api: onChainIdRegistryEventByAddress */
   getIdRegistryOnChainEventByAddress(
     request: IdRegistryEventByAddressRequest,
     callback: (error: ServiceError | null, response: OnChainEvent) => void,
@@ -787,6 +906,7 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: OnChainEvent) => void,
   ): ClientUnaryCall;
+  /** @http-api: storageLimitsByFid */
   getCurrentStorageLimitsByFid(
     request: FidRequest,
     callback: (error: ServiceError | null, response: StorageLimitsResponse) => void,
@@ -817,7 +937,10 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: FidsResponse) => void,
   ): ClientUnaryCall;
-  /** Links */
+  /**
+   * Links
+   * @http-api: linkById
+   */
   getLink(request: LinkRequest, callback: (error: ServiceError | null, response: Message) => void): ClientUnaryCall;
   getLink(
     request: LinkRequest,
@@ -845,6 +968,7 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
+  /** @http-api: linksByTargetFid */
   getLinksByTarget(
     request: LinksByTargetRequest,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
@@ -860,7 +984,12 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
-  /** Bulk Methods */
+  /**
+   * Bulk Methods
+   * The Bulk methods don't have corresponding HTTP API endpoints because the
+   * regular endpoints can be used to get all the messages
+   * @http-api: none
+   */
   getAllCastMessagesByFid(
     request: FidRequest,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
@@ -876,6 +1005,7 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
+  /** @http-api: none */
   getAllReactionMessagesByFid(
     request: FidRequest,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
@@ -891,6 +1021,7 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
+  /** @http-api: none */
   getAllVerificationMessagesByFid(
     request: FidRequest,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
@@ -906,6 +1037,7 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
+  /** @http-api: none */
   getAllUserDataMessagesByFid(
     request: FidRequest,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
@@ -921,6 +1053,7 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
+  /** @http-api: none */
   getAllLinkMessagesByFid(
     request: FidRequest,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
@@ -936,7 +1069,10 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
-  /** Sync Methods */
+  /**
+   * Sync Methods
+   * Outside the "info" RPC, the HTTP API doesn't implement any of the sync methods
+   */
   getInfo(
     request: HubInfoRequest,
     callback: (error: ServiceError | null, response: HubInfoResponse) => void,
@@ -952,6 +1088,7 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: HubInfoResponse) => void,
   ): ClientUnaryCall;
+  /** @http-api: none */
   getSyncStatus(
     request: SyncStatusRequest,
     callback: (error: ServiceError | null, response: SyncStatusResponse) => void,
@@ -967,6 +1104,7 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: SyncStatusResponse) => void,
   ): ClientUnaryCall;
+  /** @http-api: none */
   getAllSyncIdsByPrefix(
     request: TrieNodePrefix,
     callback: (error: ServiceError | null, response: SyncIds) => void,
@@ -982,6 +1120,7 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: SyncIds) => void,
   ): ClientUnaryCall;
+  /** @http-api: none */
   getAllMessagesBySyncIds(
     request: SyncIds,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
@@ -997,6 +1136,7 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
+  /** @http-api: none */
   getSyncMetadataByPrefix(
     request: TrieNodePrefix,
     callback: (error: ServiceError | null, response: TrieNodeMetadataResponse) => void,
@@ -1012,6 +1152,7 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: TrieNodeMetadataResponse) => void,
   ): ClientUnaryCall;
+  /** @http-api: none */
   getSyncSnapshotByPrefix(
     request: TrieNodePrefix,
     callback: (error: ServiceError | null, response: TrieNodeSnapshotResponse) => void,

--- a/packages/hub-web/src/generated/rpc.ts
+++ b/packages/hub-web/src/generated/rpc.ts
@@ -44,15 +44,25 @@ import { UserNameProof } from "./username_proof";
 export interface HubService {
   /** Submit Methods */
   submitMessage(request: DeepPartial<Message>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
-  /** Event Methods */
+  /**
+   * Event Methods
+   * @http-api: none
+   */
   subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpcWeb.grpc.Metadata): Observable<HubEvent>;
+  /** @http-api: events */
   getEvent(request: DeepPartial<EventRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubEvent>;
-  /** Casts */
+  /**
+   * Casts
+   * @http-api: castById
+   */
   getCast(request: DeepPartial<CastId>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
   getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
   getCastsByParent(request: DeepPartial<CastsByParentRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
   getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
-  /** Reactions */
+  /**
+   * Reactions
+   * @http-api: reactionById
+   */
   getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
   getReactionsByFid(request: DeepPartial<ReactionsByFidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
   /** To be deprecated */
@@ -64,51 +74,88 @@ export interface HubService {
     request: DeepPartial<ReactionsByTargetRequest>,
     metadata?: grpcWeb.grpc.Metadata,
   ): Promise<MessagesResponse>;
-  /** User Data */
+  /**
+   * User Data
+   * @http-api: none
+   */
   getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
   getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
-  /** Username Proof */
+  /**
+   * Username Proof
+   * @http-api: userNameProofByName
+   */
   getUsernameProof(request: DeepPartial<UsernameProofRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<UserNameProof>;
   getUserNameProofsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<UsernameProofsResponse>;
-  /** Verifications */
+  /**
+   * Verifications
+   * @http-api: none
+   */
   getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
   getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
-  /** OnChain Events */
+  /**
+   * OnChain Events
+   * @http-api: none
+   */
   getOnChainSigner(request: DeepPartial<SignerRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEvent>;
   getOnChainSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEventResponse>;
+  /** @http-api: none */
   getOnChainEvents(request: DeepPartial<OnChainEventRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEventResponse>;
+  /** @http-api: none */
   getIdRegistryOnChainEvent(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEvent>;
+  /** @http-api: onChainIdRegistryEventByAddress */
   getIdRegistryOnChainEventByAddress(
     request: DeepPartial<IdRegistryEventByAddressRequest>,
     metadata?: grpcWeb.grpc.Metadata,
   ): Promise<OnChainEvent>;
+  /** @http-api: storageLimitsByFid */
   getCurrentStorageLimitsByFid(
     request: DeepPartial<FidRequest>,
     metadata?: grpcWeb.grpc.Metadata,
   ): Promise<StorageLimitsResponse>;
   getFids(request: DeepPartial<FidsRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<FidsResponse>;
-  /** Links */
+  /**
+   * Links
+   * @http-api: linkById
+   */
   getLink(request: DeepPartial<LinkRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
   getLinksByFid(request: DeepPartial<LinksByFidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  /** @http-api: linksByTargetFid */
   getLinksByTarget(request: DeepPartial<LinksByTargetRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
-  /** Bulk Methods */
+  /**
+   * Bulk Methods
+   * The Bulk methods don't have corresponding HTTP API endpoints because the
+   * regular endpoints can be used to get all the messages
+   * @http-api: none
+   */
   getAllCastMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  /** @http-api: none */
   getAllReactionMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  /** @http-api: none */
   getAllVerificationMessagesByFid(
     request: DeepPartial<FidRequest>,
     metadata?: grpcWeb.grpc.Metadata,
   ): Promise<MessagesResponse>;
+  /** @http-api: none */
   getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  /** @http-api: none */
   getAllLinkMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
-  /** Sync Methods */
+  /**
+   * Sync Methods
+   * Outside the "info" RPC, the HTTP API doesn't implement any of the sync methods
+   */
   getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubInfoResponse>;
+  /** @http-api: none */
   getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncStatusResponse>;
+  /** @http-api: none */
   getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncIds>;
+  /** @http-api: none */
   getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  /** @http-api: none */
   getSyncMetadataByPrefix(
     request: DeepPartial<TrieNodePrefix>,
     metadata?: grpcWeb.grpc.Metadata,
   ): Promise<TrieNodeMetadataResponse>;
+  /** @http-api: none */
   getSyncSnapshotByPrefix(
     request: DeepPartial<TrieNodePrefix>,
     metadata?: grpcWeb.grpc.Metadata,

--- a/protobufs/schemas/hub_state.proto
+++ b/protobufs/schemas/hub_state.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
 message HubState {
-  uint32 last_eth_block = 1;
+//  uint32 last_eth_block = 1; // Deprecated
   uint64 last_fname_proof = 2;
   uint64 last_l2_block = 3;
-  bool syncEvents = 4;
+//  bool syncEvents = 4; // Deprecated
 }


### PR DESCRIPTION
## Motivation

Enable events sync by default

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enabling events sync by default. 

### Detailed summary
- Updated `numMessages` field in `dbStats` to use `numItems` instead of `numMessages`.
- Deprecated `last_eth_block` and `syncEvents` fields in `HubState` message.
- Updated code in `hubble.ts` and `mocks.ts` to reflect changes in `HubState` message.
- Updated code in `syncService.test.ts` to reflect the updated value of `numMessages`.
- Updated code in `merkleTrie.ts` to remove the `eventsEnabled` parameter from the `rebuild` method.
- Updated code in `multiPeerSyncEngine.test.ts` to remove calls to `enableEventsSync` method.
- Updated code in `hub_state.ts` to reflect the deprecated fields in `HubState` message.
- Updated code in `rpc.ts` to add HTTP API annotations for certain methods.

> The following files were skipped due to too many changes: `packages/hub-web/src/generated/rpc.ts`, `apps/hubble/src/network/sync/syncEngine.ts`, `apps/hubble/src/network/sync/syncEngine.test.ts`, `packages/hub-nodejs/src/generated/rpc.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->