### PR TITLE
fix: Lower seenTTL to 5 mins to reduce memory consumption

### DIFF
--- a/.changeset/nasty-mirrors-check.md
+++ b/.changeset/nasty-mirrors-check.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Lower seenTTL to 5 mins to reduce memory consumption

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -114,7 +114,7 @@ export class LibP2PNode {
       msgIdFn: this.getMessageId.bind(this),
       directPeers: options.directPeers || [],
       canRelayMessage: true,
-      seenTTL: 1000 * 60 * 10, // Bump up the default to handle large flood of messages. 2 mins was not sufficient to prevent a loop
+      seenTTL: 1000 * 60 * 5, // Bump up the default to handle large flood of messages. 2 mins was not sufficient to prevent a loop
       scoreThresholds: { ...options.scoreThresholds },
     });
 


### PR DESCRIPTION
## Motivation

We're seeing OOM issues on some hubs, the seenTTL may be too high and consuming too much memory. Safe to reduce now that all hubs have the asyncValidation turned on.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Lowered the `seenTTL` value from 10 minutes to 5 minutes in the `gossipNodeWorker.ts` file to reduce memory consumption.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->