### PR TITLE
feat: app-specific peer scoring integration

### DIFF
--- a/.changeset/breezy-dogs-beg.md
+++ b/.changeset/breezy-dogs-beg.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+Adds application-specific peer scoring to peer scoring for gossipsub with early immune list

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -124,18 +124,16 @@ export class LibP2PNode {
       scoreThresholds: { ...options.scoreThresholds },
       scoreParams: {
         appSpecificScore: (peerId) => {
+          const score = this._peerScores?.get(peerId) ?? 0;
           if (options.allowlistedImmunePeers?.includes(peerId)) {
-            if ((this._peerScores?.get(peerId) ?? 0) < -100) {
-              log.warn({ peerId }, "GossipSub: Allowlisted peer would have been kicked out.");
+            if (score < -100) {
+              log.warn({ peerId, score }, "GossipSub: Allowlisted peer would have been kicked out.");
             }
 
             return options.applicationScoreCap ?? APPLICATION_SCORE_CAP_DEFAULT;
           }
 
-          return Math.min(
-            this._peerScores?.get(peerId) ?? 0,
-            options.applicationScoreCap ?? APPLICATION_SCORE_CAP_DEFAULT,
-          );
+          return Math.min(score, options.applicationScoreCap ?? APPLICATION_SCORE_CAP_DEFAULT);
         },
       },
     });

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -34,8 +34,10 @@ import { PeerId } from "@libp2p/interface-peer-id";
 import { createFromProtobuf, exportToProtobuf } from "@libp2p/peer-id-factory";
 import { Logger } from "../../utils/logger.js";
 import { statsd } from "../../utils/statsd.js";
+import { PeerScore } from "network/sync/peerScore.js";
 
 const MultiaddrLocalHost = "/ip4/127.0.0.1";
