### PR TITLE
fix: commit version after every migration instead of all at once

### DIFF
--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -66,7 +66,11 @@ import { CheckIncomingPortsJobScheduler } from "./storage/jobs/checkIncomingPort
 import { NetworkConfig, applyNetworkConfig, fetchNetworkConfig } from "./network/utils/networkConfig.js";
 import { UpdateNetworkConfigJobScheduler } from "./storage/jobs/updateNetworkConfigJob.js";
 import { statsd } from "./utils/statsd.js";
-import { LATEST_DB_SCHEMA_VERSION, performDbMigrations } from "./storage/db/migrations/migrations.js";
+import {
+  getDbSchemaVersion,
+  LATEST_DB_SCHEMA_VERSION,
+  performDbMigrations,
+} from "./storage/db/migrations/migrations.js";
 import { S3Client, PutObjectCommand, ListObjectsV2Command, DeleteObjectsCommand } from "@aws-sdk/client-s3";
 import path from "path";
 import { addProgressBar } from "./utils/progressBars.js";
@@ -612,7 +616,7 @@ export class Hub implements HubInterface {
     );
 
     // Get the DB Schema version
-    const dbSchemaVersion = await this.getDbSchemaVersion();
+    const dbSchemaVersion = await getDbSchemaVersion(this.rocksDB);
     if (dbSchemaVersion > LATEST_DB_SCHEMA_VERSION) {
       throw new HubError(
         "unavailable.storage_failure",
@@ -1446,24 +1450,6 @@ export class Hub implements HubInterface {
 
     // get the enum value from the number
     return networkNumber.map((n) => n as FarcasterNetwork);
-  }
-
-  async getDbSchemaVersion(): Promise<number> {
-    const dbResult = await ResultAsync.fromPromise(
-      this.rocksDB.get(Buffer.from([RootPrefix.DBSchemaVersion])),
-      (e) => e as HubError,
-    );
-    if (dbResult.isErr()) {
-      return 0;
-    }
-
-    // parse the buffer as an int
-    const schemaVersion = Result.fromThrowable(
-      () => dbResult.value.readUInt32BE(0),
-      (e) => e as HubError,
-    )();
-
-    return schemaVersion.unwrapOr(0);
   }
 
   async setDbNetwork(network: FarcasterNetwork): HubAsyncResult<void> {

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -625,7 +625,6 @@ export class Hub implements HubInterface {
       const success = await performDbMigrations(this.rocksDB, dbSchemaVersion);
       if (success) {
         log.info({}, "All DB migrations successful");
-        await this.setDbSchemaVersion(LATEST_DB_SCHEMA_VERSION);
       } else {
         throw new HubError("unavailable.storage_failure", "DB migrations failed");
       }
@@ -1465,15 +1464,6 @@ export class Hub implements HubInterface {
     )();
 
     return schemaVersion.unwrapOr(0);
-  }
-
-  async setDbSchemaVersion(version: number): HubAsyncResult<void> {
-    const txn = this.rocksDB.transaction();
-    const value = Buffer.alloc(4);
-    value.writeUInt32BE(version, 0);
-    txn.put(Buffer.from([RootPrefix.DBSchemaVersion]), value);
-
-    return ResultAsync.fromPromise(this.rocksDB.commit(txn), (e) => e as HubError);
   }
 
   async setDbNetwork(network: FarcasterNetwork): HubAsyncResult<void> {

--- a/apps/hubble/src/storage/db/migrations/migrations.test.ts
+++ b/apps/hubble/src/storage/db/migrations/migrations.test.ts
@@ -1,5 +1,5 @@
 import RocksDB from "../rocksdb.js";
-import { LATEST_DB_SCHEMA_VERSION, performDbMigrations } from "./migrations.js";
+import { getDbSchemaVersion, LATEST_DB_SCHEMA_VERSION, performDbMigrations } from "./migrations.js";
 
 const dbName = "migrations.test.db";
 
@@ -17,7 +17,9 @@ describe("migration", () => {
   });
 
   test("should not fail for an empty database", async () => {
+    expect(await getDbSchemaVersion(db)).toBe(0);
     const success = await performDbMigrations(db, 1, LATEST_DB_SCHEMA_VERSION);
     expect(success).toBe(true);
+    expect(await getDbSchemaVersion(db)).toBe(LATEST_DB_SCHEMA_VERSION);
   });
 });


### PR DESCRIPTION
## Motivation

This means we don't migrations when a one of them fails within a batch.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new function `getDbSchemaVersion` and refactoring the code to use it. 

### Detailed summary
- Added `getDbSchemaVersion` function to retrieve the schema version from the database.
- Refactored code to use `getDbSchemaVersion` instead of `this.getDbSchemaVersion`.
- Removed `getDbSchemaVersion` and `setDbSchemaVersion` functions from the `Hub` class.
- Updated tests to use `getDbSchemaVersion` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->