### PR TITLE
fix: Avoid displaying large time estimates for Replicator

### DIFF
--- a/.changeset/warm-peas-shave.md
+++ b/.changeset/warm-peas-shave.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/replicator": patch
+---
+
+Don't show very large time estimates

--- a/apps/replicator/src/hubReplicator.ts
+++ b/apps/replicator/src/hubReplicator.ts
@@ -213,7 +213,9 @@ export class HubReplicator {
         (elapsedMs / (dataBackfilled - alreadyBackfilled)) * (maxFid - alreadyBackfilled - dataBackfilled),
       );
       const timeRemaining =
-        millisRemaining === Infinity ? "Calculating..." : humanizeDuration(millisRemaining, { round: true });
+        millisRemaining === Infinity || millisRemaining > 864000000
+          ? "Calculating..."
+          : humanizeDuration(millisRemaining, { round: true });
 
       this.log.info(
         `Backfilled registrations for ${dataBackfilled} of ${maxFid} FIDs. Estimated time remaining: ${timeRemaining}`,
@@ -248,7 +250,9 @@ export class HubReplicator {
         (elapsedMs / (dataBackfilled - alreadyBackfilled)) * (maxFid - alreadyBackfilled - dataBackfilled),
       );
       const timeRemaining =
-        millisRemaining === Infinity ? "Calculating..." : humanizeDuration(millisRemaining, { round: true });
+        millisRemaining === Infinity || millisRemaining > 864000000
+          ? "Calculating..."
+          : humanizeDuration(millisRemaining, { round: true });
       this.log.info(
         `Backfilled events for ${dataBackfilled} of ${maxFid} FIDs. Estimated time remaining: ${timeRemaining}`,
       );


### PR DESCRIPTION
## Motivation

Sometimes a large number just renders as "Infinity". Check if it's just a large number.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving time estimates in the `HubReplicator` class. 

### Detailed summary
- Updated the logic to not show very large time estimates
- Added a condition to show "Calculating..." for time estimates greater than 10 days

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->