### PR TITLE
fix: Stop old messages from being broadcast on gossip

### DIFF
--- a/.changeset/big-donuts-glow.md
+++ b/.changeset/big-donuts-glow.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Don't broadcast old messages on gossip

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1013,7 +1013,7 @@ export class Hub implements HubInterface {
       const cutOffTime = getFarcasterTime().unwrapOr(0) - GOSSIP_SEEN_TTL;
 
       if (gossipMessage.timestamp < cutOffTime) {
-        this.gossipNode.reportValid(msgId, peerIdFromString(source.toString()).toBytes(), false);
+        await this.gossipNode.reportValid(msgId, peerIdFromString(source.toString()).toBytes(), false);
         reportedAsInvalid = true;
       }
     }
@@ -1046,7 +1046,7 @@ export class Hub implements HubInterface {
       const result = await this.submitMessage(message, "gossip");
       if (result.isOk()) {
         if (!reportedAsInvalid) {
-          this.gossipNode.reportValid(msgId, peerIdFromString(source.toString()).toBytes(), true);
+          await this.gossipNode.reportValid(msgId, peerIdFromString(source.toString()).toBytes(), true);
         }
       } else {
         log.info(
@@ -1060,7 +1060,7 @@ export class Hub implements HubInterface {
           "Received bad gossip message from peer",
         );
         if (!reportedAsInvalid) {
-          this.gossipNode.reportValid(msgId, peerIdFromString(source.toString()).toBytes(), false);
+          await this.gossipNode.reportValid(msgId, peerIdFromString(source.toString()).toBytes(), false);
         }
       }
 

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -594,8 +594,8 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
     this.callMethod("updateApplicationPeerScore", peerId, score);
   }
 
-  reportValid(messageId: string, propagationSource: Uint8Array, isValid: boolean) {
-    this.callMethod("reportValid", messageId, propagationSource, isValid);
+  async reportValid(messageId: string, propagationSource: Uint8Array, isValid: boolean): Promise<void> {
+    return await this.callMethod("reportValid", messageId, propagationSource, isValid);
   }
 
   /* -------------------------------------------------------------------------- */

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -29,12 +29,11 @@ import { ConnectionFilter } from "./connectionFilter.js";
 import { tcp } from "@libp2p/tcp";
 import { mplex } from "@libp2p/mplex";
 import { noise } from "@chainsafe/libp2p-noise";
-import { GOSSIP_PROTOCOL_VERSION, msgIdFnStrictNoSign, msgIdFnStrictSign } from "./protocol.js";
+import { GOSSIP_PROTOCOL_VERSION, msgIdFnStrictNoSign } from "./protocol.js";
 import { PeerId } from "@libp2p/interface-peer-id";
 import { createFromProtobuf, exportToProtobuf } from "@libp2p/peer-id-factory";
 import { Logger } from "../../utils/logger.js";
 import { statsd } from "../../utils/statsd.js";
-import { PeerScore } from "network/sync/peerScore.js";
 
 const MultiaddrLocalHost = "/ip4/127.0.0.1";
 const APPLICATION_SCORE_CAP_DEFAULT = 10;

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -20,6 +20,7 @@ import {
   HubError,
   HubResult,
   Message,
+  toFarcasterTime,
 } from "@farcaster/hub-nodejs";
 import { addressInfoFromParts, checkNodeAddrs, ipMultiAddrStrFromAddressInfo } from "../../utils/p2p.js";
 import { createLibp2p, Libp2p } from "libp2p";
@@ -360,6 +361,7 @@ export class LibP2PNode {
       topics: [GossipNode.primaryTopicForNetwork(this._network)],
       peerId: this.peerId?.toBytes() ?? new Uint8Array(),
       version: GOSSIP_PROTOCOL_VERSION,
+      timestamp: toFarcasterTime(Date.now()).unwrapOr(0),
     });
     return this.publish(gossipMessage);
   }
