### PR TITLE
chore: Release 1.9.6

### DIFF
--- a/.changeset/calm-mails-notice.md
+++ b/.changeset/calm-mails-notice.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Remove score penalty for duplicate gossip messages

--- a/.changeset/grumpy-otters-retire.md
+++ b/.changeset/grumpy-otters-retire.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: reduce sync freqency to help reduce hub load

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/hubble
 
+## 1.9.6
+
+### Patch Changes
+
+- 577d698d: fix: Remove score penalty for duplicate gossip messages
+- 57ce2c66: fix: reduce sync freqency to help reduce hub load
+
 ## 1.9.5
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",


### PR DESCRIPTION
## Motivation

Some performance and peer scoring improvements which should help with hub stability

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of the `@farcaster/hubble` package to `1.9.6` and includes two patch changes: 
- Remove score penalty for duplicate gossip messages
- Reduce sync frequency to help reduce hub load

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->