### PR TITLE
fix: Keep the old message type name for backwards compatibility

### DIFF
--- a/apps/hubble/src/storage/db/message.ts
+++ b/apps/hubble/src/storage/db/message.ts
@@ -100,7 +100,7 @@ export const typeToSetPostfix = (type: MessageType): UserMessagePostfix => {
     return UserPostfix.ReactionMessage;
   }
 
-  if (type === MessageType.VERIFICATION_ADD_ADDRESS || type === MessageType.VERIFICATION_REMOVE) {
+  if (type === MessageType.VERIFICATION_ADD_ETH_ADDRESS || type === MessageType.VERIFICATION_REMOVE) {
     return UserPostfix.VerificationMessage;
   }
 

--- a/apps/hubble/src/storage/jobs/pruneMessagesJob.test.ts
+++ b/apps/hubble/src/storage/jobs/pruneMessagesJob.test.ts
@@ -138,7 +138,7 @@ describe("doJobs", () => {
       }
 
       expect(prunedMessages.length).toEqual(2); // 1 verification for each of the 2 fids
-      expect(prunedMessages.filter((m) => m.data?.type !== MessageType.VERIFICATION_ADD_ADDRESS)).toEqual([]);
+      expect(prunedMessages.filter((m) => m.data?.type !== MessageType.VERIFICATION_ADD_ETH_ADDRESS)).toEqual([]);
     },
     15 * 1000,
   );

--- a/apps/hubble/src/storage/stores/verificationStore.ts
+++ b/apps/hubble/src/storage/stores/verificationStore.ts
@@ -112,7 +112,7 @@ class VerificationStore extends Store<VerificationAddAddressMessage, Verificatio
 
   override _isAddType = isVerificationAddAddressMessage;
   override _isRemoveType = isVerificationRemoveMessage;
