### PR TITLE
fix: Increase default `CONCURRENCY` for replicator

### DIFF
--- a/apps/replicator/README.md
+++ b/apps/replicator/README.md
@@ -30,7 +30,11 @@ Once the Docker images have finished downloading, you should start to see messag
 ...
 ```
 
+If you are connected to a hub over the internet (rather than on the same machine or private network) the increased latency will make this take longer, and you will likely need to wait some time before an estimation of the time remaining will appear. This is expected.
+
 You may see messages out of order—this is fine. If messages like above are appearing, replication is working as expected.
+
+Note that the number of messages in the Postgres table will **not** match the number in the hub, because the replicator doesn't backfill "Remove" messages (like `CastRemove` and `ReactionRemove`) since these technically indicate an absence of content, not the presence.
 
 ### Connecting to Postgres
 

--- a/scripts/replicator.sh
+++ b/scripts/replicator.sh
@@ -170,7 +170,8 @@ write_env_file() {
     fi
 
     if ! key_exists "CONCURRENCY"; then
-        echo "CONCURRENCY=$(portable_nproc)" >> .env
+        echo "# Set this higher the further the hub is from the replicator"
+        echo "CONCURRENCY=$(expr 4 \* $(portable_nproc))" >> .env
     fi
 
     if ! key_exists "WORKER_TYPE"; then


### PR DESCRIPTION
## Motivation

Since most users seem to connect to a remote hub, increase the default concurrency.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Added a comment explaining how to set the `CONCURRENCY` variable in the `.env` file.
- Increased the value of the `CONCURRENCY` variable by multiplying it by 4 times the number of available processors.
- Added a note about replication messages appearing out of order and the reason for it.
- Added a note about the number of messages in the Postgres table not matching the number in the hub due to the replicator not backfilling "Remove" messages.
- Added information about being able to query data from Postgres while the syncing process is ongoing.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->