### PR TITLE
fix: Additional performance tweaks and logging

### DIFF
--- a/.changeset/wet-hairs-cross.md
+++ b/.changeset/wet-hairs-cross.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Minor performance tweaks and logging

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -235,22 +235,20 @@ app
     // try to load the config file
     // biome-ignore lint/suspicious/noExplicitAny: legacy code, avoid using ignore for new code
     let hubConfig: any = DefaultConfig;
-    if (cliOptions.config) {
-      if (!cliOptions.config.endsWith(".js")) {
+    const hubConfigFile = cliOptions.config || process.env["HUB_CONFIG"];
+    if (hubConfigFile) {
+      if (!hubConfigFile.endsWith(".js")) {
         startupCheck.printStartupCheckStatus(StartupCheckStatus.ERROR, "Config file must be a .js file");
-        throw new Error(`Config file ${cliOptions.config} must be a .js file`);
+        throw new Error(`Config file ${hubConfigFile} must be a .js file`);
       }
 
-      if (!fs.existsSync(resolve(cliOptions.config))) {
-        startupCheck.printStartupCheckStatus(
-          StartupCheckStatus.ERROR,
-          `Config file ${cliOptions.config} does not exist`,
-        );
-        throw new Error(`Config file ${cliOptions.config} does not exist`);
+      if (!fs.existsSync(resolve(hubConfigFile))) {
+        startupCheck.printStartupCheckStatus(StartupCheckStatus.ERROR, `Config file ${hubConfigFile} does not exist`);
+        throw new Error(`Config file ${hubConfigFile} does not exist`);
       }
 
-      startupCheck.printStartupCheckStatus(StartupCheckStatus.OK, `Loading config file ${cliOptions.config}`);
-      hubConfig = (await import(resolve(cliOptions.config))).Config;
+      startupCheck.printStartupCheckStatus(StartupCheckStatus.OK, `Loading config file ${hubConfigFile}`);
+      hubConfig = (await import(resolve(hubConfigFile))).Config;
     }
 
     const disableConsoleStatus = cliOptions.disableConsoleStatus ?? hubConfig.disableConsoleStatus ?? false;

--- a/apps/hubble/src/network/sync/periodicSyncJob.ts
+++ b/apps/hubble/src/network/sync/periodicSyncJob.ts
@@ -10,8 +10,8 @@ const log = logger.child({
 
 type SchedulerStatus = "started" | "stopped";
 
-// Every 2 hours, at 00:45 seconds, to avoid clashing with the prune job
-const DEFAULT_PERIODIC_SYNC_JOB_CRON = "45 * */2 * * *";
+// Every 2 hours, at 1 minute mark, to avoid clashing with the prune job
+const DEFAULT_PERIODIC_SYNC_JOB_CRON = "1 */2 * * *";
 
 export class PeriodicSyncJobScheduler {
   private _hub: Hub;

--- a/apps/hubble/src/storage/jobs/pruneMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/pruneMessagesJob.ts
@@ -5,7 +5,7 @@ import Engine from "../engine/index.js";
 import { logger } from "../../utils/logger.js";
 import { statsd } from "../../utils/statsd.js";
 
-export const DEFAULT_PRUNE_MESSAGES_JOB_CRON = "0 * * * *"; // Every hour at :00
+export const DEFAULT_PRUNE_MESSAGES_JOB_CRON = "0 */2 * * *"; // Every two hours
 
 const log = logger.child({
   component: "PruneMessagesJob",

--- a/apps/hubble/src/storage/stores/storageCache.ts
+++ b/apps/hubble/src/storage/stores/storageCache.ts
@@ -147,10 +147,9 @@ export class StorageCache {
       // Recheck the count in case it was set by another thread (i.e. no race conditions)
       if (this._counts.get(key) === undefined) {
         this._counts.set(key, total);
-        log.info(
-          { fid, set, total, prepopulateComplete: this.prepopulateComplete },
-          `storage cache miss for fid: ${fid}`,
-        );
+        if (this.prepopulateComplete) {
+          log.info({ fid, set, total }, `storage cache miss for fid: ${fid}`);
+        }
       }
     }
 

--- a/apps/hubble/src/storage/stores/storageCache.ts
+++ b/apps/hubble/src/storage/stores/storageCache.ts
@@ -37,6 +37,7 @@ export class StorageCache {
   private _counts: Map<string, number>;
   private _earliestTsHashes: Map<string, Uint8Array>;
   private _activeStorageSlots: Map<number, StorageSlot>;
+  private prepopulateComplete = false;
 
   constructor(db: RocksDB, usage?: Map<string, number>) {
     this._counts = usage ?? new Map();
@@ -97,6 +98,7 @@ export class StorageCache {
   async prepopulateMessageCounts(): Promise<void> {
     let prevFid = 0;
     let prevPostfix = 0;
+    let totalFids = 0;
 
     const start = Date.now();
     log.info("starting storage cache prepopulation");
@@ -113,6 +115,7 @@ export class StorageCache {
             await this.getMessageCount(fid, postfix);
 
             if (prevFid !== fid) {
+              totalFids += 1;
               // Sleep to allow other threads to run between each fid
               await sleep(1);
             }
@@ -125,7 +128,8 @@ export class StorageCache {
       { values: false },
       1 * 60 * 60 * 1000, // 1 hour
     );
-    log.info({ timeTakenMs: Date.now() - start }, "storage cache prepopulation finished");
+    this.prepopulateComplete = true;
+    log.info({ timeTakenMs: Date.now() - start, totalFids }, "storage cache prepopulation finished");
   }
 
   async getMessageCount(fid: number, set: UserMessagePostfix): HubAsyncResult<number> {
@@ -143,6 +147,10 @@ export class StorageCache {
       // Recheck the count in case it was set by another thread (i.e. no race conditions)
       if (this._counts.get(key) === undefined) {
         this._counts.set(key, total);
+        log.info(
+          { fid, set, total, prepopulateComplete: this.prepopulateComplete },
+          `storage cache miss for fid: ${fid}`,
+        );
       }
     }
 

--- a/apps/hubble/src/storage/stores/storeEventHandler.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.ts
@@ -42,7 +42,7 @@ import {
 import { logger } from "../../utils/logger.js";
 
 const PRUNE_TIME_LIMIT_DEFAULT = 60 * 60 * 24 * 3 * 1000; // 3 days in ms
-const DEFAULT_LOCK_MAX_PENDING = 1_000;
+const DEFAULT_LOCK_MAX_PENDING = 2_500;
 const DEFAULT_LOCK_TIMEOUT = 500; // in ms
 
 // @ts-ignore


### PR DESCRIPTION
## Motivation

Minor tweaks to help with performance

## Change Summary

- Increase async lock commit queue size to see if it helps with timeouts
- Logging for storage cache misses to debug why it happens
- Allow `HUB_CONFIG` env var for docker compose users to customize hub params
- Always perform one sync on discovering the first peer
- Fix sync jobs from running every minute
- Move prune job top every 2 hours


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Minor performance tweaks and logging improvements
- Increased the default value of `DEFAULT_LOCK_MAX_PENDING` from 1,000 to 2,500
- Changed the cron schedule for the `DEFAULT_PRUNE_MESSAGES_JOB_CRON` to run every two hours instead of every hour
- Changed the cron schedule for the `DEFAULT_PERIODIC_SYNC_JOB_CRON` to avoid clashing with the prune job
- Added a flag `performedFirstSync` to track if the first sync has been performed
- Added a flag `prepopulateComplete` to track if the storage cache prepopulation is complete
- Updated the logic for loading the hub configuration file

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->