### PR TITLE
fix: add memory stats

### DIFF
--- a/.changeset/ninety-experts-peel.md
+++ b/.changeset/ninety-experts-peel.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": minor
+---
+
+add memory stats

--- a/apps/hubble/grafana/grafana-dashboard.json
+++ b/apps/hubble/grafana/grafana-dashboard.json
@@ -1342,12 +1342,119 @@
       "type": "timeseries"
     },
     {
+      "datasource": "Graphite",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.0.3",
+      "targets": [
+        {
+          "datasource": "Graphite",
+          "refCount": 0,
+          "refId": "A",
+          "target": "stats.gauges.hubble.memory.external"
+        },
+        {
+          "datasource": "Graphite",
+          "hide": false,
+          "refCount": 0,
+          "refId": "B",
+          "target": "stats.gauges.hubble.memory.heap_total"
+        },
+        {
+          "datasource": "Graphite",
+          "hide": false,
+          "refCount": 0,
+          "refId": "C",
+          "target": "stats.gauges.hubble.memory.heap_used"
+        },
+        {
+          "datasource": "Graphite",
+          "hide": false,
+          "refCount": 0,
+          "refId": "D",
+          "target": "stats.gauges.hubble.memory.rss"
+        }
+      ],
+      "title": "Memory Usage",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 51
       },
       "id": 15,
       "panels": [],
@@ -1438,7 +1545,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 44
+        "y": 52
       },
       "id": 16,
       "options": {
@@ -1547,7 +1654,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 44
+        "y": 52
       },
       "id": 17,
       "options": {
@@ -1579,7 +1686,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 52
+        "y": 60
       },
       "id": 28,
       "panels": [],
@@ -1644,7 +1751,7 @@
         "h": 10,
         "w": 7,
         "x": 0,
-        "y": 53
+        "y": 61
       },
       "id": 30,
       "options": {
@@ -1742,7 +1849,7 @@
         "h": 10,
         "w": 9,
         "x": 7,
-        "y": 53
+        "y": 61
       },
       "id": 27,
       "options": {
@@ -1826,7 +1933,7 @@
         "h": 10,
         "w": 8,
         "x": 16,
-        "y": 53
+        "y": 61
       },
       "id": 29,
       "options": {
@@ -1900,7 +2007,7 @@
         "h": 9,
         "w": 7,
         "x": 0,
-        "y": 63
+        "y": 71
       },
       "id": 32,
       "options": {

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1201,12 +1201,6 @@ export class Hub implements HubInterface {
           source,
         };
         const msg = "submitMessage success";
-        // track memory usage on successful merges
-        const memoryData = process.memoryUsage();
-        statsd().gauge("memory.rss", memoryData.rss);
-        statsd().gauge("memory.heap_total", memoryData.heapTotal);
-        statsd().gauge("memory.heap_used", memoryData.heapUsed);
-        statsd().gauge("memory.external", memoryData.external);
 
         if (source === "sync") {
           log.debug(logData, msg);

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1201,6 +1201,12 @@ export class Hub implements HubInterface {
           source,
         };
         const msg = "submitMessage success";
+        // track memory usage on successful merges
+        const memoryData = process.memoryUsage();
+        statsd().gauge("memory.rss", memoryData.rss);
+        statsd().gauge("memory.heap_total", memoryData.heapTotal);
+        statsd().gauge("memory.heap_used", memoryData.heapUsed);
+        statsd().gauge("memory.external", memoryData.external);
 
         if (source === "sync") {
           log.debug(logData, msg);

--- a/apps/hubble/src/storage/jobs/gossipContactInfoJob.ts
+++ b/apps/hubble/src/storage/jobs/gossipContactInfoJob.ts
@@ -2,6 +2,7 @@ import cron from "node-cron";
 import { HubInterface } from "../../hubble.js";
 import { logger } from "../../utils/logger.js";
 import { HubAsyncResult } from "@farcaster/core";
+import { statsd } from "../../utils/statsd.js";
 
 const log = logger.child({
   component: "GossipContactInfo",
@@ -34,6 +35,11 @@ export class GossipContactInfoJobScheduler {
 
   async doJobs(): HubAsyncResult<void> {
     log.info({}, "starting gossip contact info job");
+    const memoryData = process.memoryUsage();
+    statsd().gauge("memory.rss", memoryData.rss);
+    statsd().gauge("memory.heap_total", memoryData.heapTotal);
+    statsd().gauge("memory.heap_used", memoryData.heapUsed);
+    statsd().gauge("memory.external", memoryData.external);
 
     return await this._hub.gossipContactInfo();
   }


### PR DESCRIPTION
## Motivation

Nice to be able to track memory on Grafana

## Change Summary

Added guages for memory stats

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
<img width="1414" alt="image" src="https://github.com/farcasterxyz/hub-monorepo/assets/107961892/77b29efd-c4a7-46bc-a9d9-e3987df87f43">

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds memory stats to the `GossipContactInfoJobScheduler` in the `hubble` app. It also updates the Grafana dashboard to display memory usage.

### Detailed summary
- Added memory stats to `GossipContactInfoJobScheduler`
- Updated Grafana dashboard to display memory usage

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->