### PR TITLE
fix: Handle L2 event errors

### DIFF
--- a/.changeset/wild-tigers-beam.md
+++ b/.changeset/wild-tigers-beam.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Handle errors from L2 getevents

--- a/apps/hubble/src/eth/l2EventsProvider.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.ts
@@ -702,13 +702,18 @@ export class L2EventsProvider {
     toBlock: bigint;
     strict: boolean;
   }) {
-    if (this._useFilters) {
-      const filter = await this._publicClient.createContractEventFilter(params);
-      return this._publicClient.getFilterLogs({
-        filter,
-      });
-    } else {
-      return this._publicClient.getContractEvents(params);
+    try {
+      if (this._useFilters) {
+        const filter = await this._publicClient.createContractEventFilter(params);
+        return this._publicClient.getFilterLogs({
+          filter,
+        });
+      } else {
+        return this._publicClient.getContractEvents(params);
+      }
+    } catch (err) {
+      log.error({ err, params }, "failed to get contract events");
+      return [];
     }
   }
 


### PR DESCRIPTION
## Motivation
Handle errors if we run out of quota for the L2 provider

Fixes https://github.com/farcasterxyz/hub-monorepo/issues/1482

## Change Summary
Handle uncaught exception

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the handling of errors from L2 getevents. 

### Detailed summary
- Added error handling for L2 getevents in `eth/l2EventsProvider.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->