### PR TITLE
feat: Save connected peers in DB

### DIFF
--- a/.changeset/tame-pillows-marry.md
+++ b/.changeset/tame-pillows-marry.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: Save connected peers in DB

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -521,6 +521,7 @@ app
       enableSnapshotToS3,
       s3SnapshotBucket: cliOptions.s3SnapshotBucket ?? hubConfig.s3SnapshotBucket,
       hubOperatorFid: parseInt(cliOptions.hubOperatorFid ?? hubConfig.hubOperatorFid),
+      connectToDbPeers: hubConfig.connectToDbPeers ?? true,
     };
 
     // Startup check for Hub Operator FID

--- a/apps/hubble/src/defaultConfig.ts
+++ b/apps/hubble/src/defaultConfig.ts
@@ -68,4 +68,5 @@ export const Config = {
   // enableSnapshotToS3: false,
   /** S3 bucket name */
   // s3BucketName: '',
+  connectToDbPeers: true,
 };

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -284,6 +284,9 @@ export interface HubOptions {
 
   /** If set, requires gossip messages to utilize StrictNoSign */
   strictNoSign?: boolean;
+
+  /** Should we connect to DB peers on startup */
+  connectToDbPeers?: boolean;
 }
 
 /** @returns A randomized string of the format `rocksdb.tmp.*` used for the DB Name */
@@ -373,7 +376,7 @@ export class Hub implements HubInterface {
     }
 
     this.rocksDB = new RocksDB(options.rocksDBName ? options.rocksDBName : randomDbName());
-    this.gossipNode = new GossipNode(this.options.network);
+    this.gossipNode = new GossipNode(this.rocksDB, this.options.network);
 
     this.s3_snapshot_bucket = options.s3SnapshotBucket ?? SNAPSHOT_S3_DEFAULT_BUCKET;
 
@@ -685,6 +688,7 @@ export class Hub implements HubInterface {
       allowlistedImmunePeers: this.options.allowlistedImmunePeers,
       applicationScoreCap: this.options.applicationScoreCap,
       strictNoSign: this.strictNoSign,
+      connectToDbPeers: this.options.connectToDbPeers,
     });
 
     await this.registerEventHandlers();

