### PR TITLE
fix: Filter existing messages during sync

### DIFF
--- a/.changeset/honest-experts-unite.md
+++ b/.changeset/honest-experts-unite.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Check sync trie before fetching messages


### PR DESCRIPTION
## Motivation

When doing a quicksync, don't attempt to repair the sync trie by re-fetching existing messages. This should reduce the "already exsists, duplicate" messages during quick sync.

## Change Summary

- During quick sync, check if a message exists in the sync trie before fetching it. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)
