### PR TITLE
Add instructions to run replicator manually

### DIFF
--- a/apps/replicator/.env.sample
+++ b/apps/replicator/.env.sample
@@ -7,5 +7,5 @@ WEB_UI_PORT=9000
 REDIS_URL=redis:6379
 POSTGRES_URL=postgres://replicator:password@postgres:5432/replicator
 STATSD_HOST=statsd:8125
-HUB_HOST=my-hub.domain.com:2283
+HUB_HOST=localhost:2283
 HUB_SSL=false

--- a/apps/replicator/.env.sample
+++ b/apps/replicator/.env.sample
@@ -1,0 +1,11 @@
+LOG_LEVEL=info
+COLORIZE=true
+# Set this higher the further the hub is from the replicator
+CONCURRENCY=32
+WORKER_TYPE=thread
+WEB_UI_PORT=9000
+REDIS_URL=redis:6379
+POSTGRES_URL=postgres://replicator:password@postgres:5432/replicator
+STATSD_HOST=statsd:8125
+HUB_HOST=my-hub.domain.com:2283
+HUB_SSL=false

--- a/apps/replicator/README.md
+++ b/apps/replicator/README.md
@@ -17,8 +17,15 @@ Note: these are the bare minimum and are likely to increase as the network incre
 
 ### Instructions
 
+#### Automatic Boostrap Script
+
 1. Run: `curl -sSL https://download.farcaster.xyz/bootstrap-replicator.sh | bash`
 2. Answer the prompts.
+
+#### Running Manually
+
+1. Copy .env.sample into .env in this folder
+2. Run: `docker compose up -d`
 
 Once the Docker images have finished downloading, you should start to see messages like:
 

--- a/scripts/replicator.sh
+++ b/scripts/replicator.sh
@@ -170,7 +170,7 @@ write_env_file() {
     fi
 
     if ! key_exists "CONCURRENCY"; then
-        echo "# Set this higher the further the hub is from the replicator"
+        echo "# Set this higher the further the hub is from the replicator" >> .env
         echo "CONCURRENCY=$(expr 4 \* $(portable_nproc))" >> .env
     fi
 


### PR DESCRIPTION
## Motivation

There is currently no instructions to run the replicator manually. The automatic install script wouldn't work correctly for me as I already had something else running on port 9000 and I needed to make some manual docker-compose changes. 

So adding these scripts and commands for others who wish to run it without the automatic script. 

## Change Summary

- Adds instructions to replicator README to run using the docker compose file without the automatic script.
- Adds .env.sample file for this manual docker compose run
- Fixes small bug with replicator.sh script where it was echo'ing information to the terminal instead of the .env file.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The `replicator.sh` script now appends a line to the `.env` file.
- The `.env.sample` file in the `replicator` app has been updated with new environment variables.
- The `README.md` file in the `replicator` app now includes instructions for automatic and manual setup.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->