### PR TITLE
fix: Use pendingUpdates size to flush updates

### DIFF
--- a/.changeset/twelve-guests-type.md
+++ b/.changeset/twelve-guests-type.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Use the pendingDbUpdates to decide when to write updates to merkle trie


### PR DESCRIPTION
## Motivation

Use pendingUpdates size to decide when to flush merkle trie cache.

## Change Summary

- Use the size of the pendingUpdates directly to decide when to flush the cache for the merkle trie. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the performance of the MerkleTrieImpl class by optimizing the unloading process. 

### Detailed summary
- Removed the `_callsSinceLastUnload` variable and related logic
- Instead, now use the size of `_pendingDbUpdates` to determine when to unload the trie
- Improved logging messages for trie commits

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->