### PR TITLE
fix: correctly reportValid more messages and bump up seen ttl

### DIFF
--- a/.changeset/odd-maps-matter.md
+++ b/.changeset/odd-maps-matter.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Fix contactInfo messages not being forwarded and increase seen ttl to prevent future loops

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -933,6 +933,7 @@ export class Hub implements HubInterface {
       return result.map(() => undefined);
     } else if (gossipMessage.contactInfoContent) {
       await this.handleContactInfo(peerIdResult.value, gossipMessage.contactInfoContent);
+      this.gossipNode.reportValid(msgId, peerIdFromString(source.toString()).toBytes());
       return ok(undefined);
     } else {
       return err(new HubError("bad_request.invalid_param", "invalid message type"));

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -917,7 +917,7 @@ export class Hub implements HubInterface {
       // Merge the message
       const result = await this.submitMessage(message, "gossip");
       if (result.isOk()) {
-        this.gossipNode.reportValid(msgId, peerIdFromString(source.toString()).toBytes());
+        this.gossipNode.reportValid(msgId, peerIdFromString(source.toString()).toBytes(), true);
       } else {
         log.info(
           {
@@ -929,11 +929,12 @@ export class Hub implements HubInterface {
           },
           "Received bad gossip message from peer",
         );
+        this.gossipNode.reportValid(msgId, peerIdFromString(source.toString()).toBytes(), false);
       }
       return result.map(() => undefined);
     } else if (gossipMessage.contactInfoContent) {
       await this.handleContactInfo(peerIdResult.value, gossipMessage.contactInfoContent);
-      this.gossipNode.reportValid(msgId, peerIdFromString(source.toString()).toBytes());
+      this.gossipNode.reportValid(msgId, peerIdFromString(source.toString()).toBytes(), true);
       return ok(undefined);
     } else {
       return err(new HubError("bad_request.invalid_param", "invalid message type"));

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -84,7 +84,7 @@ export interface LibP2PNodeInterface {
   subscribe: (topic: string) => Promise<void>;
   gossipMessage: (message: Uint8Array) => Promise<SuccessOrError & { peerIds: Uint8Array[] }>;
   gossipContactInfo: (contactInfo: Uint8Array) => Promise<SuccessOrError & { peerIds: Uint8Array[] }>;
-  reportValid: (messageId: string, propagationSource: Uint8Array) => Promise<void>;
+  reportValid: (messageId: string, propagationSource: Uint8Array, isValid: boolean) => Promise<void>;
 }
 
 // Extract the method names (as strings) from the LibP2PNodeInterface
@@ -399,7 +399,7 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
         statsd().increment("gossip.messages");
       } else {
         // Report other messages we don't care about (peer discovery mainly) as being valid, so they can be forwarded correctly
-        this.reportValid(detail.msgId, peerIdFromString(detail.propagationSource.toString()).toBytes());
+        this.reportValid(detail.msgId, peerIdFromString(detail.propagationSource.toString()).toBytes(), true);
       }
     });
   }
@@ -473,8 +473,8 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
     this.callMethod("updateDeniedPeerIds", peerIds);
   }
 
-  reportValid(messageId: string, propagationSource: Uint8Array) {
-    this.callMethod("reportValid", messageId, propagationSource);
+  reportValid(messageId: string, propagationSource: Uint8Array, isValid: boolean) {
+    this.callMethod("reportValid", messageId, propagationSource, isValid);
   }
 
   /* -------------------------------------------------------------------------- */

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -13,7 +13,7 @@ import {
 } from "@farcaster/hub-nodejs";
 import { Connection } from "@libp2p/interface-connection";
 import { PeerId } from "@libp2p/interface-peer-id";
-import { peerIdFromBytes } from "@libp2p/peer-id";
+import { peerIdFromBytes, peerIdFromString } from "@libp2p/peer-id";
 import { multiaddr, Multiaddr } from "@multiformats/multiaddr";
 import { err, ok, Result } from "neverthrow";
 import { TypedEmitter } from "tiny-typed-emitter";
@@ -386,7 +386,6 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
           } else {
             data = Buffer.from(Object.values(detail.msg.data as unknown as Record<string, number>));
           }
-          const messageId = detail.msg;
           this.emit(
             "message",
             detail.msg.topic,
@@ -398,6 +397,9 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
           logger.error({ e, data: detail.msg.data }, "Failed to decode message");
         }
         statsd().increment("gossip.messages");
+      } else {
+        // Report other messages we don't care about (peer discovery mainly) as being valid, so they can be forwarded correctly
+        this.reportValid(detail.msgId, peerIdFromString(detail.propagationSource.toString()).toBytes());
       }
     });
   }

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -374,8 +374,12 @@ export class LibP2PNode {
     }
   }
 
-  async reportValid(messageId: string, propagationSource: PeerId) {
-    this.gossip?.reportMessageValidationResult(messageId, propagationSource, TopicValidatorResult.Accept);
+  async reportValid(messageId: string, propagationSource: PeerId, isValid: boolean) {
+    this.gossip?.reportMessageValidationResult(
+      messageId,
+      propagationSource,
+      isValid ? TopicValidatorResult.Accept : TopicValidatorResult.Reject,
+    );
   }
 
   registerEventListeners() {
@@ -580,9 +584,9 @@ parentPort?.on("message", async (msg: LibP2PNodeMethodGenericMessage) => {
     }
     case "reportValid": {
       const specificMsg = msg as LibP2PNodeMessage<"reportValid">;
-      const [msgId, source] = specificMsg.args;
+      const [msgId, source, isValid] = specificMsg.args;
       const sourceId = peerIdFromBytes(source);
-      await libp2pNode.reportValid(msgId, sourceId);
+      await libp2pNode.reportValid(msgId, sourceId, isValid);
       parentPort?.postMessage({ methodCallId, result: makeResult<"reportValid">(undefined) });
       break;
     }

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -114,6 +114,7 @@ export class LibP2PNode {
       msgIdFn: this.getMessageId.bind(this),
       directPeers: options.directPeers || [],
       canRelayMessage: true,
+      seenTTL: 1000 * 60 * 10, // Bump up the default to handle large flood of messages. 2 mins was not sufficient to prevent a loop
       scoreThresholds: { ...options.scoreThresholds },
     });
 

--- a/apps/hubble/src/test/e2e/gossipNetwork.test.ts
+++ b/apps/hubble/src/test/e2e/gossipNetwork.test.ts
@@ -76,7 +76,9 @@ describe("gossip network tests", () => {
 
             // we'll treat reaction add messages as invalid and everything else as valid
             if (gossipMessage.message && !isReactionAddMessage(gossipMessage.message)) {
-              n.reportValid(msgId, peerIdFromString(source.toString()).toBytes());
+              n.reportValid(msgId, peerIdFromString(source.toString()).toBytes(), true);
+            } else {
+              n.reportValid(msgId, peerIdFromString(source.toString()).toBytes(), false);
             }
           });
           n.registerDebugListeners();


### PR DESCRIPTION
## Motivation

 - Need to call reportValid for all kinds of messages
 - Increase seen ttl as additional protection against loops when there are lots of messages

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
Fixing contactInfo messages not being forwarded and increasing seen ttl to prevent future loops.

### Detailed summary:
- Added a new parameter `isValid` to the `reportValid` function in `gossipNodeWorker.ts`.
- Updated the `reportValid` function calls in `hubble.ts` and `gossipNetwork.test.ts` to pass the `isValid` parameter.
- Bumped up the `seenTTL` value in `gossipNodeWorker.ts` to handle a large flood of messages and prevent loops.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->