### PR TITLE
chore: Release 1.7

### DIFF
--- a/.changeset/new-fireants-smile.md
+++ b/.changeset/new-fireants-smile.md
@@ -1,7 +1,0 @@
----
-"@farcaster/hub-web": minor
-"@farcaster/core": minor
-"@farcaster/hubble": minor
----
-
-Adds support for contact info content signing + strictNoSign

--- a/.changeset/pink-beds-beg.md
+++ b/.changeset/pink-beds-beg.md
@@ -1,8 +1,0 @@
----
-"@farcaster/hubble": minor
-"@farcaster/hub-nodejs": patch
-"@farcaster/hub-web": patch
-"@farcaster/core": patch
----
-
-feat: Support v2 id and key registry contracts

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @farcaster/hubble
 
+## 1.7.0
+
+### Minor Changes
+
+- 3313c232: Adds support for contact info content signing + strictNoSign
+- f3d32227: feat: Support v2 id and key registry contracts
+
+### Patch Changes
+
+- Updated dependencies [f3d32227]
+  - @farcaster/hub-nodejs@0.10.16
+
 ## 1.6.6
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.6.6",
+  "version": "1.7.0",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -69,7 +69,7 @@
     "@chainsafe/libp2p-gossipsub": "6.1.0",
     "@chainsafe/libp2p-noise": "^11.0.0 ",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.10.15",
+    "@farcaster/hub-nodejs": "^0.10.16",
     "@farcaster/rocksdb": "^5.5.0",
     "@fastify/cors": "^8.4.0",
     "@grpc/grpc-js": "~1.8.21",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @farcaster/core
 
+## 0.13.0
+
+### Minor Changes
+
+- 3313c232: Adds support for contact info content signing + strictNoSign
+
+### Patch Changes
+
+- f3d32227: feat: Support v2 id and key registry contracts
+
 ## 0.12.15
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.12.15",
+  "version": "0.13.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @farcaster/hub-nodejs
 
+## 0.10.16
+
+### Patch Changes
+
+- f3d32227: feat: Support v2 id and key registry contracts
+- Updated dependencies [3313c232]
+- Updated dependencies [f3d32227]
+  - @farcaster/core@0.13.0
+
 ## 0.10.15
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@farcaster/core": "0.12.15",
+    "@farcaster/core": "0.13.0",
     "@grpc/grpc-js": "~1.8.21",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"

--- a/packages/hub-web/CHANGELOG.md
+++ b/packages/hub-web/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @farcaster/hub-web
 
+## 0.7.0
+
+### Minor Changes
+
+- 3313c232: Adds support for contact info content signing + strictNoSign
+
+### Patch Changes
+
+- f3d32227: feat: Support v2 id and key registry contracts
+- Updated dependencies [3313c232]
+- Updated dependencies [f3d32227]
+  - @farcaster/core@0.13.0
+
 ## 0.6.10
 
 ### Patch Changes

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-web",
-  "version": "0.6.10",
+  "version": "0.7.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -28,7 +28,7 @@
     "ts-proto": "^1.146.0"
   },
   "dependencies": {
-    "@farcaster/core": "^0.12.15",
+    "@farcaster/core": "^0.13.0",
     "@improbable-eng/grpc-web": "^0.15.0",
     "rxjs": "^7.8.0"
   }


### PR DESCRIPTION
## Motivation

Release 1.7 with support for new contracts and app signed contactInfo messages.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the versions of various packages and adding support for contact info content signing and v2 id and key registry contracts. 

### Detailed summary
- Updated version of `@farcaster/core` to `0.13.0`
- Added support for contact info content signing and strictNoSign
- Updated version of `@farcaster/hub-nodejs` to `0.10.16`
- Updated dependencies in `@farcaster/hub-nodejs` and `@farcaster/hub-web`
- Updated version of `@farcaster/hub-web` to `0.7.0`
- Updated version of `@farcaster/hubble` to `1.7.0`
- Added support for v2 id and key registry contracts

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->