### PR TITLE
fix: Reduce sync frequency

### DIFF
--- a/.changeset/grumpy-otters-retire.md
+++ b/.changeset/grumpy-otters-retire.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: reduce sync freqency to help reduce hub load

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1180,13 +1180,15 @@ export class Hub implements HubInterface {
     // Check if we already have this client
     const result = this.syncEngine.addContactInfoForPeerId(peerId, message);
     if (result.isOk()) {
-      const syncResult = await ResultAsync.fromPromise(
-        this.syncEngine.diffSyncIfRequired(this, peerId.toString()),
-        (e) => e,
-      );
-      if (syncResult.isErr()) {
-        log.error({ error: syncResult.error, peerId }, "Failed to sync with new peer");
-      }
+      // Temporarily disable sync with new peers
+      log.debug({ peerInfo: message }, "New peer but skipping sync");
+      // const syncResult = await ResultAsync.fromPromise(
+      //   this.syncEngine.diffSyncIfRequired(this, peerId.toString()),
+      //   (e) => e,
+      // );
+      // if (syncResult.isErr()) {
+      //   log.error({ error: syncResult.error, peerId }, "Failed to sync with new peer");
+      // }
     } else {
       log.debug({ peerInfo: message }, "Already have this peer, skipping sync");
     }

--- a/apps/hubble/src/network/sync/periodicSyncJob.ts
+++ b/apps/hubble/src/network/sync/periodicSyncJob.ts
@@ -11,7 +11,7 @@ const log = logger.child({
 type SchedulerStatus = "started" | "stopped";
 
 // Every 2 minutes, at 00:45 seconds, to avoid clashing with the prune job
-const DEFAULT_PERIODIC_SYNC_JOB_CRON = "45 */2 * * * *";
+const DEFAULT_PERIODIC_SYNC_JOB_CRON = "45 * */2 * * *";
 
 export class PeriodicSyncJobScheduler {
   private _hub: Hub;

--- a/apps/hubble/src/network/sync/periodicSyncJob.ts
+++ b/apps/hubble/src/network/sync/periodicSyncJob.ts
@@ -10,7 +10,7 @@ const log = logger.child({
 
 type SchedulerStatus = "started" | "stopped";
 
-// Every 2 minutes, at 00:45 seconds, to avoid clashing with the prune job
+// Every 2 hours, at 00:45 seconds, to avoid clashing with the prune job
 const DEFAULT_PERIODIC_SYNC_JOB_CRON = "45 * */2 * * *";
 
 export class PeriodicSyncJobScheduler {


### PR DESCRIPTION
## Motivation

Hubs are under significant load, we're syncing too often. Reducing sync frequency should help.

Will look into switching to probabilistic syncing across different time frames (higher frequency for recent timeframes and lower frequency for longer timeframes).

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR reduces the sync frequency of the Hubble app to help reduce the load on the hub.

### Detailed summary
- Reduces the sync frequency from every 2 minutes to every 2 hours in the `PeriodicSyncJobScheduler`.
- Temporarily disables sync with new peers in the `hubble.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->