### PR TITLE
fix: Consolidate to a single subscribe stream in Replicator

### DIFF
--- a/.changeset/short-radios-sparkle.md
+++ b/.changeset/short-radios-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/replicator": patch
+---
+
+Consolidate to single subscription connection


### PR DESCRIPTION
## Motivation

We were seeing issues where events would arrive out of order when processing two streams. To avoid this, have them be processed on the same stream, where hubs will ensure they are emitted in order (specifically FID registration followed by messages for the given FID).

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR consolidates the subscription connections in the HubReplicator class. 

### Detailed summary
- Consolidates the chain events and other events subscriptions into a single "all-events" subscription.
- Updates the corresponding variables and keys.
- Removes unused imports and variables.
- Updates the event processing logic.
- Starts and stops the new subscription.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->