### PR TITLE
fix: prevent hub startup if protocol version is expired

### DIFF
--- a/.changeset/neat-flowers-pretend.md
+++ b/.changeset/neat-flowers-pretend.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Prevent hub startup if protocol version is expired

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -45,7 +45,7 @@ import {
   p2pMultiAddrStr,
 } from "./utils/p2p.js";
 import { PeriodicTestDataJobScheduler, TestUser } from "./utils/periodicTestDataJob.js";
-import { ensureAboveMinFarcasterVersion, VersionSchedule } from "./utils/versions.js";
+import { ensureAboveMinFarcasterVersion, getMinFarcasterVersion, VersionSchedule } from "./utils/versions.js";
 import { CheckFarcasterVersionJobScheduler } from "./storage/jobs/checkFarcasterVersionJob.js";
 import { ValidateOrRevokeMessagesJobScheduler } from "./storage/jobs/validateOrRevokeMessagesJob.js";
 import { GossipContactInfoJobScheduler } from "./storage/jobs/gossipContactInfoJob.js";
@@ -335,6 +335,10 @@ export class Hub implements HubInterface {
     } else {
       log.warn("No FName Registry URL provided, unable to sync fname events");
       throw new HubError("bad_request.invalid_param", "Invalid fname server url");
+    }
+
+    if (getMinFarcasterVersion().isErr()) {
+      throw new HubError("unavailable", `Farcaster version ${FARCASTER_VERSION} expired, please upgrade hub`);
     }
 
     this.rocksDB = new RocksDB(options.rocksDBName ? options.rocksDBName : randomDbName());


### PR DESCRIPTION
## Motivation

The protocol version check job only runs once a day. When it kills the hub, docker compose may restart it automatically and the expired hub will not die again for another day. Check on startup to see if the protocol version is expired to prevent this.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
Prevent hub startup if protocol version is expired.

### Detailed summary:
- Added a check to prevent hub startup if the minimum Farcaster version is expired.
- Updated the import statement for `getMinFarcasterVersion` in `hubble.ts`.
- Added error handling to throw a `HubError` if the minimum Farcaster version is expired.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->