### PR TITLE
fix: prefer peers with more messages to sync with

### DIFF
--- a/.changeset/flat-chairs-smash.md
+++ b/.changeset/flat-chairs-smash.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: prefer peers with more messages to sync with

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -486,9 +486,10 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
       // Prefer hubs that have more messages than us, if no such hub is available, pick a random one
       const snapshotResult = await this.getSnapshot();
       if (snapshotResult.isOk()) {
-        peers = Array.from(this.currentHubPeerContacts.values()).filter(
-          (p) => p.contactInfo.count > snapshotResult.value.numMessages,
-        );
+        // Use a buffer of 5% of our messages so the peer with the highest message count does not get picked
+        // disproportionately
+        const messageThreshold = snapshotResult.value.numMessages * 0.95;
+        peers = Array.from(this.currentHubPeerContacts.values()).filter((p) => p.contactInfo.count > messageThreshold);
       }
 
       if (peers.length === 0) {

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -481,14 +481,31 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
 
     // If we don't have a peer contact, get a random one from the current list
     if (!peerContact) {
-      // Pick a random key
-      const randomPeer = Array.from(this.currentHubPeerContacts.keys())[
-        Math.floor(Math.random() * this.currentHubPeerContacts.size)
-      ] as string;
+      let peers: PeerContact[] = [];
 
-      const c = this.currentHubPeerContacts.get(randomPeer);
-      peerContact = c?.contactInfo;
-      peerId = c?.peerId;
+      // Prefer hubs that have more messages than us, if no such hub is available, pick a random one
+      const snapshotResult = await this.getSnapshot();
+      if (snapshotResult.isOk()) {
+        peers = Array.from(this.currentHubPeerContacts.values()).filter(
+          (p) => p.contactInfo.count > snapshotResult.value.numMessages,
+        );
+      }
+
+      if (peers.length === 0) {
+        peers = Array.from(this.currentHubPeerContacts.values());
+        log.info(
+          { peersCount: this.currentHubPeerContacts.size, eligiblePeers: peers.length },
+          `Diffsync: Choosing random peer among ${peers.length} peers with fewer messages`,
+        );
+      } else {
+        log.info(
+          { peersCount: this.currentHubPeerContacts.size, eligiblePeers: peers.length },
+          `Diffsync: Choosing random peer among ${peers.length} peers with more messages`,
+        );
+      }
+      const randomPeer = peers[Math.floor(Math.random() * peers.length)];
+      peerContact = randomPeer?.contactInfo;
+      peerId = randomPeer?.peerId;
     }
 
     // If we still don't have a peer, skip the sync

--- a/apps/hubble/src/storage/jobs/gossipContactInfoJob.ts
+++ b/apps/hubble/src/storage/jobs/gossipContactInfoJob.ts
@@ -20,7 +20,7 @@ export class GossipContactInfoJobScheduler {
 
   start(cronSchedule?: string) {
     const randomMinute = Math.floor(Math.random() * 60);
-    const defaultSchedule = `${randomMinute} */4 * * *`; // Every 4 hours at a random minute
+    const defaultSchedule = `${randomMinute} */2 * * *`; // Every 2 hours at a random minute
     this._cronTask = cron.schedule(cronSchedule ?? defaultSchedule, () => this.doJobs());
   }
 


### PR DESCRIPTION
## Motivation

When there are a lot of peers on the network that are behind, choosing a random peer is detrimental. Prefer to sync with peers that have more messages than us. If there are no such peers, pick a random peer.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the peer selection process in the Hubble app. It prioritizes peers with more messages to sync with.

### Detailed summary
- Updated the cron schedule to run every 2 hours instead of every 4 hours.
- Modified the logic for selecting a random peer from the current list.
- Added a preference for peers with more messages to sync with.
- Added logging statements to indicate the selection criteria for the random peer.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->