### PR TITLE
feat: Add a new DB for Merkle Trie data (#1664)

### DIFF
--- a/.changeset/swift-goats-lie.md
+++ b/.changeset/swift-goats-lie.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: Add a new DB for trie data

--- a/apps/hubble/src/network/sync/merkleTrie.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.ts
@@ -53,6 +53,7 @@ export interface MerkleTrieInterface {
   rootHash(): Promise<string>;
   commitToDb(): Promise<void>;
   unloadChildrenAtPrefix(prefix: Uint8Array): Promise<void>;
+  stop(): Promise<void>;
 }
 
 // Typescript types to make sending messages to the worker thread type-safe
@@ -112,7 +113,7 @@ class MerkleTrie {
     } else {
       const workerPath = new URL("../../../build/network/sync/merkleTrieWorker.js", import.meta.url);
       this._worker = new Worker(workerPath, {
-        workerData: { statsdInitialization: getStatusdInitialization() },
+        workerData: { statsdInitialization: getStatusdInitialization(), dbPath: this._db.location },
       });
     }
 
@@ -196,6 +197,7 @@ class MerkleTrie {
   }
 
   public async stop(): Promise<void> {
+    await this.callMethod("stop");
     this._worker.removeAllListeners("message");
 
     if (this._terminateWorkerOnStop) {
@@ -210,6 +212,10 @@ class MerkleTrie {
 
   public async initialize(): Promise<void> {
     return this.callMethod("initialize");
+  }
+
+  public async clear(): Promise<void> {
+    return this.callMethod("clear");
   }
 
   public async rebuild(): Promise<void> {

--- a/apps/hubble/src/network/sync/merkleTrieWorker.ts
+++ b/apps/hubble/src/network/sync/merkleTrieWorker.ts
@@ -11,6 +11,9 @@ import { Logger } from "../../utils/logger.js";
 import ReadWriteLock from "rwlock";
 import { TrieNode, TrieSnapshot } from "./trieNode.js";
 import { StatsDInitParams, initializeStatsd, statsd } from "../../utils/statsd.js";
+import RocksDB from "../../storage/db/rocksdb.js";
+import path from "path";
+import { ResultAsync } from "neverthrow";
 
 // The number of messages to process before unloading the trie from memory
 // Approx 100k * 10 nodes * 65 bytes per node = approx 64MB of cached data
@@ -43,37 +46,75 @@ class MerkleTrieImpl {
   private _lock: ReadWriteLock;
   private _pendingDbUpdates = new Map<Buffer, Buffer>();
 
+  _trieDb: RocksDB | undefined;
+
   private _dbCallId = 0;
-  _dbGetCallMap = new Map<number, { resolve: (value: Buffer | undefined) => void }>();
+  _dbGetCallMap = new Map<number, { resolve: (value: Buffer | undefined) => void; key: Buffer }>();
   _dbPutMap = new Map<number, { resolve: () => void }>();
 
-  constructor(statsdInitialization?: StatsDInitParams) {
+  constructor(statsdInitialization?: StatsDInitParams, dbPath?: string) {
     this._lock = new ReadWriteLock();
     this._root = new TrieNode();
 
     if (statsdInitialization) {
       initializeStatsd(statsdInitialization.host, statsdInitialization.port);
     }
+
+    // Don't open a separate DB for the trie during tests
+    if (dbPath && process.env["NODE_ENV"] !== "test") {
+      log.info({ dbPath }, "MerkleTrieImpl: initializing");
+      this._trieDb = new RocksDB(`${path.basename(dbPath)}/trieDb`);
+      log.info({ triePath: this._trieDb.location }, "MerkleTrieImpl: created DB");
+    } else {
+      log.debug("MerkleTrieImpl: using main in-memory DB for tests");
+      this._trieDb = undefined;
+    }
   }
 
   // Get a DB value from the main thread
-  private async _dbGet(key: Buffer): Promise<Buffer | undefined> {
-    return new Promise((resolve) => {
-      this._dbCallId++;
-      this._dbGetCallMap.set(this._dbCallId, { resolve });
+  async _dbGet(key: Buffer): Promise<Buffer | undefined> {
+    // We'll attempt to get it from the trieDb first
+    const value = this._trieDb
+      ? await ResultAsync.fromPromise(this._trieDb.get(Buffer.from(key)), (e) => e as Error)
+      : undefined;
 
-      parentPort?.postMessage({ dbGetCallId: this._dbCallId, key: Uint8Array.from(key) });
-    });
+    if (value?.isOk()) {
+      statsd().increment("rocksdb.trie.get.hit");
+      return value.value;
+    } else {
+      // Else, we'll get it from the main thread
+      statsd().increment("rocksdb.trie.get.miss");
+      return new Promise((resolve) => {
+        this._dbCallId++;
+        this._dbGetCallMap.set(this._dbCallId, { resolve, key });
+
+        parentPort?.postMessage({ dbGetCallId: this._dbCallId, key });
+      });
+    }
   }
 
   // Write DB values to the DB via the main thread
-  private async _dbPut(dbKeyValues: MerkleTrieKV[]): Promise<void> {
-    return new Promise((resolve) => {
-      this._dbCallId++;
-      this._dbPutMap.set(this._dbCallId, { resolve });
+  async _dbPut(dbKeyValues: MerkleTrieKV[]): Promise<void> {
+    if (this._trieDb) {
+      // We'll only write to the trieDb.
+      const txn = this._trieDb.transaction();
+      for (const { key, value } of dbKeyValues) {
+        if (value && value.length > 0) {
+          txn.put(Buffer.from(key), Buffer.from(value));
+        } else {
+          txn.del(Buffer.from(key));
+        }
+      }
 
-      parentPort?.postMessage({ dbKeyValuesCallId: this._dbCallId, dbKeyValues });
-    });
+      await this._trieDb.commit(txn);
+    } else {
+      return new Promise((resolve) => {
+        this._dbCallId++;
+        this._dbPutMap.set(this._dbCallId, { resolve });
+
+        parentPort?.postMessage({ dbKeyValuesCallId: this._dbCallId, dbKeyValues });
+      });
+    }
   }
 
   private _dbGetter(): DBGetter {
@@ -96,6 +137,8 @@ class MerkleTrieImpl {
         this._root = new TrieNode();
         this._pendingDbUpdates.clear();
 
+        await this._trieDb?.clear();
+
         resolve();
         release();
       });
@@ -105,6 +148,17 @@ class MerkleTrieImpl {
   async initialize(): Promise<void> {
     return new Promise((resolve) => {
       this._lock.writeLock(async (release) => {
+        // Initialize the trie DB first
+        if (this._trieDb) {
+          const dbResult = await ResultAsync.fromPromise(this._trieDb.open(), (e) => e as Error);
+          if (dbResult.isErr()) {
+            log.error({ err: dbResult.error }, "Error opening trie DB");
+            throw dbResult.error;
+          }
+
+          log.info({ triePath: this._trieDb.location }, "MerkleTrieImpl: opened DB");
+        }
+
         const rootBytes = await this._dbGet(TrieNode.makePrimaryKey(new Uint8Array()));
         if (rootBytes && rootBytes.length > 0) {
           this._root = TrieNode.deserialize(rootBytes);
@@ -122,6 +176,19 @@ class MerkleTrieImpl {
       });
     });
   }
+
+  async stop(): Promise<void> {
+    return new Promise((resolve) => {
+      this._lock.writeLock(async (release) => {
+        await this._unloadFromMemory(true, true);
+        await this._trieDb?.close();
+
+        resolve();
+        release();
+      });
+    });
+  }
+
   /**
    * Check if we need to unload the trie from memory. This is not protected by a lock, since it is only called
    * from within a lock.
@@ -156,6 +223,9 @@ class MerkleTrieImpl {
 
       this._pendingDbUpdates.clear();
       this._root.unloadChildren();
+
+      statsd().gauge("merkle_trie.num_messages", this._root.items);
+      statsd().gauge("rocksdb.trie.approximate_size", (await this._trieDb?.approximateSize()) || 0);
     };
 
     if (force || this._pendingDbUpdates.size >= TRIE_UNLOAD_THRESHOLD) {
@@ -180,7 +250,6 @@ class MerkleTrieImpl {
       this._lock.writeLock(async (release) => {
         try {
           const { status, dbUpdatesMap } = await this._root.insert(id, this._dbGetter(), new Map());
-          statsd().gauge("merkle_trie.num_messages", this._root.items);
 
           this._updatePendingDbUpdates(dbUpdatesMap);
 
@@ -347,7 +416,10 @@ class MerkleTrieImpl {
   }
 }
 
-const merkleTrie = new MerkleTrieImpl(workerData.statsdInitialization as StatsDInitParams | undefined);
+const merkleTrie = new MerkleTrieImpl(
+  workerData.statsdInitialization as StatsDInitParams | undefined,
+  workerData.dbPath as string,
+);
 
 // This function is a no-op at runtime, but exists to typecheck the return values
 // the worker thread sends back to the main thread. Getting this wrong will cause
@@ -379,9 +451,17 @@ parentPort?.on(
       const dbGetCall = merkleTrie._dbGetCallMap.get(dbGetCallId);
       if (!dbGetCall) {
         log.error({ value }, `Received response for unknown DB get call ID ${dbGetCallId}`);
+        return;
       }
       merkleTrie._dbGetCallMap.delete(dbGetCallId);
-      dbGetCall?.resolve(value ? Buffer.from(value) : undefined);
+      dbGetCall.resolve(value ? Buffer.from(value) : undefined);
+
+      // Also save the value to the trie DB
+      if (value && merkleTrie._trieDb) {
+        const key = Uint8Array.from(dbGetCall.key);
+        const dbKeyValues = [{ key, value }];
+        merkleTrie._dbPut(dbKeyValues);
+      }
 
       return;
     }
@@ -478,6 +558,12 @@ parentPort?.on(
         const node = await merkleTrie.getNode(prefix);
         node?.unloadChildren();
         parentPort?.postMessage({ methodCallId, result: makeResult<"unloadChildrenAtPrefix">(undefined) });
+        break;
+      }
+      case "stop": {
+        log.info("MerkleTrieImpl: stopping");
+        await merkleTrie.stop();
+        parentPort?.postMessage({ methodCallId, result: makeResult<"stop">(undefined) });
         break;
       }
     }

--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -65,12 +65,15 @@ describe("SyncEngine", () => {
 
   beforeEach(async () => {
     engine = new Engine(testDb, FarcasterNetwork.TESTNET, undefined, publicClient);
+    await engine.start();
     hub = new MockHub(testDb, engine);
     syncEngine = new SyncEngine(hub, testDb);
+    await syncEngine.start();
   }, TEST_TIMEOUT_SHORT);
 
   afterEach(async () => {
     await syncEngine.stop();
+
     await engine.stop();
   }, TEST_TIMEOUT_SHORT);
 

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -357,6 +357,10 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     log.info({ rootHash }, "Sync engine initialized");
   }
 
+  public async clear() {
+    await this._trie.clear();
+  }
+
   /** Rebuild the entire Sync Trie */
   public async rebuildSyncTrie() {
     log.info("Rebuilding sync trie...");


### PR DESCRIPTION
* feat: Add a new DB for Merkle Trie data

* cleanup

* move keys from main -> trie DB

Add the new Rocks DB for merkle trie code back again

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding a new DB for trie data in the Hubble app.

### Detailed summary:
- Added a new DB for trie data in the Hubble app.
- Added a `clear` method to clear the trie data.
- Added a `rebuildSyncTrie` method to rebuild the entire Sync Trie.
- Added a `start` method to start the sync engine.
- Added a `stop` method to stop the sync engine.
- Updated the MerkleTrie class to use the new trie DB.
- Updated the MerkleTrieWorker class to handle DB operations.
- Updated the MerkleTrieImpl class to initialize and stop the trie DB.
- Updated the MerkleTrieImpl class to save DB values to the trie DB.
- Updated the MerkleTrieImpl class to unload the trie from memory when necessary.
- Updated the MerkleTrieImpl class to handle trie DB operations in the worker thread.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->