### PR TITLE
Fix http api example

### DIFF
--- a/apps/hubble/www/docs/docs/httpapi/httpapi.md
+++ b/apps/hubble/www/docs/docs/httpapi/httpapi.md
@@ -27,7 +27,7 @@ try {
     const response = await axios.get(`${server}/v1/castsByFid?fid=${fid}`);
 
     console.log(`API Returned HTTP status ${response.status}`);    
-    console.log(`First Cast's text is ${response.messages[0].data.castAddBody.text}`);
+    console.log(`First Cast's text is ${response.data.messages[0].data.castAddBody.text}`);
 } catch (e) {
     // Handle errors
     console.log(response);


### PR DESCRIPTION

## Change Summary

- The latest version of Axios returns the body in `response.data` so we need to pull messages out of there. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a bug in the code related to accessing the text of the first cast in the API response.

### Detailed summary
- Updated code to access the text of the first cast in the API response by correcting the object path.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->