### PR TITLE
fix: catch and ignore provider errors during retry

### DIFF
--- a/.changeset/good-shrimps-smile.md
+++ b/.changeset/good-shrimps-smile.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: catch and ignore provider errors during retry

--- a/apps/hubble/src/eth/l2EventsProvider.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.ts
@@ -558,7 +558,11 @@ export class L2EventsProvider {
     this._retryDedupMap.set(blockNumber, true);
 
     // Sync old events
-    await this.syncHistoricalEvents(blockNumber, blockNumber + 1, 1);
+    try {
+      await this.syncHistoricalEvents(blockNumber, blockNumber + 1, 1);
+    } catch (e) {
+      log.error(e, `Error retrying events from block ${blockNumber}`);
+    }
   }
 
   private setAddresses(


### PR DESCRIPTION
## Motivation

Currently hub crashes when it hits a rate limit error:
```
hubble-hubble-1  | {"level":50,"time":1699646142590,"pid":1,"hostname":"58bbe902717e","reason":"Unhandled Rejection","err":{"type":"HttpRequestError","message":"HTTP request failed.\n\nStatus: 429\nURL: https://opt-mainnet.g.alchemy.com/v2/PRIVATE_KEY\nRequest body: {\"method\":\"eth_getFilterLogs\",\"params\":[\"0xd01c87ecce67458269476e637364f209\"]}\n\nDetails: {\"code\":429,\"message\":\"Your app has exceeded its compute units per second capacity. If you have retries enabled, you can safely ignore this message. If not, check out https://docs.alchemy.com/refPRIVATE_KEYiem@1.12.2","stack":"HttpRequestError: HTTP request failed.\n\nStatus: 429\nURL: https://opt-mainnet.g.alchemy.com/v2/PRIVATE_KEY\nRequest body: {\"method\":\"eth_getFilterLogs\",\"params\":[\"0xd01c87ecce67458269476e637364f209\"]}\n\nDetails: {\"code\":429,\"message\":\"Your app has exceeded its compute units per second capacity. If you have retries enabled, you can safely ignore this message. If not, check out https://docs.alchemy.com/refPRIVATE_KEYiem@1.12.2\n    at Object.http (file:///home/node/app/node_modules/viem/_esm/utils/rpc.js:42:19)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async fn (file:///home/node/app/node_modules/viem/_esm/clients/transports/http.js:39:24)\n    at async request (file:///home/node/app/node_modules/viem/_esm/clients/transports/http.js:40:45)\n    at async withRetry.delay.count.count (file:///home/node/app/node_modules/viem/_esm/utils/buildRequest.js:26:20)\n    at async attemptRetry (file:///home/node/app/node_modules/viem/_esm/utils/promise/withRetry.js:12:30)","details":"{\"code\":429,\"message\":\"Your app has exceeded its compute units per second capacity. If you have retries enabled, you can safely ignore this message. If not, check out https://docs.alchemy.com/refPRIVATE_KEYges":["Status: 429","URL: https://opt-mainnet.g.alchemy.com/v2/PRIVATE_KEY","Request body: {\"method\":\"eth_getFilterLogs\",\"params\":[\"0xd01c87ecce67458269476e637364f209\"]}"],"shortMessage":"HTTP request failed.","name":"HttpRequestError","version":"viem@1.12.2","body":{"method":"eth_getFilterLogs","params":["0xd01c87ecce67458269476e637364f209"]},"headers":{},"status":429,"url":"https://opt-mainnet.g.alchemy.com/v2/PRIVATE_KEY"},"msg":"shutting down hub"}

```


## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on fixing an issue where provider errors during retry were not being caught and ignored.

### Detailed summary:
- Added a try-catch block to catch and handle errors during the retry of historical events synchronization.
- If an error occurs during the retry, it is logged with the corresponding block number.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->