### PR TITLE
Fix typo in replicator.sh

### DIFF
--- a/scripts/replicator.sh
+++ b/scripts/replicator.sh
@@ -142,9 +142,9 @@ get_hub_ssl() {
     while true; do
         read -p "> Does your hub use SSL? " HUB_SSL
 
-        local answer=$(echo "$HUB_SSL" | tr '[:upper:]' '[:lower:]')
+        local lower_answer=$(echo "$HUB_SSL" | tr '[:upper:]' '[:lower:]')
 
-        if [[ $lower_response == true || $lower_answer == t || $lower_answer == y ]]; then
+        if [[ $lower_answer == true || $lower_answer == t || $lower_answer == y ]]; then
             echo "HUB_SSL=true" >> .env
             break
         elif [[ $lower_answer == false || $lower_answer = f || $lower_answer == n ]]; then


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- Renamed the variable `answer` to `lower_answer` for better clarity.
- Updated the condition in the `if` statement to check for the variable `lower_answer` instead of `lower_response`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->