### PR TITLE
fix: Don't backfill chain events that were already backfilled

### DIFF
--- a/.changeset/fuzzy-scissors-confess.md
+++ b/.changeset/fuzzy-scissors-confess.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/replicator": patch
+---
+
+Don't backfill chain events that were already backfilled

--- a/apps/replicator/src/jobs/backfillFidData.ts
+++ b/apps/replicator/src/jobs/backfillFidData.ts
@@ -45,7 +45,7 @@ export const BackfillFidData = registerJob({
     if (!(await redis.sismember("backfilled-username-proofs", fid))) {
       await BackfillFidUserNameProofs.enqueue({ fid });
     }
-    if (!(await redis.sismember("backfilled-other-chain-events", fid))) {
+    if (!(await redis.sismember("backfilled-other-onchain-events", fid))) {
       await BackfillFidOtherOnChainEvents.enqueue({ fid });
     }
   },


### PR DESCRIPTION
## Motivation

We had a typo in the key we were checking, which was causing issues.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
Fixing a bug in the `replicator` app related to backfilling chain events.

### Detailed summary:
- Updated the condition to enqueue `BackfillFidOtherOnChainEvents` job by changing the set name from "backfilled-other-chain-events" to "backfilled-other-onchain-events".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->