### PR TITLE
chore: Minor cleanup

### DIFF
--- a/.changeset/pretty-tools-do.md
+++ b/.changeset/pretty-tools-do.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+chore: rename/remove v2 contract address cli params after migration

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -80,8 +80,6 @@ app
   .option("-l, --l2-rpc-url <url>", "RPC URL of a mainnet Optimism Node (or comma separated list of URLs)")
   .option("--l2-id-registry-address <address>", "The address of the L2 Farcaster ID Registry contract")
   .option("--l2-key-registry-address <address>", "The address of the L2 Farcaster Key Registry contract")
-  .option("--l2-id-registry-v2-address <address>", "The address of the L2 Farcaster ID Registry V2 contract")
-  .option("--l2-key-registry-v2-address <address>", "The address of the L2 Farcaster Key Registry V2 contract")
   .option("--l2-storage-registry-address <address>", "The address of the L2 Farcaster Storage Registry contract")
   .option("--l2-resync-events", "Resync events from the L2 Farcaster contracts before starting (default: disabled)")
   .option("--l2-clear-events", "Deletes all events from the L2 Farcaster contracts before starting (default: disabled)")
@@ -488,8 +486,6 @@ app
       l2RpcUrl: cliOptions.l2RpcUrl ?? hubConfig.l2RpcUrl,
       l2IdRegistryAddress: cliOptions.l2IdRegistryAddress ?? hubConfig.l2IdRegistryAddress,
       l2KeyRegistryAddress: cliOptions.l2KeyRegistryAddress ?? hubConfig.l2KeyRegistryAddress,
-      l2IdRegistryV2Address: cliOptions.l2IdRegistryV2Address ?? hubConfig.l2IdRegistryV2Address,
-      l2KeyRegistryV2Address: cliOptions.l2KeyRegistryV2Address ?? hubConfig.l2KeyRegistryV2Address,
       l2StorageRegistryAddress: cliOptions.l2StorageRegistryAddress ?? hubConfig.l2StorageRegistryAddress,
       l2FirstBlock: cliOptions.l2FirstBlock ?? hubConfig.l2FirstBlock,
       l2ChunkSize: cliOptions.l2ChunkSize ?? hubConfig.l2ChunkSize,

--- a/apps/hubble/src/console/console.ts
+++ b/apps/hubble/src/console/console.ts
@@ -5,6 +5,8 @@ import {
   getAuthMetadata,
   getInsecureHubRpcClient,
   getSSLHubRpcClient,
+  toFarcasterTime,
+  fromFarcasterTime,
 } from "@farcaster/hub-nodejs";
 import path from "path";
 import * as repl from "repl";
@@ -15,6 +17,7 @@ import { GenCommand } from "./genCommand.js";
 import { FactoriesCommand, ProtobufCommand } from "./protobufCommand.js";
 import { RpcClientCommand } from "./rpcClientCommand.js";
 import { WarpcastTestCommand } from "./warpcastTestCommand.js";
+import { SyncId } from "../network/sync/syncId.js";
 
 export const DEFAULT_RPC_CONSOLE = "127.0.0.1:2283";
 
@@ -86,6 +89,9 @@ export const startConsole = async (addressString: string, useInsecure: boolean) 
 
   // Add some utility functions
   replServer.context["getAuthMetadata"] = getAuthMetadata;
