### PR TITLE
fix: Fix off by one error when inserting into trie

### DIFF
--- a/.changeset/unlucky-toes-bake.md
+++ b/.changeset/unlucky-toes-bake.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Fix off by one error when inserting into trie

--- a/apps/hubble/src/network/sync/merkleTrie.test.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.test.ts
@@ -147,7 +147,8 @@ describe("MerkleTrie", () => {
       const syncId2 = SyncId.fromOnChainEvent(event2);
       const idLength = syncId1.syncId().length;
 
-      expect(syncId1).not.toEqual(syncId2);
+      expect(syncId1.syncId()).not.toEqual(syncId2.syncId());
+      expect(syncId1.syncId().length).toEqual(syncId2.syncId().length);
       expect(syncId1.syncId().slice(0, idLength - 1)).toEqual(syncId2.syncId().slice(0, idLength - 1));
 
       expect(await trie.insert(syncId1)).toBeTruthy();
@@ -155,6 +156,16 @@ describe("MerkleTrie", () => {
 
       expect(await trie.exists(syncId1)).toBeTruthy();
       expect(await trie.exists(syncId2)).toBeTruthy();
+
+      await trie.deleteBySyncId(syncId1);
+
+      expect(await trie.exists(syncId1)).toBeFalsy();
+      expect(await trie.exists(syncId2)).toBeTruthy();
+
+      await trie.deleteBySyncId(syncId2);
+
+      expect(await trie.exists(syncId1)).toBeFalsy();
+      expect(await trie.exists(syncId2)).toBeFalsy();
     });
 
     test(

--- a/apps/hubble/src/network/sync/trieNode.ts
+++ b/apps/hubble/src/network/sync/trieNode.ts
@@ -74,7 +74,7 @@ class TrieNode {
     dbUpdatesMap: Map<Buffer, Buffer>,
     current_index = 0,
   ): Promise<TrieNodeOpResult> {
-    if (current_index >= key.length) {
+    if (current_index > key.length) {
       throw new Error("Key length exceeded");
     }
     const char = key.at(current_index) as number;

--- a/apps/hubble/src/network/sync/trieNode.ts
+++ b/apps/hubble/src/network/sync/trieNode.ts
@@ -155,7 +155,7 @@ class TrieNode {
       }
     }
 
-    if (current_index >= key.length) {
+    if (current_index > key.length) {
       throw "Key length exceeded2";
     }
     const char = key.at(current_index) as number;
@@ -216,7 +216,7 @@ class TrieNode {
       return true;
     }
 
-    if (current_index >= key.length) {
+    if (current_index > key.length) {
       throw "Key length exceeded3";
     }
     const char = key.at(current_index) as number;


### PR DESCRIPTION
## Motivation

Inserting sync ids that were only differing on the last byte would cause errors due to a bad if check.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on fixing an off by one error when inserting into a trie.

### Detailed summary:
- Fixed off by one error when inserting into trie
- Updated error message when key length is exceeded
- Added import of `Factories` and `SyncId` in `merkleTrie.test.ts`
- Added a test for inserting multiple items that differ by one byte

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->