### PR TITLE
fix: Gossip seen TTL to 10 mins

### DIFF
--- a/.changeset/yellow-wombats-confess.md
+++ b/.changeset/yellow-wombats-confess.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Bump gossip TTL to 10 mins

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -30,7 +30,7 @@ import { PeerScore } from "network/sync/peerScore.js";
 /** The maximum number of pending merge messages before we drop new incoming gossip or sync messages. */
 export const MAX_MESSAGE_QUEUE_SIZE = 100_000;
 /** The TTL for messages in the seen cache */
-export const GOSSIP_SEEN_TTL = 1000 * 60 * 5;
+export const GOSSIP_SEEN_TTL = 1000 * 60 * 10;
 
 const log = logger.child({ component: "GossipNode" });
 const workerLog = logger.child({ component: "GossipNodeWorker" });


### PR DESCRIPTION
## Change Summary

Bump Gossip TTL to 10 mins to reduce dups

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an issue related to the gossip TTL in the `GossipNode` module. The notable change is bumping the gossip TTL to 10 minutes.

### Detailed summary
- Bumped the gossip TTL to 10 minutes in the `GossipNode` module.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->