### PR TITLE
fix: Allow syncTrie to handle names that are substrings

### DIFF
--- a/.changeset/smart-terms-smile.md
+++ b/.changeset/smart-terms-smile.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+fix: Allow syncTrie to handle names that are substrings

--- a/apps/hubble/src/network/sync/syncId.test.ts
+++ b/apps/hubble/src/network/sync/syncId.test.ts
@@ -1,4 +1,4 @@
-import { Factories, FarcasterNetwork, Message } from "@farcaster/hub-nodejs";
+import { Factories, FarcasterNetwork, Message, validations } from "@farcaster/hub-nodejs";
 import { FNameSyncId, MessageSyncId, OnChainEventSyncId, SyncId, SyncIdType, TIMESTAMP_LENGTH } from "./syncId.js";
 import { makeFidKey, makeMessagePrimaryKeyFromMessage } from "../../storage/db/message.js";
 import { FID_BYTES, RootPrefix } from "../../storage/db/types.js";
@@ -44,6 +44,39 @@ describe("SyncId", () => {
       expect(unpackedSyncId.type).toEqual(SyncIdType.FName);
       expect(unpackedSyncId.fid).toEqual(fnameProof.fid);
       expect(unpackedSyncId.name).toEqual(fnameProof.name);
+    });
+
+    test("names that are substrings of each other are padded correctly", async () => {
+      const fnameProof = Factories.UserNameProof.build({ name: Buffer.from("net") });
+      const fnameProof2 = Factories.UserNameProof.build({ name: Buffer.from("network") });
+      const syncId = SyncId.fromFName(fnameProof);
+      const syncId2 = SyncId.fromFName(fnameProof2);
+      expect(syncId.syncId().length).toEqual(syncId2.syncId().length);
+      expect(syncId.syncId().length).toEqual(TIMESTAMP_LENGTH + 1 + FID_BYTES + 20);
+
+      const unpackedSyncId = syncId.unpack() as FNameSyncId;
+      const unpackedSyncId2 = syncId2.unpack() as FNameSyncId;
+      expect(Buffer.from(unpackedSyncId.name)).toEqual(Buffer.from("net"));
+      expect(Buffer.from(unpackedSyncId2.name)).toEqual(Buffer.from("network"));
+    });
+
+    test("handles names that end with 0", async () => {
+      const fnameProof = Factories.UserNameProof.build({ name: Buffer.from("net00") });
+      const unpackedSyncId = SyncId.fromFName(fnameProof).unpack() as FNameSyncId;
+      expect(Buffer.from(unpackedSyncId.name)).toEqual(Buffer.from("net00"));
+    });
+
+    test("handles max length names", async () => {
+      const fnameProof = Factories.UserNameProof.build({ name: Buffer.from("iamaverylongname.eth") });
+      const unpackedSyncId = SyncId.fromFName(fnameProof).unpack() as FNameSyncId;
+      expect(Buffer.from(unpackedSyncId.name).length).toEqual(validations.USERNAME_MAX_LENGTH);
+      expect(Buffer.from(unpackedSyncId.name)).toEqual(Buffer.from("iamaverylongname.eth"));
+    });
+
+    test("works if names are longer than expected", async () => {
+      const fnameProof = Factories.UserNameProof.build({ name: Buffer.from("iamaverylongname.eth.toolong") });
+      const unpackedSyncId = SyncId.fromFName(fnameProof).unpack() as FNameSyncId;
+      expect(Buffer.from(unpackedSyncId.name)).toEqual(Buffer.from("iamaverylongname.eth.toolong"));
     });
   });
 

--- a/apps/hubble/src/network/sync/syncId.ts
+++ b/apps/hubble/src/network/sync/syncId.ts
@@ -1,6 +1,13 @@
 import { makeFidKey, makeMessagePrimaryKey, typeToSetPostfix } from "../../storage/db/message.js";
 import { FID_BYTES, HASH_LENGTH, RootPrefix } from "../../storage/db/types.js";
