### PR TITLE
fix: Correct additional typos in replicator.sh

### DIFF
--- a/scripts/replicator.sh
+++ b/scripts/replicator.sh
@@ -143,10 +143,10 @@ get_hub_ssl() {
         read -p "> Does your hub use SSL? " HUB_SSL
 
         local lower_response=$(echo "$HUB_SSL" | tr '[:upper:]' '[:lower:]')
-        if [[ $lower_response == "true" || $lower_answer == "t" || $lower_answer == "y" || $lower_answer == "yes" ]]; then
+        if [[ $lower_response == "true" || $lower_response == "t" || $lower_response == "y" || $lower_response == "yes" ]]; then
             echo "HUB_SSL=true" >> .env
             break
-        elif [[ $lower_answer == "false" || $lower_answer = "f" || $lower_answer == "n" || $lower_answer == "no" ]]; then
+        elif [[ $lower_response == "false" || $lower_response = "f" || $lower_response == "n" || $lower_response == "no" ]]; then
             echo "HUB_SSL=false" >> .env
             break
         else


### PR DESCRIPTION
## Motivation

Missed in 2781c2c9.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a bug in the `replicator.sh` script related to the `HUB_SSL` variable. 

### Detailed summary
- Fixed a typo in variable name `lower_answer` to `lower_response`.
- Updated the conditions in the `if` and `elif` statements to use the correct variable `lower_response`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->