### PR TITLE
fix: Job to Purge FIDs that don't have storage

### DIFF
--- a/.changeset/nine-ligers-flow.md
+++ b/.changeset/nine-ligers-flow.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Purge FIDs that don't have storage every 3 hours

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -441,6 +441,10 @@ class Engine extends TypedEmitter<EngineEvents> {
     return ok(undefined);
   }
 
+  async removeOnChainIdRegisterEventByFid(fid: number): Promise<void> {
+    return this._onchainEventsStore.removeOnChainIdRegisterEventByFid(fid);
+  }
+
   /* -------------------------------------------------------------------------- */
   /*                             Event Methods                                  */
   /* -------------------------------------------------------------------------- */

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -441,8 +441,8 @@ class Engine extends TypedEmitter<EngineEvents> {
     return ok(undefined);
   }
 
-  async removeOnChainIdRegisterEventByFid(fid: number): Promise<void> {
-    return this._onchainEventsStore.removeOnChainIdRegisterEventByFid(fid);
+  async removeOnChainIdRegisterEventByFid(event: OnChainEvent): Promise<void> {
+    return this._onchainEventsStore.removeOnChainIdRegisterEventByFid(event);
   }
 
   /* -------------------------------------------------------------------------- */

--- a/apps/hubble/src/storage/jobs/removeFidsWithNoStorageJob.test.ts
+++ b/apps/hubble/src/storage/jobs/removeFidsWithNoStorageJob.test.ts
@@ -1,0 +1,60 @@
+import { Factories, FarcasterNetwork } from "@farcaster/hub-nodejs";
+import { jestRocksDB } from "../db/jestUtils.js";
+import Engine from "../engine/index.js";
+import { IdRegisterOnChainEvent } from "@farcaster/core";
+import SyncEngine from "../../network/sync/syncEngine.js";
+import { RemoveFidsWithNoStorageJobScheduler } from "./removeFidsWithNoStorageJob.js";
+import { MockHub } from "../../test/mocks.js";
+import { HubInterface } from "../../hubble.js";
+
+const db = jestRocksDB("jobs.removeFidsWithNoStorage.test");
+const network = FarcasterNetwork.TESTNET;
+const fid = Factories.Fid.build();
+const signer = Factories.Ed25519Signer.build();
+const custodySigner = Factories.Eip712Signer.build();
+
+let custodyEvent: IdRegisterOnChainEvent;
+
+let hub: HubInterface;
+let engine: Engine;
+let syncEngine: SyncEngine;
+let scheduler: RemoveFidsWithNoStorageJobScheduler;
+
+describe("RemoveFidsWithNoStorageJob", () => {
+  beforeAll(async () => {
+    engine = new Engine(db, FarcasterNetwork.TESTNET);
+    hub = new MockHub(db, engine);
+    syncEngine = new SyncEngine(hub, db);
+    scheduler = new RemoveFidsWithNoStorageJobScheduler(engine, syncEngine);
+
+    const custodySignerKey = (await custodySigner.getSignerKey())._unsafeUnwrap();
+    custodyEvent = Factories.IdRegistryOnChainEvent.build({ fid }, { transient: { to: custodySignerKey } });
+  });
+
+  afterAll(async () => {
+    await syncEngine.stop();
+    await engine.stop();
+    scheduler.stop();
+  });
+
+  test("should remove fids with no storage", async () => {
+    const rcustody = await engine.mergeOnChainEvent(custodyEvent);
+    expect(rcustody.isOk()).toBeTruthy();
+
+    // Make sure its in the engine and sync trie
+    const custody = await engine.getIdRegistryOnChainEvent(fid);
+    expect(custody.isOk()).toBeTruthy();
+    expect(custody._unsafeUnwrap().fid).toEqual(fid);
+
+    expect(await syncEngine.trie.items()).toBe(1);
+
+    // Run the job
+    await scheduler.doJobs();
+
+    // Make sure its not in the engine and sync trie
+    const custody2 = await engine.getIdRegistryOnChainEvent(fid);
+    expect(custody2.isErr()).toBeTruthy();
+
+    expect(await syncEngine.trie.items()).toBe(0);
+  });
+});

--- a/apps/hubble/src/storage/jobs/removeFidsWithNoStorageJob.ts
+++ b/apps/hubble/src/storage/jobs/removeFidsWithNoStorageJob.ts
@@ -1,0 +1,120 @@
+import { HubAsyncResult } from "@farcaster/hub-nodejs";
+import { err, ok } from "neverthrow";
+import cron from "node-cron";
+import { logger } from "../../utils/logger.js";
+import Engine from "../engine/index.js";
+import { statsd } from "../../utils/statsd.js";
+import SyncEngine from "../../network/sync/syncEngine.js";
+import { SyncId } from "../../network/sync/syncId.js";
+
+export const DEFAULT_REMOVE_FIDS_WITH_NO_STORAGE_CRON = "0 */3 * * *"; // Every 3 hours
+
+const log = logger.child({
+  component: "RemoveFidsWithNoStorageJob",
+});
+
+type SchedulerStatus = "started" | "stopped";
+
+export class RemoveFidsWithNoStorageJobScheduler {
+  private _engine: Engine;
+  private _syncEngine: SyncEngine;
+  private _cronTask?: cron.ScheduledTask;
+  private _running = false;
+
+  constructor(engine: Engine, syncEngine: SyncEngine) {
+    this._engine = engine;
+    this._syncEngine = syncEngine;
+  }
+
+  start(cronSchedule?: string) {
+    this._cronTask = cron.schedule(cronSchedule ?? DEFAULT_REMOVE_FIDS_WITH_NO_STORAGE_CRON, () => this.doJobs());
+
+    // Run once on startup
+    setTimeout(() => {
+      this.doJobs();
+    }, 10 * 1000);
+  }
+
+  stop() {
+    if (this._cronTask) {
+      this._cronTask.stop();
+    }
+  }
+
+  status(): SchedulerStatus {
+    return this._cronTask ? "started" : "stopped";
+  }
+
+  async doJobs(): HubAsyncResult<void> {
+    if (this._running) {
+      log.info({}, "RemoveFidsWithNoStorageJobScheduler already running, skipping");
+      return ok(undefined);
+    }
+
+    log.info({}, "starting RemoveFidsWithNoStorageJobScheduler");
+    this._running = true;
+
+    const start = Date.now();
+
+    const allFids = [];
+    let finished = false;
+    let pageToken: Uint8Array | undefined;
+    do {
+      const fidsPage = await this._engine.getFids({ pageToken, pageSize: 100 });
+      if (fidsPage.isErr()) {
+        return err(fidsPage.error);
+      }
+      const { fids, nextPageToken } = fidsPage.value;
+      if (!nextPageToken) {
+        finished = true;
+      } else {
+        pageToken = nextPageToken;
+      }
+      allFids.push(...fids);
+    } while (!finished);
+
+    let totalFidsRemoved = 0;
+
+    const numFids = allFids.length;
+
+    for (let i = 0; i < numFids; i++) {
+      const fid = allFids[i] as number;
+      const numChecked = await this.doJobForFid(fid);
+      totalFidsRemoved += numChecked.unwrapOr(0);
+    }
+
+    const timeTakenMs = Date.now() - start;
+    log.info(
+      { timeTakenMs, numFids, totalMessagesChecked: totalFidsRemoved },
+      "finished RemoveFidsWithNoStorageJobScheduler",
+    );
+
+    // StatsD metrics
+    statsd().timing("RemoveFidsWithNoStorageJobScheduler.timeTakenMs", timeTakenMs);
+    statsd().gauge("RemoveFidsWithNoStorageJobScheduler.totalMessagesChecked", totalFidsRemoved);
+
+    this._running = false;
+    return ok(undefined);
+  }
+
+  async doJobForFid(fid: number): HubAsyncResult<number> {
+    // See if this FID has any storage
+    const storage = await this._engine.getCurrentStorageLimitsByFid(fid);
+    if (storage.isOk() && storage.value.limits[0]?.limit === 0) {
+      await this._engine.removeOnChainIdRegisterEventByFid(fid);
+
+      const onChainEvent = await this._engine.getIdRegistryOnChainEvent(fid);
+      if (onChainEvent.isOk()) {
+        const syncId = SyncId.fromOnChainEvent(onChainEvent.value);
+        const result = await this._syncEngine.trie.deleteBySyncId(syncId);
+        if (!result) {
+          log.error({ fid }, "RemoveFidsWithNoStorageJobScheduler trie.deleteBySyncId failed");
+        }
+      }
+
+      log.info({ fid }, "RemoveFids removed OnChainIdRegisterEvent for FID with no storage");
+    }
+
+    return ok(1);
+  }
+}

--- a/apps/hubble/src/storage/jobs/removeFidsWithNoStorageJob.ts
+++ b/apps/hubble/src/storage/jobs/removeFidsWithNoStorageJob.ts
@@ -105,8 +105,9 @@ export class RemoveFidsWithNoStorageJobScheduler {
       }
 
       log.info({ fid }, "RemoveFids removed OnChainIdRegisterEvent for FID with no storage");
+      return ok(1);
     }
 