--- a/apps/hubble/src/network/p2p/gossipNode.test.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.test.ts
@@ -137,31 +137,6 @@ describe("GossipNode", () => {
     TEST_TIMEOUT_SHORT,
   );
 
-  test(
-    "adding peers adds to the DB",
-    async () => {
-      const node1 = new GossipNode(db);
-      await node1.start([]);
-
-      const node2 = new GossipNode();
-      await node2.start([]);
-
-      try {
-        const dialResult = await node1.connect(node2);
-        expect(dialResult.isOk()).toBeTruthy();
-
-        // Make sure that node1 has node2 in it's DB too
-        const dbKey = node1.makePeerKey(node2.peerId()?.toString() || "");
-        await sleepWhile(async () => (await ResultAsync.fromPromise(db.get(dbKey), (e) => e)).isErr(), 5 * 1000);
-        expect((await db.get(dbKey)).toString("ascii")).toBe(node2.multiaddrs()[0]?.toString());
-      } finally {
-        await node1.stop();
-        await node2.stop();
-      }
-    },
-    TEST_TIMEOUT_SHORT,
-  );
-
   describe("gossip messages", () => {
     const network = FarcasterNetwork.TESTNET;
     const fid = Factories.Fid.build();

--- a/apps/hubble/src/network/p2p/gossipNodeDb.test.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeDb.test.ts
@@ -1,0 +1,57 @@
+import { GossipNode } from "./gossipNode.js";
+import { jestRocksDB } from "../../storage/db/jestUtils.js";
+import { PeerId } from "@libp2p/interface-peer-id";
+import { sleepWhile } from "../../utils/crypto.js";
+import { ResultAsync } from "neverthrow";
+
+const TEST_TIMEOUT_SHORT = 10 * 1000;
+const db = jestRocksDB("network.p2p.gossipNodeDb.test");
+
+describe("GossipNode", () => {
+  test(
+    "adding peers adds to the DB",
+    async () => {
+      const node1 = new GossipNode(db);
+      await node1.start([]);
+
+      const node2 = new GossipNode();
+      await node2.start([]);
+
+      try {
+        const dialResult = await node1.connect(node2);
+        expect(dialResult.isOk()).toBeTruthy();
+
+        // Make sure that node1 has node2 in it's DB too
+        const dbKey = node1.makePeerKey(node2.peerId()?.toString() || "");
+        await sleepWhile(async () => (await ResultAsync.fromPromise(db.get(dbKey), (e) => e)).isErr(), 5 * 1000);
+        expect((await db.get(dbKey)).toString("ascii")).toBe(node2.multiaddrs()[0]?.toString());
+
+        // Disconnect
+        await node1.removePeerFromAddressBook(node2.peerId() as PeerId);
+
+        // Sleep to allow the connection to be closed
+        await sleepWhile(async () => (await node1.getPeerAddresses(node2.peerId() as PeerId)).length > 0, 10 * 1000);
+
+        // Make sure the connection is closed
+        const other = await node1.getPeerAddresses(node2.peerId() as PeerId);
+        expect(other).toEqual([]);
+        expect(await node2.allPeerIds()).toEqual([]);
+
+        // Now connect again using the DB
+        await node1.connectToDbPeers();
+
+        const other2 = await node1.getPeerAddresses(node2.peerId() as PeerId);
+        const na = node2.multiaddrs()[0]?.nodeAddress();
+
+        other2.map((a) => {
+          expect(a.nodeAddress().address).toEqual(na?.address);
+          expect(a.nodeAddress().port).toEqual(na?.port);
+        });
+      } finally {
+        await node1.stop();
+        await node2.stop();
+      }
+    },
+    TEST_TIMEOUT_SHORT,
+  );
+});

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -267,7 +267,7 @@ export class LibP2PNode {
       const conn = await this._node?.dial(address);
 
       if (conn) {
-        log.info({ identity: this.identity, address }, `Connected to peer at address: ${address}`);
+        log.info({ identity: this.identity, address: address.toString() }, `Connected to peer at address: ${address}`);
         return ok(undefined);
       }
       // biome-ignore lint/suspicious/noExplicitAny: error catching

--- a/apps/hubble/src/profile/gossipProfileWorker.js
+++ b/apps/hubble/src/profile/gossipProfileWorker.js
@@ -111,7 +111,7 @@ class GossipTestNode {
   sentMessages = 0;
   recievedMessages = new Map(); // Id -> timestamp
   constructor() {
-    this.gossipNode = new GossipNode({});
+    this.gossipNode = new GossipNode();
   }
   async start() {
     await this.gossipNode.start([]);

--- a/apps/hubble/src/storage/db/rocksdb.ts
+++ b/apps/hubble/src/storage/db/rocksdb.ts
@@ -296,7 +296,7 @@ class RocksDB {
   }
 
   /**
-   * forEach iterator, but with a prefix. See @forEachITerator for more details
+   * forEach iterator, but with a prefix. See @forEachIterator for more details
    */
   async forEachIteratorByPrefix<T>(
     prefix: Buffer,

--- a/apps/hubble/src/storage/db/types.ts
+++ b/apps/hubble/src/storage/db/types.ts
@@ -75,6 +75,9 @@ export enum RootPrefix {
 
   /* Used to index verifications by address */
   VerificationByAddress = 25,
+
+  /* Store the connected peers */
+  ConnectedPeers = 26,
 }
 
 /**

--- a/apps/hubble/src/storage/jobs/gossipContactInfoJob.ts
+++ b/apps/hubble/src/storage/jobs/gossipContactInfoJob.ts
@@ -19,7 +19,8 @@ export class GossipContactInfoJobScheduler {
   }
 
   start(cronSchedule?: string) {
-    const defaultSchedule = "10 */4 * * *"; // Every 4 hours at :10
+    const randomMinute = Math.floor(Math.random() * 60);
+    const defaultSchedule = `${randomMinute} */4 * * *`; // Every 4 hours at a random minute
     this._cronTask = cron.schedule(cronSchedule ?? defaultSchedule, () => this.doJobs());
   }
 

--- a/apps/hubble/src/test/e2e/hubbleStartup.test.ts
+++ b/apps/hubble/src/test/e2e/hubbleStartup.test.ts
@@ -45,6 +45,7 @@ describe("hubble startup tests", () => {
       rocksDBName,
       announceIp: "127.0.0.1",
       disableSnapshotSync: true,
+      connectToDbPeers: false,
     };
   });
 


### PR DESCRIPTION
## Motivation

When a node restarts, it connects to the bootstrap hubs and has to rediscover all the nodes again. Now, we'll save all peers we successfully connected to in the DB, so we can attempt to reconnect to them on restart

## Change Summary

- Save connected peers to DB
- At startup, after bootstrap peers, try previously connected peers. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on saving connected peers in the database. 

### Detailed summary
- Added `connectToDbPeers` option in `defaultConfig.ts` and `cli.ts`.
- Modified `gossipProfileWorker.js` to store connected peers.
- Updated `gossipNodeWorker.ts` to log connected peer address.
- Modified `gossipNode.ts` to connect to peers stored in the DB.
- Added tests in `hubbleStartup.test.ts`, `gossipNode.test.ts`, `gossipNodeDb.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->