### PR TITLE
Hubble experiments

### DIFF
--- a/packages/core/src/protobufs/generated/message.ts
+++ b/packages/core/src/protobufs/generated/message.ts
@@ -99,6 +99,8 @@ export enum MessageType {
   USER_DATA_ADD = 11,
   /** USERNAME_PROOF - Add or replace a username proof */
   USERNAME_PROOF = 12,
+  /** SOCIAL_DATA_ADD - Add new social data */
+  SOCIAL_DATA_ADD = 13,
 }
 
 export function messageTypeFromJSON(object: any): MessageType {
@@ -136,6 +138,9 @@ export function messageTypeFromJSON(object: any): MessageType {
     case 12:
     case "MESSAGE_TYPE_USERNAME_PROOF":
       return MessageType.USERNAME_PROOF;
+    case 13:
+    case "MESSAGE_TYPE_SOCIAL_DATA_ADD":
+      return MessageType.SOCIAL_DATA_ADD;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum MessageType");
   }
@@ -165,6 +170,8 @@ export function messageTypeToJSON(object: MessageType): string {
       return "MESSAGE_TYPE_USER_DATA_ADD";
     case MessageType.USERNAME_PROOF:
       return "MESSAGE_TYPE_USERNAME_PROOF";
+    case MessageType.SOCIAL_DATA_ADD:
+      return "MESSAGE_TYPE_SOCIAL_DATA_ADD";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum MessageType");
   }
@@ -212,6 +219,42 @@ export function farcasterNetworkToJSON(object: FarcasterNetwork): string {
       return "FARCASTER_NETWORK_DEVNET";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum FarcasterNetwork");
+  }
+}
+
+/** Type of SocialDatat */
+export enum SocialDataType {
+  NONE = 0,
+  NETFLIX = 1,
+  PLAYSTATION = 2,
+}
+
+export function socialDataTypeFromJSON(object: any): SocialDataType {
+  switch (object) {
+    case 0:
+    case "SOCIAL_DATA_TYPE_NONE":
+      return SocialDataType.NONE;
+    case 1:
+    case "SOCIAL_DATA_TYPE_NETFLIX":
+      return SocialDataType.NETFLIX;
+    case 2:
+    case "SOCIAL_DATA_TYPE_PLAYSTATION":
+      return SocialDataType.PLAYSTATION;
+    default:
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum SocialDataType");
+  }
+}
+
+export function socialDataTypeToJSON(object: SocialDataType): string {
+  switch (object) {
+    case SocialDataType.NONE:
+      return "SOCIAL_DATA_TYPE_NONE";
+    case SocialDataType.NETFLIX:
+      return "SOCIAL_DATA_TYPE_NETFLIX";
+    case SocialDataType.PLAYSTATION:
+      return "SOCIAL_DATA_TYPE_PLAYSTATION";
+    default:
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum SocialDataType");
   }
 }
 
@@ -362,6 +405,13 @@ export interface MessageData {
   /** SignerRemoveBody signer_remove_body = 13; // Deprecated */
   linkBody?: LinkBody | undefined;
   usernameProofBody?: UserNameProof | undefined;
+  socialDataBody?: SocialDataBody | undefined;
+}
+
+/** Adds social data about a user */
+export interface SocialDataBody {
+  type: SocialDataType;
+  emailAddress: string;
 }
 
 /** Adds metadata about a user */
@@ -621,6 +671,7 @@ function createBaseMessageData(): MessageData {
     userDataBody: undefined,
     linkBody: undefined,
     usernameProofBody: undefined,
+    socialDataBody: undefined,
   };
 }
 
@@ -661,6 +712,9 @@ export const MessageData = {
     }
     if (message.usernameProofBody !== undefined) {
       UserNameProof.encode(message.usernameProofBody, writer.uint32(122).fork()).ldelim();
+    }
+    if (message.socialDataBody !== undefined) {
+      SocialDataBody.encode(message.socialDataBody, writer.uint32(130).fork()).ldelim();
     }
     return writer;
   },
