### PR TITLE
chore: Release 1.6.6

### DIFF
--- a/.changeset/breezy-dogs-beg.md
+++ b/.changeset/breezy-dogs-beg.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-Adds application-specific peer scoring to peer scoring for gossipsub with early immune list

--- a/.changeset/chatty-guests-try.md
+++ b/.changeset/chatty-guests-try.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: hubble autoupgrade should ensure dependencies and clean unused docker data

--- a/.changeset/kind-plums-grab.md
+++ b/.changeset/kind-plums-grab.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Fix stale contactInfo caches on SyncEngine

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hubble
 
+## 1.6.6
+
+### Patch Changes
+
+- b47c65bb: Adds application-specific peer scoring to peer scoring for gossipsub with early immune list
+- 559afd0e: fix: hubble autoupgrade should ensure dependencies and clean unused docker data
+- 173c9d61: fix: Fix stale contactInfo caches on SyncEngine
+
 ## 1.6.5
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",


### PR DESCRIPTION
## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of "@farcaster/hubble" to 1.6.6. 

### Detailed summary
- Adds application-specific peer scoring to peer scoring for gossipsub with early immune list
- Fixes hubble autoupgrade to ensure dependencies and clean unused docker data
- Fixes stale contactInfo caches on SyncEngine

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->