### PR TITLE
fix: Backfill reactions and storage allocations in Replicator

### DIFF
--- a/.changeset/heavy-books-suffer.md
+++ b/.changeset/heavy-books-suffer.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/replicator": patch
+---
+
+Include storage allocations and reactions

--- a/apps/replicator/src/jobs/backfillFidOtherOnChainEvents.ts
+++ b/apps/replicator/src/jobs/backfillFidOtherOnChainEvents.ts
@@ -12,7 +12,7 @@ export const BackfillFidOtherOnChainEvents = registerJob({
     for await (const events of getOnChainEventsByFidInBatchesOf(hub, {
       fid,
       pageSize: MAX_PAGE_SIZE,
-      eventTypes: [OnChainEventType.EVENT_TYPE_ID_REGISTER, OnChainEventType.EVENT_TYPE_STORAGE_RENT],
+      eventTypes: [OnChainEventType.EVENT_TYPE_ID_REGISTER],
       idRegisterEventTypes: [
         // We've already processed REGISTER events by this point, so skip them
         IdRegisterEventType.TRANSFER,

--- a/apps/replicator/src/jobs/backfillFidStorageAllocations.ts
+++ b/apps/replicator/src/jobs/backfillFidStorageAllocations.ts
@@ -1,0 +1,21 @@
+import { OnChainEventType } from "@farcaster/hub-nodejs";
+import { getOnChainEventsByFidInBatchesOf } from "../hub.js";
+import { registerJob } from "../jobs.js";
+import { processOnChainEvents } from "../processors/index.js";
+
+export const BackfillFidStorageAllocations = registerJob({
+  name: "BackfillFidStorageAllocations",
+  run: async ({ fid }: { fid: number }, { db, log, redis, hub }) => {
+    const registrationEvents = getOnChainEventsByFidInBatchesOf(hub, {
+      fid,
+      pageSize: 3_000,
+      eventTypes: [OnChainEventType.EVENT_TYPE_STORAGE_RENT],      
+    });
+
+    for await (const events of registrationEvents) {
+      await processOnChainEvents(events, db, log, redis);
+    }
+
+    await redis.sadd("backfilled-storage-allocations", fid);
+  },
+});


### PR DESCRIPTION
## Motivation

The Replicator wasn't correctly backfilling reactions and storage allocations for users.

Replaces #1589.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on including storage allocations and reactions in the backfill process for a specific fid.

### Detailed summary
- Added storage allocations and reactions to the eventTypes for backfilling a specific fid.
- Created a new job `BackfillFidStorageAllocations` to handle the backfilling of storage allocations.
- Imported necessary modules and functions for the new job.
- Updated `BackfillFidData` job to enqueue the `BackfillFidStorageAllocations` job if storage allocations have not been backfilled for the fid.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->