### PR TITLE
fix: Solved input error for the replicator's hub SSL option

### DIFF
--- a/scripts/replicator.sh
+++ b/scripts/replicator.sh
@@ -142,13 +142,9 @@ get_hub_ssl() {
     while true; do
         read -p "> Does your hub use SSL? " HUB_SSL
 
-        local answer=$(echo "$HUB_SSL" | tr '[:upper:]' '[:lower:]')
-
-        if [[ $lower_response == true || $lower_answer == t || $lower_answer == y ]]; then
-            echo "HUB_SSL=true" >> .env
-            break
-        elif [[ $lower_answer == false || $lower_answer = f || $lower_answer == n ]]; then
-            echo "HUB_SSL=false" >> .env
+        local lower_answer=$(echo "$HUB_SSL" | tr '[:upper:]' '[:lower:]')
+        if [[ "$lower_answer" == "true" || "$lower_answer" == "false" ]]; then
+            echo "HUB_SSL=$lower_answer" >> .env
             break
         else
             echo "!!! Invalid !!!"


### PR DESCRIPTION
## Motivation

<img width="683" alt="Input error for the replicators hub SSL option" src="https://github.com/farcasterxyz/hub-monorepo/assets/12853808/20676872-2cb9-414e-bcea-aace24678cf9">

When answering the prompts during the replicator's installation, the `Does your hub use SSL` prompt kept returning `!!! Invalid !!!` despite entering true or false, as prompted to.

## Change Summary

The fix checks for true or false in the same statement as opposed to in two separate statements.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The code in `replicator.sh` has been modified to handle the input value of `HUB_SSL` correctly.
- The variable `answer` has been renamed to `lower_answer` for clarity.
- The conditions for setting the value of `HUB_SSL` in the `.env` file have been updated to handle valid input values of "true" or "false".
- An "Invalid" message is printed if the input value is neither "true" nor "false".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->