### PR TITLE
fix: Fix watching v2 contract events

### DIFF
--- a/apps/hubble/src/eth/l2EventsProvider.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.ts
@@ -194,12 +194,16 @@ export class L2EventsProvider {
     this._watchStorageContractEvents?.start();
     this._watchKeyRegistryContractEvents?.start();
     this._watchIdRegistryContractEvents?.start();
+    this._watchIdRegistryV2ContractEvents?.start();
+    this._watchKeyRegistryV2ContractEvents?.start();
   }
 
   public async stop() {
     this._watchStorageContractEvents?.stop();
     this._watchKeyRegistryContractEvents?.stop();
     this._watchIdRegistryContractEvents?.stop();
+    this._watchIdRegistryV2ContractEvents?.stop();
+    this._watchKeyRegistryV2ContractEvents?.stop();
     this._watchBlockNumber?.stop();
 
     // Wait for all async promises to resolve


### PR DESCRIPTION
## Motivation

Fix v2 contract polling

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `_watchIdRegistryV2ContractEvents` and `_watchKeyRegistryV2ContractEvents` to start and stop methods in `l2EventsProvider.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->