### PR TITLE
chore: Add logging around invalid gossip messages

### DIFF
--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -35,7 +35,7 @@ const workerLog = logger.child({ component: "GossipNodeWorker" });
 /** Events emitted by a Farcaster Gossip Node */
 interface NodeEvents {
   /** Triggers on receipt of a new message and includes the topic and message contents */
-  message: (topic: string, message: HubResult<GossipMessage>) => void;
+  message: (topic: string, message: HubResult<GossipMessage>, source: PeerId) => void;
   /** Triggers when a peer connects and includes the libp2p Connection object*/
   peerConnect: (connection: Connection) => void;
   /** Triggers when a peer disconnects and includes the libp2p Connection object */
@@ -385,7 +385,7 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
           } else {
             data = Buffer.from(Object.values(detail.msg.data as unknown as Record<string, number>));
           }
-          this.emit("message", detail.msg.topic, GossipNode.decodeMessage(data));
+          this.emit("message", detail.msg.topic, GossipNode.decodeMessage(data), detail.propagationSource);
         } catch (e) {
           logger.error({ e, data: detail.msg.data }, "Failed to decode message");
         }


### PR DESCRIPTION
## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding the `source` parameter to the `message` event in the `GossipNode` and `Hub` classes.

### Detailed summary:
- Added `source` parameter to the `message` event in the `GossipNode` class.
- Added `source` parameter to the `handleGossipMessage` method in the `Hub` class.
- Added `source` parameter to the `message` event callback in the `Hub` class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->