### PR TITLE
fix: Fix peer check job not actually starting

### DIFF
--- a/.changeset/tricky-birds-move.md
+++ b/.changeset/tricky-birds-move.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Fix peer check job not actually starting

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -292,6 +292,7 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
 
     // Also start the periodic job to make sure we have peers
     this._periodicPeerCheckJob = new PeriodicPeerCheckScheduler(this, bootstrapAddrs);
+    this._periodicPeerCheckJob.start();
 
     return ok(undefined);
   }

--- a/apps/hubble/src/network/p2p/periodicPeerCheck.ts
+++ b/apps/hubble/src/network/p2p/periodicPeerCheck.ts
@@ -4,7 +4,7 @@ import cron from "node-cron";
 import { GossipNode } from "./gossipNode.js";
 
 const log = logger.child({
-  component: "PeriodicSyncJob",
+  component: "PeriodicPeerCheckScheduler",
 });
 
 type SchedulerStatus = "started" | "stopped";
@@ -41,6 +41,10 @@ export class PeriodicPeerCheckScheduler {
 
   async doJobs() {
     // If there are no peers, try to connect to the bootstrap peers
+    const allPeerIds = await this._gossipNode.allPeerIds();
+    if (allPeerIds.length > 0) {
+      return;
+    }
     const result = await this._gossipNode.bootstrap(this._bootstrapPeers);
     if (result.isErr()) {
       log.warn({ err: result.error }, "No Connected Peers");


### PR DESCRIPTION
## Motivation

The periodic peer check job was not actually started. So if bootstrap failed for any reason, the hub would never retry.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
Fixing the issue where the peer check job was not starting properly.

### Detailed summary:
- Fixed the `PeriodicPeerCheckScheduler` component name in the logger.
- Added a check to only connect to bootstrap peers if there are no existing peers.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->