@@ -756,6 +810,13 @@ export const MessageData = {
 
           message.usernameProofBody = UserNameProof.decode(reader, reader.uint32());
           continue;
+        case 16:
+          if (tag != 130) {
+            break;
+          }
+
+          message.socialDataBody = SocialDataBody.decode(reader, reader.uint32());
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -783,6 +844,7 @@ export const MessageData = {
       userDataBody: isSet(object.userDataBody) ? UserDataBody.fromJSON(object.userDataBody) : undefined,
       linkBody: isSet(object.linkBody) ? LinkBody.fromJSON(object.linkBody) : undefined,
       usernameProofBody: isSet(object.usernameProofBody) ? UserNameProof.fromJSON(object.usernameProofBody) : undefined,
+      socialDataBody: isSet(object.socialDataBody) ? SocialDataBody.fromJSON(object.socialDataBody) : undefined,
     };
   },
 
@@ -810,6 +872,8 @@ export const MessageData = {
     message.linkBody !== undefined && (obj.linkBody = message.linkBody ? LinkBody.toJSON(message.linkBody) : undefined);
     message.usernameProofBody !== undefined &&
       (obj.usernameProofBody = message.usernameProofBody ? UserNameProof.toJSON(message.usernameProofBody) : undefined);
+    message.socialDataBody !== undefined &&
+      (obj.socialDataBody = message.socialDataBody ? SocialDataBody.toJSON(message.socialDataBody) : undefined);
     return obj;
   },
 
