### PR TITLE
fix: Add a check to see if we have at least 16GB of RAM

### DIFF
--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -188,19 +188,18 @@ app
       `Farcaster: ${FARCASTER_VERSION} Hubble: ${APP_VERSION}`,
     );
 
-    // First, we'll check if we have > 8G of RAM.
-    const totalMemory = os.totalmem();
-    if (totalMemory < 16 * 1024 * 1024 * 1024) {
+    // First, we'll check if we have >16G of RAM. If you have 16GB installed, it
+    // detects it as slightly under that depending on OS, so we'll only error if
+    // it's less than 15GB.
+    const totalMemory = Math.floor(os.totalmem() / 1024 / 1024 / 1024);
+    if (totalMemory < 15) {
       startupCheck.printStartupCheckStatus(
         StartupCheckStatus.ERROR,
-        `Hubble requires at least 16GB of RAM to run. Detected ${Math.floor(totalMemory / 1024 / 1024 / 1024)}GB`,
+        `Hubble requires at least 16GB of RAM to run. Detected ${totalMemory}GB`,
       );
       process.exit(1);
     } else {
-      startupCheck.printStartupCheckStatus(
-        StartupCheckStatus.OK,
-        `Detected ${Math.floor(totalMemory / 1024 / 1024 / 1024)}GB of RAM`,
-      );
+      startupCheck.printStartupCheckStatus(StartupCheckStatus.OK, `Detected ${totalMemory}GB of RAM`);
     }
 
     // We'll write our process number to a file so that we can detect if another hub process has taken over.

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -20,7 +20,7 @@ import { profileStorageUsed } from "./profile/profile.js";
 import { profileRPCServer } from "./profile/rpcProfile.js";
 import { profileGossipServer } from "./profile/gossipProfile.js";
 import { initializeStatsd } from "./utils/statsd.js";
-import OnChainEventStore from "./storage/stores/onChainEventStore.js";
+import os from "os";
 import { startupCheck, StartupCheckStatus } from "./utils/startupCheck.js";
 import { mainnet, optimism } from "viem/chains";
 import { finishAllProgressBars } from "./utils/progressBars.js";
@@ -187,6 +187,21 @@ app
       StartupCheckStatus.OK,
       `Farcaster: ${FARCASTER_VERSION} Hubble: ${APP_VERSION}`,
     );
+
+    // First, we'll check if we have > 8G of RAM.
+    const totalMemory = os.totalmem();
+    if (totalMemory < 16 * 1024 * 1024 * 1024) {
+      startupCheck.printStartupCheckStatus(
+        StartupCheckStatus.ERROR,
+        `Hubble requires at least 16GB of RAM to run. Detected ${Math.floor(totalMemory / 1024 / 1024 / 1024)}GB`,
+      );
+      process.exit(1);
+    } else {
+      startupCheck.printStartupCheckStatus(
+        StartupCheckStatus.OK,
+        `Detected ${Math.floor(totalMemory / 1024 / 1024 / 1024)}GB of RAM`,
+      );
+    }
 
     // We'll write our process number to a file so that we can detect if another hub process has taken over.
     const processFileDir = `${DB_DIRECTORY}/process/`;

--- a/apps/hubble/www/docs/intro/install.md
+++ b/apps/hubble/www/docs/intro/install.md
@@ -6,9 +6,9 @@ We recommend running Hubble on an always-on server that has [Docker](https://doc
 
 Hubble can be installed in 30 minutes, and a full sync can take 1-2 hours to complete. You'll need a machine that has: 
 
-- 8 GB of RAM
-- 2 CPU cores or vCPUs
-- 20 GB of free storage
+- 16 GB of RAM
+- 4 CPU cores or vCPUs
+- 40 GB of free storage
 - A public IP address with ports 2282 - 2285 exposed
 
 See [tutorials](./tutorials.html) for instructions on how to set up cloud providers to run Hubble.


### PR DESCRIPTION
## Motivation

Ensure we have at least 16GB of RAM.


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the installation requirements for Hubble and adding a RAM check during startup.

### Detailed summary:
- Updated installation requirements for Hubble:
  - RAM requirement increased from 8GB to 16GB
  - CPU cores requirement increased from 2 to 4
  - Free storage requirement increased from 20GB to 40GB
- Added RAM check during startup:
  - If total RAM is less than 15GB, it throws an error and exits
  - Prints the detected RAM size if it meets the requirement

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->