### PR TITLE
fix: don't force fetch message count for non-existent fids

### DIFF
--- a/apps/hubble/src/storage/stores/storageCache.ts
+++ b/apps/hubble/src/storage/stores/storageCache.ts
@@ -132,9 +132,9 @@ export class StorageCache {
     log.info({ timeTakenMs: Date.now() - start, totalFids }, "storage cache prepopulation finished");
   }
 
-  async getMessageCount(fid: number, set: UserMessagePostfix): HubAsyncResult<number> {
+  async getMessageCount(fid: number, set: UserMessagePostfix, forceFetch = true): HubAsyncResult<number> {
     const key = makeKey(fid, set);
-    if (this._counts.get(key) === undefined) {
+    if (this._counts.get(key) === undefined && forceFetch) {
       let total = 0;
       await this._db.forEachIteratorByPrefix(
         makeMessagePrimaryKey(fid, set),

--- a/apps/hubble/src/storage/stores/store.ts
+++ b/apps/hubble/src/storage/stores/store.ts
@@ -242,7 +242,7 @@ export abstract class Store<TAdd extends Message, TRemove extends Message> {
   async pruneMessages(fid: number): HubAsyncResult<number[]> {
     const commits: number[] = [];
 
-    const cachedCount = await this._eventHandler.getCacheMessageCount(fid, this._postfix);
+    const cachedCount = await this._eventHandler.getCacheMessageCount(fid, this._postfix, false);
     const units = await this._eventHandler.getCurrentStorageUnitsForFid(fid);
 
     if (units.isErr()) {

--- a/apps/hubble/src/storage/stores/storeEventHandler.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.ts
@@ -237,8 +237,8 @@ class StoreEventHandler extends TypedEmitter<StoreEvents> {
     });
   }
 
-  async getCacheMessageCount(fid: number, set: UserMessagePostfix): HubAsyncResult<number> {
-    return this._storageCache.getMessageCount(fid, set);
+  async getCacheMessageCount(fid: number, set: UserMessagePostfix, forceFetch = true): HubAsyncResult<number> {
+    return this._storageCache.getMessageCount(fid, set, forceFetch);
   }
 
   async getEarliestTsHash(fid: number, set: UserMessagePostfix): HubAsyncResult<Uint8Array | undefined> {


### PR DESCRIPTION
## Motivation

Since we're populating the storage cache from messages in the db, fids without any storage are undefined, and the prune job is causing db fetches for fids with no storage. Save some db calls when pruning fids with no storage.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
The focus of this PR is to add an optional parameter `forceFetch` to the `getMessageCount` and `getCacheMessageCount` functions in order to control whether to fetch the message count or not.

### Detailed summary:
- Added `forceFetch` parameter to the `getMessageCount` function in `storageCache.ts`
- Added `forceFetch` parameter to the `getCacheMessageCount` function in `storeEventHandler.ts`
- Modified the usage of `getCacheMessageCount` in `store.ts` to include the `forceFetch` parameter

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->