### PR TITLE
fix: Increase sync trie cache to 64MB

### DIFF
--- a/.changeset/swift-flies-tan.md
+++ b/.changeset/swift-flies-tan.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Increase the sync trie cache to 64MB

--- a/apps/hubble/src/network/sync/merkleTrieWorker.ts
+++ b/apps/hubble/src/network/sync/merkleTrieWorker.ts
@@ -13,8 +13,8 @@ import { TrieNode, TrieSnapshot } from "./trieNode.js";
 import { StatsDInitParams, initializeStatsd, statsd } from "../../utils/statsd.js";
 
 // The number of messages to process before unloading the trie from memory
-// Approx 25k * 10 nodes * 65 bytes per node = approx 16MB of cached data
-const TRIE_UNLOAD_THRESHOLD = 25_000;
+// Approx 100k * 10 nodes * 65 bytes per node = approx 64MB of cached data
+const TRIE_UNLOAD_THRESHOLD = 100_000;
 
 // We use a proxy to log messages to the main thread
 const log = new Proxy<Logger>({} as Logger, {


### PR DESCRIPTION
## Motivation
 Bump the size of the in-memory merkle trie cache to reduce DB ops

## Change Summary

- Size from 25k -> 100k (16MB -> 64MB)

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR increases the sync trie cache from 16MB to 64MB in order to process a larger number of messages before unloading the trie from memory.

### Detailed summary
- Increased the value of `TRIE_UNLOAD_THRESHOLD` from 25,000 to 100,000.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->