### PR TITLE
fix: Add 8G heap to docker commands

### DIFF
--- a/.changeset/wild-pots-pay.md
+++ b/.changeset/wild-pots-pay.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Add 8G heap to docker commands

--- a/Dockerfile.hubble
+++ b/Dockerfile.hubble
@@ -92,4 +92,4 @@ EXPOSE 2282
 EXPOSE 2283
 WORKDIR /home/node/app/apps/hubble
 
-CMD ["node", "build/cli.js", "start", "--network", "1"]
+CMD ["node", "--max-old-space-size=8192", "build/cli.js", "start", "--network", "1"]

--- a/apps/hubble/docker-compose.yml
+++ b/apps/hubble/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     pull_policy: always
     restart: on-failure:5
     command: [
-      "node", "--no-warnings",  "build/cli.js", "start",
+      "node", "--no-warnings", "--max-old-space-size=8192",  "build/cli.js", "start",
       "--ip", "0.0.0.0",
       "--gossip-port", "${GOSSIP_PORT:-2282}",
       "--rpc-port", "${RPC_PORT:-2283}",   


### PR DESCRIPTION
## Motivation

Set the heap to 8G for docker commands too


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Fixing a bug related to memory allocation in the Docker commands for the Hubble application.

### Detailed summary:
- Added `--max-old-space-size=8192` flag to the `CMD` in `Dockerfile.hubble` to allocate 8GB heap memory.
- Added `--max-old-space-size=8192` flag to the `command` in `apps/hubble/docker-compose.yml` to allocate 8GB heap memory.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->