### PR TITLE
fix: Bind Replicator job dashboard to all interfaces

### DIFF
--- a/.changeset/five-roses-mix.md
+++ b/.changeset/five-roses-mix.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/replicator": patch
+---
+
+Bind job dashboard to all interfaces

--- a/apps/replicator/src/web.ts
+++ b/apps/replicator/src/web.ts
@@ -26,6 +26,6 @@ export function getWebApp(redis: Redis) {
   // biome-ignore lint/suspicious/noExplicitAny: legacy code, avoid using ignore for new code
   app.register(serverAdapter.registerPlugin() as any);
 
-  app.listen({ port: WEB_UI_PORT });
+  app.listen({ port: WEB_UI_PORT, host: "0.0.0.0" });
   return app;
 }


### PR DESCRIPTION
## Motivation

This ensures it is reachable when run inside a Docker container.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on binding the job dashboard to all interfaces. 

### Detailed summary
- Added `"@farcaster/replicator": patch` to dependencies
- Added `host: "0.0.0.0"` to the `app.listen` function in `web.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->