### PR TITLE
fix: make hubble.sh compatible w/ self-hosted eth nodes

### DIFF
--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -130,7 +130,7 @@ validate_and_store() {
 
     while true; do
         read -p "> Enter your $rpc_name RPC URL: " RPC_URL
-        RESPONSE=$(curl -s -X POST --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' "$RPC_URL")
+        RESPONSE=$(curl -s -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' "$RPC_URL")
 
         # Convert both the response and expected chain ID to lowercase for comparison
         local lower_response=$(echo "$RESPONSE" | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
## Motivation

Ethereum JSON-RPC requires passing content-type application/json when talking to a node you're running yourself e.g. reth. Sometimes if you're talking to Infura or Alchemy or other hosted providers, they'll still answer your query w/o the content-type header, but not when talking to your own node.

## Change Summary

Just add the JSON content type header to the curl request.
## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets) -- _no changeset needed as it's on `scripts/`_
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The focus of this PR is to modify the `hubble.sh` script to include a content-type header in the curl request.
- The changes include adding the `-H "Content-Type: application/json"` flag to the curl command.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->