### PR TITLE
chore: release v1.8.0

### DIFF
--- a/.changeset/thick-cherries-kneel.md
+++ b/.changeset/thick-cherries-kneel.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Handle docker-compose versions in hubble.sh

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @farcaster/hubble
 
+## 1.8.0
+
+### Minor Changes
+
+- Expiry date changed to 1/10/24 0:00:00 UTC
+
+### Patch Changes
+
+- 6bfb694b: fix: Handle docker-compose versions in hubble.sh
+
 ## 1.7.2
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -90,7 +90,7 @@ export const APP_NICKNAME = process.env["HUBBLE_NAME"] ?? "Farcaster Hub";
 export const SNAPSHOT_S3_DEFAULT_BUCKET = "download.farcaster.xyz";
 export const S3_REGION = "us-east-1";
 
-export const FARCASTER_VERSION = "2023.10.4";
+export const FARCASTER_VERSION = "2023.11.15";
 export const FARCASTER_VERSIONS_SCHEDULE: VersionSchedule[] = [
   { version: "2023.3.1", expiresAt: 1682553600000 }, // expires at 4/27/23 00:00 UTC
   { version: "2023.4.19", expiresAt: 1686700800000 }, // expires at 6/14/23 00:00 UTC
@@ -98,6 +98,7 @@ export const FARCASTER_VERSIONS_SCHEDULE: VersionSchedule[] = [
   { version: "2023.7.12", expiresAt: 1693958400000 }, // expires at 9/6/23 00:00 UTC
   { version: "2023.8.23", expiresAt: 1697587200000 }, // expires at 10/18/23 00:00 UTC
   { version: "2023.10.4", expiresAt: 1701216000000 }, // expires at 11/28/23 00:00 UTC
+  { version: "2023.11.15", expiresAt: 1704844800000 }, // expires at 1/10/23 00:00 UTC
 ];
 
 const MAX_CONTACT_INFO_AGE_MS = GOSSIP_SEEN_TTL;


### PR DESCRIPTION
## Motivation

Release v1.8

## Change Summary

See above

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of the `@farcaster/hubble` package to `1.8.0` and making changes to the `FARCASTER_VERSION` constant in `hubble.ts`. 

### Detailed summary
- Updated `@farcaster/hubble` package version to `1.8.0`.
- Changed the expiry date in the `FARCASTER_VERSIONS_SCHEDULE` array in `hubble.ts`.
- Updated the `FARCASTER_VERSION` constant to `"2023.11.15"` in `hubble.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->