### PR TITLE
fix: Persist Grafana across restarts for Replicator Docker Compose

### DIFF
--- a/apps/replicator/docker-compose.yml
+++ b/apps/replicator/docker-compose.yml
@@ -82,6 +82,7 @@ services:
     restart: unless-stopped
     volumes:
       - ./grafana/grafana.ini:/etc/grafana/grafana.ini
+      - ./grafana/data:/var/lib/grafana
     ports:
       - '9001:3000' # Grafana web
     networks:

--- a/scripts/replicator.sh
+++ b/scripts/replicator.sh
@@ -232,6 +232,10 @@ ensure_redis() {
 }
 
 ensure_grafana() {
+      # Create a grafana data directory if it doesn't exist
+      mkdir -p grafana/data
+      chmod 777 grafana/data
+
       if $COMPOSE_CMD ps statsd 2>&1 >/dev/null; then
           if $COMPOSE_CMD ps statsd | grep -q "Up"; then
               $COMPOSE_CMD restart statsd grafana


### PR DESCRIPTION
## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a data directory for Grafana in the Docker Compose file and ensuring its existence in the replicator script.

### Detailed summary
- Added a volume mapping for the Grafana data directory in the Docker Compose file.
- Created a directory for Grafana data if it doesn't exist in the replicator script.
- Set the permissions of the Grafana data directory to 777 in the replicator script.
- Added a check and restart command for the Grafana container in the replicator script.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->