### PR TITLE
fix: Don't add deleted fnames to sync trie

### DIFF
--- a/.changeset/dry-spies-march.md
+++ b/.changeset/dry-spies-march.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Don't add deleted fnames to sync trie

--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -562,12 +562,15 @@ describe("SyncEngine", () => {
         expect((await syncEngine.getDbStats()).numFnames).toEqual(1);
       });
       test("does not add a deleted fname to the trie", async () => {
-        userNameProof = Factories.UserNameProof.build({
+        await engine.mergeUserNameProof(userNameProof);
+        const deletionProof = Factories.UserNameProof.build({
           type: UserNameType.USERNAME_TYPE_FNAME,
+          name: userNameProof.name,
+          timestamp: userNameProof.timestamp + 10,
           fid: 0,
         });
-        expect(await syncEngine.trie.exists(SyncId.fromFName(userNameProof))).toBeFalsy();
         await engine.mergeUserNameProof(userNameProof);
+        await engine.mergeUserNameProof(deletionProof);
         expect(await syncEngine.trie.exists(SyncId.fromFName(userNameProof))).toBeFalsy();
         expect((await syncEngine.getDbStats()).numFnames).toEqual(0);
       });

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -268,7 +268,8 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
       }
       if (
         event.mergeUsernameProofBody.usernameProof &&
-        event.mergeUsernameProofBody.usernameProof.type === UserNameType.USERNAME_TYPE_FNAME
+        event.mergeUsernameProofBody.usernameProof.type === UserNameType.USERNAME_TYPE_FNAME &&
+        event.mergeUsernameProofBody.usernameProof.fid !== 0 // Deletes should not be added to the trie
       ) {
         this._syncTrieQ += 1;
         statsd().gauge("merkle_trie.merge_q", this._syncTrieQ);


### PR DESCRIPTION
## Motivation

We were adding deleted fnames to the trie which cases sync loops since they don't actually exist in the db. Check if fid is 0 and skip adding the deletes.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
Fixing an issue where deleted fnames were being added to the sync trie.

### Detailed summary:
- Modified `syncEngine.ts` to check if the `fid` of the `usernameProof` is not 0 before adding it to the sync trie.
- Added a test in `syncEngine.test.ts` to verify that a deleted fname is not added to the trie.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->