### PR TITLE
feat: Allow residual message limits for fids without any storage

### DIFF
--- a/.changeset/hungry-clouds-speak.md
+++ b/.changeset/hungry-clouds-speak.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+feat: Allow residual message limits for fids without any storage

--- a/apps/hubble/src/rpc/test/server.test.ts
+++ b/apps/hubble/src/rpc/test/server.test.ts
@@ -3,7 +3,9 @@ import {
   Factories,
   FarcasterNetwork,
   FidRequest,
+  getDefaultStoreLimit,
   getInsecureHubRpcClient,
+  getResidualStoreLimit,
   HubResult,
   HubRpcClient,
   OnChainEvent,
@@ -13,7 +15,6 @@ import {
   StorageLimit,
   StorageLimitsResponse,
   StoreType,
-  getDefaultStoreLimit,
 } from "@farcaster/hub-nodejs";
 import Engine from "../../storage/engine/index.js";
 import { MockHub } from "../../test/mocks.js";
@@ -107,8 +108,69 @@ describe("server rpc tests", () => {
     test("succeeds for user with no storage", async () => {
       const result = await client.getCurrentStorageLimitsByFid(FidRequest.create({ fid: fid - 1 }));
       // zero storage
-      expect(result._unsafeUnwrap().units).toEqual(0);
-      expect(result._unsafeUnwrap().limits.map((l) => l.limit)).toEqual([0, 0, 0, 0, 0, 0]);
+      const response = result._unsafeUnwrap();
+      expect(response.units).toEqual(0);
+      const storageLimits = response.limits;
+      expect(storageLimits).toContainEqual(
+        StorageLimit.create({
+          limit: getResidualStoreLimit(StoreType.CASTS),
+          storeType: StoreType.CASTS,
+          name: "CASTS",
+          used: 0,
+          earliestHash: new Uint8Array(),
+          earliestTimestamp: 0,
+        }),
+      );
+      expect(storageLimits).toContainEqual(
+        StorageLimit.create({
+          limit: getResidualStoreLimit(StoreType.REACTIONS),
+          storeType: StoreType.REACTIONS,
+          name: "REACTIONS",
+          used: 0,
+          earliestTimestamp: 0,
+          earliestHash: new Uint8Array(),
+        }),
+      );
+      expect(storageLimits).toContainEqual(
+        StorageLimit.create({
+          limit: getResidualStoreLimit(StoreType.LINKS),
+          storeType: StoreType.LINKS,
+          name: "LINKS",
+          used: 0,
+          earliestHash: new Uint8Array(),
+          earliestTimestamp: 0,
+        }),
+      );
+      expect(storageLimits).toContainEqual(
+        StorageLimit.create({
+          limit: getResidualStoreLimit(StoreType.USER_DATA),
+          storeType: StoreType.USER_DATA,
+          name: "USER_DATA",
+          used: 0,
+          earliestHash: new Uint8Array(),
+          earliestTimestamp: 0,
+        }),
+      );
+      expect(storageLimits).toContainEqual(
+        StorageLimit.create({
+          limit: getResidualStoreLimit(StoreType.VERIFICATIONS),
+          storeType: StoreType.VERIFICATIONS,
+          name: "VERIFICATIONS",
+          used: 0,
+          earliestHash: new Uint8Array(),
+          earliestTimestamp: 0,
+        }),
+      );
+      expect(storageLimits).toContainEqual(
+        StorageLimit.create({
+          limit: getResidualStoreLimit(StoreType.USERNAME_PROOFS),
+          storeType: StoreType.USERNAME_PROOFS,
+          name: "USERNAME_PROOFS",
+          used: 0,
+          earliestHash: new Uint8Array(),
+          earliestTimestamp: 0,
+        }),
+      );
     });
 
     test("succeeds for user with storage", async () => {

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -128,12 +128,12 @@ class Engine extends TypedEmitter<EngineEvents> {
     // Calculate total storage available per unit of store. Note that OnChainEventStore
     // is not included in this calculation because it is not pruned.
     this._totalPruneSize =
-      this._linkStore.pruneSizeLimit +
-      this._reactionStore.pruneSizeLimit +
-      this._castStore.pruneSizeLimit +
-      this._userDataStore.pruneSizeLimit +
-      this._verificationStore.pruneSizeLimit +
-      this._usernameProofStore.pruneSizeLimit;
+      this._linkStore.pruneSizeLimit(1) +
+      this._reactionStore.pruneSizeLimit(1) +
+      this._castStore.pruneSizeLimit(1) +
+      this._userDataStore.pruneSizeLimit(1) +
+      this._verificationStore.pruneSizeLimit(1) +
+      this._usernameProofStore.pruneSizeLimit(1);
 
     log.info({ totalPruneSize: this._totalPruneSize }, "total default storage limit size");
 

--- a/apps/hubble/src/storage/stores/castStore.ts
+++ b/apps/hubble/src/storage/stores/castStore.ts
@@ -114,6 +114,7 @@ const makeCastsByMentionKey = (mentionFid: number, fid?: number, tsHash?: Uint8A
  */
 class CastStore extends Store<CastAddMessage, CastRemoveMessage> {
   override _postfix: UserMessagePostfix = UserPostfix.CastMessage;
+  override _storeType: StoreType = StoreType.CASTS;
   override makeAddKey(msg: CastAddMessage) {
     return makeCastAddsKey(
       msg.data.fid,
@@ -132,14 +133,6 @@ class CastStore extends Store<CastAddMessage, CastRemoveMessage> {
   override _isRemoveType = isCastRemoveMessage;
   override _addMessageType = MessageType.CAST_ADD;
   override _removeMessageType = MessageType.CAST_REMOVE;
-
-  protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return getDefaultStoreLimit(StoreType.CASTS);
-  }
-
-  protected override get PRUNE_TIME_LIMIT_DEFAULT() {
-    return 60 * 60 * 24 * 365; // 1 year
-  }
 
   override async buildSecondaryIndices(txn: Transaction, message: CastAddMessage): HubAsyncResult<void> {
     const tsHash = makeTsHash(message.data.timestamp, message.hash);

--- a/apps/hubble/src/storage/stores/linkStore.ts
+++ b/apps/hubble/src/storage/stores/linkStore.ts
@@ -129,6 +129,7 @@ const makeLinksByTargetKey = (target: number, fid?: number, tsHash?: Uint8Array)
  */
 class LinkStore extends Store<LinkAddMessage, LinkRemoveMessage> {
   override _postfix: UserMessagePostfix = UserPostfix.LinkMessage;
+  override _storeType: StoreType = StoreType.LINKS;
 
   override makeAddKey(msg: LinkAddMessage) {
     return makeLinkAddsKey(msg.data.fid, msg.data.linkBody.type, msg.data.linkBody.targetFid) as Buffer;
@@ -150,10 +151,6 @@ class LinkStore extends Store<LinkAddMessage, LinkRemoveMessage> {
   override _isRemoveType = isLinkRemoveMessage;
   override _addMessageType = MessageType.LINK_ADD;
   override _removeMessageType = MessageType.LINK_REMOVE;
-
-  protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return getDefaultStoreLimit(StoreType.LINKS);
-  }
 
   override async buildSecondaryIndices(txn: Transaction, message: LinkAddMessage): HubAsyncResult<void> {
     const tsHash = makeTsHash(message.data.timestamp, message.hash);

--- a/apps/hubble/src/storage/stores/reactionStore.ts
+++ b/apps/hubble/src/storage/stores/reactionStore.ts
@@ -26,8 +26,6 @@ import { RootPrefix, TSHASH_LENGTH, UserMessagePostfix, UserPostfix } from "../d
 import { MessagesPage, PAGE_SIZE_MAX, PageOptions } from "../stores/types.js";
 import { Store } from "./store.js";
 
-const PRUNE_TIME_LIMIT_DEFAULT = 60 * 60 * 24 * 90; // 90 days
-
 const makeTargetKey = (target: CastId | string): Buffer => {
   return typeof target === "string" ? Buffer.from(target) : makeCastIdKey(target);
 };
@@ -126,6 +124,7 @@ const makeReactionsByTargetKey = (target: CastId | string, fid?: number, tsHash?
  */
 class ReactionStore extends Store<ReactionAddMessage, ReactionRemoveMessage> {
   override _postfix: UserMessagePostfix = UserPostfix.ReactionMessage;
+  override _storeType: StoreType = StoreType.REACTIONS;
   override makeAddKey(msg: ReactionAddMessage) {
     return makeReactionAddsKey(
       msg.data.fid,
@@ -146,14 +145,6 @@ class ReactionStore extends Store<ReactionAddMessage, ReactionRemoveMessage> {
   override _isRemoveType = isReactionRemoveMessage;
   override _addMessageType = MessageType.REACTION_ADD;
   override _removeMessageType = MessageType.REACTION_REMOVE;
-
-  protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return getDefaultStoreLimit(StoreType.REACTIONS);
-  }
-
-  protected override get PRUNE_TIME_LIMIT_DEFAULT() {
-    return PRUNE_TIME_LIMIT_DEFAULT;
-  }
 
   override async findMergeAddConflicts(_message: ReactionAddMessage): HubAsyncResult<void> {
     return ok(undefined);

--- a/apps/hubble/src/storage/stores/storeEventHandler.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.ts
@@ -330,18 +330,12 @@ class StoreEventHandler extends TypedEmitter<StoreEvents> {
       }
     }
 
-    const units = await this.getCurrentStorageUnitsForFid(message.data.fid);
-
-    if (units.isErr()) {
-      return err(units.error);
-    }
-
     const messageCount = await this.getCacheMessageCount(message.data.fid, set);
     if (messageCount.isErr()) {
       return err(messageCount.error);
     }
 
-    if (messageCount.value < sizeLimit * units.value) {
+    if (messageCount.value < sizeLimit) {
       return ok(false);
     }
 

--- a/apps/hubble/src/storage/stores/userDataStore.ts
+++ b/apps/hubble/src/storage/stores/userDataStore.ts
@@ -60,6 +60,7 @@ const makeUserDataAddsKey = (fid: number, dataType?: UserDataType): Buffer => {
  */
 class UserDataStore extends Store<UserDataAddMessage, never> {
   override _postfix: UserMessagePostfix = UserPostfix.UserDataMessage;
+  override _storeType: StoreType = StoreType.USER_DATA;
 
   override makeAddKey(msg: UserDataAddMessage) {
     return makeUserDataAddsKey(msg.data.fid, msg.data.userDataBody.type) as Buffer;
@@ -81,10 +82,6 @@ class UserDataStore extends Store<UserDataAddMessage, never> {
   override _isRemoveType = undefined;
   override _addMessageType = MessageType.USER_DATA_ADD;
   override _removeMessageType = undefined;
-
-  protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return getDefaultStoreLimit(StoreType.USER_DATA);
-  }
 
   /**
    * Finds a UserDataAdd Message by checking the adds set index

--- a/apps/hubble/src/storage/stores/usernameProofStore.test.ts
+++ b/apps/hubble/src/storage/stores/usernameProofStore.test.ts
@@ -187,7 +187,7 @@ describe("usernameProofStore", () => {
       const sizePrunedStore = new UsernameProofStore(db, eventHandler, { pruneSizeLimit: 2 });
 
       test("defaults size limit", async () => {
-        expect(set.pruneSizeLimit).toEqual(getDefaultStoreLimit(StoreType.USERNAME_PROOFS));
+        expect(set.pruneSizeLimit(1)).toEqual(getDefaultStoreLimit(StoreType.USERNAME_PROOFS));
         expect(set.pruneTimeLimit).toBeUndefined();
       });
 

--- a/apps/hubble/src/storage/stores/usernameProofStore.ts
+++ b/apps/hubble/src/storage/stores/usernameProofStore.ts
@@ -34,6 +34,7 @@ const makeUserNameProofByNameKey = (name: Uint8Array): Buffer => {
 
 class UsernameProofStore extends Store<UsernameProofMessage, never> {
   override _postfix: UserMessagePostfix = UserPostfix.UsernameProofMessage;
+  override _storeType: StoreType = StoreType.USERNAME_PROOFS;
 
   override makeAddKey(msg: UsernameProofMessage) {
     return makeUserNameProofByFidKey(msg.data.fid, msg.data.usernameProofBody.name) as Buffer;
@@ -55,10 +56,6 @@ class UsernameProofStore extends Store<UsernameProofMessage, never> {
   override _isRemoveType = undefined;
   override _addMessageType = MessageType.USERNAME_PROOF;
   override _removeMessageType = undefined;
-
-  protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return getDefaultStoreLimit(StoreType.USERNAME_PROOFS);
-  }
 
   /**
    * Finds a UserNameProof Message by checking the adds set index

--- a/apps/hubble/src/storage/stores/verificationStore.ts
+++ b/apps/hubble/src/storage/stores/verificationStore.ts
@@ -87,6 +87,7 @@ export const makeVerificationByAddressKey = (address: Uint8Array): Buffer => {
 
 class VerificationStore extends Store<VerificationAddEthAddressMessage, VerificationRemoveMessage> {
   override _postfix: UserMessagePostfix = UserPostfix.VerificationMessage;
+  override _storeType: StoreType = StoreType.VERIFICATIONS;
 
   override makeAddKey(msg: VerificationAddEthAddressMessage) {
     return makeVerificationAddsKey(
@@ -114,10 +115,6 @@ class VerificationStore extends Store<VerificationAddEthAddressMessage, Verifica
   override _isRemoveType = isVerificationRemoveMessage;
   override _addMessageType = MessageType.VERIFICATION_ADD_ETH_ADDRESS;
   override _removeMessageType = MessageType.VERIFICATION_REMOVE;
-
-  protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return getDefaultStoreLimit(StoreType.VERIFICATIONS);
-  }
 
   /**
    * Finds a VerificationAdds Message by checking the adds-set's index

--- a/packages/core/src/limits.ts
+++ b/packages/core/src/limits.ts
@@ -7,32 +7,44 @@ const USER_DATA_SIZE_LIMIT_DEFAULT = 50;
 const USERNAME_PROOFS_SIZE_LIMIT_DEFAULT = 5;
 const VERIFICATIONS_SIZE_LIMIT_DEFAULT = 25;
 
+const CASTS_SIZE_LIMIT_RESIDUAL = 50;
+const LINKS_SIZE_LIMIT_RESIDUAL = 500;
+const REACTIONS_SIZE_LIMIT_RESIDUAL = 50;
+const USER_DATA_SIZE_LIMIT_RESIDUAL = 10;
+const USERNAME_PROOFS_SIZE_LIMIT_RESIDUAL = 1;
+const VERIFICATIONS_SIZE_LIMIT_RESIDUAL = 10;
+
 export const getStoreLimits = (units: number) => [
   {
     storeType: StoreType.CASTS,
-    limit: getDefaultStoreLimit(StoreType.CASTS) * units,
+    limit: getStoreLimit(StoreType.CASTS, units),
   },
   {
     storeType: StoreType.LINKS,
-    limit: getDefaultStoreLimit(StoreType.LINKS) * units,
+    limit: getStoreLimit(StoreType.LINKS, units),
   },
   {
     storeType: StoreType.REACTIONS,
-    limit: getDefaultStoreLimit(StoreType.REACTIONS) * units,
+    limit: getStoreLimit(StoreType.REACTIONS, units),
   },
   {
     storeType: StoreType.USER_DATA,
-    limit: getDefaultStoreLimit(StoreType.USER_DATA) * units,
+    limit: getStoreLimit(StoreType.USER_DATA, units),
   },
   {
     storeType: StoreType.USERNAME_PROOFS,
-    limit: getDefaultStoreLimit(StoreType.USERNAME_PROOFS) * units,
+    limit: getStoreLimit(StoreType.USERNAME_PROOFS, units),
   },
   {
     storeType: StoreType.VERIFICATIONS,
-    limit: getDefaultStoreLimit(StoreType.VERIFICATIONS) * units,
+    limit: getStoreLimit(StoreType.VERIFICATIONS, units),
   },
 ];
+
+export const getStoreLimit = (storeType: StoreType, units: number) => {
+  return units <= 0 ? getResidualStoreLimit(storeType) : getDefaultStoreLimit(storeType) * units;
+};
+
 export const getDefaultStoreLimit = (storeType: StoreType) => {
   switch (storeType) {
     case StoreType.CASTS:
@@ -47,6 +59,25 @@ export const getDefaultStoreLimit = (storeType: StoreType) => {
       return USERNAME_PROOFS_SIZE_LIMIT_DEFAULT;
     case StoreType.VERIFICATIONS:
       return VERIFICATIONS_SIZE_LIMIT_DEFAULT;
+    default:
+      throw new Error(`Unknown store type: ${storeType}`);
+  }
+};
+
+export const getResidualStoreLimit = (storeType: StoreType) => {
+  switch (storeType) {
+    case StoreType.CASTS:
+      return CASTS_SIZE_LIMIT_RESIDUAL;
+    case StoreType.LINKS:
+      return LINKS_SIZE_LIMIT_RESIDUAL;
+    case StoreType.REACTIONS:
+      return REACTIONS_SIZE_LIMIT_RESIDUAL;
+    case StoreType.USER_DATA:
+      return USER_DATA_SIZE_LIMIT_RESIDUAL;
+    case StoreType.USERNAME_PROOFS:
+      return USERNAME_PROOFS_SIZE_LIMIT_RESIDUAL;
+    case StoreType.VERIFICATIONS:
+      return VERIFICATIONS_SIZE_LIMIT_RESIDUAL;
     default:
       throw new Error(`Unknown store type: ${storeType}`);
   }


### PR DESCRIPTION
## Motivation

Implements https://github.com/farcasterxyz/protocol/discussions/139

Adds a small amount of residual storage for fids that have 0 units for storage. This allows hubs to continue to store small amounts of data for any fid.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on allowing residual message limits for fids without any storage. 

### Detailed summary
- Added a new feature to allow residual message limits for fids without any storage.
- Modified several files to implement this feature.
- Updated test cases to reflect the changes.

> The following files were skipped due to too many changes: `apps/hubble/src/rpc/test/server.test.ts`, `apps/hubble/src/storage/stores/store.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->