### PR TITLE
fix: Correct Grafana port for Replicator dashboard

### DIFF
--- a/scripts/replicator.sh
+++ b/scripts/replicator.sh
@@ -246,7 +246,7 @@ ensure_grafana() {
 
 ## Configure Grafana
 setup_grafana() {
-    local grafana_url="http://127.0.0.1:3000"
+    local grafana_url="http://127.0.0.1:9001"
     local credentials
     local response dashboard_uid prefs
 
@@ -488,7 +488,7 @@ if [ "$1" == "upgrade" ]; then
 
     echo "✅ Upgrade complete."
     echo ""
-    echo "Monitor your replicator at http://localhost:3000/ and http://localhost:9000/"
+    echo "Monitor your replicator at http://localhost:9000/ and http://localhost:9001/"
 
     # Sleep for 5 seconds
     sleep 5


### PR DESCRIPTION
## Motivation

We were updating the dashboard on the wrong Grafana instance.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)