@@ -371,6 +373,7 @@ export class LibP2PNode {
       topics: [GossipNode.contactInfoTopicForNetwork(this._network)],
       peerId: this.peerId?.toBytes() ?? new Uint8Array(),
       version: GOSSIP_PROTOCOL_VERSION,
+      timestamp: toFarcasterTime(Date.now()).unwrapOr(0),
     });
     return this.publish(gossipMessage);
   }

--- a/packages/core/src/protobufs/generated/gossip.ts
+++ b/packages/core/src/protobufs/generated/gossip.ts
@@ -100,6 +100,8 @@ export interface GossipMessage {
   topics: string[];
   peerId: Uint8Array;
   version: GossipVersion;
+  /** Farcaster epoch timestamp in seconds when this message was first created */
+  timestamp: number;
 }
 
 function createBaseGossipAddressInfo(): GossipAddressInfo {
@@ -858,6 +860,7 @@ function createBaseGossipMessage(): GossipMessage {
     topics: [],
     peerId: new Uint8Array(),
     version: 0,
+    timestamp: 0,
   };
 }
 
@@ -880,6 +883,9 @@ export const GossipMessage = {
     }
     if (message.version !== 0) {
       writer.uint32(48).int32(message.version);
+    }
+    if (message.timestamp !== 0) {
+      writer.uint32(64).uint32(message.timestamp);
     }
     return writer;
   },
@@ -933,6 +939,13 @@ export const GossipMessage = {
 
           message.version = reader.int32() as any;
           continue;
+        case 8:
+          if (tag != 64) {
+            break;
+          }
+
+          message.timestamp = reader.uint32();
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -954,6 +967,7 @@ export const GossipMessage = {
       topics: Array.isArray(object?.topics) ? object.topics.map((e: any) => String(e)) : [],
       peerId: isSet(object.peerId) ? bytesFromBase64(object.peerId) : new Uint8Array(),
       version: isSet(object.version) ? gossipVersionFromJSON(object.version) : 0,
+      timestamp: isSet(object.timestamp) ? Number(object.timestamp) : 0,
     };
   },
 
@@ -974,6 +988,7 @@ export const GossipMessage = {
     message.peerId !== undefined &&
       (obj.peerId = base64FromBytes(message.peerId !== undefined ? message.peerId : new Uint8Array()));
     message.version !== undefined && (obj.version = gossipVersionToJSON(message.version));
+    message.timestamp !== undefined && (obj.timestamp = Math.round(message.timestamp));
     return obj;
   },
 
@@ -996,6 +1011,7 @@ export const GossipMessage = {
     message.topics = object.topics?.map((e) => e) || [];
     message.peerId = object.peerId ?? new Uint8Array();
     message.version = object.version ?? 0;
+    message.timestamp = object.timestamp ?? 0;
     return message;
   },
 };

--- a/protobufs/schemas/gossip.proto
+++ b/protobufs/schemas/gossip.proto
@@ -70,4 +70,5 @@ message GossipMessage {
   repeated string topics = 4;
   bytes peer_id = 5;
   GossipVersion version = 6;
+  uint32 timestamp = 8; // Farcaster epoch timestamp in seconds when this message was first created
 }


### PR DESCRIPTION
## Motivation

We're setting asyncValidation: true

With this setting true, libp2p doesn't forwarded immediately. They are forwarded only after the message has been merged, which can be delayed a lot on slow hubs. And then, after the message is merged it is broadcasted again to the next fanout peers and so on, adding up the delays at each step of the fanout. Essentially, each message is broadcast twice, and only when each hub reports it as reportValid(false) does the propogation stop.

This PR rejects messages older than seenTTL (even while we attempt to merge them) so that older messages don't flood the network


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a bug related to gossip message propagation. 

### Detailed summary
- Added a `timestamp` field to the `GossipMessage` protobuf schema.
- Modified the `handleGossipMessage` function to check the timestamp of incoming gossip messages.
- Added logic to report gossip messages as invalid if they are older than a certain cutoff time.
- Updated the `LibP2PNode` class to include the timestamp when publishing gossip messages.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->