### PR TITLE
fix: init merkle trie so we don't miss l2events

### DIFF
--- a/.changeset/fair-ducks-bathe.md
+++ b/.changeset/fair-ducks-bathe.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Properly init the merkle trie so we don't miss l2events

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -653,7 +653,12 @@ export class Hub implements HubInterface {
         }
       }
     }
+
+    // Start the CRDT engine
     await this.engine.start();
+
+    // Start the sync engine
+    await this.syncEngine.start(this.options.rebuildSyncTrie ?? false);
 
     // Start the RPC server
     await this.rpcServer.start(this.options.rpcServerHost, this.options.rpcPort ?? 0);
@@ -668,9 +673,6 @@ export class Hub implements HubInterface {
 
     await this.l2RegistryProvider.start();
     await this.fNameRegistryEventsProvider.start();
-
-    // Start the sync engine
-    await this.syncEngine.start(this.options.rebuildSyncTrie ?? false);
 
     const bootstrapAddrs = this.options.bootstrapAddrs ?? [];
 

--- a/apps/hubble/src/network/sync/merkleTrie.test.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.test.ts
@@ -28,6 +28,7 @@ describe("MerkleTrie", () => {
       }),
     );
     const trie = new MerkleTrie(db);
+    await trie.initialize();
     await Promise.all(syncIds.map((id) => trie.insert(id)));
     await trie.commitToDb();
     return trie;
