### PR TITLE
fix: write out cached blocks while processing L2 events

### DIFF
--- a/.changeset/itchy-flowers-cough.md
+++ b/.changeset/itchy-flowers-cough.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Process L2 blocks in batches

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -221,7 +221,10 @@ app
 
         const readProcessNum = parseInt(data.trim());
         if (!isNaN(readProcessNum) && readProcessNum !== processNum) {
-          logger.error(`Another hub process is running with processNum ${readProcessNum}, exiting`);
+          logger.error(
+            { readProcessNum, processNum },
+            `Another hub process started up with processNum ${readProcessNum}, exiting with SIGTERM`,
+          );
           handleShutdownSignal("SIGTERM");
         }
       });

--- a/apps/hubble/src/eth/l2EventsProvider.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.ts
@@ -703,7 +703,7 @@ export class L2EventsProvider {
 
       // If there are more batches, write out all the cached blocks first
       if (i < numOfRuns - 1) {
-        this.writeCachedBlocks(nextToBlock);
+        await this.writeCachedBlocks(nextToBlock);
       }
     }
 

--- a/apps/hubble/src/eth/l2EventsProvider.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.ts
@@ -798,7 +798,7 @@ export class L2EventsProvider {
     log.info({ blockNumber }, `new block: ${blockNumber}`);
     statsd().increment("l2events.blocks");
 
-    this.writeCachedBlocks(blockNumber);
+    await this.writeCachedBlocks(blockNumber);
 
     // Update the last synced block if all the historical events have been synced
     if (this._isHistoricalSyncDone) {


### PR DESCRIPTION
## Motivation

Write out batches of L2 blocks as they are processed instead of waiting for the end. 

## Change Summary

- Write out blocks in batches as they are processed instead of caching everything for the end, which might result in millions of events in RAM. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the process of handling L2 blocks in batches. 

### Detailed summary
- Fixed a bug where the process would exit if another hub process with a different process number was running.
- Changed the order of starting contract watchers and syncing historical events.
- Modified the `connectAndSyncHistoricalEvents` method to return the highest block that was synced.
- Added a new method `writeCachedBlocks` to write out all the cached blocks.
- Updated the `handleNewBlock` method to call `writeCachedBlocks` and handle new blocks.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->