### PR TITLE
feat: Add ActiveSigners cache

### DIFF
--- a/.changeset/fifty-carrots-end.md
+++ b/.changeset/fifty-carrots-end.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: Add a LRU cache to the active signers

--- a/apps/hubble/src/rpc/test/signerService.test.ts
+++ b/apps/hubble/src/rpc/test/signerService.test.ts
@@ -37,6 +37,10 @@ beforeAll(async () => {
   client = getInsecureHubRpcClient(`127.0.0.1:${port}`);
 });
 
+beforeEach(async () => {
+  engine.clearCache();
+});
+
 afterAll(async () => {
   client.close();
   await syncEngine.stop();

--- a/apps/hubble/src/storage/engine/index.test.ts
+++ b/apps/hubble/src/storage/engine/index.test.ts
@@ -93,6 +93,15 @@ beforeAll(async () => {
   );
 });
 
+beforeEach(async () => {
+  engine.clearCache();
+});
+
+afterAll(async () => {
+  await engine.stop();
+  await db.close();
+});
+
 describe("mergeOnChainEvent", () => {
   test("succeeds", async () => {
     await expect(engine.mergeOnChainEvent(custodyEvent)).resolves.toBeInstanceOf(Ok);
@@ -440,14 +449,18 @@ describe("mergeMessage", () => {
   });
 
   describe("fails when signer is invalid", () => {
-    test("with ReactionAdd", async () => {
-      await engine.mergeOnChainEvent(custodyEvent);
-      await engine.mergeOnChainEvent(Factories.SignerOnChainEvent.build({ fid }));
+    test(
+      "with ReactionAdd",
+      async () => {
+        await engine.mergeOnChainEvent(custodyEvent);
+        await engine.mergeOnChainEvent(Factories.SignerOnChainEvent.build({ fid }));
 
-      const result = await engine.mergeMessage(reactionAdd);
-      expect(result).toMatchObject(err({ errCode: "bad_request.validation_failure" }));
-      expect(result._unsafeUnwrapErr().message).toMatch("invalid signer");
-    });
+        const result = await engine.mergeMessage(reactionAdd);
+        expect(result).toMatchObject(err({ errCode: "bad_request.validation_failure" }));
+        expect(result._unsafeUnwrapErr().message).toMatch("invalid signer");
+      },
+      10 * 60 * 1000,
+    );
 
     test("with LinkAdd", async () => {
       setReferenceDateForTest(100000000000000000000000);

--- a/apps/hubble/src/storage/engine/index.test.ts
+++ b/apps/hubble/src/storage/engine/index.test.ts
@@ -449,18 +449,14 @@ describe("mergeMessage", () => {
   });
 
   describe("fails when signer is invalid", () => {
-    test(
-      "with ReactionAdd",
-      async () => {
-        await engine.mergeOnChainEvent(custodyEvent);
-        await engine.mergeOnChainEvent(Factories.SignerOnChainEvent.build({ fid }));
+    test("with ReactionAdd", async () => {
+      await engine.mergeOnChainEvent(custodyEvent);
+      await engine.mergeOnChainEvent(Factories.SignerOnChainEvent.build({ fid }));
 
-        const result = await engine.mergeMessage(reactionAdd);
-        expect(result).toMatchObject(err({ errCode: "bad_request.validation_failure" }));
-        expect(result._unsafeUnwrapErr().message).toMatch("invalid signer");
-      },
-      10 * 60 * 1000,
-    );
+      const result = await engine.mergeMessage(reactionAdd);
+      expect(result).toMatchObject(err({ errCode: "bad_request.validation_failure" }));
+      expect(result._unsafeUnwrapErr().message).toMatch("invalid signer");
+    });
 
     test("with LinkAdd", async () => {
       setReferenceDateForTest(100000000000000000000000);

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -206,6 +206,10 @@ class Engine extends TypedEmitter<EngineEvents> {
     return this._db;
   }
 
+  clearCache() {
+    this._onchainEventsStore.clearActiveSignerCache();
+  }
+
   async mergeMessages(messages: Message[]): Promise<Array<HubResult<number>>> {
     return Promise.all(messages.map((message) => this.mergeMessage(message)));
   }

--- a/apps/hubble/src/storage/stores/onChainEventStore.ts
+++ b/apps/hubble/src/storage/stores/onChainEventStore.ts
@@ -36,6 +36,13 @@ import { bytesCompare } from "@farcaster/core";
 
 const SUPPORTED_SIGNER_SCHEMES = [1];
 
+const LRU_CACHE_SIZE = 1000;
+
+type LRUCacheItem = {
+  _event: SignerOnChainEvent;
+  _lastUsed: number;
+};
+
 /**
  * OnChainStore persists On Chain Event messages in RocksDB using a grow only CRDT set
  * to guarantee eventual consistency.
@@ -46,6 +53,9 @@ const SUPPORTED_SIGNER_SCHEMES = [1];
 class OnChainEventStore {
   protected _db: RocksDB;
   protected _eventHandler: StoreEventHandler;
+
+  // Store the last 1000 active signers in memory to avoid hitting the database
+  protected _activeSignerCache = new Map<string, LRUCacheItem>();
 
   constructor(db: RocksDB, eventHandler: StoreEventHandler) {
     this._db = db;
@@ -70,13 +80,44 @@ class OnChainEventStore {
     return getManyOnChainEvents(this._db, keys);
   }
 
+  getActiveSignerCacheKey = (fid: number, signer: Uint8Array): string => {
+    return `${fid}:${Buffer.from(signer).toString("hex")}`;
+  };
+
+  clearActiveSignerCache() {
+    this._activeSignerCache.clear();
+  }
+
   async getActiveSigner(fid: number, signer: Uint8Array): Promise<SignerOnChainEvent> {
+    // See if we have this in the cache
+    const cacheKey = this.getActiveSignerCacheKey(fid, signer);
+    const cacheItem = this._activeSignerCache.get(cacheKey);
+    if (cacheItem) {
+      cacheItem._lastUsed = Date.now();
+      return cacheItem._event;
+    }
+
+    // Otherwise, look it up in the database
     const signerEventPrimaryKey = await this._db.get(makeSignerOnChainEventBySignerKey(fid, signer));
     const event = await getOnChainEventByKey<SignerOnChainEvent>(this._db, signerEventPrimaryKey);
     if (
       event.signerEventBody.eventType === SignerEventType.ADD &&
       SUPPORTED_SIGNER_SCHEMES.includes(event.signerEventBody.keyType)
     ) {
+      // Add to the cache
+      if (this._activeSignerCache.size >= LRU_CACHE_SIZE) {
+        // Evict the least 10% recently used
+        const sortedCache = [...this._activeSignerCache.entries()].sort((a, b) => a[1]._lastUsed - b[1]._lastUsed);
+        const evictCount = Math.ceil(LRU_CACHE_SIZE * 0.1);
+        for (let i = 0; i < evictCount; i++) {
+          const key = sortedCache[i]?.[0] || "";
+          this._activeSignerCache.delete(key);
+        }
+
+        logger.info(`Evicted ${evictCount} items from the active signer cache`);
+      }
+      this._activeSignerCache.set(cacheKey, { _event: event, _lastUsed: Date.now() });
+
       return event;
     } else {
       throw new HubError("not_found", "no such active signer");

--- a/apps/hubble/src/storage/stores/onChainEventStore.ts
+++ b/apps/hubble/src/storage/stores/onChainEventStore.ts
@@ -224,6 +224,11 @@ class OnChainEventStore {
       }
     }
 
+    if (event.signerEventBody.eventType === SignerEventType.REMOVE) {
+      // Remove the signer from the cache
+      this._activeSignerCache.delete(this.getActiveSignerCacheKey(event.fid, event.signerEventBody.key));
+    }
+
     if (event.signerEventBody.eventType === SignerEventType.ADMIN_RESET) {
       const signerEvents = await this.getOnChainEvents<SignerOnChainEvent>(
         OnChainEventType.EVENT_TYPE_SIGNER,

--- a/apps/hubble/src/storage/stores/onchainEventStore.test.ts
+++ b/apps/hubble/src/storage/stores/onchainEventStore.test.ts
@@ -210,9 +210,12 @@ describe("OnChainEventStore", () => {
         }),
       });
 
+      // Add the signer, make sure we can fetch it
       await set.mergeOnChainEvent(signer);
-      await set.mergeOnChainEvent(signerRemoved);
+      await expect(set.getActiveSigner(signer.fid, signer.signerEventBody.key)).resolves.toEqual(signer);
 
+      // Remove the signer, make sure we can't fetch it
+      await set.mergeOnChainEvent(signerRemoved);
       await expect(set.getActiveSigner(signer.fid, signer.signerEventBody.key)).rejects.toThrow("active signer");
     });
 


### PR DESCRIPTION
## Motivation
Add a LRU cache for active signers to avoid hitting the DB

## Change Summary

- LRU cache for Active signers

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a LRU cache to the active signers in the `OnChainEventStore` class.
- The cache stores the last 1000 active signers in memory to avoid hitting the database.
- When retrieving an active signer, it first checks the cache before looking it up in the database.
- If the active signer is not found in the cache, it is fetched from the database and added to the cache.
- If the cache is full, the least recently used items are evicted.
- The cache is cleared using the `clearCache()` method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->