### PR TITLE
docs: incorrect request parameters

### DIFF
--- a/apps/hubble/www/docs/docs/httpapi/events.md
+++ b/apps/hubble/www/docs/docs/httpapi/events.md
@@ -14,7 +14,7 @@ Get an event by its Id
 
 **Example**
 ```bash
-curl http://127.0.0.1:2281/v1/eventById?id=350909155450880
+curl http://127.0.0.1:2281/v1/eventById?event_id=350909155450880
 
 ```
 


### PR DESCRIPTION
## Change Summary
Incorrect request parameters in http api example.

## Motivation

The PR corrected the HTTP request example parameters for requesting events by event ID in the document.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- In the `events.md` file, the URL parameter `id` has been changed to `event_id` in the example cURL commands.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->