### PR TITLE
perf: Use execution timeout so we don't drop all messages in the lock queue

### DIFF
--- a/.changeset/proud-carrots-watch.md
+++ b/.changeset/proud-carrots-watch.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+perf: Use execution timeout so we don't drop all messages in the lock queue

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -379,7 +379,7 @@ export class Hub implements HubInterface {
 
     const eventHandler = new StoreEventHandler(this.rocksDB, {
       lockMaxPending: options.commitLockMaxPending,
-      lockTimeout: options.commitLockTimeout,
+      lockExecutionTimeout: options.commitLockTimeout,
     });
 
     const opMainnetRpcUrls = options.l2RpcUrl.split(",");

--- a/apps/hubble/src/storage/stores/storeEventHandler.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.ts
@@ -42,8 +42,8 @@ import {
 import { logger } from "../../utils/logger.js";
 
 const PRUNE_TIME_LIMIT_DEFAULT = 60 * 60 * 24 * 3 * 1000; // 3 days in ms
-const DEFAULT_LOCK_MAX_PENDING = 2_500;
-const DEFAULT_LOCK_TIMEOUT = 500; // in ms
+const DEFAULT_LOCK_MAX_PENDING = 5_000;
+const DEFAULT_EXECUTION_TIMEOUT = 1000; // in ms
 
 // @ts-ignore
 const STORE_TO_SET: Record<StoreType, UserMessagePostfix> = {
@@ -174,7 +174,7 @@ const putEventTransaction = (txn: Transaction, event: HubEvent): Transaction => 
 
 export type StoreEventHandlerOptions = {
   lockMaxPending?: number | undefined;
-  lockTimeout?: number | undefined;
+  lockExecutionTimeout?: number | undefined;
 };
 
 class StoreEventHandler extends TypedEmitter<StoreEvents> {
@@ -190,7 +190,7 @@ class StoreEventHandler extends TypedEmitter<StoreEvents> {
     this._generator = new HubEventIdGenerator({ epoch: FARCASTER_EPOCH });
     this._lock = new AsyncLock({
       maxPending: options.lockMaxPending ?? DEFAULT_LOCK_MAX_PENDING,
-      timeout: options.lockTimeout ?? DEFAULT_LOCK_TIMEOUT,
+      maxExecutionTime: options.lockExecutionTimeout ?? DEFAULT_EXECUTION_TIMEOUT,
     });
 
     this._storageCache = new StorageCache(this._db);


### PR DESCRIPTION
## Motivation

When lock timeout is set, we drop any message is the lock queue older than 500ms. Sometimes GC takes more than 500ms within the lock, which leads to a lot of messages being dropped in one go. Switch to using executionTimeout so we only drop the faulty message. 

Almost all messages merge within constant time, variability is likely due to GC, or populating the storage cache (within first few minutes of startup). This let's use "burst" upto 5K msgs/sec before dropping the 1 message that's causing problems. Previously, we'd if queue had 1K messages, we'd drop all of them if 1 message took 600ms instead of 500ms.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the performance of the `hubble` application by using an execution timeout for lock queues. 

### Detailed summary
- Updated the `lockTimeout` option to `lockExecutionTimeout` in the `hubble.ts` file.
- Increased the `DEFAULT_LOCK_MAX_PENDING` value from 2,500 to 5,000 in the `storeEventHandler.ts` file.
- Added a new `DEFAULT_EXECUTION_TIMEOUT` value of 1,000ms in the `storeEventHandler.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->