### PR TITLE
fix: add verification defaults

### DIFF
--- a/packages/core/src/crypto/eip712.test.ts
+++ b/packages/core/src/crypto/eip712.test.ts
@@ -1,9 +1,11 @@
+import { Factories } from "../factories";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { ok } from "neverthrow";
 import { hexStringToBytes } from "../bytes";
 import * as eip712 from "./eip712";
 import { ViemLocalEip712Signer } from "../signers";
 import { makeUserNameProofClaim } from "../userNameProof";
+import { makeVerificationEthAddressClaim } from "../verifications";
 
 const privateKey = generatePrivateKey();
 const account = privateKeyToAccount(privateKey);
@@ -40,6 +42,26 @@ describe("verifyUserNameProofClaim", () => {
       nameProof,
       signature._unsafeUnwrap(),
       hexStringToBytes("0xBc5274eFc266311015793d89E9B591fa46294741")._unsafeUnwrap(),
+    );
+    expect(valid).toEqual(ok(true));
+  });
+});
+
+describe("verifyVerificationEthAddressClaimSignature", () => {
+  test("succeeds with a generated claim", async () => {
+    const claimRes = makeVerificationEthAddressClaim(
+      Factories.Fid.build(),
+      (await signer.getSignerKey())._unsafeUnwrap(),
+      Factories.FarcasterNetwork.build(),
+      Factories.BlockHash.build(),
+    );
+    const claim = claimRes._unsafeUnwrap();
+    const signature = await signer.signVerificationEthAddressClaim(claim);
+    expect(signature.isOk()).toBeTruthy();
+    const valid = await eip712.verifyVerificationEthAddressClaimSignature(
+      claim,
+      signature._unsafeUnwrap(),
+      (await signer.getSignerKey())._unsafeUnwrap(),
     );
     expect(valid).toEqual(ok(true));
   });

--- a/packages/core/src/crypto/eip712.ts
+++ b/packages/core/src/crypto/eip712.ts
@@ -54,7 +54,7 @@ export const EIP_712_USERNAME_PROOF = [
   { name: "owner", type: "address" },
 ] as const;
 
-const verifyVerificationClaimEOASignature = async (
+export const verifyVerificationClaimEOASignature = async (
   claim: VerificationEthAddressClaim,
   signature: Uint8Array,
   address: Uint8Array,
@@ -80,7 +80,7 @@ const verifyVerificationClaimEOASignature = async (
   return valid;
 };
 
-const verifyVerificationClaimContractSignature = async (
+export const verifyVerificationClaimContractSignature = async (
   claim: VerificationEthAddressClaim,
   signature: Uint8Array,
   address: Uint8Array,
@@ -112,8 +112,8 @@ export const verifyVerificationEthAddressClaimSignature = async (
   claim: VerificationEthAddressClaim,
   signature: Uint8Array,
   address: Uint8Array,
-  verificationType: number,
-  chainId: number,
+  verificationType = 0,
+  chainId = 0,
   publicClients: PublicClients = defaultPublicClients,
 ): HubAsyncResult<boolean> => {
   if (!EIP_712_FARCASTER_VERIFICATION_CLAIM_CHAIN_IDS.includes(chainId)) {


### PR DESCRIPTION
## Motivation

I unintentionally made a breaking API change to `eip712.verifyVerificationClaimContractSignature`, by adding two new required args.

## Change Summary

Add default values for `verificationType` and `chainId`.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on making two functions in the `eip712.ts` file (`verifyVerificationClaimEOASignature` and `verifyVerificationClaimContractSignature`) and one function in the `eip712.test.ts` file (`verifyVerificationEthAddressClaimSignature`) exportable. 

### Detailed summary
- The `verifyVerificationClaimEOASignature` function is now exported.
- The `verifyVerificationClaimContractSignature` function is now exported.
- The `verifyVerificationEthAddressClaimSignature` function is now exported.
- The `eip712.test.ts` file imports the `makeVerificationEthAddressClaim` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->