### PR TITLE
fix: don't penalize peer score for duplicate messages

### DIFF
--- a/.changeset/calm-mails-notice.md
+++ b/.changeset/calm-mails-notice.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Remove score penalty for duplicate gossip messages

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -417,7 +417,7 @@ export class LibP2PNode {
     this.gossip?.reportMessageValidationResult(
       messageId,
       propagationSource,
-      isValid ? TopicValidatorResult.Accept : TopicValidatorResult.Reject,
+      isValid ? TopicValidatorResult.Accept : TopicValidatorResult.Ignore,
     );
   }
 

--- a/apps/hubble/src/test/e2e/gossipNetwork.test.ts
+++ b/apps/hubble/src/test/e2e/gossipNetwork.test.ts
@@ -105,7 +105,11 @@ describe("gossip network tests", () => {
       let numCastAddMessages = 0;
 
       nonSenderNodes.map((n) => {
-        const topics = messageStore.get(n.peerId()?.toString() ?? "");
+        const peerId = n.peerId();
+        if (!peerId) {
+          throw new Error(`peerId is undefined for node: ${n}`);
+        }
+        const topics = messageStore.get(peerId.toString());
         expect(topics).toBeDefined();
         expect(topics?.has(primaryTopic)).toBeTruthy();
         const topicMessages = topics?.get(primaryTopic) ?? [];


### PR DESCRIPTION
## Motivation


Rejecting a duplicate message lowers the peer score, which degrades the gossip mesh. Which is making performance worse and potentially causing more message lag and duplicates. Instead ignore the messages so it does not affect peer score.

Also add some additional metrics


## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Fixing a bug related to duplicate gossip messages in the Hubble application.

### Detailed summary:
- Removed score penalty for duplicate gossip messages.
- Updated the `TopicValidatorResult` from `Reject` to `Ignore` in the `gossipNodeWorker.ts` file.
- Added error handling for undefined `peerId` in the `gossipNetwork.test.ts` file.
- Updated the `messageCreatedTime` and `diff` calculations in the `hubble.ts` file.
- Added timing metrics for message delay and merge message in the `hubble.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->