@@ -87,10 +88,12 @@ describe("MerkleTrie", () => {
       const syncId2 = await NetworkFactories.SyncId.create();
 
       const firstTrie = new MerkleTrie(db);
+      await firstTrie.initialize();
       await firstTrie.insert(syncId1);
       await firstTrie.insert(syncId2);
 
       const secondTrie = new MerkleTrie(db2);
+      await secondTrie.initialize();
       await secondTrie.insert(syncId2);
       await secondTrie.insert(syncId1);
 
@@ -117,7 +120,9 @@ describe("MerkleTrie", () => {
         const syncIds = await NetworkFactories.SyncId.createList(25);
 
         const firstTrie = new MerkleTrie(db);
+        await firstTrie.initialize();
         const secondTrie = new MerkleTrie(db2);
+        await secondTrie.initialize();
 
         await Promise.all(syncIds.map(async (syncId) => firstTrie.insert(syncId)));
         const shuffledIds = syncIds.sort(() => 0.5 - Math.random());
@@ -174,6 +179,7 @@ describe("MerkleTrie", () => {
         const syncIds = await NetworkFactories.SyncId.createList(500);
 
         const trie = new MerkleTrie(db);
+        await trie.initialize();
         const insertPromise = Promise.all(syncIds.map(async (syncId) => trie.insert(syncId)));
         // Multiple parallel commitToDb calls should not cause a conflict
         const commitPromise = Promise.all([1, 2, 3, 4, 5].map(async () => trie.commitToDb()));
@@ -338,12 +344,14 @@ describe("MerkleTrie", () => {
       const syncId2 = await NetworkFactories.SyncId.create();
 
       const firstTrie = new MerkleTrie(db);
+      await firstTrie.initialize();
       await firstTrie.insert(syncId1);
       await firstTrie.insert(syncId2);
 
       await firstTrie.deleteBySyncId(syncId1);
 
       const secondTrie = new MerkleTrie(db2);
+      await secondTrie.initialize();
       await secondTrie.insert(syncId2);
 
       expect(await firstTrie.rootHash()).toEqual(await secondTrie.rootHash());

--- a/apps/hubble/src/network/sync/merkleTrie.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.ts
@@ -219,6 +219,8 @@ class MerkleTrie {
   }
 
   public async rebuild(): Promise<void> {
+    await this.initialize();
+
     // First, delete the root node
     const dbStatus = await ResultAsync.fromPromise(
       this._db.del(TrieNode.makePrimaryKey(new Uint8Array())),

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -153,6 +153,7 @@ describe("Multi peer sync engine", () => {
     engine2 = new Engine(testDb2, network);
     hub2 = new MockHub(testDb2, engine2);
     syncEngine2 = new SyncEngine(hub2, testDb2, l2EventsProvider, fnameEventsProvider, undefined, 0);
+    await syncEngine2.start();
   }, TEST_TIMEOUT_SHORT);
 
   afterEach(async () => {

--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -279,6 +279,7 @@ describe("SyncEngine", () => {
     const engine2 = new Engine(testDb2, FarcasterNetwork.TESTNET);
     const hub2 = new MockHub(testDb2, engine2);
     const syncEngine2 = new SyncEngine(hub2, testDb2);
+    await syncEngine2.start();
     await engine2.mergeOnChainEvent(custodyEvent);
     await engine2.mergeOnChainEvent(signerEvent);
     await engine2.mergeOnChainEvent(storageEvent);

--- a/apps/hubble/src/network/sync/syncEnginePerf.test.ts
+++ b/apps/hubble/src/network/sync/syncEnginePerf.test.ts
@@ -46,8 +46,11 @@ describe("SyncEnginePerfTest", () => {
 
       const hub1 = new MockHub(testDb);
       const syncEngine1 = new SyncEngine(hub1, testDb);
+      await syncEngine1.start();
+
       const hub2 = new MockHub(testDb2);
       const syncEngine2 = new SyncEngine(hub2, testDb2);
+      await syncEngine2.start();
 
       try {
         await hub1.submitOnChainEvent(custodyEvent);

--- a/apps/hubble/src/rpc/test/syncService.test.ts
+++ b/apps/hubble/src/rpc/test/syncService.test.ts
@@ -29,6 +29,7 @@ let client: HubRpcClient;
 
 beforeAll(async () => {
   syncEngine = new SyncEngine(hub, db);
+  await syncEngine.start();
   server = new Server(hub, engine, syncEngine, mockGossipNode);
   const port = await server.start();
   client = getInsecureHubRpcClient(`127.0.0.1:${port}`);

--- a/apps/hubble/src/storage/db/migrations/5.fnameSyncIds.test.ts
+++ b/apps/hubble/src/storage/db/migrations/5.fnameSyncIds.test.ts
@@ -12,6 +12,7 @@ const db = jestRocksDB("fnameSyncIds.migration.test");
 describe("fnameSyncIds migration", () => {
   test("should delete unpaddded fname syncIds", async () => {
     const syncTrie = new MerkleTrie(db);
+    await syncTrie.initialize();
 
     const proof1 = Factories.UserNameProof.build({ name: Buffer.from("test") });
     const proof2 = Factories.UserNameProof.build({ name: Buffer.from("somename") });

--- a/apps/hubble/src/storage/db/migrations/6.oldContractEvents.test.ts
+++ b/apps/hubble/src/storage/db/migrations/6.oldContractEvents.test.ts
@@ -31,6 +31,7 @@ describe("oldContractEvents migration", () => {
 
   test("should delete version 0 id and key registry events", async () => {
     const syncTrie = new MerkleTrie(db);
+    await syncTrie.initialize();
     const store = new OnChainEventStore(db, new StoreEventHandler(db));
 
     const idRegistryV0Event = Factories.IdRegistryOnChainEvent.build();

--- a/apps/hubble/src/storage/db/migrations/7.clearAdminResets.test.ts
+++ b/apps/hubble/src/storage/db/migrations/7.clearAdminResets.test.ts
@@ -31,6 +31,7 @@ describe("clearAdminResets migration", () => {
 
   test("should delete admin reset signer events", async () => {
     const syncTrie = new MerkleTrie(db);
+    await syncTrie.initialize();
     const store = new OnChainEventStore(db, new StoreEventHandler(db));
 
     const idRegistryEvent = Factories.IdRegistryOnChainEvent.build();

--- a/apps/hubble/src/storage/db/rocksdb.ts
+++ b/apps/hubble/src/storage/db/rocksdb.ts
@@ -337,7 +337,7 @@ class RocksDB {
     const stacktrace = new Error().stack || "<no stacktrace>";
     const timeoutId = setTimeout(async () => {
       await iterator.end();
-      log.warn({ ...options, stack: stacktrace }, "forEachIterator timed out. Was force closed");
+      log.warn({ ...options, stacktrace }, "forEachIterator timed out. Was force closed");
     }, timeoutMs);
 
     let returnValue: T | undefined | void;


### PR DESCRIPTION
## Motivation

Initialize the syncEngine (and therefore the merkleTrie) first, before we start fetching l2 events


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)
