### PR TITLE
fix: Admin reset key event may have reset the key sometimes

### DIFF
--- a/.changeset/modern-pillows-roll.md
+++ b/.changeset/modern-pillows-roll.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Admin reset key event may have reset the key sometimes

--- a/apps/hubble/src/storage/db/migrations/7.clearAdminResets.test.ts
+++ b/apps/hubble/src/storage/db/migrations/7.clearAdminResets.test.ts
@@ -1,0 +1,61 @@
+import { performDbMigrations } from "./migrations.js";
+import { jestRocksDB } from "../jestUtils.js";
+import { MerkleTrie } from "../../../network/sync/merkleTrie.js";
+import { SyncId } from "../../../network/sync/syncId.js";
+import { Factories, HubError, OnChainEvent, SignerEventType } from "@farcaster/hub-nodejs";
+import StoreEventHandler from "../../stores/storeEventHandler.js";
+import OnChainEventStore from "../../stores/onChainEventStore.js";
+import { getOnChainEvent } from "../onChainEvent.js";
+import { ResultAsync } from "neverthrow";
+
+const db = jestRocksDB("clearAdminResets.migration.test");
+
+describe("clearAdminResets migration", () => {
+  const addEvent = async function (event: OnChainEvent, store: OnChainEventStore, trie: MerkleTrie) {
+    await expect(store.mergeOnChainEvent(event)).resolves.toBeTruthy();
+    const syncId = SyncId.fromOnChainEvent(event);
+    await trie.insert(syncId);
+    await trie.commitToDb();
+    await expectExists(event, trie, true);
+  };
+
+  const expectExists = async function (event: OnChainEvent, trie: MerkleTrie, shouldExist: boolean) {
+    const dbResult = await ResultAsync.fromPromise(
+      getOnChainEvent(db, event.type, event.fid, event.blockNumber, event.logIndex),
+      (e) => e as HubError,
+    );
+    expect(dbResult.isOk()).toBe(shouldExist);
+    const syncId = SyncId.fromOnChainEvent(event);
+    expect(await trie.exists(syncId)).toBe(shouldExist);
+  };
+
+  test("should delete admin reset signer events", async () => {
+    const syncTrie = new MerkleTrie(db);
+    const store = new OnChainEventStore(db, new StoreEventHandler(db));
+
+    const idRegistryEvent = Factories.IdRegistryOnChainEvent.build();
+    const keyRegistryEvent = Factories.SignerOnChainEvent.build();
+    const keyRegistryResetEvent = Factories.SignerOnChainEvent.build({
+      signerEventBody: Factories.SignerEventBody.build({ eventType: SignerEventType.ADMIN_RESET }),
+    });
+    const storageRegistryEvent = Factories.StorageRentOnChainEvent.build();
+
+    await addEvent(idRegistryEvent, store, syncTrie);
+    await addEvent(keyRegistryEvent, store, syncTrie);
+    await addEvent(keyRegistryResetEvent, store, syncTrie);
+    await addEvent(storageRegistryEvent, store, syncTrie);
+
+    const success = await performDbMigrations(db, 6, 7);
+    expect(success).toBe(true);
+
+    const uncachedSyncTrie = new MerkleTrie(db);
+    await uncachedSyncTrie.initialize();
+
+    // Admin reset is removed
+    await expectExists(keyRegistryResetEvent, uncachedSyncTrie, false);
+    // Rest are unaffected
+    await expectExists(idRegistryEvent, uncachedSyncTrie, true);
+    await expectExists(keyRegistryEvent, uncachedSyncTrie, true);
+    await expectExists(storageRegistryEvent, uncachedSyncTrie, true);
+  });
+});

--- a/apps/hubble/src/storage/db/migrations/7.clearAdminResets.ts
+++ b/apps/hubble/src/storage/db/migrations/7.clearAdminResets.ts
@@ -1,0 +1,54 @@
+/**
+ Remove admin resets so they can be re-added correctly (old logic picked first signer and did not check for the exact key)
+ */
+
+import { logger } from "../../../utils/logger.js";
+import RocksDB from "../rocksdb.js";
+import { OnChainEventPostfix, RootPrefix } from "../types.js";
+import { Result } from "neverthrow";
+import { HubError, isSignerOnChainEvent, OnChainEvent, SignerEventType } from "@farcaster/hub-nodejs";
+import { SyncId } from "../../../network/sync/syncId.js";
+import { MerkleTrie } from "../../../network/sync/merkleTrie.js";
+
+const log = logger.child({ component: "clearAdminResets" });
+
+export const clearAdminResets = async (db: RocksDB): Promise<boolean> => {
+  log.info({}, "Starting clearAdminResets migration");
+  const start = Date.now();
+
+  const syncTrie = new MerkleTrie(db);
+  await syncTrie.initialize();
+  let count = 0;
+
+  await db.forEachIteratorByPrefix(
+    Buffer.from([RootPrefix.OnChainEvent, OnChainEventPostfix.OnChainEvents]),
+    async (key, value) => {
+      if (!key || !value) {
+        return;
+      }
+
+      const result = Result.fromThrowable(
+        () => OnChainEvent.decode(new Uint8Array(value as Buffer)),
+        (e) => e as HubError,
+      )();
+      if (result.isOk()) {
+        const event = result.value;
+        if (isSignerOnChainEvent(event) && event.signerEventBody.eventType === SignerEventType.ADMIN_RESET) {
+          count += 1;
+          try {
+            await db.del(key);
+            await syncTrie.deleteBySyncId(SyncId.fromOnChainEvent(event));
+          } catch (e) {
+            log.error({ err: e }, `Failed to delete event ${event.type} ${event.fid} from block ${event.blockNumber}`);
+          }
+        }
+      }
+    },
+    {},
+    1 * 60 * 60 * 1000,
+  );
+  await syncTrie.commitToDb();
+  await syncTrie.stop();
+  log.info({ duration: Date.now() - start }, `Finished clearAdminResets migration. Removed ${count} events`);
+  return true;
+};

--- a/apps/hubble/src/storage/db/migrations/migrations.ts
+++ b/apps/hubble/src/storage/db/migrations/migrations.ts
@@ -10,6 +10,7 @@ import { oldContractEvents } from "./6.oldContractEvents.js";
 import { HubAsyncResult, HubError } from "@farcaster/hub-nodejs";
 import { RootPrefix } from "../types.js";
 import rocksdb from "../rocksdb.js";
+import { clearAdminResets } from "./7.clearAdminResets.js";
 
 type MigrationFunctionType = (db: RocksDB) => Promise<boolean>;
 const migrations = new Map<number, MigrationFunctionType>();
@@ -38,6 +39,10 @@ migrations.set(5, async (db: RocksDB) => {
 
 migrations.set(6, async (db: RocksDB) => {
   return await oldContractEvents(db);
+});
+
+migrations.set(7, async (db: RocksDB) => {
+  return await clearAdminResets(db);
 });
 
 // To Add a new migration


### PR DESCRIPTION
## Motivation

In at least one case, the hubs incorrectly removed a signer (probably replaced with a v1 signer that was later dropped during the v2 contract migration) because we weren't checking for the exact key match. This fixes the bug and deletes the admin reset events so they can be re-synced correctly.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an issue with the Admin reset key event in the Hubble app. 

### Detailed summary
- Added a new migration to clear Admin resets in the database.
- Imported `bytesCompare` from `@farcaster/core` in `onChainEventStore.ts`.
- Added a new file `7.clearAdminResets.ts` to handle the migration logic.
- Added tests for the new migration logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->