### PR TITLE
fix: Change quicksync cutoff to 2 days

### DIFF
--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -72,7 +72,7 @@ const SYNC_INTERRUPT_TIMEOUT = 30 * 1000; // 30 seconds
 
 // A quick sync will only sync messages that are newer than 2 weeks.
 const QUICK_SYNC_PROBABILITY = 0.7; // 70% of the time, we'll do a quick sync
-export const QUICK_SYNC_TS_CUTOFF = 2 * 7 * 24 * 60 * 60; // 2 weeks, in seconds
+export const QUICK_SYNC_TS_CUTOFF = 2 * 24 * 60 * 60; // 2 days, in seconds
 
 const COMPACTION_THRESHOLD = 100_000; // Sync
 const BAD_PEER_BLOCK_TIMEOUT = 5 * 60 * 60 * 1000; // 5 hours, arbitrary, may need to be adjusted as network grows


### PR DESCRIPTION


## Change Summary

- Change quicksync cutoff to 2 days (instead of 2 weeks)

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- The `QUICK_SYNC_TS_CUTOFF` constant has been changed from 2 weeks to 2 days.
- The `BAD_PEER_BLOCK_TIMEOUT` constant has been changed from 5 hours to an arbitrary value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->