### PR TITLE
chore: Update tag used by replicator.sh script

### DIFF
--- a/scripts/replicator.sh
+++ b/scripts/replicator.sh
@@ -9,7 +9,7 @@ CURRENT_VERSION="1"
 
 REPO="farcasterxyz/hub-monorepo"
 RAWFILE_BASE="https://raw.githubusercontent.com/$REPO"
-LATEST_TAG="@replicator-latest"
+LATEST_TAG="@farcaster/replicator@latest"
 
 DOCKER_COMPOSE_FILE_PATH="apps/replicator/docker-compose.yml"
 SCRIPT_FILE_PATH="scripts/replicator.sh"


### PR DESCRIPTION
## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the latest tag for the replicator service and modifying the Docker Compose file and script file paths.

### Detailed summary
- Updated the latest tag for the replicator service from "@replicator-latest" to "@farcaster/replicator@latest".
- Modified the Docker Compose file path to "apps/replicator/docker-compose.yml".
- Modified the script file path to "scripts/replicator.sh".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->