### PR TITLE
fix: Small optimizations for merge code

### DIFF
--- a/.changeset/funny-weeks-type.md
+++ b/.changeset/funny-weeks-type.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Small optimizations for merge code

--- a/apps/hubble/src/storage/db/onChainEvent.ts
+++ b/apps/hubble/src/storage/db/onChainEvent.ts
@@ -32,9 +32,7 @@ export const makeOnChainEventPrimaryKey = (
   logIndex: number,
 ): Buffer => {
   return Buffer.concat([
-    Buffer.from([RootPrefix.OnChainEvent]),
-    Buffer.from([OnChainEventPostfix.OnChainEvents]),
-    Buffer.from([type]),
+    Buffer.from([RootPrefix.OnChainEvent, OnChainEventPostfix.OnChainEvents, type]),
     makeFidKey(fid),
     makeBlockNumberKey(blockNumber),
     makeLogIndexKey(logIndex),
@@ -43,35 +41,25 @@ export const makeOnChainEventPrimaryKey = (
 
 export const makeSignerOnChainEventBySignerKey = (fid: number, signer: Uint8Array): Buffer => {
   return Buffer.concat([
-    Buffer.from([RootPrefix.OnChainEvent]),
-    Buffer.from([OnChainEventPostfix.SignerByFid]),
+    Buffer.from([RootPrefix.OnChainEvent, OnChainEventPostfix.SignerByFid]),
     makeFidKey(fid),
     Buffer.from(signer),
   ]);
 };
 
 export const makeIdRegisterEventByFidKey = (fid: number): Buffer => {
-  return Buffer.concat([
-    Buffer.from([RootPrefix.OnChainEvent]),
-    Buffer.from([OnChainEventPostfix.IdRegisterByFid]),
-    makeFidKey(fid),
-  ]);
+  return Buffer.concat([Buffer.from([RootPrefix.OnChainEvent, OnChainEventPostfix.IdRegisterByFid]), makeFidKey(fid)]);
 };
 
 export const makeIdRegisterEventByCustodyKey = (custodyAddress: Uint8Array): Buffer => {
   return Buffer.concat([
-    Buffer.from([RootPrefix.OnChainEvent]),
-    Buffer.from([OnChainEventPostfix.IdRegisterByCustodyAddress]),
+    Buffer.from([RootPrefix.OnChainEvent, OnChainEventPostfix.IdRegisterByCustodyAddress]),
     Buffer.from(custodyAddress),
   ]);
 };
 
 export const makeOnChainEventIteratorPrefix = (type: OnChainEventType, fid?: number): Buffer => {
-  let prefix = Buffer.concat([
-    Buffer.from([RootPrefix.OnChainEvent]),
-    Buffer.from([OnChainEventPostfix.OnChainEvents]),
-    Buffer.from([type]),
-  ]);
+  let prefix = Buffer.concat([Buffer.from([RootPrefix.OnChainEvent, OnChainEventPostfix.OnChainEvents, type])]);
   if (fid) {
     prefix = Buffer.concat([prefix, makeFidKey(fid)]);
   }

--- a/apps/hubble/src/storage/engine/messageDataBytes.test.ts
+++ b/apps/hubble/src/storage/engine/messageDataBytes.test.ts
@@ -83,7 +83,7 @@ describe("messageDataBytes", () => {
     });
 
     test("merges with dataBytes", async () => {
-      const castAddClone = Message.decode(Message.encode(castAdd).finish());
+      const castAddClone = cloneMessage(castAdd);
       castAddClone.data = undefined;
       castAddClone.dataBytes = MessageData.encode(castAdd.data).finish();
 


### PR DESCRIPTION
1. Don't create dup Buffer objects
2. Don't recompute tsHash

## Motivation

Small optimizations after profiling


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on small optimizations for the merge code. 

### Detailed summary
- Added `cloneMessage` function in `messageDataBytes.test.ts`
- Imported `makeTsHash` function in `store.test.ts`
- Optimized code in `onChainEvent.ts` and `store.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->