### PR TITLE
chore: remove old contract references

### DIFF
--- a/.changeset/silent-cooks-cheat.md
+++ b/.changeset/silent-cooks-cheat.md
@@ -1,0 +1,7 @@
+---
+"@farcaster/hub-nodejs": patch
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+fix: remove references to old contracts

--- a/apps/hubble/src/eth/l2EventsProvider.test.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.test.ts
@@ -18,8 +18,6 @@ const onChainEventStore = new OnChainEventStore(db, new StoreEventHandler(db));
 
 let l2EventsProvider: L2EventsProvider;
 let storageRegistryAddress: `0x${string}`;
-let keyRegistryAddress: `0x${string}`;
-let idRegistryAddress: `0x${string}`;
 let keyRegistryV2Address: `0x${string}`;
 let idRegistryV2Address: `0x${string}`;
 
@@ -28,8 +26,6 @@ const TEST_TIMEOUT_LONG = 30 * 1000; // 30s timeout
 beforeAll(() => {
   // Poll aggressively for fast testing
   storageRegistryAddress = bytesToHexString(Factories.EthAddress.build())._unsafeUnwrap();
-  idRegistryAddress = bytesToHexString(Factories.EthAddress.build())._unsafeUnwrap();
-  keyRegistryAddress = bytesToHexString(Factories.EthAddress.build())._unsafeUnwrap();
   idRegistryV2Address = bytesToHexString(Factories.EthAddress.build())._unsafeUnwrap();
   keyRegistryV2Address = bytesToHexString(Factories.EthAddress.build())._unsafeUnwrap();
   L2EventsProvider.blockPollingInterval = 10;
@@ -47,8 +43,6 @@ describe("build", () => {
       "http://some-url",
       false,
       storageRegistryAddress,
-      keyRegistryAddress,
-      idRegistryAddress,
       keyRegistryV2Address,
       idRegistryV2Address,
       1,
@@ -69,8 +63,6 @@ describe("build", () => {
       "http://some-url,http://some-other-url",
       false,
       storageRegistryAddress,
-      keyRegistryAddress,
-      idRegistryAddress,
       keyRegistryV2Address,
       idRegistryV2Address,
       1,
@@ -96,8 +88,6 @@ describe("process events", () => {
       hub,
       publicClient,
       storageRegistryAddress,
-      keyRegistryAddress,
-      idRegistryAddress,
       keyRegistryV2Address,
       idRegistryV2Address,
       1,

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -340,10 +340,8 @@ export class Hub implements HubInterface {
         options.l2RpcUrl,
         options.rankRpcs ?? false,
         options.l2StorageRegistryAddress ?? OptimismConstants.StorageRegistryAddress,
-        options.l2KeyRegistryAddress ?? OptimismConstants.KeyRegistryAddress,
-        options.l2IdRegistryAddress ?? OptimismConstants.IdRegistryAddress,
-        options.l2KeyRegistryV2Address,
-        options.l2IdRegistryV2Address,
+        options.l2KeyRegistryV2Address ?? OptimismConstants.KeyRegistryV2Address,
+        options.l2IdRegistryV2Address ?? OptimismConstants.IdRegistryV2Address,
         options.l2FirstBlock ?? OptimismConstants.FirstBlock,
         options.l2ChunkSize ?? OptimismConstants.ChunkSize,
         options.l2ChainId ?? OptimismConstants.ChainId,
@@ -746,10 +744,6 @@ export class Hub implements HubInterface {
       this.strictContactInfoValidation = !!strictContactInfoValidation;
       const shouldRestart = this.strictNoSign !== !!strictNoSign;
       this.strictNoSign = !!strictNoSign;
-
-      if (networkConfig.idRegistryV2Address && networkConfig.keyRegistryV2Address) {
-        this.l2RegistryProvider.setV2Addresses(networkConfig.keyRegistryV2Address, networkConfig.idRegistryV2Address);
-      }
 
       log.info({ allowedPeerIds, deniedPeerIds, allowlistedImmunePeers }, "Network config applied");
 

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -45,6 +45,8 @@ import { SingleBar } from "cli-progress";
 import { SemVer } from "semver";
 import { FNameRegistryEventsProvider } from "../../eth/fnameRegistryEventsProvider.js";
 import { PeerScore, PeerScorer } from "./peerScore.js";
+import { getOnChainEvent } from "../../storage/db/onChainEvent.js";
+import { getFNameProofByFid, getUserNameProof } from "../../storage/db/nameRegistryEvent.js";
 
 // Number of seconds to wait for the network to "settle" before syncing. We will only
 // attempt to sync messages that are older than this time.
@@ -1075,6 +1077,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     } else if (theirNodeResult.value.numMessages === 0) {
       // If there are no messages, we're done, but something is probably wrong, since we should never have
       // a node with no messages.
+      await this.revokeCorruptedSyncIds(ourNode);
       log.warn({ prefix, peerId: this._currentSyncStatus.peerId }, "No messages for prefix, skipping");
       return -3;
     } else if (ourNode?.hash === theirNodeResult.value.hash) {
@@ -1150,28 +1153,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
             missingHashes = [];
             statsd().increment("syncengine.peer_counts.get_all_syncids_by_prefix_already_exists", 1);
 
-            if (ourNode?.prefix) {
-              const suspectSyncIDs = await this.trie.getAllValues(ourNode?.prefix);
-              const messageSyncIds = suspectSyncIDs
-                .map((s) => SyncId.fromBytes(s))
-                .filter((syncId) => syncId.unpack().type === SyncIdType.Message);
-              const messagesResult = await this.getAllMessagesBySyncIds(messageSyncIds);
-
-              if (messagesResult.isOk()) {
-                const corruptedSyncIds = this.findCorruptedSyncIDs(messagesResult.value, messageSyncIds);
-
-                if (corruptedSyncIds.length > 0) {
-                  log.warn(
-                    { num: corruptedSyncIds.length },
-                    "Found corrupted messages during sync, rebuilding some syncIDs",
-                  );
-
-                  // Don't wait for this to finish, just return the messages we have.
-                  await this.revokeSyncIds(corruptedSyncIds);
-                  revokedSyncIds = corruptedSyncIds.length;
-                }
-              }
-            }
+            revokedSyncIds += await this.revokeCorruptedSyncIds(ourNode);
           }
         }
         fetchedMessages = missingHashes.length;
@@ -1202,6 +1184,13 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
           // Hashes match, not recursively fetching
           numChildrenSkipped += 1;
         }
+      }
+
+      const theirKeys = new Set(theirNode.children.keys());
+      const theirMissingKeys = [...(ourNode?.children?.keys() || [])].filter((x) => !theirKeys.has(x));
+      for (const theirMissingKey of theirMissingKeys) {
+        const ourPrefixMissingInTheirs = ourNode?.children?.get(theirMissingKey);
+        await this.revokeCorruptedSyncIds(ourPrefixMissingInTheirs);
       }
 
       const r = await Promise.all(promises);
@@ -1465,6 +1454,66 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     } else {
       return ok(0);
     }
+  }
+
+  // We have a prefix that's not present in the other peer, validate our trie is correct, and remove any syncIds that are not in our db
+  private async revokeCorruptedSyncIds(ourNode: NodeMetadata | undefined) {
+    if (!ourNode) {
+      return 0;
+    }
+
+    if (ourNode.numMessages > 500) {
+      log.warn(`Our node has more than 500 messages, but the other peer does not have this prefix: ${ourNode.prefix}`);
+      return 0;
+    }
+
+    let revokedSyncIds = 0;
+    const suspectSyncIDs = (await this.trie.getAllValues(ourNode.prefix)).map((s) => SyncId.fromBytes(s));
+    const messageSyncIds = suspectSyncIDs.filter((syncId) => syncId.unpack().type === SyncIdType.Message);
+    const messagesResult = await this.getAllMessagesBySyncIds(messageSyncIds);
+    if (messagesResult.isOk()) {
+      const corruptedSyncIds = this.findCorruptedSyncIDs(messagesResult.value, messageSyncIds);
+      if (corruptedSyncIds.length > 0) {
+        log.warn({ num: corruptedSyncIds.length }, "Found corrupted messages during sync, rebuilding some syncIDs");
+
+        // Don't wait for this to finish, just return the messages we have.
+        await this.revokeSyncIds(corruptedSyncIds);
+        revokedSyncIds += corruptedSyncIds.length;
+      }
+    }
+
+    for (const syncId of suspectSyncIDs) {
+      const unpacked = syncId.unpack();
+      if (unpacked.type === SyncIdType.OnChainEvent) {
+        const result = await ResultAsync.fromPromise(
+          getOnChainEvent(this._db, unpacked.eventType, unpacked.fid, unpacked.blockNumber, unpacked.logIndex),
+          (e) => e as HubError,
+        );
+        if (result.isErr()) {
+          log.warn(
+            `Found corrupted on chain event during sync, revoking syncId for blockNumber: ${unpacked.blockNumber} and logIndex: ${unpacked.logIndex}`,
+          );
+          await this.revokeSyncIds([syncId]);
+          revokedSyncIds += 1;
+        }
+      } else if (unpacked.type === SyncIdType.FName) {
+        const result = await ResultAsync.fromPromise(getUserNameProof(this._db, unpacked.name), (e) => e as HubError);
+        let validSyncId = result.isOk();
+        if (result.isOk()) {
+          validSyncId = result.value.fid === unpacked.fid;
+        }
+        if (!validSyncId) {
+          log.warn(
+            `Found corrupted fname during sync, revoking syncId for name: ${Buffer.from(unpacked.name).toString(
+              "utf-8",
+            )} and fid: ${unpacked.fid}`,
+          );
+          await this.revokeSyncIds([syncId]);
+          revokedSyncIds += 1;
+        }
+      }
+    }
+    return revokedSyncIds;
   }
 }
 

--- a/apps/hubble/src/network/sync/syncId.test.ts
+++ b/apps/hubble/src/network/sync/syncId.test.ts
@@ -1,4 +1,4 @@
-import { Factories, FarcasterNetwork, Message, validations } from "@farcaster/hub-nodejs";
+import { Factories, FarcasterNetwork, Message, validations, OnChainEventType } from "@farcaster/hub-nodejs";
 import { FNameSyncId, MessageSyncId, OnChainEventSyncId, SyncId, SyncIdType, TIMESTAMP_LENGTH } from "./syncId.js";
 import { makeFidKey, makeMessagePrimaryKeyFromMessage } from "../../storage/db/message.js";
 import { FID_BYTES, RootPrefix } from "../../storage/db/types.js";
@@ -87,8 +87,10 @@ describe("SyncId", () => {
       expect(syncId.type()).toEqual(SyncIdType.OnChainEvent);
       const unpackedSyncId = syncId.unpack() as OnChainEventSyncId;
       expect(unpackedSyncId.type).toEqual(SyncIdType.OnChainEvent);
+      expect(unpackedSyncId.eventType).toEqual(OnChainEventType.EVENT_TYPE_ID_REGISTER);
       expect(unpackedSyncId.fid).toEqual(onChainEvent.fid);
       expect(unpackedSyncId.blockNumber).toEqual(onChainEvent.blockNumber);
+      expect(unpackedSyncId.logIndex).toEqual(onChainEvent.logIndex);
     });
   });
 

--- a/apps/hubble/src/network/sync/syncId.ts
+++ b/apps/hubble/src/network/sync/syncId.ts
@@ -4,6 +4,7 @@ import {
   bytesToUtf8String,
   Message,
   OnChainEvent,
+  OnChainEventType,
   toFarcasterTime,
   UserNameProof,
   validations,
@@ -43,7 +44,9 @@ export type FNameSyncId = BaseUnpackedSyncId & {
 
 export type OnChainEventSyncId = BaseUnpackedSyncId & {
   type: SyncIdType.OnChainEvent;
+  eventType: OnChainEventType;
   blockNumber: number;
+  logIndex: number;
 };
 
 export type UnpackedSyncId = UnknownSyncId | MessageSyncId | FNameSyncId | OnChainEventSyncId;
@@ -172,8 +175,10 @@ class SyncId {
     } else if (rootPrefix === RootPrefix.OnChainEvent) {
       return {
         type: SyncIdType.OnChainEvent,
+        eventType: idBuf.readUInt8(TIMESTAMP_LENGTH + 1 + 1),
         fid: idBuf.readUInt32BE(TIMESTAMP_LENGTH + 1 + 1 + 1), // 1 byte for the root prefix, 1 byte for the postfix, 1 byte for the event type
         blockNumber: idBuf.readUInt32BE(TIMESTAMP_LENGTH + 1 + 1 + 1 + FID_BYTES),
+        logIndex: idBuf.readUInt32BE(TIMESTAMP_LENGTH + 1 + 1 + 1 + FID_BYTES + 4),
       };
     }
     return {

--- a/apps/hubble/src/storage/db/migrations/6.oldContractEvents.test.ts
+++ b/apps/hubble/src/storage/db/migrations/6.oldContractEvents.test.ts
@@ -1,0 +1,59 @@
+import { performDbMigrations } from "./migrations.js";
+import { jestRocksDB } from "../jestUtils.js";
+import { MerkleTrie } from "../../../network/sync/merkleTrie.js";
+import { SyncId } from "../../../network/sync/syncId.js";
+import { Factories, HubError, OnChainEvent } from "@farcaster/hub-nodejs";
+import StoreEventHandler from "../../stores/storeEventHandler.js";
+import OnChainEventStore from "../../stores/onChainEventStore.js";
+import { getOnChainEvent } from "../onChainEvent.js";
+import { ResultAsync } from "neverthrow";
+
+const db = jestRocksDB("oldContractEvents.migration.test");
+
+describe("oldContractEvents migration", () => {
+  const addEvent = async function (event: OnChainEvent, store: OnChainEventStore, trie: MerkleTrie) {
+    await expect(store.mergeOnChainEvent(event)).resolves.toBeTruthy();
+    const syncId = SyncId.fromOnChainEvent(event);
+    await trie.insert(syncId);
+    await trie.commitToDb();
+    await expectExists(event, trie, true);
+  };
+
+  const expectExists = async function (event: OnChainEvent, trie: MerkleTrie, shouldExist: boolean) {
+    const dbResult = await ResultAsync.fromPromise(
+      getOnChainEvent(db, event.type, event.fid, event.blockNumber, event.logIndex),
+      (e) => e as HubError,
+    );
+    expect(dbResult.isOk()).toBe(shouldExist);
+    const syncId = SyncId.fromOnChainEvent(event);
+    expect(await trie.exists(syncId)).toBe(shouldExist);
+  };
+
+  test("should delete version 0 id and key registry events", async () => {
+    const syncTrie = new MerkleTrie(db);
+    const store = new OnChainEventStore(db, new StoreEventHandler(db));
+
+    const idRegistryV0Event = Factories.IdRegistryOnChainEvent.build();
+    const idRegistryV2Event = Factories.IdRegistryOnChainEvent.build({ version: 2 });
+    const keyRegistryV0Event = Factories.SignerOnChainEvent.build();
+    const keyRegistryV2Event = Factories.SignerOnChainEvent.build({ version: 2 });
+    const storageRegistryV0Event = Factories.StorageRentOnChainEvent.build();
+
+    await addEvent(idRegistryV0Event, store, syncTrie);
+    await addEvent(idRegistryV2Event, store, syncTrie);
+    await addEvent(keyRegistryV0Event, store, syncTrie);
+    await addEvent(keyRegistryV2Event, store, syncTrie);
+    await addEvent(storageRegistryV0Event, store, syncTrie);
+
+    const success = await performDbMigrations(db, 5, 6);
+    expect(success).toBe(true);
+
+    const uncachedSyncTrie = new MerkleTrie(db);
+    await uncachedSyncTrie.initialize();
+    await expectExists(idRegistryV0Event, uncachedSyncTrie, false);
+    await expectExists(idRegistryV2Event, uncachedSyncTrie, true);
+    await expectExists(keyRegistryV0Event, uncachedSyncTrie, false);
+    await expectExists(keyRegistryV2Event, uncachedSyncTrie, true);
+    await expectExists(storageRegistryV0Event, uncachedSyncTrie, true);
+  });
+});

--- a/apps/hubble/src/storage/db/migrations/6.oldContractEvents.ts
+++ b/apps/hubble/src/storage/db/migrations/6.oldContractEvents.ts
@@ -1,0 +1,55 @@
+/**
+ Remove old id and key registry events
+ */
+
+import { logger } from "../../../utils/logger.js";
+import RocksDB from "../rocksdb.js";
+import { OnChainEventPostfix, RootPrefix } from "../types.js";
+import { Result } from "neverthrow";
+import { HubError, OnChainEvent, OnChainEventType } from "@farcaster/hub-nodejs";
+import { SyncId } from "../../../network/sync/syncId.js";
+import { MerkleTrie } from "../../../network/sync/merkleTrie.js";
+
+const log = logger.child({ component: "oldContractEvents" });
+
+export const oldContractEvents = async (db: RocksDB): Promise<boolean> => {
+  log.info({}, "Starting oldContractEvents migration");
+  const start = Date.now();
+
+  const syncTrie = new MerkleTrie(db);
+  await syncTrie.initialize();
+  let count = 0;
+
+  await db.forEachIteratorByPrefix(
+    Buffer.from([RootPrefix.OnChainEvent, OnChainEventPostfix.OnChainEvents]),
+    async (key, value) => {
+      if (!key || !value) {
+        return;
+      }
+
+      const result = Result.fromThrowable(
+        () => OnChainEvent.decode(new Uint8Array(value as Buffer)),
+        (e) => e as HubError,
+      )();
+      if (result.isOk()) {
+        const event = result.value;
+        if (event.type !== OnChainEventType.EVENT_TYPE_STORAGE_RENT && event.version === 0) {
+          // We expect all events to be before when the contract was paused for migration. This should not be true
+          if (event.blockNumber >= 111888232) {
+            log.warn(`Would have deleted event ${event.type} ${event.fid} from block ${event.blockNumber}. Skipping`);
+            return;
+          }
+          count += 1;
+          await db.del(key);
+          await syncTrie.deleteBySyncId(SyncId.fromOnChainEvent(event));
+        }
+      }
+    },
+    {},
+    1 * 60 * 60 * 1000,
+  );
+  await syncTrie.commitToDb();
+  await syncTrie.stop();
+  log.info({ duration: Date.now() - start }, `Finished oldContractEvents migration. Removed ${count} events`);
+  return true;
+};

--- a/apps/hubble/src/storage/db/migrations/migrations.ts
+++ b/apps/hubble/src/storage/db/migrations/migrations.ts
@@ -6,6 +6,7 @@ import { fnameProofIndexMigration } from "./2.fnameproof.js";
 import { clearEventsMigration } from "./3.clearEvents.js";
 import { uniqueVerificationsMigration } from "./4.uniqueVerifications.js";
 import { fnameSyncIds } from "./5.fnameSyncIds.js";
+import { oldContractEvents } from "./6.oldContractEvents.js";
 
 type MigrationFunctionType = (db: RocksDB) => Promise<boolean>;
 const migrations = new Map<number, MigrationFunctionType>();
@@ -30,6 +31,10 @@ migrations.set(4, async (db: RocksDB) => {
 
 migrations.set(5, async (db: RocksDB) => {
   return await fnameSyncIds(db);
+});
+
+migrations.set(6, async (db: RocksDB) => {
+  return await oldContractEvents(db);
 });
 
 // To Add a new migration

--- a/packages/core/src/builders.test.ts
+++ b/packages/core/src/builders.test.ts
@@ -239,9 +239,10 @@ describe("makeMessageHash", () => {
 describe("makeMessageWithSignature", () => {
   test("succeeds", async () => {
     const body = protobufs.CastAddBody.create({ text: "test" });
-    const castAdd = await builders.makeCastAdd(body, { fid, network }, ed25519Signer);
+    const timestamp = getFarcasterTime()._unsafeUnwrap();
+    const castAdd = await builders.makeCastAdd(body, { fid, network, timestamp }, ed25519Signer);
 
-    const data = await builders.makeCastAddData(body, { fid, network });
+    const data = await builders.makeCastAddData(body, { fid, network, timestamp });
     const hash = await builders.makeMessageHash(data._unsafeUnwrap());
     const signature = (await ed25519Signer.signMessageHash(hash._unsafeUnwrap()))._unsafeUnwrap();
     const message = await builders.makeMessageWithSignature(data._unsafeUnwrap(), {


### PR DESCRIPTION
## Motivation

Remove references to old contracts

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing references to old contracts. 

### Detailed summary
- Removed references to old contracts in the codebase
- Added a new migration to remove old id and key registry events
- Updated test cases to reflect the changes

> The following files were skipped due to too many changes: `apps/hubble/src/storage/db/migrations/6.oldContractEvents.test.ts`, `apps/hubble/src/network/sync/syncEngine.ts`, `apps/hubble/src/eth/l2EventsProvider.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->