### PR TITLE
fix: Persist grafana data across restart

### DIFF
--- a/.changeset/five-gifts-relate.md
+++ b/.changeset/five-gifts-relate.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Persist grafana container data

--- a/apps/hubble/docker-compose.yml
+++ b/apps/hubble/docker-compose.yml
@@ -71,6 +71,7 @@ services:
     # Mount the grafana config file
     volumes:
       - ./grafana/grafana.ini:/etc/grafana/grafana.ini
+      - ./grafana/data:/var/lib/grafana  # Persistent Grafana data
     ports:
       - '3000:3000' # Grafana web
     networks:

--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -199,6 +199,10 @@ write_env_file() {
 }
 
 ensure_grafana() {
+      # Create a grafana data directory if it doesn't exist
+      mkdir -p grafana/data
+      chmod 777 grafana/data
+
       if $COMPOSE_CMD ps statsd 2>&1 >/dev/null; then
           if $COMPOSE_CMD ps statsd | grep -q "Up"; then
               $COMPOSE_CMD restart statsd grafana


### PR DESCRIPTION


## Change Summary

- Persist grafana data across docker container restarts
- Fixes https://github.com/farcasterxyz/hub-monorepo/issues/1492

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on persisting Grafana container data. 

### Detailed summary
- Added a volume mapping to persist Grafana data in `docker-compose.yml`.
- Created a directory for Grafana data and set appropriate permissions in `hubble.sh`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->