### PR TITLE
chore: Cut Replicator 0.2.6

### DIFF
--- a/.changeset/heavy-books-suffer.md
+++ b/.changeset/heavy-books-suffer.md
@@ -1,5 +1,0 @@
----
-"@farcaster/replicator": patch
----
-
-Include storage allocations and reactions

--- a/apps/replicator/CHANGELOG.md
+++ b/apps/replicator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/replicator
 
+## 0.2.6
+
+### Patch Changes
+
+- d8a5caaf: Include storage allocations and reactions
+
 ## 0.2.5
 
 ### Patch Changes

--- a/apps/replicator/package.json
+++ b/apps/replicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/replicator",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Replicate Farcaster hub data into Postgres",
   "author": "",
   "license": "",


### PR DESCRIPTION
## Motivation

Regular release.

## Change Summary

Ran `yarn changeset version`

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of `@farcaster/replicator` to `0.2.6` and adding storage allocations and reactions. 

### Detailed summary
- Updated version of `@farcaster/replicator` to `0.2.6`
- Added storage allocations and reactions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->