### PR TITLE
fix: Fix overzealous crontab upgrade entry

### DIFF
--- a/.changeset/brave-dancers-cover.md
+++ b/.changeset/brave-dancers-cover.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Fix buggy crontab entry that would try to upgrade every minute


### PR DESCRIPTION
## Motivation

We were creating entries like `* 1 * * 2`, which meant we were trying to run the upgrade script every minute during the chosen hour to upgrade. This causes hubs to keep restarting constantly. Use a constant minute so it only happens once.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a buggy crontab entry that would try to upgrade every minute. 

### Detailed summary
- Added a patch for the `@farcaster/hubble` package.
- Fixed the crontab entry in `hubble.sh` to run once an hour instead of every minute.
- Improved logging and error handling in the crontab setup.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->