### PR TITLE
fix: Dont sync deprecated syncIds

### DIFF
--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -42,6 +42,7 @@ let signerEvent: OnChainEvent;
 let storageEvent: OnChainEvent;
 let castAdd: Message;
 let fname: UserNameProof;
+const blockNumber = 111888235; // Post v2 migration block
 
 const eventsByBlock = new Map<number, OnChainEvent>();
 // biome-ignore lint/suspicious/noExplicitAny: mock used only in tests
@@ -57,7 +58,7 @@ const retryTransferByName = fnameEventsProvider.retryTransferByName;
 beforeAll(async () => {
   const custodySignerKey = (await custodySigner.getSignerKey())._unsafeUnwrap();
   const signerKey = (await signer.getSignerKey())._unsafeUnwrap();
-  custodyEvent = Factories.IdRegistryOnChainEvent.build({ fid }, { transient: { to: custodySignerKey } });
+  custodyEvent = Factories.IdRegistryOnChainEvent.build({ fid, blockNumber }, { transient: { to: custodySignerKey } });
 
   signerEvent = Factories.SignerOnChainEvent.build(
     { fid, blockNumber: custodyEvent.blockNumber + 1 },

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -880,7 +880,12 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     const promises: Promise<void>[] = [];
     for (const syncId of syncIds) {
       const unpacked = syncId.unpack();
-      if (unpacked.type === SyncIdType.FName && this._fnameEventsProvider) {
+      if (unpacked.type === SyncIdType.FName && this._fnameEventsProvider && unpacked.padded) {
+        // Temporarily add padded check here so newer hubs don't think unpadded fnames from older hubs are missing.
+        // TODO: Remove after most hubs are >1.7.1
+        if (!unpacked.padded) {
+          continue;
+        }
         log.info(`Retrying missing fname ${Buffer.from(unpacked.name).toString("utf-8")} during sync`, {
           fid: unpacked.fid,
         });
@@ -899,6 +904,11 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     for (const syncId of syncIds) {
       const unpacked = syncId.unpack();
       if (unpacked.type === SyncIdType.OnChainEvent && this._l2EventsProvider) {
+        // Add block number check here so newer hubs don't think attempt to sync v1 id and key registry events from older hubs
+        // TODO: Remove after most hubs are >1.7.1
+        if (unpacked.eventType !== OnChainEventType.EVENT_TYPE_STORAGE_RENT && unpacked.blockNumber < 111888232) {
+          continue;
+        }
         log.info(`Retrying missing block ${unpacked.blockNumber} during sync`, { fid: unpacked.fid });
         promises.push(this._l2EventsProvider.retryEventsFromBlock(unpacked.blockNumber));
       }

--- a/apps/hubble/src/network/sync/syncId.test.ts
+++ b/apps/hubble/src/network/sync/syncId.test.ts
@@ -64,6 +64,7 @@ describe("SyncId", () => {
       const fnameProof = Factories.UserNameProof.build({ name: Buffer.from("net00") });
       const unpackedSyncId = SyncId.fromFName(fnameProof).unpack() as FNameSyncId;
       expect(Buffer.from(unpackedSyncId.name)).toEqual(Buffer.from("net00"));
+      expect(unpackedSyncId.padded).toEqual(true);
     });
 
     test("handles max length names", async () => {
@@ -71,12 +72,14 @@ describe("SyncId", () => {
       const unpackedSyncId = SyncId.fromFName(fnameProof).unpack() as FNameSyncId;
       expect(Buffer.from(unpackedSyncId.name).length).toEqual(validations.USERNAME_MAX_LENGTH);
       expect(Buffer.from(unpackedSyncId.name)).toEqual(Buffer.from("iamaverylongname.eth"));
+      expect(unpackedSyncId.padded).toEqual(false);
     });
 
     test("works if names are longer than expected", async () => {
       const fnameProof = Factories.UserNameProof.build({ name: Buffer.from("iamaverylongname.eth.toolong") });
       const unpackedSyncId = SyncId.fromFName(fnameProof).unpack() as FNameSyncId;
       expect(Buffer.from(unpackedSyncId.name)).toEqual(Buffer.from("iamaverylongname.eth.toolong"));
+      expect(unpackedSyncId.padded).toEqual(false);
     });
   });
 

--- a/apps/hubble/src/network/sync/syncId.ts
+++ b/apps/hubble/src/network/sync/syncId.ts
@@ -40,6 +40,7 @@ export type MessageSyncId = BaseUnpackedSyncId & {
 export type FNameSyncId = BaseUnpackedSyncId & {
   type: SyncIdType.FName;
   name: Uint8Array;
+  padded: boolean;
 };
 
 export type OnChainEventSyncId = BaseUnpackedSyncId & {
@@ -171,6 +172,7 @@ class SyncId {
         type: SyncIdType.FName,
         fid: idBuf.readUInt32BE(TIMESTAMP_LENGTH + 1), // 1 byte for the root prefix
         name: nameBytes,
+        padded: firstZeroIndex !== -1,
       };
     } else if (rootPrefix === RootPrefix.OnChainEvent) {
       return {


### PR DESCRIPTION
## Motivation

Newer hubs shouldn't try to sync older syncIds until all hubs upgrade

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new property, `padded`, to the `SyncId` class. 

### Detailed summary
- Added `padded` property to `SyncId` class in `syncId.ts`.
- Added `blockNumber` variable in `multiPeerSyncEngine.test.ts`.
- Added assertions for `padded` property in `syncId.test.ts`.
- Added checks for `padded` property in `syncEngine.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->