### PR TITLE
chore: Release 1.6.2

### DIFF
--- a/.changeset/five-gifts-relate.md
+++ b/.changeset/five-gifts-relate.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Persist grafana container data

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/hubble
 
+## 1.6.2
+
+### Patch Changes
+
+- 17ca659b: fix: Persist grafana container data
+- e2ada603: fix: Exists check should not crash the hub
+
 ## 1.6.1
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",


### PR DESCRIPTION
## Motivation

Release crash fix from https://github.com/farcasterxyz/hub-monorepo/pull/1502

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of `@farcaster/hubble` package to `1.6.2` and includes two patch changes related to persisting Grafana container data and fixing an issue with the exists check that could crash the hub.

### Detailed summary
- Updated version of `@farcaster/hubble` package to `1.6.2`
- Patch change: Fixed an issue with persisting Grafana container data (commit: 17ca659b)
- Patch change: Fixed an issue with the exists check that could crash the hub (commit: e2ada603)

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->