### PR TITLE
fix: Increase sync max duration so hubs have more time to catch up

### DIFF
--- a/.changeset/early-hotels-reflect.md
+++ b/.changeset/early-hotels-reflect.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Increase sync max duration

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -65,7 +65,7 @@ import { getUserNameProof } from "../../storage/db/nameRegistryEvent.js";
 // attempt to sync messages that are older than this time.
 const SYNC_THRESHOLD_IN_SECONDS = 10;
 const HASHES_PER_FETCH = 128;
-const SYNC_MAX_DURATION = 60 * 60 * 1000; // 60 minutes
+const SYNC_MAX_DURATION = 110 * 60 * 1000; // 110 minutes, just slightly less than the periodic sync job frequency
 // 4x the number of CPUs, clamped between 2 and 16
 const SYNC_PARALLELISM = Math.max(Math.min(os.cpus().length * 4, 16), 2);
 const SYNC_INTERRUPT_TIMEOUT = 30 * 1000; // 30 seconds


### PR DESCRIPTION
## Motivation

Increase sync max duration so hubs have more time to catch up. With a 60 min timeout, there's an idle time of another 60 mins before the sync job kicks off again. This will make it so that we use up more of that time to catch up if the hub is really behind.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on increasing the maximum duration for synchronization in the Hubble app. 

### Detailed summary
- Increased `SYNC_MAX_DURATION` from 60 minutes to 110 minutes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->