### PR TITLE
feat: Add a new DB for Merkle Trie data

### DIFF
--- a/.changeset/swift-goats-lie.md
+++ b/.changeset/swift-goats-lie.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: Add a new DB for trie data

--- a/apps/hubble/src/network/sync/merkleTrie.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.ts
@@ -53,6 +53,7 @@ export interface MerkleTrieInterface {
   rootHash(): Promise<string>;
   commitToDb(): Promise<void>;
   unloadChildrenAtPrefix(prefix: Uint8Array): Promise<void>;
+  stop(): Promise<void>;
 }
 
 // Typescript types to make sending messages to the worker thread type-safe
@@ -112,7 +113,7 @@ class MerkleTrie {
     } else {
       const workerPath = new URL("../../../build/network/sync/merkleTrieWorker.js", import.meta.url);
       this._worker = new Worker(workerPath, {
-        workerData: { statsdInitialization: getStatusdInitialization() },
+        workerData: { statsdInitialization: getStatusdInitialization(), dbPath: this._db.location },
       });
     }
 
@@ -196,6 +197,7 @@ class MerkleTrie {
   }
 
   public async stop(): Promise<void> {
+    await this.callMethod("stop");
     this._worker.removeAllListeners("message");
 
     if (this._terminateWorkerOnStop) {
@@ -210,6 +212,10 @@ class MerkleTrie {
 
   public async initialize(): Promise<void> {
     return this.callMethod("initialize");
+  }
+
+  public async clear(): Promise<void> {
+    return this.callMethod("clear");
   }
 
   public async rebuild(): Promise<void> {

--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -65,12 +65,15 @@ describe("SyncEngine", () => {
 
   beforeEach(async () => {
     engine = new Engine(testDb, FarcasterNetwork.TESTNET, undefined, publicClient);
+    await engine.start();
     hub = new MockHub(testDb, engine);
     syncEngine = new SyncEngine(hub, testDb);
+    await syncEngine.start();
   }, TEST_TIMEOUT_SHORT);
 
   afterEach(async () => {
     await syncEngine.stop();
+
     await engine.stop();
   }, TEST_TIMEOUT_SHORT);
 

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -357,6 +357,10 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     log.info({ rootHash }, "Sync engine initialized");
   }
 
+  public async clear() {
+    await this._trie.clear();
+  }
+
   /** Rebuild the entire Sync Trie */
   public async rebuildSyncTrie() {
     log.info("Rebuilding sync trie...");


### PR DESCRIPTION
## Motivation
Separate out all the Merkle Trie data into its own DB to reduce DB contention on the main DB

## Change Summary

- New trie DB created in a subfolder
- Read from new DB first, if miss, read old DB. Write only to new DB

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new DB for trie data in the `hubble` app. 

### Detailed summary
- Added a new DB for trie data in the `syncEngine.ts` file
- Added a `clear` method in the `syncEngine.ts` file
- Added a `start` method in the `syncEngine.test.ts` file
- Added a `stop` method in the `merkleTrie.ts` file
- Modified the `initialize` method in the `merkleTrie.ts` file
- Added a `stop` method in the `merkleTrieWorker.ts` file
- Modified the `_dbGet` method in the `merkleTrieWorker.ts` file
- Modified the `_dbPut` method in the `merkleTrieWorker.ts` file

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->