### PR TITLE
fix: disallow empty casts

### DIFF
--- a/.changeset/seven-moose-brake.md
+++ b/.changeset/seven-moose-brake.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+fix: disallow empty casts

--- a/apps/hubble/src/storage/stores/store.test.ts
+++ b/apps/hubble/src/storage/stores/store.test.ts
@@ -77,7 +77,7 @@ describe("store", () => {
     const ed25519Signer = new NobleEd25519Signer(privKey);
     const castAdd = await makeCastAdd(
       {
-        text: "",
+        text: "test",
         embeds: [],
         embedsDeprecated: [],
         mentions: [],

--- a/packages/core/src/builders.test.ts
+++ b/packages/core/src/builders.test.ts
@@ -238,7 +238,7 @@ describe("makeMessageHash", () => {
 
 describe("makeMessageWithSignature", () => {
   test("succeeds", async () => {
-    const body = protobufs.CastAddBody.create();
+    const body = protobufs.CastAddBody.create({ text: "test" });
     const castAdd = await builders.makeCastAdd(body, { fid, network }, ed25519Signer);
 
     const data = await builders.makeCastAddData(body, { fid, network });
@@ -260,7 +260,7 @@ describe("makeMessageWithSignature", () => {
     const signature = hexStringToBytes(
       "0xf8dc77d52468483806addab7d397836e802551bfb692604e2d7df4bc4820556c63524399a63d319ae4b027090ce296ade08286878dc1f414b62412f89e8bc4e01b",
     )._unsafeUnwrap();
-    const data = await builders.makeCastAddData(protobufs.CastAddBody.create(), { fid, network });
+    const data = await builders.makeCastAddData(protobufs.CastAddBody.create({ text: "test" }), { fid, network });
     expect(data.isOk()).toBeTruthy();
     const message = await builders.makeMessageWithSignature(data._unsafeUnwrap(), {
       signer: (await ed25519Signer.getSignerKey())._unsafeUnwrap(),

--- a/packages/core/src/validations.test.ts
+++ b/packages/core/src/validations.test.ts
@@ -326,6 +326,17 @@ describe("validateCastAddBody", () => {
         body = Factories.CastAddBody.build({ embeds: [], embedsDeprecated: [`${faker.random.alphaNumeric(254)}🤓`] });
         hubErrorMessage = "url > 256 bytes";
       });
+
+      test("when cast is empty", () => {
+        body = Factories.CastAddBody.build({
+          text: "",
+          mentions: [],
+          mentionsPositions: [],
+          embeds: [],
+          embedsDeprecated: [],
+        });
+        hubErrorMessage = "cast is empty";
+      });
     });
   });
 

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -438,6 +438,15 @@ export const validateCastAddBody = (
     return err(new HubError("bad_request.validation_failure", "cannot use both embeds and string embeds"));
   }
 
+  if (
+    body.text.length === 0 &&
+    body.embeds.length === 0 &&
+    body.embedsDeprecated.length === 0 &&
+    body.mentions.length === 0
+  ) {
+    return err(new HubError("bad_request.validation_failure", "cast is empty"));
+  }
+
   for (let i = 0; i < body.embeds.length; i++) {
     const embed = body.embeds[i];
 


### PR DESCRIPTION
## Motivation

Do no allow completely empty casts (no text, embeds or mentions).

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Fixing an issue that allowed empty casts to be created.

### Detailed summary:
- Updated `store.test.ts` to ensure that an empty cast cannot be created.
- Added a test case in `validations.test.ts` to check for empty casts.
- Modified `validations.ts` to handle the validation of empty casts.
- Updated `builders.test.ts` to include the text field in the `makeCastAddData` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->