### PR TITLE
chore: Cut replicator release 0.2.0

### DIFF
--- a/.changeset/hip-squids-doubt.md
+++ b/.changeset/hip-squids-doubt.md
@@ -1,5 +1,0 @@
----
-"@farcaster/replicator": minor
----
-
-Fix Replicator Docker image build

--- a/apps/replicator/CHANGELOG.md
+++ b/apps/replicator/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @farcaster/replicator
+
+## 0.2.0
+
+### Minor Changes
+
+- 998f61b0: Fix Replicator Docker image build
+
+### Patch Changes
+
+- Updated dependencies [81e6d8ec]
+- Updated dependencies [aacff028]

--- a/apps/replicator/package.json
+++ b/apps/replicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/replicator",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Replicate Farcaster hub data into Postgres",
   "author": "",
   "license": "",
@@ -28,7 +28,7 @@
     "@bull-board/api": "^5.8.4",
     "@bull-board/fastify": "^5.8.4",
     "@commander-js/extra-typings": "^11.0.0",
-    "@farcaster/hub-nodejs": "^0.10.9",
+    "@farcaster/hub-nodejs": "^0.10.11",
     "bullmq": "^4.11.4",
     "commander": "^11.0.0",
     "dotenv": "^16.3.1",


### PR DESCRIPTION
## Motivation

Fixes the Docker build.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of `@farcaster/hub-nodejs` dependency in the `package.json` file of the `replicator` app. 

### Detailed summary
- Updated `@farcaster/hub-nodejs` dependency from `0.10.9` to `0.10.11`
- Fixed Replicator Docker image build
- Updated other dependencies

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->