### PR TITLE
feat: Add quicksync

### DIFF
--- a/.changeset/slimy-snakes-love.md
+++ b/.changeset/slimy-snakes-love.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: Add quicksync

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -13,7 +13,7 @@ import {
   MessageData,
 } from "@farcaster/hub-nodejs";
 import { APP_NICKNAME, APP_VERSION, HubInterface } from "../../hubble.js";
-import SyncEngine from "./syncEngine.js";
+import SyncEngine, { QUICK_SYNC_TS_CUTOFF } from "./syncEngine.js";
 import { SyncId } from "./syncId.js";
 import Server from "../../rpc/server.js";
 import { jestRocksDB } from "../../storage/db/jestUtils.js";
@@ -279,63 +279,59 @@ describe("Multi peer sync engine", () => {
     TEST_TIMEOUT_LONG,
   );
 
-  test(
-    "sync should respect 2-week cutoff",
-    async () => {
-      // Add signer custody event to engine 1
-      await expect(engine1.mergeOnChainEvent(custodyEvent)).resolves.toBeDefined();
-      await expect(engine1.mergeOnChainEvent(signerEvent)).resolves.toBeDefined();
-      await expect(engine1.mergeOnChainEvent(storageEvent)).resolves.toBeDefined();
-      await expect(engine1.mergeUserNameProof(fname)).resolves.toBeDefined();
+  test("sync should respect 2-week cutoff", async () => {
+    // Add signer custody event to engine 1
+    await expect(engine1.mergeOnChainEvent(custodyEvent)).resolves.toBeDefined();
+    await expect(engine1.mergeOnChainEvent(signerEvent)).resolves.toBeDefined();
+    await expect(engine1.mergeOnChainEvent(storageEvent)).resolves.toBeDefined();
+    await expect(engine1.mergeUserNameProof(fname)).resolves.toBeDefined();
 
-      // Sync engine 2 with engine 1, this should get all the onchain events and fnames
-      await syncEngine2.performSync("engine1", (await syncEngine1.getSnapshot())._unsafeUnwrap(), clientForServer1);
-      await sleepWhile(() => syncEngine2.syncTrieQSize > 0, SLEEPWHILE_TIMEOUT);
+    // Sync engine 2 with engine 1, this should get all the onchain events and fnames
+    await syncEngine2.performSync("engine1", (await syncEngine1.getSnapshot())._unsafeUnwrap(), clientForServer1);
+    await sleepWhile(() => syncEngine2.syncTrieQSize > 0, SLEEPWHILE_TIMEOUT);
 
-      // Make sure root hash matches
-      expect(await syncEngine1.trie.rootHash()).toEqual(await syncEngine2.trie.rootHash());
-      // Add messages to engine 1. The first message is 4 weeks old, the second is new.
-      const nowFsTime = getFarcasterTime()._unsafeUnwrap();
-      const oldFsTime = nowFsTime - 60 * 60 * 24 * 7 * 4;
+    // Make sure root hash matches
+    expect(await syncEngine1.trie.rootHash()).toEqual(await syncEngine2.trie.rootHash());
+    // Add messages to engine 1. The first message is > 2 weeks old, the second is new.
+    const nowFsTime = getFarcasterTime()._unsafeUnwrap();
+    const oldFsTime = nowFsTime - QUICK_SYNC_TS_CUTOFF - 1;
 
-      const oldCast = await Factories.CastAddMessage.create(
-        { data: { fid, network, timestamp: oldFsTime } },
-        { transient: { signer } },
-      );
-      const newCast = await Factories.CastAddMessage.create(
-        { data: { fid, network, timestamp: nowFsTime } },
-        { transient: { signer } },
-      );
+    const oldCast = await Factories.CastAddMessage.create(
+      { data: { fid, network, timestamp: oldFsTime } },
+      { transient: { signer } },
+    );
+    const newCast = await Factories.CastAddMessage.create(
+      { data: { fid, network, timestamp: nowFsTime } },
+      { transient: { signer } },
+    );
 
-      // Merge the casts in
-      let result = await engine1.mergeMessage(oldCast);
-      expect(result.isOk()).toBeTruthy();
-      result = await engine1.mergeMessage(newCast);
-      expect(result.isOk()).toBeTruthy();
+    // Merge the casts in
+    let result = await engine1.mergeMessage(oldCast);
+    expect(result.isOk()).toBeTruthy();
+    result = await engine1.mergeMessage(newCast);
+    expect(result.isOk()).toBeTruthy();
 
-      await sleepWhile(() => syncEngine1.syncTrieQSize > 0, SLEEPWHILE_TIMEOUT);
+    await sleepWhile(() => syncEngine1.syncTrieQSize > 0, SLEEPWHILE_TIMEOUT);
 
-      // Engine 2 should sync with engine1 (inlcuding onchain events and fnames)
-      expect(
-        (await syncEngine2.syncStatus("engine2", (await syncEngine1.getSnapshot())._unsafeUnwrap()))._unsafeUnwrap()
-          .shouldSync,
-      ).toBeTruthy();
+    // Engine 2 should sync with engine1 (inlcuding onchain events and fnames)
+    expect(
+      (await syncEngine2.syncStatus("engine2", (await syncEngine1.getSnapshot())._unsafeUnwrap()))._unsafeUnwrap()
+        .shouldSync,
+    ).toBeTruthy();
 
-      // Sync engine 2 with engine 1
-      await syncEngine2.performSync(
-        "engine1",
-        (await syncEngine1.getSnapshot())._unsafeUnwrap(),
-        clientForServer1,
-        false,
-        nowFsTime - 1,
-      );
+    // Sync engine 2 with engine 1
+    await syncEngine2.performSync(
+      "engine1",
+      (await syncEngine1.getSnapshot())._unsafeUnwrap(),
+      clientForServer1,
+      false,
+      nowFsTime - 1,
+    );
 
-      // Expect the new cast to be in the sync trie, but not the old one
-      expect(await syncEngine2.trie.exists(SyncId.fromMessage(newCast))).toBeTruthy();
-      expect(await syncEngine2.trie.exists(SyncId.fromMessage(oldCast))).toBeFalsy();
-    },
-    30 * 60 * 1000,
-  );
+    // Expect the new cast to be in the sync trie, but not the old one
+    expect(await syncEngine2.trie.exists(SyncId.fromMessage(newCast))).toBeTruthy();
+    expect(await syncEngine2.trie.exists(SyncId.fromMessage(oldCast))).toBeFalsy();
+  });
 
   test("cast remove should remove from trie", async () => {
     // Add signer custody event to engine 1

--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -20,7 +20,7 @@ import SyncEngine from "./syncEngine.js";
 import { SyncId } from "./syncId.js";
 import { jestRocksDB } from "../../storage/db/jestUtils.js";
 import Engine from "../../storage/engine/index.js";
-import { sleep, sleepWhile } from "../../utils/crypto.js";
+import { sleepWhile } from "../../utils/crypto.js";
 import { NetworkFactories } from "../../network/utils/factories.js";
 import { HubInterface } from "../../hubble.js";
 import { MockHub } from "../../test/mocks.js";

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -28,7 +28,14 @@ import { err, ok, Result, ResultAsync } from "neverthrow";
 import { TypedEmitter } from "tiny-typed-emitter";
 import { APP_VERSION, FARCASTER_VERSION, Hub, HubInterface } from "../../hubble.js";
 import { MerkleTrie, NodeMetadata } from "./merkleTrie.js";
-import { formatPrefix, prefixToTimestamp, SyncId, SyncIdType, timestampToPaddedTimestampPrefix } from "./syncId.js";
+import {
+  formatPrefix,
+  prefixToTimestamp,
+  SyncId,
+  SyncIdType,
+  TIMESTAMP_LENGTH,
+  timestampToPaddedTimestampPrefix,
+} from "./syncId.js";
 import { TrieSnapshot } from "./trieNode.js";
 import { getManyMessages } from "../../storage/db/message.js";
 import RocksDB from "../../storage/db/rocksdb.js";
@@ -36,7 +43,13 @@ import { sleepWhile } from "../../utils/crypto.js";
 import { statsd } from "../../utils/statsd.js";
 import { logger, messageToLog } from "../../utils/logger.js";
 import { OnChainEventPostfix, RootPrefix } from "../../storage/db/types.js";
-import { bytesCompare, bytesStartsWith, fromFarcasterTime, isIdRegisterOnChainEvent } from "@farcaster/core";
+import {
+  bytesCompare,
+  bytesStartsWith,
+  fromFarcasterTime,
+  isIdRegisterOnChainEvent,
+  toFarcasterTime,
+} from "@farcaster/core";
 import { L2EventsProvider } from "../../eth/l2EventsProvider.js";
 import { SyncEngineProfiler } from "./syncEngineProfiler.js";
 import os from "os";
@@ -46,7 +59,7 @@ import { SemVer } from "semver";
 import { FNameRegistryEventsProvider } from "../../eth/fnameRegistryEventsProvider.js";
 import { PeerScore, PeerScorer } from "./peerScore.js";
 import { getOnChainEvent } from "../../storage/db/onChainEvent.js";
-import { getFNameProofByFid, getUserNameProof } from "../../storage/db/nameRegistryEvent.js";
+import { getUserNameProof } from "../../storage/db/nameRegistryEvent.js";
 
 // Number of seconds to wait for the network to "settle" before syncing. We will only
 // attempt to sync messages that are older than this time.
@@ -56,6 +69,10 @@ const SYNC_MAX_DURATION = 30 * 60 * 1000; // 30 minutes
 // 4x the number of CPUs, clamped between 2 and 16
 const SYNC_PARALLELISM = Math.max(Math.min(os.cpus().length * 4, 16), 2);
 const SYNC_INTERRUPT_TIMEOUT = 30 * 1000; // 30 seconds
+
+// A quick sync will only sync messages that are newer than 2 weeks.
+const QUICK_SYNC_PROBABILITY = 0.7; // 70% of the time, we'll do a quick sync
+const QUICK_SYNC_TS_CUTOFF = 2 * 7 * 24 * 60 * 60; // 2 weeks, in seconds
 
 const COMPACTION_THRESHOLD = 100_000; // Sync
 const BAD_PEER_BLOCK_TIMEOUT = 5 * 60 * 60 * 1000; // 5 hours, arbitrary, may need to be adjusted as network grows
@@ -560,10 +577,16 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
       this._peerSyncSnapshot.set(updatedPeerIdString, syncStatus.theirSnapshot);
 
       if (syncStatus.shouldSync === true) {
-        log.info({ peerId }, "Diffsync: Starting Sync with peer");
         const start = Date.now();
 
-        const result = await this.performSync(updatedPeerIdString, peerState, rpcClient, true);
+        // Do a quick sync with a 70% chance. A quick sync will only sync messages that are newer than 2 weeks.
+        const isQuickSync = Math.random() < QUICK_SYNC_PROBABILITY;
+        const quickSyncCutoff = isQuickSync
+          ? toFarcasterTime(Date.now() - QUICK_SYNC_TS_CUTOFF * 1000).unwrapOr(-1)
+          : -1;
+
+        log.info({ peerId, isQuickSync, quickSyncCutoff }, "Diffsync: Starting Sync with peer");
+        const result = await this.performSync(updatedPeerIdString, peerState, rpcClient, true, quickSyncCutoff);
 
         log.info({ peerId, result, timeTakenMs: Date.now() - start }, "Diffsync: complete");
         this.emit("syncComplete", true);
@@ -642,6 +665,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     otherSnapshot: TrieSnapshot,
     rpcClient: HubRpcClient,
     doAudit = false,
+    quickSyncCutoff = -1,
   ): Promise<MergeResult> {
     log.info({ peerId }, "Perform sync: Start");
 
@@ -694,38 +718,43 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
           auditPeerPromise = Promise.resolve();
         }
 
-        await this.compareNodeAtPrefix(divergencePrefix, rpcClient, async (missingIds: Uint8Array[]) => {
-          const missingSyncIds = missingIds.map((id) => SyncId.fromBytes(id));
-          const missingMessageIds = missingSyncIds.filter((id) => id.type() === SyncIdType.Message);
+        await this.compareNodeAtPrefix(
+          divergencePrefix,
+          rpcClient,
+          async (missingIds: Uint8Array[]) => {
+            const missingSyncIds = missingIds.map((id) => SyncId.fromBytes(id));
+            const missingMessageIds = missingSyncIds.filter((id) => id.type() === SyncIdType.Message);
 
-          // Merge on chain events first
-          const result = await this.validateAndMergeOnChainEvents(
-            missingSyncIds.filter((id) => id.type() === SyncIdType.OnChainEvent),
-          );
+            // Merge on chain events first
+            const result = await this.validateAndMergeOnChainEvents(
+              missingSyncIds.filter((id) => id.type() === SyncIdType.OnChainEvent),
+            );
 
-          // Then Fnames
-          const fnameResult = await this.validateAndMergeFnames(
-            missingSyncIds.filter((id) => id.type() === SyncIdType.FName),
-          );
-          result.addResult(fnameResult);
+            // Then Fnames
+            const fnameResult = await this.validateAndMergeFnames(
+              missingSyncIds.filter((id) => id.type() === SyncIdType.FName),
+            );
+            result.addResult(fnameResult);
 
-          // And finally messages
-          const messagesResult = await this.fetchAndMergeMessages(missingMessageIds, rpcClient);
-          result.addResult(messagesResult);
+            // And finally messages
+            const messagesResult = await this.fetchAndMergeMessages(missingMessageIds, rpcClient);
+            result.addResult(messagesResult);
 
-          fullSyncResult.addResult(result);
-          progressBar?.increment(result.total);
+            fullSyncResult.addResult(result);
+            progressBar?.increment(result.total);
 
-          const avgPeerNumMessages = this.avgPeerNumMessages();
-          statsd().gauge(
-            "syncengine.sync_percent",
-            avgPeerNumMessages > 0 ? Math.min(1, (await this.trie.items()) / avgPeerNumMessages) : 0,
-          );
+            const avgPeerNumMessages = this.avgPeerNumMessages();
+            statsd().gauge(
+              "syncengine.sync_percent",
+              avgPeerNumMessages > 0 ? Math.min(1, (await this.trie.items()) / avgPeerNumMessages) : 0,
+            );
 
-          statsd().increment("syncengine.sync_messages.success", result.successCount);
-          statsd().increment("syncengine.sync_messages.error", result.errCount);
-          statsd().increment("syncengine.sync_messages.deferred", result.deferredCount);
-        });
+            statsd().increment("syncengine.sync_messages.success", result.successCount);
+            statsd().increment("syncengine.sync_messages.error", result.errCount);
+            statsd().increment("syncengine.sync_messages.deferred", result.deferredCount);
+          },
+          quickSyncCutoff,
+        );
 
         await auditPeerPromise; // Wait for audit to complete
 
@@ -1056,11 +1085,22 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     prefix: Uint8Array,
     rpcClient: HubRpcClient,
     onMissingHashes: (missingHashes: Uint8Array[]) => Promise<void>,
+    tsCutoff = -1,
   ): Promise<number> {
     // Check if we should interrupt the sync
     if (this._currentSyncStatus.interruptSync) {
       log.info("Interrupting sync");
       return -1;
+    }
+
+    // If the prefix is before the cutoff, then we won't recurse into this node.
+    if (tsCutoff >= 0) {
+      const tsPrefix = Buffer.from(prefix.slice(0, 10)).toString("ascii");
+      const maxTs = parseInt(tsPrefix.padEnd(TIMESTAMP_LENGTH, "9"), 10);
+      if (maxTs < tsCutoff) {
+        log.debug({ prefix, maxTs, tsCutoff }, "Skipping prefix before cutoff");
+        return 0;
+      }
     }
 
     const ourNode = await this._trie.getTrieNodeMetadata(prefix);
@@ -1090,6 +1130,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
         ourNode,
         rpcClient,
         onMissingHashes,
+        tsCutoff,
       );
       return 1;
     }
@@ -1100,6 +1141,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     ourNode: NodeMetadata | undefined,
     rpcClient: HubRpcClient,
     onMissingHashes: (missingHashes: Uint8Array[]) => Promise<void>,
+    tsCutoff: number,
   ): Promise<void> {
     if (this._currentSyncStatus.interruptSync) {
       log.info("Interrupting sync");
@@ -1169,7 +1211,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
       for (const [theirChildChar, theirChild] of reversedEntries) {
         // recursively fetch hashes for every node where the hashes don't match
         if (ourNode?.children?.get(theirChildChar)?.hash !== theirChild.hash) {
-          const r = this.compareNodeAtPrefix(theirChild.prefix, rpcClient, onMissingHashes);
+          const r = this.compareNodeAtPrefix(theirChild.prefix, rpcClient, onMissingHashes, tsCutoff);
           numChildrenFetched += 1;
 
           // If we're fetching more than HASHES_PER_FETCH, we'll wait for the first batch to finish before starting


### PR DESCRIPTION
Quicksync will perform a sync for messages only newer than 2 weeks.

## Motivation

To cut down on redundant syncs, we'll do a "quick sync" 70% of the time which only syncs messages newer than 2 weeks old. 

## Change Summary

- Add quick sync selector
- Test

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

@sanjayprabhu - I've added the params as constants. Let me know if you were thinking them to be CLI params, and I can add them.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds the feature of quick sync to the `syncEngine` module. It includes the following changes:

- Adds the `QUICK_SYNC_TS_CUTOFF` constant to define the cutoff time for quick sync
- Modifies the `performSync` method to include a `quickSyncCutoff` parameter
- Updates the `compareNodeAtPrefix` method to skip nodes older than the quick sync cutoff
- Adds logging and metrics related to quick sync

> The following files were skipped due to too many changes: `apps/hubble/src/network/sync/syncEngine.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->