-  override _addMessageType = MessageType.VERIFICATION_ADD_ADDRESS;
+  override _addMessageType = MessageType.VERIFICATION_ADD_ETH_ADDRESS;
   override _removeMessageType = MessageType.VERIFICATION_REMOVE;
 
   protected override get PRUNE_SIZE_LIMIT_DEFAULT() {

--- a/apps/replicator/src/processors/index.ts
+++ b/apps/replicator/src/processors/index.ts
@@ -155,7 +155,7 @@ export async function processMessage(
         log.debug(`Processing LinkRemoveMessage ${hash} (fid ${fid})`, { fid, hash });
         await processLinkRemove(message, operation, trx);
         break;
-      case MessageType.VERIFICATION_ADD_ADDRESS:
+      case MessageType.VERIFICATION_ADD_ETH_ADDRESS:
         if (!isVerificationAddAddressMessage(message))
           throw new AssertionError(`Invalid VerificationAddEthAddressMessage: ${message}`);
         log.debug(`Processing VerificationAddEthAddressMessage ${hash} (fid ${fid})`, { fid, hash });

--- a/apps/replicator/src/processors/verification.ts
+++ b/apps/replicator/src/processors/verification.ts
@@ -10,11 +10,11 @@ const { processAdd: processAddEthereum, processRemove } = buildAddRemoveMessageP
   Selectable<VerificationRow>
 >({
   conflictRule: "last-write-wins",
-  addMessageType: MessageType.VERIFICATION_ADD_ADDRESS,
+  addMessageType: MessageType.VERIFICATION_ADD_ETH_ADDRESS,
   removeMessageType: MessageType.VERIFICATION_REMOVE,
   withConflictId(message) {
     const ethAddress =
-      message.data.type === MessageType.VERIFICATION_ADD_ADDRESS
+      message.data.type === MessageType.VERIFICATION_ADD_ETH_ADDRESS
         ? message.data.verificationAddAddressBody.address
         : message.data.verificationRemoveBody.address;
 
@@ -24,7 +24,7 @@ const { processAdd: processAddEthereum, processRemove } = buildAddRemoveMessageP
   },
   async getDerivedRow(message, trx) {
     const ethAddress =
-      message.data.type === MessageType.VERIFICATION_ADD_ADDRESS
+      message.data.type === MessageType.VERIFICATION_ADD_ETH_ADDRESS
         ? message.data.verificationAddAddressBody.address
         : message.data.verificationRemoveBody.address;
 

--- a/apps/replicator/src/util.ts
+++ b/apps/replicator/src/util.ts
@@ -189,7 +189,7 @@ export function convertProtobufMessageBodyToJson(message: Message): MessageBodyJ
       }
       return body;
     }
-    case MessageType.VERIFICATION_ADD_ADDRESS: {
+    case MessageType.VERIFICATION_ADD_ETH_ADDRESS: {
       if (!message.data.verificationAddAddressBody) {
         throw new Error("Missing verificationAddEthAddressBody");
       }

--- a/packages/core/src/builders.ts
+++ b/packages/core/src/builders.ts
@@ -262,7 +262,7 @@ export const makeVerificationAddEthAddressData = (
 ): HubAsyncResult<protobufs.VerificationAddAddressData> => {
   return makeMessageData(
     { verificationAddAddressBody: body },
-    protobufs.MessageType.VERIFICATION_ADD_ADDRESS,
+    protobufs.MessageType.VERIFICATION_ADD_ETH_ADDRESS,
     dataOptions,
     publicClients,
   );

--- a/packages/core/src/factories.ts
+++ b/packages/core/src/factories.ts
@@ -157,7 +157,7 @@ const MessageTypeFactory = Factory.define<protobufs.MessageType>(() => {
     protobufs.MessageType.REACTION_ADD,
     protobufs.MessageType.REACTION_REMOVE,
     protobufs.MessageType.USER_DATA_ADD,
-    protobufs.MessageType.VERIFICATION_ADD_ADDRESS,
+    protobufs.MessageType.VERIFICATION_ADD_ETH_ADDRESS,
     protobufs.MessageType.VERIFICATION_REMOVE,
   ]);
 });
@@ -441,7 +441,7 @@ const VerificationAddEthAddressDataFactory = Factory.define<
   return MessageDataFactory.build({
     // verificationAddEthAddressBody will not be valid until onCreate
     verificationAddAddressBody: VerificationAddEthAddressBodyFactory.build({}),
-    type: protobufs.MessageType.VERIFICATION_ADD_ADDRESS,
+    type: protobufs.MessageType.VERIFICATION_ADD_ETH_ADDRESS,
   }) as protobufs.VerificationAddAddressData;
 });
 

--- a/packages/core/src/protobufs/generated/message.ts
+++ b/packages/core/src/protobufs/generated/message.ts
@@ -87,8 +87,8 @@ export enum MessageType {
   LINK_ADD = 5,
   /** LINK_REMOVE - Remove an existing Link */
   LINK_REMOVE = 6,
-  /** VERIFICATION_ADD_ADDRESS - Add a Verification of an Ethereum Address */
-  VERIFICATION_ADD_ADDRESS = 7,
+  /** VERIFICATION_ADD_ETH_ADDRESS - Add a Verification of an Ethereum Address */
+  VERIFICATION_ADD_ETH_ADDRESS = 7,
   /** VERIFICATION_REMOVE - Remove a Verification */
   VERIFICATION_REMOVE = 8,
   /**
@@ -127,8 +127,8 @@ export function messageTypeFromJSON(object: any): MessageType {
     case "MESSAGE_TYPE_LINK_REMOVE":
       return MessageType.LINK_REMOVE;
     case 7:
-    case "MESSAGE_TYPE_VERIFICATION_ADD_ADDRESS":
-      return MessageType.VERIFICATION_ADD_ADDRESS;
+    case "MESSAGE_TYPE_VERIFICATION_ADD_ETH_ADDRESS":
+      return MessageType.VERIFICATION_ADD_ETH_ADDRESS;
     case 8:
     case "MESSAGE_TYPE_VERIFICATION_REMOVE":
       return MessageType.VERIFICATION_REMOVE;
@@ -162,8 +162,8 @@ export function messageTypeToJSON(object: MessageType): string {
       return "MESSAGE_TYPE_LINK_ADD";
     case MessageType.LINK_REMOVE:
       return "MESSAGE_TYPE_LINK_REMOVE";
-    case MessageType.VERIFICATION_ADD_ADDRESS:
-      return "MESSAGE_TYPE_VERIFICATION_ADD_ADDRESS";
+    case MessageType.VERIFICATION_ADD_ETH_ADDRESS:
+      return "MESSAGE_TYPE_VERIFICATION_ADD_ETH_ADDRESS";
     case MessageType.VERIFICATION_REMOVE:
       return "MESSAGE_TYPE_VERIFICATION_REMOVE";
     case MessageType.USER_DATA_ADD:

--- a/packages/core/src/protobufs/typeguards.ts
+++ b/packages/core/src/protobufs/typeguards.ts
@@ -81,7 +81,7 @@ export const isVerificationAddEthAddressData = (
   data: protobufs.MessageData,
 ): data is types.VerificationAddAddressData => {
   return (
-    data.type === protobufs.MessageType.VERIFICATION_ADD_ADDRESS &&
+    data.type === protobufs.MessageType.VERIFICATION_ADD_ETH_ADDRESS &&
     typeof data.verificationAddAddressBody !== "undefined"
   );
 };

--- a/packages/core/src/protobufs/types.ts
+++ b/packages/core/src/protobufs/types.ts
@@ -67,7 +67,7 @@ export type ReactionRemoveMessage = protobufs.Message & {
 };
 
 export type VerificationAddAddressData = protobufs.MessageData & {
-  type: protobufs.MessageType.VERIFICATION_ADD_ADDRESS;
+  type: protobufs.MessageType.VERIFICATION_ADD_ETH_ADDRESS;
   verificationAddAddressBody: protobufs.VerificationAddAddressBody;
 };
 

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -296,7 +296,10 @@ export const validateMessageData = async <T extends protobufs.MessageData>(
     bodyResult = validateLinkBody(data.linkBody);
   } else if (validType.value === protobufs.MessageType.USER_DATA_ADD && !!data.userDataBody) {
     bodyResult = validateUserDataAddBody(data.userDataBody);
-  } else if (validType.value === protobufs.MessageType.VERIFICATION_ADD_ADDRESS && !!data.verificationAddAddressBody) {
+  } else if (
+    validType.value === protobufs.MessageType.VERIFICATION_ADD_ETH_ADDRESS &&
+    !!data.verificationAddAddressBody
+  ) {
     // Special check for verification claim
     bodyResult = await validateVerificationAddEthAddressBody(
       data.verificationAddAddressBody,

--- a/packages/hub-nodejs/src/generated/message.ts
+++ b/packages/hub-nodejs/src/generated/message.ts
@@ -87,8 +87,8 @@ export enum MessageType {
   LINK_ADD = 5,
   /** LINK_REMOVE - Remove an existing Link */
   LINK_REMOVE = 6,
-  /** VERIFICATION_ADD_ADDRESS - Add a Verification of an Ethereum Address */
-  VERIFICATION_ADD_ADDRESS = 7,
+  /** VERIFICATION_ADD_ETH_ADDRESS - Add a Verification of an Ethereum Address */
+  VERIFICATION_ADD_ETH_ADDRESS = 7,
   /** VERIFICATION_REMOVE - Remove a Verification */
   VERIFICATION_REMOVE = 8,
   /**
@@ -127,8 +127,8 @@ export function messageTypeFromJSON(object: any): MessageType {
     case "MESSAGE_TYPE_LINK_REMOVE":
       return MessageType.LINK_REMOVE;
     case 7:
-    case "MESSAGE_TYPE_VERIFICATION_ADD_ADDRESS":
-      return MessageType.VERIFICATION_ADD_ADDRESS;
+    case "MESSAGE_TYPE_VERIFICATION_ADD_ETH_ADDRESS":
+      return MessageType.VERIFICATION_ADD_ETH_ADDRESS;
     case 8:
     case "MESSAGE_TYPE_VERIFICATION_REMOVE":
       return MessageType.VERIFICATION_REMOVE;
@@ -162,8 +162,8 @@ export function messageTypeToJSON(object: MessageType): string {
       return "MESSAGE_TYPE_LINK_ADD";
     case MessageType.LINK_REMOVE:
       return "MESSAGE_TYPE_LINK_REMOVE";
-    case MessageType.VERIFICATION_ADD_ADDRESS:
-      return "MESSAGE_TYPE_VERIFICATION_ADD_ADDRESS";
+    case MessageType.VERIFICATION_ADD_ETH_ADDRESS:
+      return "MESSAGE_TYPE_VERIFICATION_ADD_ETH_ADDRESS";
     case MessageType.VERIFICATION_REMOVE:
       return "MESSAGE_TYPE_VERIFICATION_REMOVE";
     case MessageType.USER_DATA_ADD:

--- a/packages/hub-web/src/generated/message.ts
+++ b/packages/hub-web/src/generated/message.ts
@@ -87,8 +87,8 @@ export enum MessageType {
   LINK_ADD = 5,
   /** LINK_REMOVE - Remove an existing Link */
   LINK_REMOVE = 6,
-  /** VERIFICATION_ADD_ADDRESS - Add a Verification of an Ethereum Address */
-  VERIFICATION_ADD_ADDRESS = 7,
+  /** VERIFICATION_ADD_ETH_ADDRESS - Add a Verification of an Ethereum Address */
+  VERIFICATION_ADD_ETH_ADDRESS = 7,
   /** VERIFICATION_REMOVE - Remove a Verification */
   VERIFICATION_REMOVE = 8,
   /**
@@ -127,8 +127,8 @@ export function messageTypeFromJSON(object: any): MessageType {
     case "MESSAGE_TYPE_LINK_REMOVE":
       return MessageType.LINK_REMOVE;
     case 7:
-    case "MESSAGE_TYPE_VERIFICATION_ADD_ADDRESS":
-      return MessageType.VERIFICATION_ADD_ADDRESS;
+    case "MESSAGE_TYPE_VERIFICATION_ADD_ETH_ADDRESS":
+      return MessageType.VERIFICATION_ADD_ETH_ADDRESS;
     case 8:
     case "MESSAGE_TYPE_VERIFICATION_REMOVE":
       return MessageType.VERIFICATION_REMOVE;
@@ -162,8 +162,8 @@ export function messageTypeToJSON(object: MessageType): string {
       return "MESSAGE_TYPE_LINK_ADD";
     case MessageType.LINK_REMOVE:
       return "MESSAGE_TYPE_LINK_REMOVE";
-    case MessageType.VERIFICATION_ADD_ADDRESS:
-      return "MESSAGE_TYPE_VERIFICATION_ADD_ADDRESS";
+    case MessageType.VERIFICATION_ADD_ETH_ADDRESS:
+      return "MESSAGE_TYPE_VERIFICATION_ADD_ETH_ADDRESS";
     case MessageType.VERIFICATION_REMOVE:
       return "MESSAGE_TYPE_VERIFICATION_REMOVE";
     case MessageType.USER_DATA_ADD:

--- a/protobufs/schemas/message.proto
+++ b/protobufs/schemas/message.proto
@@ -61,7 +61,7 @@ enum MessageType {
   MESSAGE_TYPE_REACTION_REMOVE = 4; // Remove a Reaction from a Cast
   MESSAGE_TYPE_LINK_ADD = 5; // Add a new Link
   MESSAGE_TYPE_LINK_REMOVE = 6; // Remove an existing Link
-  MESSAGE_TYPE_VERIFICATION_ADD_ADDRESS = 7; // Add a Verification of an Ethereum Address
+  MESSAGE_TYPE_VERIFICATION_ADD_ETH_ADDRESS = 7; // Add a Verification of an Ethereum Address
   MESSAGE_TYPE_VERIFICATION_REMOVE = 8; // Remove a Verification
 //  Deprecated
 //  MESSAGE_TYPE_SIGNER_ADD = 9; // Add a new Ed25519 key pair that signs messages for a user


### PR DESCRIPTION
## Motivation

Changing the message type enum name will change it in the http response, which can break existing clients. For now, keep the old name.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on renaming the `VERIFICATION_ADD_ADDRESS` message type to `VERIFICATION_ADD_ETH_ADDRESS` throughout the codebase.

### Detailed summary:
- Renamed `VERIFICATION_ADD_ADDRESS` to `VERIFICATION_ADD_ETH_ADDRESS` in various files and functions.
- Updated type definitions and typeguards related to the message type.
- Updated test cases and assertions related to the message type.
- Updated message schemas and factories related to the message type.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->