### PR TITLE
fix: Don't throw if unable to migrate certain rows

### DIFF
--- a/apps/hubble/src/storage/db/migrations/6.oldContractEvents.ts
+++ b/apps/hubble/src/storage/db/migrations/6.oldContractEvents.ts
@@ -40,8 +40,12 @@ export const oldContractEvents = async (db: RocksDB): Promise<boolean> => {
             return;
           }
           count += 1;
-          await db.del(key);
-          await syncTrie.deleteBySyncId(SyncId.fromOnChainEvent(event));
+          try {
+            await db.del(key);
+            await syncTrie.deleteBySyncId(SyncId.fromOnChainEvent(event));
+          } catch (e) {
+            log.error({ err: e }, `Failed to delete event ${event.type} ${event.fid} from block ${event.blockNumber}`);
+          }
         }
       }
     },


### PR DESCRIPTION
## Motivation

Some hubs are hitting a `DB migration failed` due to `bad_request.invalid_param` in the fname migration.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on handling potential errors when deleting events and fname sync IDs from the database. 

### Detailed summary
- Added try-catch blocks to handle errors when deleting events and fname sync IDs.
- Logged error messages with relevant information when deletion fails.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->