### PR TITLE
fix: Correct Replicator Docker Compose config and bootstrap script

### DIFF
--- a/.changeset/hip-squids-doubt.md
+++ b/.changeset/hip-squids-doubt.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/replicator": minor
+---
+
+Fix Replicator Docker image build

--- a/apps/replicator/docker-compose.yml
+++ b/apps/replicator/docker-compose.yml
@@ -2,11 +2,10 @@ version: '3.9'
 
 services:
   replicator:
-    build:
-      context: ../.. # Repository root
-      dockerfile: Dockerfile.replicator
+    image: farcasterxyz/replicator:latest
     restart: unless-stopped
     init: true
+    command: ['node', 'build/app.js', 'start']
     environment:
       - LOG_LEVEL
       - HUB_HOST

--- a/apps/replicator/package.json
+++ b/apps/replicator/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@bull-board/api": "^5.8.4",
     "@bull-board/fastify": "^5.8.4",
+    "@commander-js/extra-typings": "^11.0.0",
     "@farcaster/hub-nodejs": "^0.10.9",
     "bullmq": "^4.11.4",
     "commander": "^11.0.0",
@@ -46,7 +47,6 @@
     "viem": "^1.12.1"
   },
   "devDependencies": {
-    "@commander-js/extra-typings": "^11.0.0",
     "@types/humanize-duration": "^3.27.1",
     "@types/pg": "^8.10.3",
     "@types/pg-cursor": "^2.7.0",


### PR DESCRIPTION
## Motivation

We want the bootstrap script to ask the user where their hub is.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the Replicator Docker image build. 

### Detailed summary
- Updated the `docker-compose.yml` file to use the latest Replicator image (`farcasterxyz/replicator:latest`).
- Added a command to start the Replicator (`['node', 'build/app.js', 'start']`) in the `docker-compose.yml` file.
- Added a new dependency `@commander-js/extra-typings` to the `package.json` file.
- Added a new function `get_hub_host()` and `get_hub_ssl()` in the `replicator.sh` script to prompt for HUB_HOST and HUB_SSL values respectively.
- Updated the `write_env_file()` function in the `replicator.sh` script to include HUB_HOST and HUB_SSL values in the .env file if they are not already present.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->