### PR TITLE
Fix POSTGRES_URL default for replicator

### DIFF
--- a/scripts/replicator.sh
+++ b/scripts/replicator.sh
@@ -202,7 +202,7 @@ write_env_file() {
     fi
 
     if ! key_exists "POSTGRES_URL"; then
-        echo "POSTGRES_URL=postgres://replicator:password@postgres:6541/replicator" >> .env
+        echo "POSTGRES_URL=postgres://replicator:password@postgres:5432/replicator" >> .env
     fi
 
     if ! key_exists "STATSD_HOST"; then


### PR DESCRIPTION
## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `POSTGRES_URL` in the `replicator.sh` script from port `6541` to `5432`.

### Detailed summary
- Updated `POSTGRES_URL` from `postgres://replicator:password@postgres:6541/replicator` to `postgres://replicator:password@postgres:5432/replicator`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->