-import { Message, OnChainEvent, toFarcasterTime, UserNameProof } from "@farcaster/hub-nodejs";
+import {
+  bytesToUtf8String,
+  Message,
+  OnChainEvent,
+  toFarcasterTime,
+  UserNameProof,
+  validations,
+} from "@farcaster/hub-nodejs";
 import { makeOnChainEventPrimaryKey } from "../../storage/db/onChainEvent.js";
 
 const TIMESTAMP_LENGTH = 10; // Used to represent a decimal timestamp
@@ -80,12 +87,19 @@ class SyncId {
     if (timestampRes.isErr()) {
       throw timestampRes.error;
     }
+    const nameStrResult = bytesToUtf8String(usernameProof.name);
+    if (nameStrResult.isErr()) {
+      throw nameStrResult.error;
+    }
+    // Pad the name with null bytes to ensure all names have the same length. The trie cannot handle entries that are
+    // substrings for another (e.g. "net" and "network")
+    const paddedName = nameStrResult.value.padEnd(validations.USERNAME_MAX_LENGTH, "\0");
     return SyncId.fromTimestamp(
       timestampRes.value,
       Buffer.concat([
         Buffer.from([RootPrefix.FNameUserNameProof]),
         makeFidKey(usernameProof.fid),
-        Buffer.from(usernameProof.name),
+        Buffer.from(paddedName),
       ]),
     );
   }
