### PR TITLE
fix: viem client interface, pass clients to builders

### DIFF
--- a/.changeset/nice-bulldogs-return.md
+++ b/.changeset/nice-bulldogs-return.md
@@ -4,4 +4,4 @@
 "@farcaster/hub-web": patch
 ---
 
-use interface for Viem PublicClient, add optional publicClients to builders
+fix: use interface for Viem PublicClient, add optional publicClients to builders

--- a/.changeset/nice-bulldogs-return.md
+++ b/.changeset/nice-bulldogs-return.md
@@ -1,0 +1,7 @@
+---
+"@farcaster/core": patch
+"@farcaster/hub-nodejs": patch
+"@farcaster/hub-web": patch
+---
+
+use interface for Viem PublicClient, add optional publicClients to builders

--- a/packages/core/src/builders.ts
+++ b/packages/core/src/builders.ts
@@ -5,6 +5,7 @@ import { HubAsyncResult } from "./errors";
 import { Signer } from "./signers";
 import { getFarcasterTime } from "./time";
 import * as validations from "./validations";
+import { PublicClients, defaultPublicClients } from "./eth/clients";
 
 /** Internal Types  */
 
@@ -32,6 +33,7 @@ const makeMessageData = async <TData extends protobufs.MessageData>(
   bodyOptions: MessageBodyOptions,
   messageType: protobufs.MessageType,
   dataOptions: MessageDataOptions,
+  publicClients: PublicClients = defaultPublicClients,
 ): HubAsyncResult<TData> => {
   if (!dataOptions.timestamp) {
     getFarcasterTime().map((timestamp) => {
@@ -45,7 +47,7 @@ const makeMessageData = async <TData extends protobufs.MessageData>(
     ...dataOptions,
   });
 
-  return validations.validateMessageData(data as TData);
+  return validations.validateMessageData(data as TData, publicClients);
 };
 
 const makeMessage = async <TMessage extends protobufs.Message>(
@@ -231,8 +233,9 @@ export const makeVerificationAddEthAddress = async (
   body: protobufs.VerificationAddEthAddressBody,
   dataOptions: MessageDataOptions,
   signer: Signer,
+  publicClients: PublicClients = defaultPublicClients,
 ): HubAsyncResult<protobufs.VerificationAddEthAddressMessage> => {
-  const data = await makeVerificationAddEthAddressData(body, dataOptions);
+  const data = await makeVerificationAddEthAddressData(body, dataOptions, publicClients);
   if (data.isErr()) {
     return err(data.error);
   }
@@ -254,11 +257,13 @@ export const makeVerificationRemove = async (
 export const makeVerificationAddEthAddressData = (
   body: protobufs.VerificationAddEthAddressBody,
   dataOptions: MessageDataOptions,
+  publicClients: PublicClients = defaultPublicClients,
 ): HubAsyncResult<protobufs.VerificationAddEthAddressData> => {
   return makeMessageData(
     { verificationAddEthAddressBody: body },
     protobufs.MessageType.VERIFICATION_ADD_ETH_ADDRESS,
     dataOptions,
+    publicClients,
   );
 };
 

--- a/packages/core/src/eth/clients.ts
+++ b/packages/core/src/eth/clients.ts
@@ -1,26 +1,30 @@
-import { PublicClient, createPublicClient, http } from "viem";
+import { VerifyTypedDataParameters, createPublicClient, http } from "viem";
 import { mainnet, goerli, optimism, optimismGoerli } from "viem/chains";
 
+export interface ViemPublicClient {
+  verifyTypedData: (args: VerifyTypedDataParameters) => Promise<boolean>;
+}
+
 export type PublicClients = {
-  [chainId: number]: PublicClient;
+  [chainId: number]: ViemPublicClient;
 };
 
-export const defaultL1PublicClient: PublicClient = createPublicClient({
+export const defaultL1PublicClient: ViemPublicClient = createPublicClient({
   chain: mainnet,
   transport: http(),
 });
 
-export const defaultL2PublicClient: PublicClient = createPublicClient({
+export const defaultL2PublicClient: ViemPublicClient = createPublicClient({
   chain: optimism,
   transport: http(),
 });
 
-export const defaultL1PublicTestClient: PublicClient = createPublicClient({
+export const defaultL1PublicTestClient: ViemPublicClient = createPublicClient({
   chain: goerli,
   transport: http(),
 });
 
-export const defaultL2PublicTestClient: PublicClient = createPublicClient({
+export const defaultL2PublicTestClient: ViemPublicClient = createPublicClient({
   chain: optimismGoerli,
   transport: http(),
 });


### PR DESCRIPTION
## Motivation

1) The `PublicClient` type I defined is too restrictive: it's already changed in the latest Viem. We should use an interface instead.
2) The `makeVerificationEthAddress` builder calls validations internally and needs to be passed `publicClients`.

## Change Summary

1) Replace usage of the viem `PublicClient` type with a `ViemPublicClient` interface.
2) Pass optional `publicClients` to `makeVerificationEthAddress` and `makeMessageData`

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on using an interface for Viem PublicClient and adding optional publicClients to builders.

### Detailed summary:
- Added `ViemPublicClient` interface.
- Replaced `PublicClient` with `ViemPublicClient` in `PublicClients` type.
- Updated `defaultL1PublicClient`, `defaultL2PublicClient`, `defaultL1PublicTestClient`, and `defaultL2PublicTestClient` variables to use `ViemPublicClient`.
- Imported `PublicClients` and `defaultPublicClients` in `builders.ts`.
- Added `publicClients` parameter to the `makeMessageData` and `makeVerificationAddEthAddressData` functions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->