### PR TITLE
tests: Fix flaky syncEngine test

### DIFF
--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -569,7 +569,9 @@ describe("SyncEngine", () => {
         await engine.mergeUserNameProof(userNameProof);
         expect(await syncEngine.trie.exists(SyncId.fromFName(userNameProof))).toBeTruthy();
         await engine.mergeUserNameProof(supercedingUserNameProof);
-        await sleep(10); // Have to wait for the worker to finish processing messages
+
+        await sleepWhile(() => syncEngine.syncTrieQSize > 0, SLEEPWHILE_TIMEOUT);
+
         expect(await syncEngine.trie.exists(SyncId.fromFName(userNameProof))).toBeFalsy();
         expect(await syncEngine.trie.exists(SyncId.fromFName(supercedingUserNameProof))).toBeTruthy();
       });
@@ -590,7 +592,7 @@ describe("SyncEngine", () => {
         expect(eventResult._unsafeUnwrapErr().errCode).toEqual("bad_request.duplicate");
         expect(fnameResult._unsafeUnwrapErr().errCode).toEqual("bad_request.duplicate");
 
-        await sleep(10);
+        await sleepWhile(() => syncEngine.syncTrieQSize > 0, SLEEPWHILE_TIMEOUT);
 
         expect(await syncEngine.trie.exists(SyncId.fromFName(userNameProof))).toBeTruthy();
         expect(await syncEngine.trie.exists(SyncId.fromOnChainEvent(custodyEvent))).toBeTruthy();


### PR DESCRIPTION


## Change Summary

- Fix flaky syncengine test

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Replaced `sleep(10)` with `sleepWhile()` function to wait for the worker to finish processing messages in `syncEngine.test.ts`.
- Added a timeout parameter to `sleepWhile()` function call.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->