### PR TITLE
fix: Remove infinite prompt loop in replicator.sh

### DIFF
--- a/scripts/replicator.sh
+++ b/scripts/replicator.sh
@@ -134,10 +134,8 @@ portable_nproc() {
 }
 
 get_hub_host() {
-    while true; do
-        read -p "> Enter your HUB_HOST (e.g. my-hub.domain.com:2283): " HUB_HOST
-        echo "HUB_HOST=$HUB_HOST" >> .env
-    done
+    read -p "> Enter your HUB_HOST (e.g. my-hub.domain.com:2283): " HUB_HOST
+    echo "HUB_HOST=$HUB_HOST" >> .env
 }
 
 get_hub_ssl() {


### PR DESCRIPTION
## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The `while` loop in the `get_hub_host` function has been removed.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->