### PR TITLE
docs: inline comment refers to 32-byte fid instead of 4-byte fid.

### DIFF
--- a/apps/hubble/src/storage/db/types.ts
+++ b/apps/hubble/src/storage/db/types.ts
@@ -21,7 +21,7 @@ export const TSHASH_LENGTH = 4 + HASH_LENGTH;
  * RootPrefix indicates the purpose of the key. It is the 1st byte of every key.
  */
 export enum RootPrefix {
-  /* Used for multiple purposes, starts with a 32-byte fid */
+  /* Used for multiple purposes, starts with a 4-byte fid */
   User = 1,
   /* Used to index casts by parent */
   CastsByParent = 2,


### PR DESCRIPTION
## Motivation

Fixes #1611

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `RootPrefix` enum in `types.ts` file. The notable changes include:

- Changing the starting byte length of `User` prefix from 32 bytes to 4 bytes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->