@@ -849,6 +913,80 @@ export const MessageData = {
     message.usernameProofBody = (object.usernameProofBody !== undefined && object.usernameProofBody !== null)
       ? UserNameProof.fromPartial(object.usernameProofBody)
       : undefined;
+    message.socialDataBody = (object.socialDataBody !== undefined && object.socialDataBody !== null)
+      ? SocialDataBody.fromPartial(object.socialDataBody)
+      : undefined;
+    return message;
+  },
+};
+
+function createBaseSocialDataBody(): SocialDataBody {
+  return { type: 0, emailAddress: "" };
+}
+
+export const SocialDataBody = {
+  encode(message: SocialDataBody, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.type !== 0) {
+      writer.uint32(8).int32(message.type);
+    }
+    if (message.emailAddress !== "") {
+      writer.uint32(18).string(message.emailAddress);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): SocialDataBody {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSocialDataBody();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.type = reader.int32() as any;
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.emailAddress = reader.string();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SocialDataBody {
+    return {
+      type: isSet(object.type) ? socialDataTypeFromJSON(object.type) : 0,
+      emailAddress: isSet(object.emailAddress) ? String(object.emailAddress) : "",
+    };
+  },
+
+  toJSON(message: SocialDataBody): unknown {
+    const obj: any = {};
+    message.type !== undefined && (obj.type = socialDataTypeToJSON(message.type));
+    message.emailAddress !== undefined && (obj.emailAddress = message.emailAddress);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SocialDataBody>, I>>(base?: I): SocialDataBody {
+    return SocialDataBody.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SocialDataBody>, I>>(object: I): SocialDataBody {
+    const message = createBaseSocialDataBody();
+    message.type = object.type ?? 0;
+    message.emailAddress = object.emailAddress ?? "";
     return message;
   },
 };

--- a/packages/hub-nodejs/src/generated/message.ts
+++ b/packages/hub-nodejs/src/generated/message.ts
@@ -99,6 +99,8 @@ export enum MessageType {
   USER_DATA_ADD = 11,
   /** USERNAME_PROOF - Add or replace a username proof */
   USERNAME_PROOF = 12,
+  /** SOCIAL_DATA_ADD - Add new social data */
+  SOCIAL_DATA_ADD = 13,
 }
 
 export function messageTypeFromJSON(object: any): MessageType {
@@ -136,6 +138,9 @@ export function messageTypeFromJSON(object: any): MessageType {
     case 12:
     case "MESSAGE_TYPE_USERNAME_PROOF":
       return MessageType.USERNAME_PROOF;
+    case 13:
+    case "MESSAGE_TYPE_SOCIAL_DATA_ADD":
+      return MessageType.SOCIAL_DATA_ADD;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum MessageType");
   }
@@ -165,6 +170,8 @@ export function messageTypeToJSON(object: MessageType): string {
       return "MESSAGE_TYPE_USER_DATA_ADD";
     case MessageType.USERNAME_PROOF:
       return "MESSAGE_TYPE_USERNAME_PROOF";
+    case MessageType.SOCIAL_DATA_ADD:
+      return "MESSAGE_TYPE_SOCIAL_DATA_ADD";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum MessageType");
   }
@@ -212,6 +219,42 @@ export function farcasterNetworkToJSON(object: FarcasterNetwork): string {
       return "FARCASTER_NETWORK_DEVNET";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum FarcasterNetwork");
+  }
+}
+
+/** Type of SocialDatat */
+export enum SocialDataType {
+  NONE = 0,
+  NETFLIX = 1,
+  PLAYSTATION = 2,
+}
+
+export function socialDataTypeFromJSON(object: any): SocialDataType {
+  switch (object) {
+    case 0:
+    case "SOCIAL_DATA_TYPE_NONE":
+      return SocialDataType.NONE;
+    case 1:
+    case "SOCIAL_DATA_TYPE_NETFLIX":
+      return SocialDataType.NETFLIX;
+    case 2:
+    case "SOCIAL_DATA_TYPE_PLAYSTATION":
+      return SocialDataType.PLAYSTATION;
+    default:
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum SocialDataType");
+  }
+}
+
+export function socialDataTypeToJSON(object: SocialDataType): string {
+  switch (object) {
+    case SocialDataType.NONE:
+      return "SOCIAL_DATA_TYPE_NONE";
+    case SocialDataType.NETFLIX:
+      return "SOCIAL_DATA_TYPE_NETFLIX";
+    case SocialDataType.PLAYSTATION:
+      return "SOCIAL_DATA_TYPE_PLAYSTATION";
+    default:
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum SocialDataType");
   }
 }
 
@@ -362,6 +405,13 @@ export interface MessageData {
   /** SignerRemoveBody signer_remove_body = 13; // Deprecated */
   linkBody?: LinkBody | undefined;
   usernameProofBody?: UserNameProof | undefined;
+  socialDataBody?: SocialDataBody | undefined;
+}
+
+/** Adds social data about a user */
+export interface SocialDataBody {
+  type: SocialDataType;
+  emailAddress: string;
 }
 
 /** Adds metadata about a user */
@@ -621,6 +671,7 @@ function createBaseMessageData(): MessageData {
     userDataBody: undefined,
     linkBody: undefined,
     usernameProofBody: undefined,
+    socialDataBody: undefined,
   };
 }
 
@@ -661,6 +712,9 @@ export const MessageData = {
     }
     if (message.usernameProofBody !== undefined) {
       UserNameProof.encode(message.usernameProofBody, writer.uint32(122).fork()).ldelim();
+    }
+    if (message.socialDataBody !== undefined) {
+      SocialDataBody.encode(message.socialDataBody, writer.uint32(130).fork()).ldelim();
     }
     return writer;
   },
@@ -756,6 +810,13 @@ export const MessageData = {
 
           message.usernameProofBody = UserNameProof.decode(reader, reader.uint32());
           continue;
+        case 16:
+          if (tag != 130) {
+            break;
+          }
+
+          message.socialDataBody = SocialDataBody.decode(reader, reader.uint32());
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -783,6 +844,7 @@ export const MessageData = {
       userDataBody: isSet(object.userDataBody) ? UserDataBody.fromJSON(object.userDataBody) : undefined,
       linkBody: isSet(object.linkBody) ? LinkBody.fromJSON(object.linkBody) : undefined,
       usernameProofBody: isSet(object.usernameProofBody) ? UserNameProof.fromJSON(object.usernameProofBody) : undefined,
+      socialDataBody: isSet(object.socialDataBody) ? SocialDataBody.fromJSON(object.socialDataBody) : undefined,
     };
   },
 
@@ -810,6 +872,8 @@ export const MessageData = {
     message.linkBody !== undefined && (obj.linkBody = message.linkBody ? LinkBody.toJSON(message.linkBody) : undefined);
     message.usernameProofBody !== undefined &&
       (obj.usernameProofBody = message.usernameProofBody ? UserNameProof.toJSON(message.usernameProofBody) : undefined);
+    message.socialDataBody !== undefined &&
+      (obj.socialDataBody = message.socialDataBody ? SocialDataBody.toJSON(message.socialDataBody) : undefined);
     return obj;
   },
 
@@ -849,6 +913,80 @@ export const MessageData = {
     message.usernameProofBody = (object.usernameProofBody !== undefined && object.usernameProofBody !== null)
       ? UserNameProof.fromPartial(object.usernameProofBody)
       : undefined;
+    message.socialDataBody = (object.socialDataBody !== undefined && object.socialDataBody !== null)
+      ? SocialDataBody.fromPartial(object.socialDataBody)
+      : undefined;
+    return message;
+  },
+};
+
+function createBaseSocialDataBody(): SocialDataBody {
+  return { type: 0, emailAddress: "" };
+}
+
+export const SocialDataBody = {
+  encode(message: SocialDataBody, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.type !== 0) {
+      writer.uint32(8).int32(message.type);
+    }
+    if (message.emailAddress !== "") {
+      writer.uint32(18).string(message.emailAddress);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): SocialDataBody {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSocialDataBody();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.type = reader.int32() as any;
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.emailAddress = reader.string();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SocialDataBody {
+    return {
+      type: isSet(object.type) ? socialDataTypeFromJSON(object.type) : 0,
+      emailAddress: isSet(object.emailAddress) ? String(object.emailAddress) : "",
+    };
+  },
+
+  toJSON(message: SocialDataBody): unknown {
+    const obj: any = {};
+    message.type !== undefined && (obj.type = socialDataTypeToJSON(message.type));
+    message.emailAddress !== undefined && (obj.emailAddress = message.emailAddress);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SocialDataBody>, I>>(base?: I): SocialDataBody {
+    return SocialDataBody.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SocialDataBody>, I>>(object: I): SocialDataBody {
+    const message = createBaseSocialDataBody();
+    message.type = object.type ?? 0;
+    message.emailAddress = object.emailAddress ?? "";
     return message;
   },
 };

--- a/packages/hub-web/src/generated/message.ts
+++ b/packages/hub-web/src/generated/message.ts
@@ -99,6 +99,8 @@ export enum MessageType {
   USER_DATA_ADD = 11,
   /** USERNAME_PROOF - Add or replace a username proof */
   USERNAME_PROOF = 12,
+  /** SOCIAL_DATA_ADD - Add new social data */
+  SOCIAL_DATA_ADD = 13,
 }
 
 export function messageTypeFromJSON(object: any): MessageType {
@@ -136,6 +138,9 @@ export function messageTypeFromJSON(object: any): MessageType {
     case 12:
     case "MESSAGE_TYPE_USERNAME_PROOF":
       return MessageType.USERNAME_PROOF;
+    case 13:
+    case "MESSAGE_TYPE_SOCIAL_DATA_ADD":
+      return MessageType.SOCIAL_DATA_ADD;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum MessageType");
   }
@@ -165,6 +170,8 @@ export function messageTypeToJSON(object: MessageType): string {
       return "MESSAGE_TYPE_USER_DATA_ADD";
     case MessageType.USERNAME_PROOF:
       return "MESSAGE_TYPE_USERNAME_PROOF";
+    case MessageType.SOCIAL_DATA_ADD:
+      return "MESSAGE_TYPE_SOCIAL_DATA_ADD";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum MessageType");
   }
@@ -212,6 +219,42 @@ export function farcasterNetworkToJSON(object: FarcasterNetwork): string {
       return "FARCASTER_NETWORK_DEVNET";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum FarcasterNetwork");
+  }
+}
+
+/** Type of SocialDatat */
+export enum SocialDataType {
+  NONE = 0,
+  NETFLIX = 1,
+  PLAYSTATION = 2,
+}
+
+export function socialDataTypeFromJSON(object: any): SocialDataType {
+  switch (object) {
+    case 0:
+    case "SOCIAL_DATA_TYPE_NONE":
+      return SocialDataType.NONE;
+    case 1:
+    case "SOCIAL_DATA_TYPE_NETFLIX":
+      return SocialDataType.NETFLIX;
+    case 2:
+    case "SOCIAL_DATA_TYPE_PLAYSTATION":
+      return SocialDataType.PLAYSTATION;
+    default:
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum SocialDataType");
+  }
+}
+
+export function socialDataTypeToJSON(object: SocialDataType): string {
+  switch (object) {
+    case SocialDataType.NONE:
+      return "SOCIAL_DATA_TYPE_NONE";
+    case SocialDataType.NETFLIX:
+      return "SOCIAL_DATA_TYPE_NETFLIX";
+    case SocialDataType.PLAYSTATION:
+      return "SOCIAL_DATA_TYPE_PLAYSTATION";
+    default:
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum SocialDataType");
   }
 }
 
@@ -362,6 +405,13 @@ export interface MessageData {
   /** SignerRemoveBody signer_remove_body = 13; // Deprecated */
   linkBody?: LinkBody | undefined;
   usernameProofBody?: UserNameProof | undefined;
+  socialDataBody?: SocialDataBody | undefined;
+}
+
+/** Adds social data about a user */
+export interface SocialDataBody {
+  type: SocialDataType;
+  emailAddress: string;
 }
 
 /** Adds metadata about a user */
@@ -621,6 +671,7 @@ function createBaseMessageData(): MessageData {
     userDataBody: undefined,
     linkBody: undefined,
     usernameProofBody: undefined,
+    socialDataBody: undefined,
   };
 }
 
@@ -661,6 +712,9 @@ export const MessageData = {
     }
     if (message.usernameProofBody !== undefined) {
       UserNameProof.encode(message.usernameProofBody, writer.uint32(122).fork()).ldelim();
+    }
+    if (message.socialDataBody !== undefined) {
+      SocialDataBody.encode(message.socialDataBody, writer.uint32(130).fork()).ldelim();
     }
     return writer;
   },
@@ -756,6 +810,13 @@ export const MessageData = {
 
           message.usernameProofBody = UserNameProof.decode(reader, reader.uint32());
           continue;
+        case 16:
+          if (tag != 130) {
+            break;
+          }
+
+          message.socialDataBody = SocialDataBody.decode(reader, reader.uint32());
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -783,6 +844,7 @@ export const MessageData = {
       userDataBody: isSet(object.userDataBody) ? UserDataBody.fromJSON(object.userDataBody) : undefined,
       linkBody: isSet(object.linkBody) ? LinkBody.fromJSON(object.linkBody) : undefined,
       usernameProofBody: isSet(object.usernameProofBody) ? UserNameProof.fromJSON(object.usernameProofBody) : undefined,
+      socialDataBody: isSet(object.socialDataBody) ? SocialDataBody.fromJSON(object.socialDataBody) : undefined,
     };
   },
 
@@ -810,6 +872,8 @@ export const MessageData = {
     message.linkBody !== undefined && (obj.linkBody = message.linkBody ? LinkBody.toJSON(message.linkBody) : undefined);
     message.usernameProofBody !== undefined &&
       (obj.usernameProofBody = message.usernameProofBody ? UserNameProof.toJSON(message.usernameProofBody) : undefined);
+    message.socialDataBody !== undefined &&
+      (obj.socialDataBody = message.socialDataBody ? SocialDataBody.toJSON(message.socialDataBody) : undefined);
     return obj;
   },
 
@@ -849,6 +913,80 @@ export const MessageData = {
     message.usernameProofBody = (object.usernameProofBody !== undefined && object.usernameProofBody !== null)
       ? UserNameProof.fromPartial(object.usernameProofBody)
       : undefined;
+    message.socialDataBody = (object.socialDataBody !== undefined && object.socialDataBody !== null)
+      ? SocialDataBody.fromPartial(object.socialDataBody)
+      : undefined;
+    return message;
+  },
+};
+
+function createBaseSocialDataBody(): SocialDataBody {
+  return { type: 0, emailAddress: "" };
+}
+
+export const SocialDataBody = {
+  encode(message: SocialDataBody, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.type !== 0) {
+      writer.uint32(8).int32(message.type);
+    }
+    if (message.emailAddress !== "") {
+      writer.uint32(18).string(message.emailAddress);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): SocialDataBody {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSocialDataBody();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.type = reader.int32() as any;
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.emailAddress = reader.string();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SocialDataBody {
+    return {
+      type: isSet(object.type) ? socialDataTypeFromJSON(object.type) : 0,
+      emailAddress: isSet(object.emailAddress) ? String(object.emailAddress) : "",
+    };
+  },
+
+  toJSON(message: SocialDataBody): unknown {
+    const obj: any = {};
+    message.type !== undefined && (obj.type = socialDataTypeToJSON(message.type));
+    message.emailAddress !== undefined && (obj.emailAddress = message.emailAddress);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SocialDataBody>, I>>(base?: I): SocialDataBody {
+    return SocialDataBody.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SocialDataBody>, I>>(object: I): SocialDataBody {
+    const message = createBaseSocialDataBody();
+    message.type = object.type ?? 0;
+    message.emailAddress = object.emailAddress ?? "";
     return message;
   },
 };

--- a/protobufs/schemas/message.proto
+++ b/protobufs/schemas/message.proto
@@ -35,6 +35,7 @@ message MessageData {
     // SignerRemoveBody signer_remove_body = 13; // Deprecated
     LinkBody link_body = 14;
     UserNameProof username_proof_body = 15;
+    SocialDataBody social_data_body = 16;
   } // Properties specific to the MessageType
 }
 
@@ -67,6 +68,7 @@ enum MessageType {
 //  MESSAGE_TYPE_SIGNER_REMOVE = 10; // Remove an Ed25519 key pair that signs messages for a user
   MESSAGE_TYPE_USER_DATA_ADD = 11; // Add metadata about a user
   MESSAGE_TYPE_USERNAME_PROOF = 12; // Add or replace a username proof
+  MESSAGE_TYPE_SOCIAL_DATA_ADD = 13; // Add new social data
 }
 
 /** Farcaster network the message is intended for */
@@ -75,6 +77,19 @@ enum FarcasterNetwork {
   FARCASTER_NETWORK_MAINNET = 1; // Public primary network
   FARCASTER_NETWORK_TESTNET = 2; // Public test network
   FARCASTER_NETWORK_DEVNET = 3; // Private test network
+}
+
+/** Adds social data about a user */
+message SocialDataBody {
+  SocialDataType type = 1;
+  string email_address = 2;
+}
+
+/** Type of SocialDatat */
+enum SocialDataType {
+  SOCIAL_DATA_TYPE_NONE = 0;
+  SOCIAL_DATA_TYPE_NETFLIX = 1;
+  SOCIAL_DATA_TYPE_PLAYSTATION = 2;
 }
 
 /** Adds metadata about a user */


### PR DESCRIPTION
## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.
- [Completed] Declare a sample type
- [In progress] Consume type within hubble
- [In progress] Transfer responsibility of storage cost away from users to hub runners.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding support for social data in the message protocol. 

### Detailed summary
- Added `SocialDataBody` message in the `message.proto` file.
- Added `SOCIAL_DATA_ADD` enum value in the `MessageType` enum.
- Added `SocialDataType` enum in the `message.ts` files.
- Updated encoding and decoding functions for `SocialDataBody` in the `message.ts` files.

> The following files were skipped due to too many changes: `packages/hub-nodejs/src/generated/message.ts`, `packages/core/src/protobufs/generated/message.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->