### PR TITLE
chore: Remove crontab cmd from replicator.sh

### DIFF
--- a/scripts/replicator.sh
+++ b/scripts/replicator.sh
@@ -386,14 +386,6 @@ set_platform_commands() {
         echo "Error: No suitable hash command found."
         exit 1
     fi
-
-    if [[ "$(uname)" == "Linux" ]]; then
-        # Extract the username from the current directory, since we're running as root
-        local user=$(pwd | cut -d/ -f3)
-        CRONTAB_CMD="crontab -u ${user}"
-    else
-        CRONTAB_CMD="crontab"
-    fi
 }
 
 reexec_as_root_if_needed() {


### PR DESCRIPTION

## Change Summary

Remove unnecessary line from replicator.sh

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying the `replicator.sh` script and removing unnecessary code. 

### Detailed summary:
- Removed the condition for Linux OS and extracting the username from the current directory.
- Removed the `CRONTAB_CMD` variable and simplified the `reexec_as_root_if_needed` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->