### PR TITLE
fix: Handle docker-compose versions

### DIFF
--- a/.changeset/thick-cherries-kneel.md
+++ b/.changeset/thick-cherries-kneel.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Handle docker-compose versions in hubble.sh

--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -209,7 +209,7 @@ ensure_grafana() {
       mkdir -p grafana/data
       chmod 777 grafana/data
 
-      if $COMPOSE_CMD ps statsd 2>&1 >/dev/null; then
+      if $COMPOSE_CMD ps 2>&1 >/dev/null; then
           if $COMPOSE_CMD ps statsd | grep -q "Up"; then
               $COMPOSE_CMD restart statsd grafana
           else


### PR DESCRIPTION
## Motivation

On some versions of docker-compose, the `docker compose ps` command returns true (0), but if you specify a not-running container, it returns false (1), making it incorrectly think docker compose is not installed. 

Fix by just checking for docker compose

## Change Summary

- Don't pass container name when checking for docker-compose

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an issue with handling docker-compose versions in the `hubble.sh` script. 

### Detailed summary
- Added a patch for the `@farcaster/hubble` dependency.
- Modified the `hubble.sh` script to handle docker-compose versions correctly.
- Changed the permissions of the `grafana/data` file to allow execution.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->