### PR TITLE
fix: network docker-compose.yml

### DIFF
--- a/apps/hubble/docker-compose.yml
+++ b/apps/hubble/docker-compose.yml
@@ -30,8 +30,6 @@ services:
     volumes:
       - ./.hub:/home/node/app/apps/hubble/.hub
       - ./.rocks:/home/node/app/apps/hubble/.rocks
-    networks:
-      - my-network
     logging:
       driver: "json-file"
       options:
@@ -49,8 +47,6 @@ services:
       # - '7002:7002' # Carbon cache query
       - '8125:8125/udp' # StatsD
       - '8126:8126' # StatsD admin
-    networks:
-      - my-network
 
   # Start this if you want to see perf metrics for your hubble node. Remember to start `statsd` as well.
   grafana:
@@ -62,9 +58,3 @@ services:
       - ./grafana/data:/var/lib/grafana  # Persistent Grafana data
     ports:
       - '3000:3000' # Grafana web
-    networks:
-      - my-network
-
-networks: 
-  my-network:
- 


### PR DESCRIPTION
I'm running hubble on a GCP VM & when *my-network* was enabled in docker-compose.yml  The hubble was not able to connect to L1 Node & L2 Node

  networks:
      - my-network

Docker already creates a docker network by default when running docker compose up -d & this one works.

## Motivation

Otherwise not able to run Hubble on GCP VM

## Change Summary

Delete all occurences of my-network in docker-compose.yml

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing unused volumes and networks in the docker-compose.yml file for the Hubble and Grafana services.

### Detailed summary
- Removed unused volumes and networks for the Hubble service
- Removed unused volumes and networks for the Grafana service

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->