### PR TITLE
fix: Don't check if hub exposes HTTP port in replicator.sh

### DIFF
--- a/scripts/replicator.sh
+++ b/scripts/replicator.sh
@@ -135,21 +135,8 @@ portable_nproc() {
 
 get_hub_host() {
     while true; do
-        read -p "> Enter your HUB_HOST (e.g. localhost:2283 or my-hub.domain.com:2283): " HUB_HOST
-        RESPONSE=$(curl -s -X GET "$HUB_HOST/v1/info")
-
-        # Convert both the response and expected chain ID to lowercase for comparison
-        local lower_response=$(echo "$RESPONSE" | tr '[:upper:]' '[:lower:]')
-
-        if [[ $lower_response == *'"version":'* ]]; then
-            echo "HUB_HOST=$HUB_HOST" >> .env
-            break
-        else
-            echo "!!! Invalid !!!"
-            echo "Hub host is not reachable or returned invalid response. Please retry."
-            echo "It is recommended that you point the replicator at a local hub to reduce sync time."
-            echo "Server returned \"$RESPONSE\""
-        fi
+        read -p "> Enter your HUB_HOST (e.g. my-hub.domain.com:2283): " HUB_HOST
+        echo "HUB_HOST=$HUB_HOST" >> .env
     done
 }
 


### PR DESCRIPTION
## Motivation

Not all hubs support this. Let's just accept what the user provides for now.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying the process of setting the `HUB_HOST` in the `replicator.sh` script. 

### Detailed summary
- Removed the check for the validity of the `HUB_HOST` by sending a GET request to the provided host.
- Directly writes the `HUB_HOST` value to the `.env` file without further validation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->