### PR TITLE
chore: remove envoy and grpc-web

### DIFF
--- a/.changeset/late-radios-wonder.md
+++ b/.changeset/late-radios-wonder.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/hub-web": patch
+"@farcaster/hubble": patch
+---
+
+chore: Remove grpc-web

--- a/apps/hubble/docker-compose.yml
+++ b/apps/hubble/docker-compose.yml
@@ -38,18 +38,6 @@ services:
         max-size: "1g"
         max-file: "2"
   
-  # Start if you want to expose your hub over grpc-web (for browser clients)
-  envoy:
-    image: envoyproxy/envoy:v1.26.1
-    depends_on:
-      - hubble
-    ports:
-      - '2285:2285'
-    volumes:
-      - ./envoy/envoy.yaml:/etc/envoy/envoy.yaml
-    networks:
-      - my-network
-
   # Start this if you want perf metrics for your hubble node. Remember to start `grafana` as well.
   statsd:
     image: graphiteapp/graphite-statsd:1.1.10-5

--- a/apps/hubble/envoy/README.md
+++ b/apps/hubble/envoy/README.md
@@ -1,6 +1,13 @@
+
+**Deprecation Notice:**
+grpc-web has been deprecated and is no longer supported. Please use the [HTTP API](https://www.thehubble.xyz/docs/httpapi/httpapi.html) instead. This original document has been kept only for historical reference.
+
+
+## Using grpc-web
+While grpc-web is not supported via Hubble, you can run your own envoy proxy to use grpc-web if you need to. 
 In order for farcaster to support grpc-web, we need to set up envoy alongside the server.
 
-## Requirement
+## Requirements
 
 Install docker if the farcaster instance doesn't support docker yet
 
@@ -13,11 +20,9 @@ re-login
 ```
 
 ## Infra setting
-
 update inbound/outbound traffic to allow tcp through envoy port (default: 2284)
 
 ## Start envoy
-
 update envoy.yaml for the correct rpc port (default: 2283) and envoy port (default: 2284)
 
 ```

--- a/packages/hub-web/README.grpcweb.md
+++ b/packages/hub-web/README.grpcweb.md
@@ -1,7 +1,7 @@
 # @farcaster/hub-web
 
 **Deprecation Notice:**
-grpc-web has been deprecated and will be removed in a future release. Please use the [HTTP API](./README.md) instead.
+grpc-web has been deprecated and is no longer supported. Please use the [HTTP API](./README.md) instead. This original document has been kept only for historical reference.
 
 
 A lightweight, fast Typescript interface for Farcaster Hubs. Designed to work with [Hubble](https://github.com/farcasterxyz/hubble/) and any other Hub that implements the [Farcaster protocol](https://github.com/farcasterxyz/protocol).

--- a/packages/hub-web/README.md
+++ b/packages/hub-web/README.md
@@ -45,7 +45,7 @@ yarn start
 ```
 
 ## grpc-Web
-grpc-web was an older way of proxying to the grpc API from web environments. This has been deprecated, and will be removed in a future release. You can read the [grpc-web documentation and examples here](./README.grpcweb.md).
+grpc-web was an older way of proxying to the grpc API from web environments. This has been deprecated and is no longer supported. You can read the original [grpc-web documentation and examples here](./README.grpcweb.md).
 
 ## Contributing
 

--- a/packages/hub-web/examples/grpc-web-chron-feed/README.md
+++ b/packages/hub-web/examples/grpc-web-chron-feed/README.md
@@ -1,1 +1,5 @@
+
+**Deprecation Notice:**
+grpc-web has been deprecated and is no longer supported. Please use the [HTTP API](../../README.md) instead. This original document has been kept only for historical reference.
+
 ## Generate a chronological feed


### PR DESCRIPTION

## Change Summary

- Delete deprecated envoy and update docs to reflect that. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Removed `grpc-web` from `@farcaster/hub-web` and `@farcaster/hubble` packages.
- Added deprecation notices and updated documentation for `grpc-web` in various files.
- Updated requirements and instructions for using `grpc-web` in `apps/hubble/envoy/README.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->