### PR TITLE
fix: hubble autoupgrade should ensure dependencies and clean unused docker data

### DIFF
--- a/.changeset/chatty-guests-try.md
+++ b/.changeset/chatty-guests-try.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: hubble autoupgrade should ensure dependencies and clean unused docker data

--- a/apps/hubble/docker-compose.yml
+++ b/apps/hubble/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   hubble:
     image: farcasterxyz/hubble:latest
     pull_policy: always
-    restart: unless-stopped
+    restart: on-failure:5
     command: [
       "node", "--no-warnings",  "build/cli.js", "start",
       "--ip", "0.0.0.0",

--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -77,7 +77,13 @@ fetch_file_from_repo() {
 }
 
 # Upgrade the script
-self_upgrade() {    
+self_upgrade() {
+    # To allow easier testing
+    if key_exists "SKIP_SELF_UPGRADE"; then
+      echo "Skipping self upgrade"
+      return 1
+    fi
+
     local tmp_file
     tmp_file=$(mktemp)
     fetch_file_from_repo "$SCRIPT_FILE_PATH" "$tmp_file"

--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -429,7 +429,7 @@ start_hubble() {
 cleanup() {
   # Prune unused docker cruft. Make sure to call this only when hub is already running
   echo "Pruning unused docker images and volumes"
-  $COMPOSE_CMD system prune --volumes -f
+  docker system prune --volumes -f
 }
 
 set_compose_command() {
@@ -592,10 +592,10 @@ if [ "$1" == "autoupgrade" ]; then
     fetch_latest_docker_compose_and_dashboard
     ensure_grafana
     start_hubble
-    echo "$(date) Completed hubble autoupgrade"
-
     sleep 5
     cleanup
+
+    echo "$(date) Completed hubble autoupgrade"
 
     exit 0
 fi

--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -420,6 +420,12 @@ start_hubble() {
     $COMPOSE_CMD up -d hubble
 }
 
+cleanup() {
+  # Prune unused docker cruft. Make sure to call this only when hub is already running
+  echo "Pruning unused docker images and volumes"
+  $COMPOSE_CMD system prune --volumes -f
+}
+
 set_compose_command() {
     # Detect whether "docker-compose" or "docker compose" is available
     if command -v docker-compose &> /dev/null; then
@@ -568,6 +574,10 @@ if [ "$1" == "autoupgrade" ]; then
 
     echo "$(date) Attempting hubble autoupgrade..."
 
+    # Since cronjob is running under root, make sure the dependencies are installed
+    install_jq
+    install_docker "$@"
+
     set_platform_commands
     set_compose_command
 
@@ -577,6 +587,9 @@ if [ "$1" == "autoupgrade" ]; then
     ensure_grafana
     start_hubble
     echo "$(date) Completed hubble autoupgrade"
+
+    sleep 5
+    cleanup
 
     exit 0
 fi


### PR DESCRIPTION
## Motivation

Fixes https://github.com/farcasterxyz/hub-monorepo/issues/1528. And also docker volumes taking up too much space.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the hubble autoupgrade process by ensuring dependencies and cleaning unused docker data.

### Detailed summary
- Patched the "@farcaster/hubble" package.
- Updated the restart policy in the hubble/docker-compose.yml file.
- Added a check to skip self upgrade for easier testing.
- Added a cleanup function to prune unused docker images and volumes.
- Installed dependencies and docker as root in the autoupgrade script.
- Added a sleep command before cleanup in the autoupgrade script.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->