+const APPLICATION_SCORE_CAP_DEFAULT = 10;
 
 // We use a proxy to log messages to the main thread
 const log = new Proxy<Logger>({} as Logger, {
@@ -56,9 +58,11 @@ export class LibP2PNode {
   _node?: Libp2p;
   private _connectionGater?: ConnectionFilter;
   private _network: FarcasterNetwork;
+  private _peerScores: Map<string, number>;
 
   constructor(network: FarcasterNetwork) {
     this._network = network;
+    this._peerScores = new Map<string, number>();
   }
 
   get identity() {
@@ -118,6 +122,22 @@ export class LibP2PNode {
       canRelayMessage: true,
       seenTTL: GOSSIP_SEEN_TTL, // Bump up the default to handle large flood of messages. 2 mins was not sufficient to prevent a loop
       scoreThresholds: { ...options.scoreThresholds },
+      scoreParams: {
+        appSpecificScore: (peerId) => {
+          if (options.allowlistedImmunePeers?.includes(peerId)) {
+            if ((this._peerScores?.get(peerId) ?? 0) < -100) {
+              log.warn({ peerId }, "GossipSub: Allowlisted peer would have been kicked out.");
+            }
+
+            return options.applicationScoreCap ?? APPLICATION_SCORE_CAP_DEFAULT;
+          }
+
+          return Math.min(
+            this._peerScores?.get(peerId) ?? 0,
+            options.applicationScoreCap ?? APPLICATION_SCORE_CAP_DEFAULT,
+          );
+        },
+      },
     });
 
     if (options.allowedPeerIdStrs) {
@@ -403,6 +423,10 @@ export class LibP2PNode {
     );
   }
 
+  updateApplicationPeerScore(peerId: string, score: number) {
+    this._peerScores.set(peerId, score);
+  }
+
   registerEventListeners() {
     // When serializing data, we need to handle some data types specially.
     // 1, BigInts are not supported by JSON.stringify, so we convert them to strings
@@ -652,6 +676,16 @@ parentPort?.on("message", async (msg: LibP2PNodeMethodGenericMessage) => {
       parentPort?.postMessage({
         methodCallId,
         result: makeResult<"reportValid">(undefined),
+      });
+      break;
+    }
+    case "updateApplicationPeerScore": {
+      const specificMsg = msg as LibP2PNodeMessage<"updateApplicationPeerScore">;
+      const [peerId, score] = specificMsg.args;
+      await libp2pNode.updateApplicationPeerScore(peerId, score);
+      parentPort?.postMessage({
+        methodCallId,
+        result: makeResult<"updateApplicationPeerScore">(undefined),
       });
       break;
     }

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -132,7 +132,7 @@ describe("Multi peer sync engine", () => {
     // Engine 1 is where we add events, and see if engine 2 will sync them
     engine1 = new Engine(testDb1, network);
     hub1 = new MockHub(testDb1, engine1);
-    syncEngine1 = new SyncEngine(hub1, testDb1);
+    syncEngine1 = new SyncEngine(hub1, testDb1, undefined, undefined, undefined, 0);
     await syncEngine1.start();
     server1 = new Server(hub1, engine1, syncEngine1);
     port1 = await server1.start();
@@ -152,7 +152,7 @@ describe("Multi peer sync engine", () => {
     });
     engine2 = new Engine(testDb2, network);
     hub2 = new MockHub(testDb2, engine2);
-    syncEngine2 = new SyncEngine(hub2, testDb2, l2EventsProvider, fnameEventsProvider);
+    syncEngine2 = new SyncEngine(hub2, testDb2, l2EventsProvider, fnameEventsProvider, undefined, 0);
   }, TEST_TIMEOUT_SHORT);
 
   afterEach(async () => {

--- a/apps/hubble/src/network/sync/peerScore.test.ts
+++ b/apps/hubble/src/network/sync/peerScore.test.ts
@@ -3,9 +3,16 @@ import { MergeResult } from "./syncEngine.js";
 
 describe("peerScore", () => {
   let peerScorer: PeerScorer;
+  let scoreChanged: Map<string, number>;
 
   beforeEach(() => {
-    peerScorer = new PeerScorer();
+    scoreChanged = new Map<string, number>();
+    peerScorer = new PeerScorer({
+      onPeerScoreChanged(peerId, score) {
+        scoreChanged.set(peerId, score);
+      },
+      overrideBadSyncWindowThreshold: 0,
+    });
   });
 
   test("not blocked by default", () => {
@@ -40,5 +47,12 @@ describe("peerScore", () => {
     expect(peerScorer.getScore("peerId")?.score).toBe(1);
     expect(peerScorer.getBadPeerIds()).toEqual([]);
     expect(peerScorer.getScore("peerId")?.blocked).toBe(false);
+  });
+
+  test("changing score reports back to optional callback", () => {
+    peerScorer.incrementScore("peerId", 2);
+    expect(scoreChanged.get("peerId")).toBe(2);
+    peerScorer.decrementScore("peerId", 3);
+    expect(scoreChanged.get("peerId")).toBe(-1);
   });
 });

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -168,7 +168,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
   private _peerSyncSnapshot = new Map<string, TrieSnapshot>();
 
   // Peer Scoring
-  private _peerScorer = new PeerScorer();
+  private _peerScorer: PeerScorer;
 
   // Has the syncengine started yet?
   private _started = false;
@@ -185,6 +185,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     l2EventsProvider?: L2EventsProvider,
     fnameEventsProvider?: FNameRegistryEventsProvider,
     profileSync = false,
+    minSyncWindow?: number,
   ) {
     super();
 
@@ -200,6 +201,10 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     }
 
     this._hub = hub;
+    this._peerScorer = new PeerScorer({
+      onPeerScoreChanged: this._hub.updateApplicationPeerScore,
+      overrideBadSyncWindowThreshold: minSyncWindow,
+    });
 
     this._hub.engine.eventHandler.on("mergeMessage", async (event: MergeMessageHubEvent) => {
       const { message, deletedMessages } = event.mergeMessageBody;

--- a/apps/hubble/src/network/utils/networkConfig.test.ts
+++ b/apps/hubble/src/network/utils/networkConfig.test.ts
@@ -16,9 +16,10 @@ describe("networkConfig", () => {
       storageRegistryAddress: undefined,
       keyRegistryAddress: undefined,
       idRegistryAddress: undefined,
+      allowlistedImmunePeers: undefined,
     };
 
-    const result = applyNetworkConfig(networkConfig, existingPeerIds, [], network);
+    const result = applyNetworkConfig(networkConfig, existingPeerIds, [], network, []);
     expect(result.allowedPeerIds).toEqual(["1", "2", "3"]);
     expect(result.shouldExit).toEqual(false);
   });
@@ -32,9 +33,10 @@ describe("networkConfig", () => {
       storageRegistryAddress: undefined,
       keyRegistryAddress: undefined,
       idRegistryAddress: undefined,
+      allowlistedImmunePeers: undefined,
     };
 
-    const result = applyNetworkConfig(networkConfig, undefined, [], network);
+    const result = applyNetworkConfig(networkConfig, undefined, [], network, []);
     expect(result.allowedPeerIds).toEqual(undefined);
     expect(result.deniedPeerIds).toEqual([]);
     expect(result.shouldExit).toEqual(false);
@@ -51,9 +53,10 @@ describe("networkConfig", () => {
       storageRegistryAddress: undefined,
       keyRegistryAddress: undefined,
       idRegistryAddress: undefined,
+      allowlistedImmunePeers: undefined,
     };
 
-    const result = applyNetworkConfig(networkConfig, existingPeerIds, [], network);
+    const result = applyNetworkConfig(networkConfig, existingPeerIds, [], network, []);
     expect(result.allowedPeerIds).toEqual(["1", "2", "3"]);
     expect(result.deniedPeerIds).toEqual([]);
     expect(result.shouldExit).toEqual(false);
@@ -70,9 +73,10 @@ describe("networkConfig", () => {
       storageRegistryAddress: undefined,
       keyRegistryAddress: undefined,
       idRegistryAddress: undefined,
+      allowlistedImmunePeers: undefined,
     };
 
-    const result = applyNetworkConfig(networkConfig, existingPeerIds, [], network);
+    const result = applyNetworkConfig(networkConfig, existingPeerIds, [], network, []);
     expect(result.allowedPeerIds).toEqual(["1", "2", "3", "4", "5"]);
     expect(result.shouldExit).toEqual(false);
   });
@@ -88,9 +92,10 @@ describe("networkConfig", () => {
       storageRegistryAddress: undefined,
       keyRegistryAddress: undefined,
       idRegistryAddress: undefined,
+      allowlistedImmunePeers: undefined,
     };
 
-    const result = applyNetworkConfig(networkConfig, existingPeerIds, [], network);
+    const result = applyNetworkConfig(networkConfig, existingPeerIds, [], network, []);
     expect(result.allowedPeerIds).toEqual(["1", "2", "3"]);
     expect(result.deniedPeerIds).toEqual(["4", "5"]);
     expect(result.shouldExit).toEqual(false);
@@ -107,9 +112,10 @@ describe("networkConfig", () => {
       storageRegistryAddress: undefined,
       keyRegistryAddress: undefined,
       idRegistryAddress: undefined,
+      allowlistedImmunePeers: undefined,
     };
 
-    const result = applyNetworkConfig(networkConfig, existingPeerIds, [], network);
+    const result = applyNetworkConfig(networkConfig, existingPeerIds, [], network, []);
     expect(result.allowedPeerIds).toEqual(["1", "2", "3", "4"]);
     expect(result.shouldExit).toEqual(false);
   });
@@ -123,9 +129,10 @@ describe("networkConfig", () => {
       storageRegistryAddress: undefined,
       keyRegistryAddress: undefined,
       idRegistryAddress: undefined,
+      allowlistedImmunePeers: undefined,
     };
 
-    const result = applyNetworkConfig(networkConfig, undefined, [], network);
+    const result = applyNetworkConfig(networkConfig, undefined, [], network, []);
     expect(result.allowedPeerIds).toEqual(undefined);
     expect(result.deniedPeerIds).toEqual(["1", "2", "3"]);
     expect(result.shouldExit).toEqual(false);
@@ -142,9 +149,10 @@ describe("networkConfig", () => {
       storageRegistryAddress: undefined,
       keyRegistryAddress: undefined,
       idRegistryAddress: undefined,
+      allowlistedImmunePeers: undefined,
     };
 
-    const result = applyNetworkConfig(networkConfig, existingPeerIds, [], network);
+    const result = applyNetworkConfig(networkConfig, existingPeerIds, [], network, []);
     expect(result.allowedPeerIds).toEqual(["1", "2", "3"]);
     expect(result.shouldExit).toEqual(false);
   });
@@ -158,9 +166,10 @@ describe("networkConfig", () => {
       storageRegistryAddress: undefined,
       keyRegistryAddress: undefined,
       idRegistryAddress: undefined,
+      allowlistedImmunePeers: undefined,
     };
 
-    const result = applyNetworkConfig(networkConfig, [], [], network);
+    const result = applyNetworkConfig(networkConfig, [], [], network, []);
     expect(result.shouldExit).toEqual(true);
 
     const prevVer = `${semver.major(APP_VERSION)}.${semver.minor(APP_VERSION)}.${semver.patch(APP_VERSION) - 1}`;
@@ -172,9 +181,10 @@ describe("networkConfig", () => {
       storageRegistryAddress: undefined,
       keyRegistryAddress: undefined,
       idRegistryAddress: undefined,
+      allowlistedImmunePeers: undefined,
     };
 
-    const result2 = applyNetworkConfig(networkConfig2, [], [], network);
+    const result2 = applyNetworkConfig(networkConfig2, [], [], network, []);
     expect(result2.shouldExit).toEqual(false);
   });
 });

--- a/apps/hubble/src/test/mocks.ts
+++ b/apps/hubble/src/test/mocks.ts
@@ -72,4 +72,8 @@ export class MockHub implements HubInterface {
   async getRPCClientForPeer(_peerId: PeerId, _peer: ContactInfoContent): Promise<HubRpcClient | undefined> {
     return undefined;
   }
+
+  async updateApplicationPeerScore(_peerId: String, _score: number) {
+    return ok(undefined);
+  }
 }


### PR DESCRIPTION
## Motivation

Application-specific peer scoring had already been added in #1441, but needed to be connected to gossipsub to alter the scores used. Additionally, until we have confirmed full stability of the peer scoring mechanism, a number of peer ids are added to a configurable allowlist. Peer scores are private and relative to each node – no node will necessarily have the same peer score to every other node. This is an intentional behavior of gossipsub in order to ensure the mesh maintains a healthy balance.

## Change Summary

This PR connects the scoring mechanism into the gossipsub peer score calculation. We additionally log when allowlisted peers would have otherwise been pruned by score, and set a maximum score cap for the application-specific scoring.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview


> The following files were skipped due to too many changes: `apps/hubble/src/hubble.ts`, `apps/hubble/src/network/utils/networkConfig.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->