### PR TITLE
fix: Exists check should not crash the hub

### DIFF
--- a/apps/hubble/src/network/sync/merkleTrieWorker.ts
+++ b/apps/hubble/src/network/sync/merkleTrieWorker.ts
@@ -197,7 +197,7 @@ class MerkleTrieImpl {
 
           resolve(status);
         } catch (e) {
-          log.error({ e }, "Insert Error");
+          log.error({ e }, `Insert Error for ${id}: ${e?.toString()}`);
 
           resolve(false);
         }
@@ -217,7 +217,7 @@ class MerkleTrieImpl {
 
           resolve(status);
         } catch (e) {
-          log.error({ e }, "Delete Error");
+          log.error({ e }, `Delete Error for ${id}: ${e?.toString()}`);
 
           resolve(false);
         }
@@ -233,11 +233,15 @@ class MerkleTrieImpl {
   public async exists(id: Uint8Array): Promise<boolean> {
     return new Promise((resolve) => {
       this._lock.readLock(async (release) => {
-        const r = await this._root.exists(id, this._dbGetter());
+        try {
+          const r = await this._root.exists(id, this._dbGetter());
+          await this._unloadFromMemory(false);
 
-        await this._unloadFromMemory(false);
-
-        resolve(r);
+          resolve(r);
+        } catch (e) {
+          log.error({ e }, `Exists Error for ${id}: ${e?.toString()}`);
+          resolve(false);
+        }
         release();
       });
     });


### PR DESCRIPTION
## Motivation

`exists` is missing a try/catch which is causing hubs to crash. Add a wrapper just like insert and delete. Still working on figuring out the underlying cause.

```
UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "Key length exceeded3".
```

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on improving error logging in the `MerkleTrieWorker` class.

### Detailed summary:
- Improved error logging for insert, delete, and exists operations in the `MerkleTrieImpl` class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->