### PR TITLE
fix: Cache numFnames and numFids

### DIFF
--- a/.changeset/mean-singers-agree.md
+++ b/.changeset/mean-singers-agree.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Cache numFids and numFnames

--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -121,6 +121,8 @@ describe("SyncEngine", () => {
     expect(await syncEngine.trie.exists(SyncId.fromOnChainEvent(signerEvent))).toBeTruthy();
     expect(await syncEngine.trie.exists(SyncId.fromOnChainEvent(storageEvent))).toBeTruthy();
     expect(await syncEngine.trie.exists(SyncId.fromFName(fnameProof))).toBeTruthy();
+    expect((await syncEngine.getDbStats()).numFids).toEqual(1);
+    expect((await syncEngine.getDbStats()).numFnames).toEqual(1);
   });
 
   test("trie is not updated on merge failure", async () => {
@@ -556,6 +558,7 @@ describe("SyncEngine", () => {
         expect(await syncEngine.trie.exists(SyncId.fromFName(userNameProof))).toBeFalsy();
         await engine.mergeUserNameProof(userNameProof);
         expect(await syncEngine.trie.exists(SyncId.fromFName(userNameProof))).toBeTruthy();
+        expect((await syncEngine.getDbStats()).numFnames).toEqual(1);
       });
       test("removes deleted fname proofs", async () => {
         const supercedingUserNameProof = Factories.UserNameProof.build({
@@ -565,15 +568,18 @@ describe("SyncEngine", () => {
 
         expect(await syncEngine.trie.exists(SyncId.fromFName(userNameProof))).toBeFalsy();
         expect(await syncEngine.trie.exists(SyncId.fromFName(supercedingUserNameProof))).toBeFalsy();
+        expect((await syncEngine.getDbStats()).numFnames).toEqual(0);
 
         await engine.mergeUserNameProof(userNameProof);
         expect(await syncEngine.trie.exists(SyncId.fromFName(userNameProof))).toBeTruthy();
-        await engine.mergeUserNameProof(supercedingUserNameProof);
+        expect((await syncEngine.getDbStats()).numFnames).toEqual(1);
 
+        await engine.mergeUserNameProof(supercedingUserNameProof);
         await sleepWhile(() => syncEngine.syncTrieQSize > 0, SLEEPWHILE_TIMEOUT);
 
         expect(await syncEngine.trie.exists(SyncId.fromFName(userNameProof))).toBeFalsy();
         expect(await syncEngine.trie.exists(SyncId.fromFName(supercedingUserNameProof))).toBeTruthy();
+        expect((await syncEngine.getDbStats()).numFnames).toEqual(1);
       });
 
       test("adds sync ids to the trie when not present and egnine rejects as duplicate", async () => {


### PR DESCRIPTION
## Change Summary

- Cache numFIds and numFnames in syncengine, instead of iterating over the whole db for `getInfo`

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a caching issue in the `SyncEngine` class. 

### Detailed summary
- Fixed caching of `numFids` and `numFnames` in `SyncEngine`
- Updated tests to reflect the changes in caching

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->