### PR TITLE
fix: Fallback to docker-compose if docker install fails

### DIFF
--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -321,6 +321,11 @@ install_docker() {
     # Install using Docker's convenience script
     curl -fsSL https://get.docker.com -o get-docker.sh
     sh get-docker.sh
+    if [[ $? -ne 0 ]]; then
+        echo "❌ Failed to install Docker via official script. Falling back to docker-compose."
+        curl -fsSL "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+        chmod +x /usr/local/bin/docker-compose
+    fi
     rm get-docker.sh
 
     # Add current user to the docker group


### PR DESCRIPTION
## Motivation

Installing docker on amazon linux fails with:

```
# Executing docker install script, commit: e5543d473431b782227f8908005543bb4389b8de

ERROR: Unsupported distribution 'amzn'
```

because the https://get.docker.com script does not support the distro. Fall back to docker-compose in that case.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
