### PR TITLE
fix: Add missing network to Redis container for replicator

### DIFF
--- a/apps/replicator/docker-compose.yml
+++ b/apps/replicator/docker-compose.yml
@@ -61,6 +61,8 @@ services:
       timeout: 10s
       retries: 3
       start_period: 5s
+    networks:
+      - replicator-network
 
   statsd:
     image: graphiteapp/graphite-statsd:1.1.10-5


### PR DESCRIPTION
## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new network called "replicator-network" to the docker-compose.yml file. 

### Detailed summary
- Added a new network called "replicator-network" to the docker-compose.yml file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->