-    return ok(1);
+    return ok(0);
   }
 }

--- a/apps/hubble/src/storage/jobs/removeFidsWithNoStorageJob.ts
+++ b/apps/hubble/src/storage/jobs/removeFidsWithNoStorageJob.ts
@@ -101,8 +101,6 @@ export class RemoveFidsWithNoStorageJobScheduler {
     // See if this FID has any storage
     const storage = await this._engine.getCurrentStorageLimitsByFid(fid);
     if (storage.isOk() && storage.value.limits[0]?.limit === 0) {
-      await this._engine.removeOnChainIdRegisterEventByFid(fid);
-
       const onChainEvent = await this._engine.getIdRegistryOnChainEvent(fid);
       if (onChainEvent.isOk()) {
         const syncId = SyncId.fromOnChainEvent(onChainEvent.value);
@@ -111,6 +109,7 @@ export class RemoveFidsWithNoStorageJobScheduler {
           log.error({ fid }, "RemoveFidsWithNoStorageJobScheduler trie.deleteBySyncId failed");
         }
       }
+      await this._engine.removeOnChainIdRegisterEventByFid(fid);
 
       log.info({ fid }, "RemoveFids removed OnChainIdRegisterEvent for FID with no storage");
     }

--- a/apps/hubble/src/storage/stores/onChainEventStore.ts
+++ b/apps/hubble/src/storage/stores/onChainEventStore.ts
@@ -55,6 +55,18 @@ class OnChainEventStore {
     return this._mergeEvent(event);
   }
 
+  async removeOnChainIdRegisterEventByFid(fid: number): Promise<void> {
+    const id = makeIdRegisterEventByFidKey(fid);
+    const txn = this._db.transaction();
+    txn.del(id);
+    // TODO: Do we need an event handler for this?
+    // this._eventHandler.commitTransaction(txn, {
+    //   type: HubEventType.REMOVE_ON_CHAIN_ID_REGISTER_EVENT,
+    //   removeOnChainIdRegisterEventBody: { fid },
+    // });
+    await this._db.commit(txn);
+  }
+
   async getOnChainEvents<T extends OnChainEvent>(type: OnChainEventType, fid: number): Promise<T[]> {
     const keys: Buffer[] = [];
     await this._db.forEachIteratorByPrefix(


### PR DESCRIPTION
## Motivation

FIDs that don't have any storage are annoying, so purge them from the DB and syncTrie every 3 hours. 

## Change Summary



## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a bug related to purging FIDs that don't have storage. 

### Detailed summary
- Adds a new method `removeOnChainIdRegisterEventByFid` to the `onChainEventStore` class.
- Adds a new job scheduler `RemoveFidsWithNoStorageJobScheduler` to remove FIDs with no storage every 3 hours.
- Adds a new test file `removeFidsWithNoStorageJob.test.ts` to test the job scheduler.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->