@@ -143,10 +157,17 @@ class SyncId {
         hash: syncId.slice(TIMESTAMP_LENGTH + 1 + FID_BYTES + 1), // 1 byte after fid for the set postfix
       };
     } else if (rootPrefix === RootPrefix.FNameUserNameProof) {
+      // Name bytes could be zero padded, so we need to trim the null bytes
+      const paddedNameBytes = syncId.slice(TIMESTAMP_LENGTH + 1 + FID_BYTES);
+      const firstZeroIndex = paddedNameBytes.findIndex((byte) => byte === 0);
+      let nameBytes = paddedNameBytes;
+      if (firstZeroIndex !== -1) {
+        nameBytes = paddedNameBytes.slice(0, firstZeroIndex);
+      }
       return {
         type: SyncIdType.FName,
         fid: idBuf.readUInt32BE(TIMESTAMP_LENGTH + 1), // 1 byte for the root prefix
-        name: syncId.slice(TIMESTAMP_LENGTH + 1 + FID_BYTES),
+        name: nameBytes,
       };
     } else if (rootPrefix === RootPrefix.OnChainEvent) {
       return {

--- a/apps/hubble/src/storage/db/migrations/5.fnameSyncIds.test.ts
+++ b/apps/hubble/src/storage/db/migrations/5.fnameSyncIds.test.ts
@@ -1,0 +1,55 @@
+import { performDbMigrations } from "./migrations.js";
+import { jestRocksDB } from "../jestUtils.js";
+import { MerkleTrie } from "../../../network/sync/merkleTrie.js";
+import { SyncId, TIMESTAMP_LENGTH } from "../../../network/sync/syncId.js";
+import { Factories } from "@farcaster/hub-nodejs";
+import UserDataStore from "../../stores/userDataStore.js";
+import StoreEventHandler from "../../stores/storeEventHandler.js";
+import { FID_BYTES } from "../types.js";
+
+const db = jestRocksDB("fnameSyncIds.migration.test");
+
+describe("fnameSyncIds migration", () => {
+  test("should delete unpaddded fname syncIds", async () => {
+    const syncTrie = new MerkleTrie(db);
+
+    const proof1 = Factories.UserNameProof.build({ name: Buffer.from("test") });
+    const proof2 = Factories.UserNameProof.build({ name: Buffer.from("somename") });
+    const proof3 = Factories.UserNameProof.build({ name: Buffer.from("anothername") });
+    const proofStore = new UserDataStore(db, new StoreEventHandler(db));
+    await proofStore.mergeUserNameProof(proof1);
+    await proofStore.mergeUserNameProof(proof2);
+    await proofStore.mergeUserNameProof(proof3);
+
+    const paddedFnameSyncId = SyncId.fromFName(proof1);
+    const unpaddedFnameSyncId1 = SyncId.fromFName(proof2).syncId();
+    const unpaddedFnameSyncId2 = SyncId.fromFName(proof3).syncId();
+    const nameStartIndex = TIMESTAMP_LENGTH + 1 + FID_BYTES;
+    const unpaddedFnameSyncId1Bytes = unpaddedFnameSyncId1.slice(
+      0,
+      nameStartIndex + unpaddedFnameSyncId1.slice(nameStartIndex).findIndex((byte) => byte === 0),
+    );
+    const unpaddedFnameSyncId2Bytes = unpaddedFnameSyncId2.slice(
+      0,
+      nameStartIndex + unpaddedFnameSyncId2.slice(nameStartIndex).findIndex((byte) => byte === 0),
+    );
+
+    await syncTrie.insert(paddedFnameSyncId);
+    await syncTrie.callMethod("insert", unpaddedFnameSyncId1Bytes);
+    await syncTrie.callMethod("insert", unpaddedFnameSyncId2Bytes);
+    await syncTrie.commitToDb();
+
+    expect(await syncTrie.existsByBytes(paddedFnameSyncId.syncId())).toBe(true);
+    expect(await syncTrie.existsByBytes(unpaddedFnameSyncId1Bytes)).toBe(true);
+    expect(await syncTrie.existsByBytes(unpaddedFnameSyncId2Bytes)).toBe(true);
+
+    const success = await performDbMigrations(db, 4, 5);
+    expect(success).toBe(true);
+
+    const uncachedSyncTrie = new MerkleTrie(db);
+    await uncachedSyncTrie.initialize();
+    expect(await uncachedSyncTrie.existsByBytes(paddedFnameSyncId.syncId())).toBe(true);
+    expect(await uncachedSyncTrie.existsByBytes(unpaddedFnameSyncId1Bytes)).toBe(false);
+    expect(await uncachedSyncTrie.existsByBytes(unpaddedFnameSyncId2Bytes)).toBe(false);
+  });
+});

--- a/apps/hubble/src/storage/db/migrations/5.fnameSyncIds.ts
+++ b/apps/hubble/src/storage/db/migrations/5.fnameSyncIds.ts
@@ -1,0 +1,52 @@
+/**
+ Remove unpadded fname sync ids from the sync trie
+ */
+
+import { logger } from "../../../utils/logger.js";
+import RocksDB from "../rocksdb.js";
+import { FID_BYTES, RootPrefix } from "../types.js";
+import { Result } from "neverthrow";
+import { HubError, UserNameProof } from "@farcaster/hub-nodejs";
+import { SyncId, TIMESTAMP_LENGTH } from "../../../network/sync/syncId.js";
+import { MerkleTrie } from "../../../network/sync/merkleTrie.js";
+
+const log = logger.child({ component: "fnameSyncIds" });
+
+export const fnameSyncIds = async (db: RocksDB): Promise<boolean> => {
+  log.info({}, "Starting fnameSyncIds migration");
+  const start = Date.now();
+
+  const syncTrie = new MerkleTrie(db);
+  await syncTrie.initialize();
+  let count = 0;
+
+  await db.forEachIteratorByPrefix(
+    Buffer.from([RootPrefix.FNameUserNameProof]),
+    async (key, value) => {
+      const proof = Result.fromThrowable(
+        () => UserNameProof.decode(new Uint8Array(value as Buffer)),
+        (e) => e as HubError,
+      )();
+      if (proof.isOk()) {
+        const paddedSyncIdBytes = SyncId.fromFName(proof.value).syncId();
+        const nameStartIndex = TIMESTAMP_LENGTH + 1 + FID_BYTES;
+        const firstZeroIndex = paddedSyncIdBytes.slice(nameStartIndex).findIndex((byte) => byte === 0);
+        if (firstZeroIndex === -1) {
+          return;
+        }
+        const unpaddedBytes = paddedSyncIdBytes.slice(0, nameStartIndex + firstZeroIndex);
+
+        if (await syncTrie.existsByBytes(unpaddedBytes)) {
+          count += 1;
+          await syncTrie.deleteByBytes(unpaddedBytes);
+        }
+      }
+    },
+    {},
+    1 * 60 * 60 * 1000,
+  );
+  await syncTrie.commitToDb();
+  await syncTrie.stop();
+  log.info({ duration: Date.now() - start }, `Finished fnameSyncIds migration. Removed ${count} fnames`);
+  return true;
+};

--- a/apps/hubble/src/storage/db/migrations/migrations.ts
+++ b/apps/hubble/src/storage/db/migrations/migrations.ts
@@ -5,6 +5,7 @@ import { usernameProofIndexMigration } from "./1.usernameproof.js";
 import { fnameProofIndexMigration } from "./2.fnameproof.js";
 import { clearEventsMigration } from "./3.clearEvents.js";
 import { uniqueVerificationsMigration } from "./4.uniqueVerifications.js";
+import { fnameSyncIds } from "./5.fnameSyncIds.js";
 
 type MigrationFunctionType = (db: RocksDB) => Promise<boolean>;
 const migrations = new Map<number, MigrationFunctionType>();
@@ -25,6 +26,10 @@ migrations.set(3, async (db: RocksDB) => {
 });
 migrations.set(4, async (db: RocksDB) => {
   return await uniqueVerificationsMigration(db);
+});
+
+migrations.set(5, async (db: RocksDB) => {
+  return await fnameSyncIds(db);
 });
 
 // To Add a new migration

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -16,6 +16,8 @@ export const ALLOWED_CLOCK_SKEW_SECONDS = 10 * 60;
 export const FNAME_REGEX = /^[a-z0-9][a-z0-9-]{0,15}$/;
 export const HEX_REGEX = /^(0x)?[0-9A-Fa-f]+$/;
 
+export const USERNAME_MAX_LENGTH = 20;
+
 export const EMBEDS_V1_CUTOFF = 73612800; // 5/3/23 00:00 UTC
 
 /**
@@ -673,6 +675,7 @@ export const validateFname = <T extends string | Uint8Array>(fnameP?: T | null):
     return err(new HubError("bad_request.validation_failure", "fname is missing"));
   }
 
+  // FNAME_MAX_LENGTH - ".eth".length
   if (fname.length > 16) {
     return err(new HubError("bad_request.validation_failure", `fname "${fname}" > 16 characters`));
   }
@@ -720,7 +723,7 @@ export const validateEnsName = <T extends string | Uint8Array>(ensNameP?: T | nu
     return err(new HubError("bad_request.validation_failure", `ensName "${ensName}" unsupported subdomain`));
   }
 
-  if (ensName.length > 20) {
+  if (ensName.length > USERNAME_MAX_LENGTH) {
     return err(new HubError("bad_request.validation_failure", `ensName "${ensName}" > 20 characters`));
   }
 

--- a/turbo.json
+++ b/turbo.json
@@ -12,6 +12,7 @@
       "cache": false
     },
     "lint": {
+      "dependsOn": ["build"],
       "outputs": []
     },
     "lint:ci": {


### PR DESCRIPTION
## Motivation

Fixes https://github.com/farcasterxyz/hub-monorepo/issues/1507. Makes all fnames unique by zero padding them.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a new migration `5.fnameSyncIds` to remove unpadded fname sync ids from the sync trie.
- Updated the `SyncId` class to pad the name with null bytes to ensure all names have the same length.
- Updated the `validateFname` function to use the `USERNAME_MAX_LENGTH` constant.
- Added tests for handling names that are substrings of each other and names that end with 0.
- Added a test for the `fnameSyncIds` migration to delete unpadded fname sync ids.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->