### PR TITLE
fix: Set heap size to 8GB during dev/running from code

### DIFF
--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -26,7 +26,7 @@
     "lint": "yarn lint:customjs && biome format src/ --write && biome check src/ --apply",
     "lint:ci": "yarn lint:customjs && biome ci src/",
     "lint:customjs": "node scripts/linter.cjs",
-    "start": "node --no-warnings build/cli.js start",
+    "start": "node --max-old-space-size=8192 --no-warnings build/cli.js start",
     "identity": "node --no-warnings build/cli.js identity",
     "dbreset": "node build/cli.js dbreset",
     "events-reset": "node build/cli.js events-reset",


### PR DESCRIPTION
## Motivation

Set max heap to 8GB when running frmo code.


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `--max-old-space-size=8192` flag to the `start` script in `package.json` to increase the maximum heap size for Node.js

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->