### PR TITLE
Update replicator.sh to ensure Postgres/Redis are running

### DIFF
--- a/scripts/replicator.sh
+++ b/scripts/replicator.sh
@@ -220,6 +220,32 @@ write_env_file() {
     echo "✅ .env file updated."
 }
 
+ensure_postgres() {
+      if $COMPOSE_CMD ps postgres 2>&1 >/dev/null; then
+          if $COMPOSE_CMD ps postgres | grep -q "Up"; then
+              $COMPOSE_CMD restart postgres
+          else
+              $COMPOSE_CMD up -d postgres
+          fi
+      else
+          echo "❌ Docker is not running or there's another issue with Docker. Please start Docker manually."
+          exit 1
+      fi
+}
+
+ensure_redis() {
+      if $COMPOSE_CMD ps redis 2>&1 >/dev/null; then
+          if $COMPOSE_CMD ps redis | grep -q "Up"; then
+              $COMPOSE_CMD restart redis
+          else
+              $COMPOSE_CMD up -d redis
+          fi
+      else
+          echo "❌ Docker is not running or there's another issue with Docker. Please start Docker manually."
+          exit 1
+      fi
+}
+
 ensure_grafana() {
       if $COMPOSE_CMD ps statsd 2>&1 >/dev/null; then
           if $COMPOSE_CMD ps statsd | grep -q "Up"; then
@@ -466,6 +492,10 @@ if [ "$1" == "upgrade" ]; then
     # Fetch the latest docker-compose.yml
     fetch_latest_docker_compose_and_dashboard
 
+    # Setup persistent stores
+    ensure_postgres
+    ensure_redis
+
     # Setup the Grafana dashboard
     setup_grafana
 
@@ -473,7 +503,7 @@ if [ "$1" == "upgrade" ]; then
 
     echo "✅ Upgrade complete."
     echo ""
-    echo "Monitor your node at http://localhost:3000/"
+    echo "Monitor your replicator at http://localhost:3000/ and http://localhost:9000/"
 
     # Sleep for 5 seconds
     sleep 5


### PR DESCRIPTION
## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding functions to ensure the availability of Postgres, Redis, and Grafana services in the replicator script.

### Detailed summary
- Added `ensure_postgres` function to check and restart Postgres service if necessary
- Added `ensure_redis` function to check and restart Redis service if necessary
- Added `ensure_grafana` function to check and restart Grafana service if necessary
- Updated upgrade message to include URLs for monitoring the replicator

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->