### PR TITLE
fix: Run protoc as user

### DIFF
--- a/.changeset/sharp-students-explode.md
+++ b/.changeset/sharp-students-explode.md
@@ -1,0 +1,7 @@
+---
+"@farcaster/hub-nodejs": patch
+"@farcaster/hub-web": patch
+"@farcaster/core": patch
+---
+
+fix: Run protoc as user instead of root

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,9 +11,7 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "MIT",
   "dependencies": {
     "@noble/curves": "^1.0.0",
@@ -26,7 +24,7 @@
   "scripts": {
     "build": "tsup --config tsup.config.ts",
     "clean": "rimraf ./dist",
-    "protoc": "docker run --rm -v $(pwd)/../../node_modules:/node_modules -v $(pwd)/../../protobufs/schemas:/defs -v $(pwd)/src/protobufs/generated:/out namely/protoc:1.50_1 --plugin=/node_modules/ts-proto/protoc-gen-ts_proto --ts_proto_out=/out --ts_proto_opt=esModuleInterop=true,exportCommonSymbols=false,outputServices=false,useOptionals=none,unrecognizedEnum=false,removeEnumPrefix=true --proto_path=/defs $(ls ../../protobufs/schemas/*.proto | xargs -n 1 basename | xargs -I{} echo '/defs/{}' | tr '\n' ' ')",
+    "protoc": "docker run --rm --user $(id -u):$(id -g) -v $(pwd)/../../node_modules:/node_modules -v $(pwd)/../../protobufs/schemas:/defs -v $(pwd)/src/protobufs/generated:/out namely/protoc:1.50_1 --plugin=/node_modules/ts-proto/protoc-gen-ts_proto --ts_proto_out=/out --ts_proto_opt=esModuleInterop=true,exportCommonSymbols=false,outputServices=false,useOptionals=none,unrecognizedEnum=false,removeEnumPrefix=true --proto_path=/defs $(ls ../../protobufs/schemas/*.proto | xargs -n 1 basename | xargs -I{} echo '/defs/{}' | tr '\n' ' ')",
     "lint": "biome format src/ --write && biome check src/ --apply",
     "lint:ci": "biome ci src/",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -11,9 +11,7 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "MIT",
   "dependencies": {
     "@farcaster/core": "0.12.11",
@@ -24,7 +22,7 @@
   "scripts": {
     "build": "tsup --config tsup.config.ts",
     "clean": "rimraf ./dist",
-    "protoc": "docker run --rm -v $(pwd)/../../node_modules:/node_modules -v $(pwd)/../../protobufs/schemas:/defs -v $(pwd)/src/generated:/out namely/protoc:1.50_1 --plugin=/node_modules/ts-proto/protoc-gen-ts_proto --ts_proto_out=/out --ts_proto_opt=esModuleInterop=true,exportCommonSymbols=false,outputServices=grpc-js,useOptionals=none,unrecognizedEnum=false,removeEnumPrefix=true --proto_path=/defs /defs/rpc.proto",
+    "protoc": "docker run --rm --user $(id -u):$(id -g) -v $(pwd)/../../node_modules:/node_modules -v $(pwd)/../../protobufs/schemas:/defs -v $(pwd)/src/generated:/out namely/protoc:1.50_1 --plugin=/node_modules/ts-proto/protoc-gen-ts_proto --ts_proto_out=/out --ts_proto_opt=esModuleInterop=true,exportCommonSymbols=false,outputServices=grpc-js,useOptionals=none,unrecognizedEnum=false,removeEnumPrefix=true --proto_path=/defs /defs/rpc.proto",
     "lint": "biome format src/ examples/ --write && biome check src/ examples --apply",
     "lint:ci": "biome ci src/ examples/",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -11,14 +11,12 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "MIT",
   "scripts": {
     "build": "tsup --config tsup.config.ts",
     "clean": "rimraf ./dist",
-    "protoc": "docker run --rm -v $(pwd)/../../node_modules:/node_modules -v $(pwd)/../../protobufs/schemas:/defs -v $(pwd)/src/generated:/out namely/protoc:1.50_1 --plugin=/node_modules/ts-proto/protoc-gen-ts_proto --ts_proto_out=/out --ts_proto_opt=esModuleInterop=true,exportCommonSymbols=false,outputClientImpl=grpc-web,useOptionals=none,unrecognizedEnum=false,removeEnumPrefix=true,lowerCaseServiceMethods=true --proto_path=/defs /defs/rpc.proto",
+    "protoc": "docker run --rm --user $(id -u):$(id -g) -v $(pwd)/../../node_modules:/node_modules -v $(pwd)/../../protobufs/schemas:/defs -v $(pwd)/src/generated:/out namely/protoc:1.50_1 --plugin=/node_modules/ts-proto/protoc-gen-ts_proto --ts_proto_out=/out --ts_proto_opt=esModuleInterop=true,exportCommonSymbols=false,outputClientImpl=grpc-web,useOptionals=none,unrecognizedEnum=false,removeEnumPrefix=true,lowerCaseServiceMethods=true --proto_path=/defs /defs/rpc.proto",
     "lint": "biome format src/ examples/ --write && biome check src/ examples/ --apply",
     "lint:ci": "biome ci src/ examples/",
     "prepublishOnly": "yarn run build"


### PR DESCRIPTION
## Motivation

When running protoc in docker, make sure to run as user instead of root so that file permissions dont get messed up


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the issue of running `protoc` as root by running it as a user instead. 

### Detailed summary
- Updated the `protoc` script in `hub-web`, `hub-nodejs`, and `core` packages to run as a user instead of root.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->