### PR TITLE
feat: create FrameAction message and add validation endpoint

### DIFF
--- a/.changeset/purple-hornets-glow.md
+++ b/.changeset/purple-hornets-glow.md
@@ -1,0 +1,9 @@
+---
+"@farcaster/hub-nodejs": patch
+"@farcaster/hub-web": patch
+"@farcaster/replicator": patch
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+feat: Add support for FrameAction and validateMessage

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -110,6 +110,7 @@ export interface HubInterface {
   identity: string;
   hubOperatorFid?: number;
   submitMessage(message: Message, source?: HubSubmitSource): HubAsyncResult<number>;
+  validateMessage(message: Message): HubAsyncResult<Message>;
   submitUserNameProof(usernameProof: UserNameProof, source?: HubSubmitSource): HubAsyncResult<number>;
   submitOnChainEvent(event: OnChainEvent, source?: HubSubmitSource): HubAsyncResult<number>;
   getHubState(): HubAsyncResult<HubState>;
@@ -1368,6 +1369,10 @@ export class Hub implements HubInterface {
     statsd().timing("hub.merge_message", Date.now() - start);
 
     return mergeResult;
+  }
+
+  async validateMessage(message: Message): HubAsyncResult<Message> {
+    return this.engine.validateMessage(message);
   }
 
   async submitUserNameProof(usernameProof: UserNameProof, source?: HubSubmitSource): HubAsyncResult<number> {

--- a/apps/hubble/src/rpc/httpServer.ts
+++ b/apps/hubble/src/rpc/httpServer.ts
@@ -19,6 +19,7 @@ import {
   sendUnaryData,
   userDataTypeFromJSON,
   utf8StringToBytes,
+  ValidationResponse,
 } from "@farcaster/hub-nodejs";
 import { Metadata, ServerUnaryCall } from "@grpc/grpc-js";
 import fastify from "fastify";
@@ -569,6 +570,42 @@ export class HttpAPIServer {
       const metadata = this.getMetadataFromAuthString(request?.headers?.authorization);
       const call = getCallObject("submitMessage", message, request, metadata);
       this.grpcImpl.submitMessage(call, handleResponse(reply, Message));
+    });
+
+    //==================Validate Message==================
+    // @doc-tag: /validateMessage
+    this.app.post<{ Body: Buffer }>("/v1/validateMessage", (request, reply) => {
+      // Get the Body content-type
+      const contentType = request.headers["content-type"] as string;
+
+      let message;
+      if (contentType === "application/octet-stream") {
+        // The Posted Body is a serialized Message protobuf
+        const parsedMessage = Result.fromThrowable(
+          () => Message.decode(request.body),
+          (e) => e as Error,
+        )();
+
+        if (parsedMessage.isErr()) {
+          reply.code(400).send({
+            error:
+              "Could not parse Message. This API accepts only Message protobufs encoded into bytes (application/octet-stream)",
+            errorDetail: parsedMessage.error.message,
+          });
+          return;
+        } else {
+          message = parsedMessage.value;
+        }
+      } else {
+        reply.code(400).send({
+          error: "Unsupported Media Type",
+          errorDetail: `Content-Type ${contentType} is not supported`,
+        });
+        return;
+      }
+
+      const call = getCallObject("validateMessage", message, request);
+      this.grpcImpl.validateMessage(call, handleResponse(reply, ValidationResponse));
     });
 
     //==================Events==================

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -31,6 +31,7 @@ import {
   UserDataAddMessage,
   VerificationAddEthAddressMessage,
   VerificationRemoveMessage,
+  ValidationResponse,
   UserNameProof,
   UsernameProofsResponse,
   OnChainEventResponse,
@@ -572,6 +573,18 @@ export default class Server {
         result?.match(
           () => {
             callback(null, message);
+          },
+          (err: HubError) => {
+            callback(toServiceError(err));
+          },
+        );
+      },
+      validateMessage: async (call, callback) => {
+        const message = call.request;
+        const result = await this.hub?.validateMessage(message);
+        result?.match(
+          (message: Message) => {
+            callback(null, ValidationResponse.create({ valid: true, message }));
           },
           (err: HubError) => {
             callback(toServiceError(err));

--- a/apps/hubble/src/rpc/test/httpServer.test.ts
+++ b/apps/hubble/src/rpc/test/httpServer.test.ts
@@ -19,6 +19,7 @@ import {
   UsernameProofMessage,
   UserNameType,
   utf8StringToBytes,
+  ValidationResponse,
   VerificationAddEthAddressMessage,
 } from "@farcaster/hub-nodejs";
 import Engine from "../../storage/engine/index.js";
@@ -194,6 +195,26 @@ describe("httpServer", () => {
       expect(response.status).toBe(200);
 
       await authServer.stop();
+    });
+  });
+
+  describe("validateMessage", () => {
+    test("succeeds", async () => {
+      const frameAction = await Factories.FrameActionMessage.create(
+        { data: { fid, network } },
+        { transient: { signer } },
+      );
+      const postConfig = { headers: { "Content-Type": "application/octet-stream" } };
+      const url = getFullUrl("/v1/validateMessage");
+
+      // Encode the message into a Buffer (of bytes)
+      const messageBytes = Buffer.from(Message.encode(frameAction).finish());
+      const response = await axios.post(url, messageBytes, postConfig);
+
+      expect(response.status).toBe(200);
+      expect(response.data).toEqual(
+        protoToJSON(ValidationResponse.create({ valid: true, message: frameAction }), ValidationResponse),
+      );
     });
   });
 

--- a/apps/hubble/src/storage/engine/index.test.ts
+++ b/apps/hubble/src/storage/engine/index.test.ts
@@ -494,6 +494,39 @@ describe("mergeMessage", () => {
     await mainnetEngine.stop();
   });
 
+  describe("FrameAction messages", () => {
+    // These messages types are not intended to be persisted to the hub
+    test("even valid frame action messages cannot be merged", async () => {
+      await engine.mergeOnChainEvent(custodyEvent);
+      await engine.mergeOnChainEvent(signerAddEvent);
+      await engine.mergeOnChainEvent(storageEvent);
+
+      const frameAction = await Factories.FrameActionMessage.create(
+        { data: { fid, network } },
+        { transient: { signer } },
+      );
+      const validationResult = await engine.validateMessage(frameAction);
+      expect(validationResult.isOk()).toBeTruthy();
+      const result = await engine.mergeMessage(frameAction);
+      expect(result).toMatchObject(err({ errCode: "bad_request.validation_failure" }));
+      expect(result._unsafeUnwrapErr().message).toMatch("invalid message type");
+    });
+
+    test("validation fails correctly for invalid users", async () => {
+      const frameAction = await Factories.FrameActionMessage.create(
+        { data: { fid, network } },
+        { transient: { signer } },
+      );
+      let result = await engine.validateMessage(frameAction);
+      expect(result._unsafeUnwrapErr().message).toMatch("unknown fid");
+
+      await engine.mergeOnChainEvent(custodyEvent);
+
+      result = await engine.validateMessage(frameAction);
+      expect(result._unsafeUnwrapErr().message).toMatch("invalid signer");
+    });
+  });
+
   describe("UsernameProof messages", () => {
     const randomEthAddress = bytesToHexString(Factories.EthAddress.build())._unsafeUnwrap();
     let usernameProofEvents: MergeUserNameProofBody[] = [];

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -20,6 +20,7 @@ import {
   MergeOnChainEventHubEvent,
   MergeUsernameProofHubEvent,
   Message,
+  MessageType,
   OnChainEvent,
   OnChainEventResponse,
   OnChainEventType,
@@ -242,6 +243,11 @@ class Engine extends TypedEmitter<EngineEvents> {
   }
 
   async mergeMessageToStore(message: Message): HubAsyncResult<number> {
+    // Frame actions cannot be stored
+    if (message.data?.type === MessageType.FRAME_ACTION) {
+      return err(new HubError("bad_request.validation_failure", "invalid message type"));
+    }
+
     // biome-ignore lint/style/noNonNullAssertion: legacy code, avoid using ignore for new code
     const setPostfix = typeToSetPostfix(message.data!.type);
 

--- a/apps/hubble/src/test/mocks.ts
+++ b/apps/hubble/src/test/mocks.ts
@@ -42,6 +42,10 @@ export class MockHub implements HubInterface {
     return result;
   }
 
+  async validateMessage(message: Message): HubAsyncResult<Message> {
+    return this.engine.validateMessage(message);
+  }
+
   async submitUserNameProof(proof: UserNameProof): HubAsyncResult<number> {
     return this.engine.mergeUserNameProof(proof);
   }

--- a/apps/hubble/www/docs/docs/httpapi/message.md
+++ b/apps/hubble/www/docs/docs/httpapi/message.md
@@ -1,9 +1,9 @@
 
 
-# SubmitMessage API
-The SubmitMessage API lets you submit signed Farcaster protocol messages to the Hub. Note that the message has to be sent as the encoded bytestream of the protobuf (`Message.encode(msg).finish()` in typescript), as POST data to the endpoint. 
+# Message API
+The Message API lets you validate and submit signed Farcaster protocol messages to the Hub. Note that the message has to be sent as the encoded bytestream of the protobuf (`Message.encode(msg).finish()` in typescript), as POST data to the endpoint. 
 
-The encoding of the POST data has to be set to `application/octet-stream`. The endpoint returns the Message object as JSON if it was successfully submitted
+The encoding of the POST data has to be set to `application/octet-stream`. The endpoint returns the Message object as JSON if it was successfully submitted or validated
 
 ## submitMessage
 Submit a signed protobuf-serialized message to the Hub
@@ -81,6 +81,53 @@ try {
     const response = await axios.post(url, messageBytes, postConfig);
 } catch (e) {
     // handle errors...
+}
+```
+
+## validateMessage
+Validate a signed protobuf-serialized message with the Hub. This can be used to verify that the hub will consider the 
+message valid. Or to validate message that cannot be submitted (e.g. Frame actions) 
+
+**Query Parameters**
+| Parameter | Description | Example |
+| --------- | ----------- | ------- |
+|  | This endpoint accepts no parameters |  |
+
+
+**Example**
+```bash
+curl -X POST "http://127.0.0.1:2281/v1/validateMessage" \
+     -H "Content-Type: application/octet-stream" \
+     --data-binary "@message.encoded.protobuf"
+
+```
+
+
+**Response**
+```json
+{
+  "valid": true,
+  "message": {
+    "data": {
+      "type": "MESSAGE_TYPE_FRAME_ACTION",
+      "fid": 2,
+      "timestamp": 48994466,
+      "network": "FARCASTER_NETWORK_MAINNET",
+      "frameActionBody": {
+        "url": "https://fcpolls.com/polls/1",
+        "buttonId": "2",
+        "castId": {
+          "fid": 226,
+          "hash": "0xa48dd46161d8e57725f5e26e34ec19c13ff7f3b9"
+        }
+      }
+    },
+    "hash": "0xd2b1ddc6c88e865a33cb1a565e0058d757042974",
+    "hashScheme": "HASH_SCHEME_BLAKE3",
+    "signature": "3msLXzxB4eEYe...dHrY1vkxcPAA==",
+    "signatureScheme": "SIGNATURE_SCHEME_ED25519",
+    "signer": "0x78ff9a...58c"
+  }
 }
 ```
 

--- a/apps/hubble/www/docs/docs/httpapi/message.md
+++ b/apps/hubble/www/docs/docs/httpapi/message.md
@@ -115,7 +115,7 @@ curl -X POST "http://127.0.0.1:2281/v1/validateMessage" \
       "network": "FARCASTER_NETWORK_MAINNET",
       "frameActionBody": {
         "url": "https://fcpolls.com/polls/1",
-        "buttonId": "2",
+        "buttonIndex": 2,
         "castId": {
           "fid": 226,
           "hash": "0xa48dd46161d8e57725f5e26e34ec19c13ff7f3b9"

--- a/apps/replicator/src/processors/index.ts
+++ b/apps/replicator/src/processors/index.ts
@@ -177,6 +177,8 @@ export async function processMessage(
         log.debug(`Processing UsernameProofMessage ${hash} (fid ${fid})`, { fid, hash });
         await processUserNameProofMessage(message, operation, trx);
         break;
+      case MessageType.FRAME_ACTION:
+        throw new AssertionError("Unexpected FRAME_ACTION message type");
       case MessageType.NONE:
         throw new AssertionError("Message contained no type");
       default:

--- a/apps/replicator/src/util.ts
+++ b/apps/replicator/src/util.ts
@@ -222,6 +222,8 @@ export function convertProtobufMessageBodyToJson(message: Message): MessageBodyJ
         type,
       } satisfies UsernameProofBodyJson;
     }
+    case MessageType.FRAME_ACTION:
+      throw new AssertionError("Unexpected FRAME_ACTION message type");
     case MessageType.NONE:
       throw new AssertionError("Message has no type");
     default:

--- a/packages/core/src/builders.test.ts
+++ b/packages/core/src/builders.test.ts
@@ -396,3 +396,19 @@ describe("username proof", () => {
     });
   });
 });
+
+describe("makeFrameAction", () => {
+  test("succeeds", async () => {
+    const message = await builders.makeFrameAction(
+      protobufs.FrameActionBody.create({
+        buttonId: Buffer.from("1"),
+        url: Buffer.from("https://example.com"),
+        castId: { fid, hash: Factories.MessageHash.build() },
+      }),
+      { fid, network },
+      ed25519Signer,
+    );
+    const isValid = await validations.validateMessage(message._unsafeUnwrap());
+    expect(isValid.isOk()).toBeTruthy();
+  });
+});

--- a/packages/core/src/builders.test.ts
+++ b/packages/core/src/builders.test.ts
@@ -401,7 +401,7 @@ describe("makeFrameAction", () => {
   test("succeeds", async () => {
     const message = await builders.makeFrameAction(
       protobufs.FrameActionBody.create({
-        buttonId: Buffer.from("1"),
+        buttonIndex: 1,
         url: Buffer.from("https://example.com"),
         castId: { fid, hash: Factories.MessageHash.build() },
       }),

--- a/packages/core/src/builders.ts
+++ b/packages/core/src/builders.ts
@@ -25,6 +25,7 @@ type MessageBodyOptions = Pick<
   | "userDataBody"
   | "linkBody"
   | "usernameProofBody"
+  | "frameActionBody"
 >;
 
 /** Generic Methods */
@@ -314,4 +315,23 @@ export const makeUsernameProofData = (
   dataOptions: MessageDataOptions,
 ): HubAsyncResult<protobufs.UsernameProofData> => {
   return makeMessageData({ usernameProofBody: body }, protobufs.MessageType.USERNAME_PROOF, dataOptions);
+};
+
+export const makeFrameAction = async (
+  body: protobufs.FrameActionBody,
+  dataOptions: MessageDataOptions,
+  signer: Signer,
+): HubAsyncResult<protobufs.FrameActionMessage> => {
+  const data = await makeFrameActionData(body, dataOptions);
+  if (data.isErr()) {
+    return err(data.error);
+  }
+  return makeMessage(data.value, signer);
+};
+
+export const makeFrameActionData = (
+  body: protobufs.FrameActionBody,
+  dataOptions: MessageDataOptions,
+): HubAsyncResult<protobufs.FrameActionData> => {
+  return makeMessageData({ frameActionBody: body }, protobufs.MessageType.FRAME_ACTION, dataOptions);
 };

--- a/packages/core/src/factories.ts
+++ b/packages/core/src/factories.ts
@@ -543,7 +543,7 @@ const UsernameProofMessageFactory = Factory.define<protobufs.UsernameProofMessag
 const FrameActionBodyFactory = Factory.define<protobufs.FrameActionBody>(() => {
   return protobufs.FrameActionBody.create({
     url: Buffer.from(faker.internet.url()),
-    buttonId: Buffer.from(faker.random.alphaNumeric(5)),
+    buttonIndex: faker.datatype.number({ min: 1, max: 4 }),
     castId: CastIdFactory.build(),
   });
 });

--- a/packages/core/src/factories.ts
+++ b/packages/core/src/factories.ts
@@ -540,6 +540,34 @@ const UsernameProofMessageFactory = Factory.define<protobufs.UsernameProofMessag
   },
 );
 
+const FrameActionBodyFactory = Factory.define<protobufs.FrameActionBody>(() => {
+  return protobufs.FrameActionBody.create({
+    url: Buffer.from(faker.internet.url()),
+    buttonId: Buffer.from(faker.random.alphaNumeric(5)),
+    castId: CastIdFactory.build(),
+  });
+});
+
+const FrameActionDataFactory = Factory.define<protobufs.FrameActionData>(() => {
+  return MessageDataFactory.build({
+    frameActionBody: FrameActionBodyFactory.build(),
+    type: protobufs.MessageType.FRAME_ACTION,
+  }) as protobufs.FrameActionData;
+});
+
+const FrameActionMessageFactory = Factory.define<protobufs.FrameActionMessage, { signer?: Ed25519Signer }>(
+  ({ onCreate, transientParams }) => {
+    onCreate((message) => {
+      return MessageFactory.create(message, { transient: transientParams }) as Promise<protobufs.FrameActionMessage>;
+    });
+
+    return MessageFactory.build(
+      { data: FrameActionDataFactory.build(), signatureScheme: protobufs.SignatureScheme.ED25519 },
+      { transient: transientParams },
+    ) as protobufs.FrameActionMessage;
+  },
+);
+
 const OnChainEventFactory = Factory.define<protobufs.OnChainEvent>(() => {
   return protobufs.OnChainEvent.create({
     type: OnChainEventType.EVENT_TYPE_SIGNER,
@@ -659,6 +687,9 @@ export const Factories = {
   CastRemoveBody: CastRemoveBodyFactory,
   CastRemoveData: CastRemoveDataFactory,
   CastRemoveMessage: CastRemoveMessageFactory,
+  FrameActionBody: FrameActionBodyFactory,
+  FrameActionData: FrameActionDataFactory,
+  FrameActionMessage: FrameActionMessageFactory,
   LinkBody: LinkBodyFactory,
   LinkAddData: LinkAddDataFactory,
   LinkAddMessage: LinkAddMessageFactory,

--- a/packages/core/src/protobufs/generated/message.ts
+++ b/packages/core/src/protobufs/generated/message.ts
@@ -469,8 +469,8 @@ export interface LinkBody {
 export interface FrameActionBody {
   /** URL of the Frame triggering the action */
   url: Uint8Array;
-  /** The identifier of the button pressed */
-  buttonId: Uint8Array;
+  /** The index of the button pressed (1-4) */
+  buttonIndex: number;
   /** The cast which contained the frame url */
   castId: CastId | undefined;
 }
@@ -1702,7 +1702,7 @@ export const LinkBody = {
 };
 
 function createBaseFrameActionBody(): FrameActionBody {
-  return { url: new Uint8Array(), buttonId: new Uint8Array(), castId: undefined };
+  return { url: new Uint8Array(), buttonIndex: 0, castId: undefined };
 }
 
 export const FrameActionBody = {
@@ -1710,8 +1710,8 @@ export const FrameActionBody = {
     if (message.url.length !== 0) {
       writer.uint32(10).bytes(message.url);
     }
-    if (message.buttonId.length !== 0) {
-      writer.uint32(18).bytes(message.buttonId);
+    if (message.buttonIndex !== 0) {
+      writer.uint32(16).uint32(message.buttonIndex);
     }
     if (message.castId !== undefined) {
       CastId.encode(message.castId, writer.uint32(26).fork()).ldelim();
@@ -1734,11 +1734,11 @@ export const FrameActionBody = {
           message.url = reader.bytes();
           continue;
         case 2:
-          if (tag != 18) {
+          if (tag != 16) {
             break;
           }
 
-          message.buttonId = reader.bytes();
+          message.buttonIndex = reader.uint32();
           continue;
         case 3:
           if (tag != 26) {
@@ -1759,7 +1759,7 @@ export const FrameActionBody = {
   fromJSON(object: any): FrameActionBody {
     return {
       url: isSet(object.url) ? bytesFromBase64(object.url) : new Uint8Array(),
-      buttonId: isSet(object.buttonId) ? bytesFromBase64(object.buttonId) : new Uint8Array(),
+      buttonIndex: isSet(object.buttonIndex) ? Number(object.buttonIndex) : 0,
       castId: isSet(object.castId) ? CastId.fromJSON(object.castId) : undefined,
     };
   },
@@ -1768,8 +1768,7 @@ export const FrameActionBody = {
     const obj: any = {};
     message.url !== undefined &&
       (obj.url = base64FromBytes(message.url !== undefined ? message.url : new Uint8Array()));
-    message.buttonId !== undefined &&
-      (obj.buttonId = base64FromBytes(message.buttonId !== undefined ? message.buttonId : new Uint8Array()));
+    message.buttonIndex !== undefined && (obj.buttonIndex = Math.round(message.buttonIndex));
     message.castId !== undefined && (obj.castId = message.castId ? CastId.toJSON(message.castId) : undefined);
     return obj;
   },
@@ -1781,7 +1780,7 @@ export const FrameActionBody = {
   fromPartial<I extends Exact<DeepPartial<FrameActionBody>, I>>(object: I): FrameActionBody {
     const message = createBaseFrameActionBody();
     message.url = object.url ?? new Uint8Array();
-    message.buttonId = object.buttonId ?? new Uint8Array();
+    message.buttonIndex = object.buttonIndex ?? 0;
     message.castId = (object.castId !== undefined && object.castId !== null)
       ? CastId.fromPartial(object.castId)
       : undefined;

--- a/packages/core/src/protobufs/generated/message.ts
+++ b/packages/core/src/protobufs/generated/message.ts
@@ -99,6 +99,8 @@ export enum MessageType {
   USER_DATA_ADD = 11,
   /** USERNAME_PROOF - Add or replace a username proof */
   USERNAME_PROOF = 12,
+  /** FRAME_ACTION - A Farcaster Frame action */
+  FRAME_ACTION = 13,
 }
 
 export function messageTypeFromJSON(object: any): MessageType {
@@ -136,6 +138,9 @@ export function messageTypeFromJSON(object: any): MessageType {
     case 12:
     case "MESSAGE_TYPE_USERNAME_PROOF":
       return MessageType.USERNAME_PROOF;
+    case 13:
+    case "MESSAGE_TYPE_FRAME_ACTION":
+      return MessageType.FRAME_ACTION;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum MessageType");
   }
@@ -165,6 +170,8 @@ export function messageTypeToJSON(object: MessageType): string {
       return "MESSAGE_TYPE_USER_DATA_ADD";
     case MessageType.USERNAME_PROOF:
       return "MESSAGE_TYPE_USERNAME_PROOF";
+    case MessageType.FRAME_ACTION:
+      return "MESSAGE_TYPE_FRAME_ACTION";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum MessageType");
   }
@@ -362,6 +369,7 @@ export interface MessageData {
   /** SignerRemoveBody signer_remove_body = 13; // Deprecated */
   linkBody?: LinkBody | undefined;
   usernameProofBody?: UserNameProof | undefined;
+  frameActionBody?: FrameActionBody | undefined;
 }
 
 /** Adds metadata about a user */
@@ -455,6 +463,16 @@ export interface LinkBody {
     | undefined;
   /** The fid the link relates to */
   targetFid?: number | undefined;
+}
+
+/** A Farcaster Frame action */
+export interface FrameActionBody {
+  /** URL of the Frame triggering the action */
+  url: Uint8Array;
+  /** The identifier of the button pressed */
+  buttonId: Uint8Array;
+  /** The cast which contained the frame url */
+  castId: CastId | undefined;
 }
 
 function createBaseMessage(): Message {
@@ -621,6 +639,7 @@ function createBaseMessageData(): MessageData {
     userDataBody: undefined,
     linkBody: undefined,
     usernameProofBody: undefined,
+    frameActionBody: undefined,
   };
 }
 
@@ -661,6 +680,9 @@ export const MessageData = {
     }
     if (message.usernameProofBody !== undefined) {
       UserNameProof.encode(message.usernameProofBody, writer.uint32(122).fork()).ldelim();
+    }
+    if (message.frameActionBody !== undefined) {
+      FrameActionBody.encode(message.frameActionBody, writer.uint32(130).fork()).ldelim();
     }
     return writer;
   },
@@ -756,6 +778,13 @@ export const MessageData = {
 
           message.usernameProofBody = UserNameProof.decode(reader, reader.uint32());
           continue;
+        case 16:
+          if (tag != 130) {
+            break;
+          }
+
+          message.frameActionBody = FrameActionBody.decode(reader, reader.uint32());
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -783,6 +812,7 @@ export const MessageData = {
       userDataBody: isSet(object.userDataBody) ? UserDataBody.fromJSON(object.userDataBody) : undefined,
       linkBody: isSet(object.linkBody) ? LinkBody.fromJSON(object.linkBody) : undefined,
       usernameProofBody: isSet(object.usernameProofBody) ? UserNameProof.fromJSON(object.usernameProofBody) : undefined,
+      frameActionBody: isSet(object.frameActionBody) ? FrameActionBody.fromJSON(object.frameActionBody) : undefined,
     };
   },
 
@@ -810,6 +840,8 @@ export const MessageData = {
     message.linkBody !== undefined && (obj.linkBody = message.linkBody ? LinkBody.toJSON(message.linkBody) : undefined);
     message.usernameProofBody !== undefined &&
       (obj.usernameProofBody = message.usernameProofBody ? UserNameProof.toJSON(message.usernameProofBody) : undefined);
+    message.frameActionBody !== undefined &&
+      (obj.frameActionBody = message.frameActionBody ? FrameActionBody.toJSON(message.frameActionBody) : undefined);
     return obj;
   },
 
@@ -848,6 +880,9 @@ export const MessageData = {
       : undefined;
     message.usernameProofBody = (object.usernameProofBody !== undefined && object.usernameProofBody !== null)
       ? UserNameProof.fromPartial(object.usernameProofBody)
+      : undefined;
+    message.frameActionBody = (object.frameActionBody !== undefined && object.frameActionBody !== null)
+      ? FrameActionBody.fromPartial(object.frameActionBody)
       : undefined;
     return message;
   },
@@ -1662,6 +1697,94 @@ export const LinkBody = {
     message.type = object.type ?? "";
     message.displayTimestamp = object.displayTimestamp ?? undefined;
     message.targetFid = object.targetFid ?? undefined;
+    return message;
+  },
+};
+
+function createBaseFrameActionBody(): FrameActionBody {
+  return { url: new Uint8Array(), buttonId: new Uint8Array(), castId: undefined };
+}
+
+export const FrameActionBody = {
+  encode(message: FrameActionBody, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.url.length !== 0) {
+      writer.uint32(10).bytes(message.url);
+    }
+    if (message.buttonId.length !== 0) {
+      writer.uint32(18).bytes(message.buttonId);
+    }
+    if (message.castId !== undefined) {
+      CastId.encode(message.castId, writer.uint32(26).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): FrameActionBody {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseFrameActionBody();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.url = reader.bytes();
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.buttonId = reader.bytes();
+          continue;
+        case 3:
+          if (tag != 26) {
+            break;
+          }
+
+          message.castId = CastId.decode(reader, reader.uint32());
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): FrameActionBody {
+    return {
+      url: isSet(object.url) ? bytesFromBase64(object.url) : new Uint8Array(),
+      buttonId: isSet(object.buttonId) ? bytesFromBase64(object.buttonId) : new Uint8Array(),
+      castId: isSet(object.castId) ? CastId.fromJSON(object.castId) : undefined,
+    };
+  },
+
+  toJSON(message: FrameActionBody): unknown {
+    const obj: any = {};
+    message.url !== undefined &&
+      (obj.url = base64FromBytes(message.url !== undefined ? message.url : new Uint8Array()));
+    message.buttonId !== undefined &&
+      (obj.buttonId = base64FromBytes(message.buttonId !== undefined ? message.buttonId : new Uint8Array()));
+    message.castId !== undefined && (obj.castId = message.castId ? CastId.toJSON(message.castId) : undefined);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<FrameActionBody>, I>>(base?: I): FrameActionBody {
+    return FrameActionBody.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<FrameActionBody>, I>>(object: I): FrameActionBody {
+    const message = createBaseFrameActionBody();
+    message.url = object.url ?? new Uint8Array();
+    message.buttonId = object.buttonId ?? new Uint8Array();
+    message.castId = (object.castId !== undefined && object.castId !== null)
+      ? CastId.fromPartial(object.castId)
+      : undefined;
     return message;
   },
 };

--- a/packages/core/src/protobufs/generated/request_response.ts
+++ b/packages/core/src/protobufs/generated/request_response.ts
@@ -290,6 +290,11 @@ export interface IdRegistryEventByAddressRequest {
   address: Uint8Array;
 }
 
+export interface ValidationResponse {
+  valid: boolean;
+  message: Message | undefined;
+}
+
 function createBaseEmpty(): Empty {
   return {};
 }
@@ -3408,6 +3413,79 @@ export const IdRegistryEventByAddressRequest = {
   ): IdRegistryEventByAddressRequest {
     const message = createBaseIdRegistryEventByAddressRequest();
     message.address = object.address ?? new Uint8Array();
+    return message;
+  },
+};
+
+function createBaseValidationResponse(): ValidationResponse {
+  return { valid: false, message: undefined };
+}
+
+export const ValidationResponse = {
+  encode(message: ValidationResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.valid === true) {
+      writer.uint32(8).bool(message.valid);
+    }
+    if (message.message !== undefined) {
+      Message.encode(message.message, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): ValidationResponse {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseValidationResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.valid = reader.bool();
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.message = Message.decode(reader, reader.uint32());
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): ValidationResponse {
+    return {
+      valid: isSet(object.valid) ? Boolean(object.valid) : false,
+      message: isSet(object.message) ? Message.fromJSON(object.message) : undefined,
+    };
+  },
+
+  toJSON(message: ValidationResponse): unknown {
+    const obj: any = {};
+    message.valid !== undefined && (obj.valid = message.valid);
+    message.message !== undefined && (obj.message = message.message ? Message.toJSON(message.message) : undefined);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ValidationResponse>, I>>(base?: I): ValidationResponse {
+    return ValidationResponse.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<ValidationResponse>, I>>(object: I): ValidationResponse {
+    const message = createBaseValidationResponse();
+    message.valid = object.valid ?? false;
+    message.message = (object.message !== undefined && object.message !== null)
+      ? Message.fromPartial(object.message)
+      : undefined;
     return message;
   },
 };

--- a/packages/core/src/protobufs/typeguards.ts
+++ b/packages/core/src/protobufs/typeguards.ts
@@ -132,6 +132,18 @@ export const isUsernameProofMessage = (message: protobufs.Message): message is t
   );
 };
 
+export const isFrameActionData = (data: protobufs.MessageData): data is types.FrameActionData => {
+  return data.type === protobufs.MessageType.FRAME_ACTION && typeof data.frameActionBody !== "undefined";
+};
+
+export const isFrameActionMessage = (message: protobufs.Message): message is types.FrameActionMessage => {
+  return (
+    message.signatureScheme === protobufs.SignatureScheme.ED25519 &&
+    typeof message.data !== "undefined" &&
+    isFrameActionData(message.data)
+  );
+};
+
 export const isSignerOnChainEvent = (event: onChainEventProtobufs.OnChainEvent): event is types.SignerOnChainEvent => {
   return (
     event.type === onChainEventProtobufs.OnChainEventType.EVENT_TYPE_SIGNER &&

--- a/packages/core/src/protobufs/types.ts
+++ b/packages/core/src/protobufs/types.ts
@@ -106,6 +106,16 @@ export type UsernameProofMessage = protobufs.Message & {
   signatureScheme: protobufs.SignatureScheme.ED25519;
 };
 
+export type FrameActionData = protobufs.MessageData & {
+  type: protobufs.MessageType.FRAME_ACTION;
+  frameActionBody: protobufs.FrameActionBody;
+};
+
+export type FrameActionMessage = protobufs.Message & {
+  data: FrameActionData;
+  signatureScheme: protobufs.SignatureScheme.ED25519;
+};
+
 export type SignerOnChainEvent = onchainEventProtobufs.OnChainEvent & {
   type: onchainEventProtobufs.OnChainEventType.EVENT_TYPE_SIGNER;
   signerEventBody: onchainEventProtobufs.SignerEventBody;

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -662,12 +662,8 @@ export const validateUsernameProofBody = (
 
 export const validateFrameActionBody = (body: protobufs.FrameActionBody): HubResult<protobufs.FrameActionBody> => {
   // url and buttonId are required and must not exceed the length limits. cast id is optional
-  if (body.buttonId !== undefined) {
-    if (body.buttonId.length === 0 || body.buttonId.length > 8) {
-      return err(new HubError("bad_request.validation_failure", "invalid button id"));
-    }
-  } else {
-    return err(new HubError("bad_request.validation_failure", "button id not provided"));
+  if (body.buttonIndex > 5) {
+    return err(new HubError("bad_request.validation_failure", "invalid button index"));
   }
 
   if (body.url !== undefined) {

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -311,6 +311,8 @@ export const validateMessageData = async <T extends protobufs.MessageData>(
     bodyResult = validateVerificationRemoveBody(data.verificationRemoveBody);
   } else if (validType.value === protobufs.MessageType.USERNAME_PROOF && !!data.usernameProofBody) {
     bodyResult = validateUsernameProofBody(data.usernameProofBody, data);
+  } else if (validType.value === protobufs.MessageType.FRAME_ACTION && !!data.frameActionBody) {
+    bodyResult = validateFrameActionBody(data.frameActionBody);
   } else {
     return err(new HubError("bad_request.invalid_param", "bodyType is invalid"));
   }
@@ -655,6 +657,34 @@ export const validateUsernameProofBody = (
       ),
     );
   }
+  return ok(body);
+};
+
+export const validateFrameActionBody = (body: protobufs.FrameActionBody): HubResult<protobufs.FrameActionBody> => {
+  // url and buttonId are required and must not exceed the length limits. cast id is optional
+  if (body.buttonId !== undefined) {
+    if (body.buttonId.length === 0 || body.buttonId.length > 8) {
+      return err(new HubError("bad_request.validation_failure", "invalid button id"));
+    }
+  } else {
+    return err(new HubError("bad_request.validation_failure", "button id not provided"));
+  }
+
+  if (body.url !== undefined) {
+    if (body.url.length === 0 || body.url.length > 256) {
+      return err(new HubError("bad_request.validation_failure", "invalid url"));
+    }
+  } else {
+    return err(new HubError("bad_request.validation_failure", "url provided"));
+  }
+
+  if (body.castId !== undefined) {
+    const result = validateCastId(body.castId);
+    if (result.isErr()) {
+      return err(result.error);
+    }
+  }
+
   return ok(body);
 };
 

--- a/packages/hub-nodejs/src/generated/message.ts
+++ b/packages/hub-nodejs/src/generated/message.ts
@@ -469,8 +469,8 @@ export interface LinkBody {
 export interface FrameActionBody {
   /** URL of the Frame triggering the action */
   url: Uint8Array;
-  /** The identifier of the button pressed */
-  buttonId: Uint8Array;
+  /** The index of the button pressed (1-4) */
+  buttonIndex: number;
   /** The cast which contained the frame url */
   castId: CastId | undefined;
 }
@@ -1702,7 +1702,7 @@ export const LinkBody = {
 };
 
 function createBaseFrameActionBody(): FrameActionBody {
-  return { url: new Uint8Array(), buttonId: new Uint8Array(), castId: undefined };
+  return { url: new Uint8Array(), buttonIndex: 0, castId: undefined };
 }
 
 export const FrameActionBody = {
@@ -1710,8 +1710,8 @@ export const FrameActionBody = {
     if (message.url.length !== 0) {
       writer.uint32(10).bytes(message.url);
     }
-    if (message.buttonId.length !== 0) {
-      writer.uint32(18).bytes(message.buttonId);
+    if (message.buttonIndex !== 0) {
+      writer.uint32(16).uint32(message.buttonIndex);
     }
     if (message.castId !== undefined) {
       CastId.encode(message.castId, writer.uint32(26).fork()).ldelim();
@@ -1734,11 +1734,11 @@ export const FrameActionBody = {
           message.url = reader.bytes();
           continue;
         case 2:
-          if (tag != 18) {
+          if (tag != 16) {
             break;
           }
 
-          message.buttonId = reader.bytes();
+          message.buttonIndex = reader.uint32();
           continue;
         case 3:
           if (tag != 26) {
@@ -1759,7 +1759,7 @@ export const FrameActionBody = {
   fromJSON(object: any): FrameActionBody {
     return {
       url: isSet(object.url) ? bytesFromBase64(object.url) : new Uint8Array(),
-      buttonId: isSet(object.buttonId) ? bytesFromBase64(object.buttonId) : new Uint8Array(),
+      buttonIndex: isSet(object.buttonIndex) ? Number(object.buttonIndex) : 0,
       castId: isSet(object.castId) ? CastId.fromJSON(object.castId) : undefined,
     };
   },
@@ -1768,8 +1768,7 @@ export const FrameActionBody = {
     const obj: any = {};
     message.url !== undefined &&
       (obj.url = base64FromBytes(message.url !== undefined ? message.url : new Uint8Array()));
-    message.buttonId !== undefined &&
-      (obj.buttonId = base64FromBytes(message.buttonId !== undefined ? message.buttonId : new Uint8Array()));
+    message.buttonIndex !== undefined && (obj.buttonIndex = Math.round(message.buttonIndex));
     message.castId !== undefined && (obj.castId = message.castId ? CastId.toJSON(message.castId) : undefined);
     return obj;
   },
@@ -1781,7 +1780,7 @@ export const FrameActionBody = {
   fromPartial<I extends Exact<DeepPartial<FrameActionBody>, I>>(object: I): FrameActionBody {
     const message = createBaseFrameActionBody();
     message.url = object.url ?? new Uint8Array();
-    message.buttonId = object.buttonId ?? new Uint8Array();
+    message.buttonIndex = object.buttonIndex ?? 0;
     message.castId = (object.castId !== undefined && object.castId !== null)
       ? CastId.fromPartial(object.castId)
       : undefined;

--- a/packages/hub-nodejs/src/generated/message.ts
+++ b/packages/hub-nodejs/src/generated/message.ts
@@ -99,6 +99,8 @@ export enum MessageType {
   USER_DATA_ADD = 11,
   /** USERNAME_PROOF - Add or replace a username proof */
   USERNAME_PROOF = 12,
+  /** FRAME_ACTION - A Farcaster Frame action */
+  FRAME_ACTION = 13,
 }
 
 export function messageTypeFromJSON(object: any): MessageType {
@@ -136,6 +138,9 @@ export function messageTypeFromJSON(object: any): MessageType {
     case 12:
     case "MESSAGE_TYPE_USERNAME_PROOF":
       return MessageType.USERNAME_PROOF;
+    case 13:
+    case "MESSAGE_TYPE_FRAME_ACTION":
+      return MessageType.FRAME_ACTION;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum MessageType");
   }
@@ -165,6 +170,8 @@ export function messageTypeToJSON(object: MessageType): string {
       return "MESSAGE_TYPE_USER_DATA_ADD";
     case MessageType.USERNAME_PROOF:
       return "MESSAGE_TYPE_USERNAME_PROOF";
+    case MessageType.FRAME_ACTION:
+      return "MESSAGE_TYPE_FRAME_ACTION";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum MessageType");
   }
@@ -362,6 +369,7 @@ export interface MessageData {
   /** SignerRemoveBody signer_remove_body = 13; // Deprecated */
   linkBody?: LinkBody | undefined;
   usernameProofBody?: UserNameProof | undefined;
+  frameActionBody?: FrameActionBody | undefined;
 }
 
 /** Adds metadata about a user */
@@ -455,6 +463,16 @@ export interface LinkBody {
     | undefined;
   /** The fid the link relates to */
   targetFid?: number | undefined;
+}
+
+/** A Farcaster Frame action */
+export interface FrameActionBody {
+  /** URL of the Frame triggering the action */
+  url: Uint8Array;
+  /** The identifier of the button pressed */
+  buttonId: Uint8Array;
+  /** The cast which contained the frame url */
+  castId: CastId | undefined;
 }
 
 function createBaseMessage(): Message {
@@ -621,6 +639,7 @@ function createBaseMessageData(): MessageData {
     userDataBody: undefined,
     linkBody: undefined,
     usernameProofBody: undefined,
+    frameActionBody: undefined,
   };
 }
 
@@ -661,6 +680,9 @@ export const MessageData = {
     }
     if (message.usernameProofBody !== undefined) {
       UserNameProof.encode(message.usernameProofBody, writer.uint32(122).fork()).ldelim();
+    }
+    if (message.frameActionBody !== undefined) {
+      FrameActionBody.encode(message.frameActionBody, writer.uint32(130).fork()).ldelim();
     }
     return writer;
   },
@@ -756,6 +778,13 @@ export const MessageData = {
 
           message.usernameProofBody = UserNameProof.decode(reader, reader.uint32());
           continue;
+        case 16:
+          if (tag != 130) {
+            break;
+          }
+
+          message.frameActionBody = FrameActionBody.decode(reader, reader.uint32());
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -783,6 +812,7 @@ export const MessageData = {
       userDataBody: isSet(object.userDataBody) ? UserDataBody.fromJSON(object.userDataBody) : undefined,
       linkBody: isSet(object.linkBody) ? LinkBody.fromJSON(object.linkBody) : undefined,
       usernameProofBody: isSet(object.usernameProofBody) ? UserNameProof.fromJSON(object.usernameProofBody) : undefined,
+      frameActionBody: isSet(object.frameActionBody) ? FrameActionBody.fromJSON(object.frameActionBody) : undefined,
     };
   },
 
@@ -810,6 +840,8 @@ export const MessageData = {
     message.linkBody !== undefined && (obj.linkBody = message.linkBody ? LinkBody.toJSON(message.linkBody) : undefined);
     message.usernameProofBody !== undefined &&
       (obj.usernameProofBody = message.usernameProofBody ? UserNameProof.toJSON(message.usernameProofBody) : undefined);
+    message.frameActionBody !== undefined &&
+      (obj.frameActionBody = message.frameActionBody ? FrameActionBody.toJSON(message.frameActionBody) : undefined);
     return obj;
   },
 
@@ -848,6 +880,9 @@ export const MessageData = {
       : undefined;
     message.usernameProofBody = (object.usernameProofBody !== undefined && object.usernameProofBody !== null)
       ? UserNameProof.fromPartial(object.usernameProofBody)
+      : undefined;
+    message.frameActionBody = (object.frameActionBody !== undefined && object.frameActionBody !== null)
+      ? FrameActionBody.fromPartial(object.frameActionBody)
       : undefined;
     return message;
   },
@@ -1662,6 +1697,94 @@ export const LinkBody = {
     message.type = object.type ?? "";
     message.displayTimestamp = object.displayTimestamp ?? undefined;
     message.targetFid = object.targetFid ?? undefined;
+    return message;
+  },
+};
+
+function createBaseFrameActionBody(): FrameActionBody {
+  return { url: new Uint8Array(), buttonId: new Uint8Array(), castId: undefined };
+}
+
+export const FrameActionBody = {
+  encode(message: FrameActionBody, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.url.length !== 0) {
+      writer.uint32(10).bytes(message.url);
+    }
+    if (message.buttonId.length !== 0) {
+      writer.uint32(18).bytes(message.buttonId);
+    }
+    if (message.castId !== undefined) {
+      CastId.encode(message.castId, writer.uint32(26).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): FrameActionBody {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseFrameActionBody();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.url = reader.bytes();
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.buttonId = reader.bytes();
+          continue;
+        case 3:
+          if (tag != 26) {
+            break;
+          }
+
+          message.castId = CastId.decode(reader, reader.uint32());
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): FrameActionBody {
+    return {
+      url: isSet(object.url) ? bytesFromBase64(object.url) : new Uint8Array(),
+      buttonId: isSet(object.buttonId) ? bytesFromBase64(object.buttonId) : new Uint8Array(),
+      castId: isSet(object.castId) ? CastId.fromJSON(object.castId) : undefined,
+    };
+  },
+
+  toJSON(message: FrameActionBody): unknown {
+    const obj: any = {};
+    message.url !== undefined &&
+      (obj.url = base64FromBytes(message.url !== undefined ? message.url : new Uint8Array()));
+    message.buttonId !== undefined &&
+      (obj.buttonId = base64FromBytes(message.buttonId !== undefined ? message.buttonId : new Uint8Array()));
+    message.castId !== undefined && (obj.castId = message.castId ? CastId.toJSON(message.castId) : undefined);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<FrameActionBody>, I>>(base?: I): FrameActionBody {
+    return FrameActionBody.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<FrameActionBody>, I>>(object: I): FrameActionBody {
+    const message = createBaseFrameActionBody();
+    message.url = object.url ?? new Uint8Array();
+    message.buttonId = object.buttonId ?? new Uint8Array();
+    message.castId = (object.castId !== undefined && object.castId !== null)
+      ? CastId.fromPartial(object.castId)
+      : undefined;
     return message;
   },
 };

--- a/packages/hub-nodejs/src/generated/request_response.ts
+++ b/packages/hub-nodejs/src/generated/request_response.ts
@@ -290,6 +290,11 @@ export interface IdRegistryEventByAddressRequest {
   address: Uint8Array;
 }
 
+export interface ValidationResponse {
+  valid: boolean;
+  message: Message | undefined;
+}
+
 function createBaseEmpty(): Empty {
   return {};
 }
@@ -3408,6 +3413,79 @@ export const IdRegistryEventByAddressRequest = {
   ): IdRegistryEventByAddressRequest {
     const message = createBaseIdRegistryEventByAddressRequest();
     message.address = object.address ?? new Uint8Array();
+    return message;
+  },
+};
+
+function createBaseValidationResponse(): ValidationResponse {
+  return { valid: false, message: undefined };
+}
+
+export const ValidationResponse = {
+  encode(message: ValidationResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.valid === true) {
+      writer.uint32(8).bool(message.valid);
+    }
+    if (message.message !== undefined) {
+      Message.encode(message.message, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): ValidationResponse {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseValidationResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.valid = reader.bool();
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.message = Message.decode(reader, reader.uint32());
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): ValidationResponse {
+    return {
+      valid: isSet(object.valid) ? Boolean(object.valid) : false,
+      message: isSet(object.message) ? Message.fromJSON(object.message) : undefined,
+    };
+  },
+
+  toJSON(message: ValidationResponse): unknown {
+    const obj: any = {};
+    message.valid !== undefined && (obj.valid = message.valid);
+    message.message !== undefined && (obj.message = message.message ? Message.toJSON(message.message) : undefined);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ValidationResponse>, I>>(base?: I): ValidationResponse {
+    return ValidationResponse.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<ValidationResponse>, I>>(object: I): ValidationResponse {
+    const message = createBaseValidationResponse();
+    message.valid = object.valid ?? false;
+    message.message = (object.message !== undefined && object.message !== null)
+      ? Message.fromPartial(object.message)
+      : undefined;
     return message;
   },
 };

--- a/packages/hub-nodejs/src/generated/rpc.ts
+++ b/packages/hub-nodejs/src/generated/rpc.ts
@@ -47,6 +47,7 @@ import {
   UserDataRequest,
   UsernameProofRequest,
   UsernameProofsResponse,
+  ValidationResponse,
   VerificationRequest,
 } from "./request_response";
 import { UserNameProof } from "./username_proof";
@@ -62,6 +63,16 @@ export const HubServiceService = {
     requestDeserialize: (value: Buffer) => Message.decode(value),
     responseSerialize: (value: Message) => Buffer.from(Message.encode(value).finish()),
     responseDeserialize: (value: Buffer) => Message.decode(value),
+  },
+  /** Validation Methods */
+  validateMessage: {
+    path: "/HubService/ValidateMessage",
+    requestStream: false,
+    responseStream: false,
+    requestSerialize: (value: Message) => Buffer.from(Message.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => Message.decode(value),
+    responseSerialize: (value: ValidationResponse) => Buffer.from(ValidationResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer) => ValidationResponse.decode(value),
   },
   /**
    * Event Methods
@@ -462,6 +473,8 @@ export const HubServiceService = {
 export interface HubServiceServer extends UntypedServiceImplementation {
   /** Submit Methods */
   submitMessage: handleUnaryCall<Message, Message>;
+  /** Validation Methods */
+  validateMessage: handleUnaryCall<Message, ValidationResponse>;
   /**
    * Event Methods
    * @http-api: none
@@ -572,6 +585,22 @@ export interface HubServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: Message) => void,
+  ): ClientUnaryCall;
+  /** Validation Methods */
+  validateMessage(
+    request: Message,
+    callback: (error: ServiceError | null, response: ValidationResponse) => void,
+  ): ClientUnaryCall;
+  validateMessage(
+    request: Message,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: ValidationResponse) => void,
+  ): ClientUnaryCall;
+  validateMessage(
+    request: Message,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: ValidationResponse) => void,
   ): ClientUnaryCall;
   /**
    * Event Methods

--- a/packages/hub-web/src/generated/message.ts
+++ b/packages/hub-web/src/generated/message.ts
@@ -469,8 +469,8 @@ export interface LinkBody {
 export interface FrameActionBody {
   /** URL of the Frame triggering the action */
   url: Uint8Array;
-  /** The identifier of the button pressed */
-  buttonId: Uint8Array;
+  /** The index of the button pressed (1-4) */
+  buttonIndex: number;
   /** The cast which contained the frame url */
   castId: CastId | undefined;
 }
@@ -1702,7 +1702,7 @@ export const LinkBody = {
 };
 
 function createBaseFrameActionBody(): FrameActionBody {
-  return { url: new Uint8Array(), buttonId: new Uint8Array(), castId: undefined };
+  return { url: new Uint8Array(), buttonIndex: 0, castId: undefined };
 }
 
 export const FrameActionBody = {
@@ -1710,8 +1710,8 @@ export const FrameActionBody = {
     if (message.url.length !== 0) {
       writer.uint32(10).bytes(message.url);
     }
-    if (message.buttonId.length !== 0) {
-      writer.uint32(18).bytes(message.buttonId);
+    if (message.buttonIndex !== 0) {
+      writer.uint32(16).uint32(message.buttonIndex);
     }
     if (message.castId !== undefined) {
       CastId.encode(message.castId, writer.uint32(26).fork()).ldelim();
@@ -1734,11 +1734,11 @@ export const FrameActionBody = {
           message.url = reader.bytes();
           continue;
         case 2:
-          if (tag != 18) {
+          if (tag != 16) {
             break;
           }
 
-          message.buttonId = reader.bytes();
+          message.buttonIndex = reader.uint32();
           continue;
         case 3:
           if (tag != 26) {
@@ -1759,7 +1759,7 @@ export const FrameActionBody = {
   fromJSON(object: any): FrameActionBody {
     return {
       url: isSet(object.url) ? bytesFromBase64(object.url) : new Uint8Array(),
-      buttonId: isSet(object.buttonId) ? bytesFromBase64(object.buttonId) : new Uint8Array(),
+      buttonIndex: isSet(object.buttonIndex) ? Number(object.buttonIndex) : 0,
       castId: isSet(object.castId) ? CastId.fromJSON(object.castId) : undefined,
     };
   },
@@ -1768,8 +1768,7 @@ export const FrameActionBody = {
     const obj: any = {};
     message.url !== undefined &&
       (obj.url = base64FromBytes(message.url !== undefined ? message.url : new Uint8Array()));
-    message.buttonId !== undefined &&
-      (obj.buttonId = base64FromBytes(message.buttonId !== undefined ? message.buttonId : new Uint8Array()));
+    message.buttonIndex !== undefined && (obj.buttonIndex = Math.round(message.buttonIndex));
     message.castId !== undefined && (obj.castId = message.castId ? CastId.toJSON(message.castId) : undefined);
     return obj;
   },
@@ -1781,7 +1780,7 @@ export const FrameActionBody = {
   fromPartial<I extends Exact<DeepPartial<FrameActionBody>, I>>(object: I): FrameActionBody {
     const message = createBaseFrameActionBody();
     message.url = object.url ?? new Uint8Array();
-    message.buttonId = object.buttonId ?? new Uint8Array();
+    message.buttonIndex = object.buttonIndex ?? 0;
     message.castId = (object.castId !== undefined && object.castId !== null)
       ? CastId.fromPartial(object.castId)
       : undefined;

--- a/packages/hub-web/src/generated/message.ts
+++ b/packages/hub-web/src/generated/message.ts
@@ -99,6 +99,8 @@ export enum MessageType {
   USER_DATA_ADD = 11,
   /** USERNAME_PROOF - Add or replace a username proof */
   USERNAME_PROOF = 12,
+  /** FRAME_ACTION - A Farcaster Frame action */
+  FRAME_ACTION = 13,
 }
 
 export function messageTypeFromJSON(object: any): MessageType {
@@ -136,6 +138,9 @@ export function messageTypeFromJSON(object: any): MessageType {
     case 12:
     case "MESSAGE_TYPE_USERNAME_PROOF":
       return MessageType.USERNAME_PROOF;
+    case 13:
+    case "MESSAGE_TYPE_FRAME_ACTION":
+      return MessageType.FRAME_ACTION;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum MessageType");
   }
@@ -165,6 +170,8 @@ export function messageTypeToJSON(object: MessageType): string {
       return "MESSAGE_TYPE_USER_DATA_ADD";
     case MessageType.USERNAME_PROOF:
       return "MESSAGE_TYPE_USERNAME_PROOF";
+    case MessageType.FRAME_ACTION:
+      return "MESSAGE_TYPE_FRAME_ACTION";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum MessageType");
   }
@@ -362,6 +369,7 @@ export interface MessageData {
   /** SignerRemoveBody signer_remove_body = 13; // Deprecated */
   linkBody?: LinkBody | undefined;
   usernameProofBody?: UserNameProof | undefined;
+  frameActionBody?: FrameActionBody | undefined;
 }
 
 /** Adds metadata about a user */
@@ -455,6 +463,16 @@ export interface LinkBody {
     | undefined;
   /** The fid the link relates to */
   targetFid?: number | undefined;
+}
+
+/** A Farcaster Frame action */
+export interface FrameActionBody {
+  /** URL of the Frame triggering the action */
+  url: Uint8Array;
+  /** The identifier of the button pressed */
+  buttonId: Uint8Array;
+  /** The cast which contained the frame url */
+  castId: CastId | undefined;
 }
 
 function createBaseMessage(): Message {
@@ -621,6 +639,7 @@ function createBaseMessageData(): MessageData {
     userDataBody: undefined,
     linkBody: undefined,
     usernameProofBody: undefined,
+    frameActionBody: undefined,
   };
 }
 
@@ -661,6 +680,9 @@ export const MessageData = {
     }
     if (message.usernameProofBody !== undefined) {
       UserNameProof.encode(message.usernameProofBody, writer.uint32(122).fork()).ldelim();
+    }
+    if (message.frameActionBody !== undefined) {
+      FrameActionBody.encode(message.frameActionBody, writer.uint32(130).fork()).ldelim();
     }
     return writer;
   },
@@ -756,6 +778,13 @@ export const MessageData = {
 
           message.usernameProofBody = UserNameProof.decode(reader, reader.uint32());
           continue;
+        case 16:
+          if (tag != 130) {
+            break;
+          }
+
+          message.frameActionBody = FrameActionBody.decode(reader, reader.uint32());
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -783,6 +812,7 @@ export const MessageData = {
       userDataBody: isSet(object.userDataBody) ? UserDataBody.fromJSON(object.userDataBody) : undefined,
       linkBody: isSet(object.linkBody) ? LinkBody.fromJSON(object.linkBody) : undefined,
       usernameProofBody: isSet(object.usernameProofBody) ? UserNameProof.fromJSON(object.usernameProofBody) : undefined,
+      frameActionBody: isSet(object.frameActionBody) ? FrameActionBody.fromJSON(object.frameActionBody) : undefined,
     };
   },
 
@@ -810,6 +840,8 @@ export const MessageData = {
     message.linkBody !== undefined && (obj.linkBody = message.linkBody ? LinkBody.toJSON(message.linkBody) : undefined);
     message.usernameProofBody !== undefined &&
       (obj.usernameProofBody = message.usernameProofBody ? UserNameProof.toJSON(message.usernameProofBody) : undefined);
+    message.frameActionBody !== undefined &&
+      (obj.frameActionBody = message.frameActionBody ? FrameActionBody.toJSON(message.frameActionBody) : undefined);
     return obj;
   },
 
@@ -848,6 +880,9 @@ export const MessageData = {
       : undefined;
     message.usernameProofBody = (object.usernameProofBody !== undefined && object.usernameProofBody !== null)
       ? UserNameProof.fromPartial(object.usernameProofBody)
+      : undefined;
+    message.frameActionBody = (object.frameActionBody !== undefined && object.frameActionBody !== null)
+      ? FrameActionBody.fromPartial(object.frameActionBody)
       : undefined;
     return message;
   },
@@ -1662,6 +1697,94 @@ export const LinkBody = {
     message.type = object.type ?? "";
     message.displayTimestamp = object.displayTimestamp ?? undefined;
     message.targetFid = object.targetFid ?? undefined;
+    return message;
+  },
+};
+
+function createBaseFrameActionBody(): FrameActionBody {
+  return { url: new Uint8Array(), buttonId: new Uint8Array(), castId: undefined };
+}
+
+export const FrameActionBody = {
+  encode(message: FrameActionBody, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.url.length !== 0) {
+      writer.uint32(10).bytes(message.url);
+    }
+    if (message.buttonId.length !== 0) {
+      writer.uint32(18).bytes(message.buttonId);
+    }
+    if (message.castId !== undefined) {
+      CastId.encode(message.castId, writer.uint32(26).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): FrameActionBody {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseFrameActionBody();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.url = reader.bytes();
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.buttonId = reader.bytes();
+          continue;
+        case 3:
+          if (tag != 26) {
+            break;
+          }
+
+          message.castId = CastId.decode(reader, reader.uint32());
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): FrameActionBody {
+    return {
+      url: isSet(object.url) ? bytesFromBase64(object.url) : new Uint8Array(),
+      buttonId: isSet(object.buttonId) ? bytesFromBase64(object.buttonId) : new Uint8Array(),
+      castId: isSet(object.castId) ? CastId.fromJSON(object.castId) : undefined,
+    };
+  },
+
+  toJSON(message: FrameActionBody): unknown {
+    const obj: any = {};
+    message.url !== undefined &&
+      (obj.url = base64FromBytes(message.url !== undefined ? message.url : new Uint8Array()));
+    message.buttonId !== undefined &&
+      (obj.buttonId = base64FromBytes(message.buttonId !== undefined ? message.buttonId : new Uint8Array()));
+    message.castId !== undefined && (obj.castId = message.castId ? CastId.toJSON(message.castId) : undefined);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<FrameActionBody>, I>>(base?: I): FrameActionBody {
+    return FrameActionBody.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<FrameActionBody>, I>>(object: I): FrameActionBody {
+    const message = createBaseFrameActionBody();
+    message.url = object.url ?? new Uint8Array();
+    message.buttonId = object.buttonId ?? new Uint8Array();
+    message.castId = (object.castId !== undefined && object.castId !== null)
+      ? CastId.fromPartial(object.castId)
+      : undefined;
     return message;
   },
 };

--- a/packages/hub-web/src/generated/request_response.ts
+++ b/packages/hub-web/src/generated/request_response.ts
@@ -290,6 +290,11 @@ export interface IdRegistryEventByAddressRequest {
   address: Uint8Array;
 }
 
+export interface ValidationResponse {
+  valid: boolean;
+  message: Message | undefined;
+}
+
 function createBaseEmpty(): Empty {
   return {};
 }
@@ -3408,6 +3413,79 @@ export const IdRegistryEventByAddressRequest = {
   ): IdRegistryEventByAddressRequest {
     const message = createBaseIdRegistryEventByAddressRequest();
     message.address = object.address ?? new Uint8Array();
+    return message;
+  },
+};
+
+function createBaseValidationResponse(): ValidationResponse {
+  return { valid: false, message: undefined };
+}
+
+export const ValidationResponse = {
+  encode(message: ValidationResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.valid === true) {
+      writer.uint32(8).bool(message.valid);
+    }
+    if (message.message !== undefined) {
+      Message.encode(message.message, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): ValidationResponse {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseValidationResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.valid = reader.bool();
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.message = Message.decode(reader, reader.uint32());
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): ValidationResponse {
+    return {
+      valid: isSet(object.valid) ? Boolean(object.valid) : false,
+      message: isSet(object.message) ? Message.fromJSON(object.message) : undefined,
+    };
+  },
+
+  toJSON(message: ValidationResponse): unknown {
+    const obj: any = {};
+    message.valid !== undefined && (obj.valid = message.valid);
+    message.message !== undefined && (obj.message = message.message ? Message.toJSON(message.message) : undefined);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ValidationResponse>, I>>(base?: I): ValidationResponse {
+    return ValidationResponse.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<ValidationResponse>, I>>(object: I): ValidationResponse {
+    const message = createBaseValidationResponse();
+    message.valid = object.valid ?? false;
+    message.message = (object.message !== undefined && object.message !== null)
+      ? Message.fromPartial(object.message)
+      : undefined;
     return message;
   },
 };

--- a/protobufs/schemas/message.proto
+++ b/protobufs/schemas/message.proto
@@ -35,6 +35,7 @@ message MessageData {
     // SignerRemoveBody signer_remove_body = 13; // Deprecated
     LinkBody link_body = 14;
     UserNameProof username_proof_body = 15;
+    FrameActionBody frame_action_body = 16;
   } // Properties specific to the MessageType
 }
 
@@ -67,6 +68,7 @@ enum MessageType {
 //  MESSAGE_TYPE_SIGNER_REMOVE = 10; // Remove an Ed25519 key pair that signs messages for a user
   MESSAGE_TYPE_USER_DATA_ADD = 11; // Add metadata about a user
   MESSAGE_TYPE_USERNAME_PROOF = 12; // Add or replace a username proof
+  MESSAGE_TYPE_FRAME_ACTION = 13; // A Farcaster Frame action
 }
 
 /** Farcaster network the message is intended for */
@@ -161,4 +163,11 @@ message LinkBody {
   oneof target {
     uint64 target_fid = 3;  // The fid the link relates to
   }
+}
+
+/** A Farcaster Frame action */
+message FrameActionBody {
+  bytes url = 1; // URL of the Frame triggering the action
+  bytes button_id = 2; // The identifier of the button pressed
+  CastId cast_id = 3; // The cast which contained the frame url
 }

--- a/protobufs/schemas/message.proto
+++ b/protobufs/schemas/message.proto
@@ -168,6 +168,6 @@ message LinkBody {
 /** A Farcaster Frame action */
 message FrameActionBody {
   bytes url = 1; // URL of the Frame triggering the action
-  bytes button_id = 2; // The identifier of the button pressed
+  uint32 button_index = 2; // The index of the button pressed (1-4)
   CastId cast_id = 3; // The cast which contained the frame url
 }

--- a/protobufs/schemas/request_response.proto
+++ b/protobufs/schemas/request_response.proto
@@ -239,3 +239,8 @@ message LinksByTargetRequest {
 message IdRegistryEventByAddressRequest {
   bytes address = 1;
 }
+
+message ValidationResponse {
+  bool valid = 1;
+  Message message = 2;
+}

--- a/protobufs/schemas/rpc.proto
+++ b/protobufs/schemas/rpc.proto
@@ -18,6 +18,9 @@ service HubService {
   // Submit Methods
   rpc SubmitMessage(Message) returns (Message);
 
+  // Validation Methods
+  rpc ValidateMessage(Message) returns (ValidationResponse);
+
   // Event Methods
   // @http-api: none
   rpc Subscribe(SubscribeRequest) returns (stream HubEvent);


### PR DESCRIPTION
## Motivation

Add support for a FrameAction message type. And add a validateMessage endpoint that can use used to validate them. FrameActions are not stored on the hub and submitMessage will reject them.

## Change Summary

Support Farcaster Frames

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding support for FrameAction messages and introducing a new validation method for messages. 

### Detailed summary
- Added `FrameAction` message type to the `request_response.proto` schema
- Implemented `validateMessage` method in `util.ts` and `hubble.ts`
- Added `FrameActionBody` message type to the `message.proto` schema
- Added `makeFrameAction` and `makeFrameActionData` functions in `builders.ts`
- Implemented `validateFrameActionBody` function in `validations.ts`
- Updated `index.ts` and `index.test.ts` to handle `FrameAction` messages
- Updated `server.ts` to handle `validateMessage` RPC call in the Hub server
- Added `ValidationResponse` message type to the `server.ts` schema
- Updated `httpServer.ts` to handle `validateMessage` API endpoint

> The following files were skipped due to too many changes: `apps/hubble/src/rpc/httpServer.ts`, `packages/core/src/factories.ts`, `apps/hubble/src/rpc/test/httpServer.test.ts`, `packages/hub-nodejs/src/generated/rpc.ts`, `packages/hub-web/src/generated/rpc.ts`, `packages/hub-web/src/generated/request_response.ts`, `packages/hub-nodejs/src/generated/request_response.ts`, `packages/core/src/protobufs/generated/request_response.ts`, `apps/hubble/www/docs/docs/httpapi/submitmessage.md`, `apps/hubble/src/rpc/test/submitService.test.ts`, `packages/hub-web/src/generated/message.ts`, `packages/hub-nodejs/src/generated/message.ts`, `packages/core/src/protobufs/generated/message.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->