### PR TITLE
fix: Install hubble.sh crontab for root instead of user

### DIFF
--- a/.changeset/smooth-berries-mate.md
+++ b/.changeset/smooth-berries-mate.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Run crontab as root for hubble.sh


### PR DESCRIPTION
## Motivation
Install the crontab for root (instead of user) because docker requires root to run on EC2 and other cloud providers

## Change Summary
- Install crontab as root
- Remove/fix existing crontab for user


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a bug related to running crontab as root for `hubble.sh`. 

### Detailed summary
- Added logic to remove crontab if installed for the current user (instead of root)
- Fixed a buggy crontab entry that would run every minute
- Exported existing crontab entries to a temporary file and removed the line containing "hubble.sh"
- Updated the logic for setting the `CRONTAB_CMD` variable

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->