### PR TITLE
fix: Detect duplicate messages early

### DIFF
--- a/.changeset/fuzzy-needles-decide.md
+++ b/.changeset/fuzzy-needles-decide.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Early detect duplicate messages

--- a/apps/hubble/src/storage/db/message.ts
+++ b/apps/hubble/src/storage/db/message.ts
@@ -134,6 +134,11 @@ export const getMessage = async <T extends Message>(
   return messageDecode(new Uint8Array(buffer)) as T;
 };
 
+export const isMessageInDB = async (db: RocksDB, message: Message): Promise<boolean> => {
+  const exists = await ResultAsync.fromPromise(db.get(makeMessagePrimaryKeyFromMessage(message)), (e) => e);
+  return exists.isOk() && exists.value.length > 0;
+};
+
 export const deleteMessage = (db: RocksDB, message: Message): Promise<void> => {
   const txn = deleteMessageTransaction(db.transaction(), message);
   return db.commit(txn);

--- a/apps/hubble/src/test/e2e/hubbleNetwork.test.ts
+++ b/apps/hubble/src/test/e2e/hubbleNetwork.test.ts
@@ -106,6 +106,11 @@ describe("hubble gossip and sync tests", () => {
         // Submit the message to hub1 via rpc, so it is gossip'd to hub2
         expect(await hub1.submitMessage(castAdd, "rpc")).toBeTruthy();
 
+        // Submitting it again should return false, as it is already in the db
+        const errResult = await hub1.submitMessage(castAdd, "rpc");
+        expect(errResult.isErr()).toBeTruthy();
+        expect(errResult._unsafeUnwrapErr().errCode).toEqual("bad_request.duplicate");
+
         // This should trigger a gossip message to hub2, where it should be merged
         await sleepWhile(async () => (await (hub2 as Hub).engine.getCast(fid, castAdd.hash)).isErr(), 2000);
 


### PR DESCRIPTION
## Motivation

Detecting a duplicate message early, before going through the whole merge process to quickly fail duplicate messages

## Change Summary

- Currently, duplicate messages are detected at the very end of the merge process
- If a hub receives a lot of duplicates, it wastes a lot of compute validating the messages
- We now check for a duplicate message in the DB quickly, and if it is a dup, we bail early.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)