+  replServer.context["SyncId"] = SyncId;
+  replServer.context["toFarcasterTime"] = toFarcasterTime;
+  replServer.context["fromFarcasterTime"] = fromFarcasterTime;
 
   // Run the info command to start
 

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -184,12 +184,6 @@ export interface HubOptions {
   /** Address of the Key Registry contract  */
   l2KeyRegistryAddress?: `0x${string}`;
 
-  /** Address of the V2 Id Registry contract  */
-  l2IdRegistryV2Address?: `0x${string}`;
-
-  /** Address of the V2 Key Registry contract  */
-  l2KeyRegistryV2Address?: `0x${string}`;
-
   /** Address of the StorageRegistry contract  */
   l2StorageRegistryAddress?: `0x${string}`;
 
@@ -344,8 +338,8 @@ export class Hub implements HubInterface {
         options.l2RpcUrl,
         options.rankRpcs ?? false,
         options.l2StorageRegistryAddress ?? OptimismConstants.StorageRegistryAddress,
-        options.l2KeyRegistryV2Address ?? OptimismConstants.KeyRegistryV2Address,
-        options.l2IdRegistryV2Address ?? OptimismConstants.IdRegistryV2Address,
+        options.l2KeyRegistryAddress ?? OptimismConstants.KeyRegistryV2Address,
+        options.l2IdRegistryAddress ?? OptimismConstants.IdRegistryV2Address,
         options.l2FirstBlock ?? OptimismConstants.FirstBlock,
         options.l2ChunkSize ?? OptimismConstants.ChunkSize,
         options.l2ChainId ?? OptimismConstants.ChainId,

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -42,7 +42,6 @@ let signerEvent: OnChainEvent;
 let storageEvent: OnChainEvent;
 let castAdd: Message;
 let fname: UserNameProof;
-const blockNumber = 111888235; // Post v2 migration block
 
 const eventsByBlock = new Map<number, OnChainEvent>();
 // biome-ignore lint/suspicious/noExplicitAny: mock used only in tests
@@ -58,7 +57,7 @@ const retryTransferByName = fnameEventsProvider.retryTransferByName;
 beforeAll(async () => {
   const custodySignerKey = (await custodySigner.getSignerKey())._unsafeUnwrap();
   const signerKey = (await signer.getSignerKey())._unsafeUnwrap();
-  custodyEvent = Factories.IdRegistryOnChainEvent.build({ fid, blockNumber }, { transient: { to: custodySignerKey } });
+  custodyEvent = Factories.IdRegistryOnChainEvent.build({ fid }, { transient: { to: custodySignerKey } });
 
   signerEvent = Factories.SignerOnChainEvent.build(
     { fid, blockNumber: custodyEvent.blockNumber + 1 },

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -880,12 +880,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     const promises: Promise<void>[] = [];
     for (const syncId of syncIds) {
       const unpacked = syncId.unpack();
-      if (unpacked.type === SyncIdType.FName && this._fnameEventsProvider && unpacked.padded) {
-        // Temporarily add padded check here so newer hubs don't think unpadded fnames from older hubs are missing.
-        // TODO: Remove after most hubs are >1.7.1
-        if (!unpacked.padded) {
-          continue;
-        }
+      if (unpacked.type === SyncIdType.FName && this._fnameEventsProvider) {
         log.info(`Retrying missing fname ${Buffer.from(unpacked.name).toString("utf-8")} during sync`, {
           fid: unpacked.fid,
         });
@@ -904,11 +899,6 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     for (const syncId of syncIds) {
       const unpacked = syncId.unpack();
       if (unpacked.type === SyncIdType.OnChainEvent && this._l2EventsProvider) {
-        // Add block number check here so newer hubs don't think attempt to sync v1 id and key registry events from older hubs
-        // TODO: Remove after most hubs are >1.7.1
-        if (unpacked.eventType !== OnChainEventType.EVENT_TYPE_STORAGE_RENT && unpacked.blockNumber < 111888232) {
-          continue;
-        }
         log.info(`Retrying missing block ${unpacked.blockNumber} during sync`, { fid: unpacked.fid });
         promises.push(this._l2EventsProvider.retryEventsFromBlock(unpacked.blockNumber));
       }

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -405,7 +405,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     const existingPeerInfo = this.getContactInfoForPeerId(peerId.toString());
     if (existingPeerInfo) {
       if (contactInfo.timestamp > existingPeerInfo.contactInfo.timestamp) {
-        log.info({ peerInfo: existingPeerInfo }, "Updating peer with latest contactInfo");
+        log.debug({ peerInfo: existingPeerInfo }, "Updating peer with latest contactInfo");
         this.currentHubPeerContacts.set(peerId.toString(), { peerId, contactInfo });
       }
       return err(new HubError("bad_request.duplicate", "peer already exists"));

--- a/apps/hubble/www/docs/docs/cli.md
+++ b/apps/hubble/www/docs/docs/cli.md
@@ -43,8 +43,6 @@ Ethereum Options:
 L2 Options:
   --l2-id-registry-address                The address of the L2 Farcaster ID Registry contract
   --l2-key-registry-address <address>     The address of the L2 Farcaster Key Registry contract
-  --l2-id-registry-v2-address             The address of the L2 Farcaster ID Registry V2 contract
-  --l2-key-registry-v2-address <address>  The address of the L2 Farcaster Key Registry V2 contract
   --l2-storage-registry-address <address> The address of the L2 Farcaster Storage Registry contract
   --l2-resync-events                      Resync events from the L2 Farcaster contracts before starting (default: disabled)
   --l2-clear-events                       Deletes all L2 events before starting (default: disabled)


### PR DESCRIPTION
## Motivation

- Add some helpers to console
- Remove some sync optimizations for hubs that haven't migrated yet.
- Reduce contact info logging noise
- Remove v2 contract address cli flags

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Renamed and removed v2 contract address CLI parameters after migration
- Removed unused variable `blockNumber` in `multiPeerSyncEngine.test.ts`
- Added `toFarcasterTime` and `fromFarcasterTime` functions in `console.ts`
- Added `SyncId` class in `console.ts`
- Updated `Hub` class to use new contract address options
- Updated CLI options for contract addresses in `cli.ts`
- Updated `app` configuration in `cli.ts` to use new contract address options
- Updated logging level in `syncEngine.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->