### PR TITLE
fix: Print stacktrace with iterator timeouts

### DIFF
--- a/apps/hubble/src/storage/db/rocksdb.ts
+++ b/apps/hubble/src/storage/db/rocksdb.ts
@@ -334,9 +334,10 @@ class RocksDB {
     timeoutMs = MAX_DB_ITERATOR_OPEN_MILLISECONDS,
   ): Promise<T | undefined> {
     const iterator = this.iterator(options, timeoutMs);
+    const stacktrace = new Error().stack || "<no stacktrace>";
     const timeoutId = setTimeout(async () => {
       await iterator.end();
-      log.warn(options, "forEachIterator timed out. Was force closed");
+      log.warn({ ...options, stack: stacktrace }, "forEachIterator timed out. Was force closed");
     }, timeoutMs);
 
     let returnValue: T | undefined | void;


### PR DESCRIPTION
## Motivation

Show the stacktrace along with iterator timeout errors


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Added stacktrace to log message when `forEachIterator` times out.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->