### PR TITLE
chore: release 1.7.2

### DIFF
--- a/.changeset/good-shrimps-smile.md
+++ b/.changeset/good-shrimps-smile.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: catch and ignore provider errors during retry

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hubble
 
+## 1.7.2
+
+### Patch Changes
+
+- 912f680f: fix: catch and ignore provider errors during retry
+
 ## 1.7.1
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",


### PR DESCRIPTION
## Motivation

Fix hub crashes when provider errors.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of the `@farcaster/hubble` package to `1.7.2` and includes a patch change to fix a provider error during retry.

### Detailed summary
- Updated the version of `@farcaster/hubble` package to `1.7.2`
- Patch change: Fixed a provider error during retry (commit: 912f680f)

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->