### PR TITLE
fix: Fetch correct replicator app version from package.json

### DIFF
--- a/.changeset/few-cooks-perform.md
+++ b/.changeset/few-cooks-perform.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/replicator": patch
+---
+
+Return correct version from package.json

--- a/apps/replicator/src/app.ts
+++ b/apps/replicator/src/app.ts
@@ -1,5 +1,6 @@
 import { Command } from "@commander-js/extra-typings";
 import * as repl from "repl";
+import { readFileSync } from "fs";
 import { DB, getDbClient, migrateToLatest, migrationStatus } from "./db.js";
 import { CONCURRENCY, HUB_HOST, HUB_SSL, POSTGRES_URL, REDIS_URL, STATSD_HOST, STATSD_METRICS_PREFIX } from "./env.js";
 import { Logger, log } from "./log.js";
@@ -121,7 +122,7 @@ async function start() {
 const program = new Command()
   .name("replicator")
   .description("Synchronizes a Farcaster Hub with a Postgres database")
-  .version("0.1.0");
+  .version(JSON.parse(readFileSync("./package.json").toString()).version);
 
 program.command("console").description("Starts a REPL console").action(console);
 


### PR DESCRIPTION
## Motivation

We were returning a hard-coded version rather than the one specified in `package.json`. Fix it.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Updated the version of the `replicator` program to match the version in `package.json`.
- Added the ability to read the version from `package.json` dynamically.

This PR focuses on updating the version of the `replicator` program to match the version specified in the `package.json` file. Additionally, it adds the ability to read the version dynamically from the `package.json` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->