### PR TITLE
fix: Run validateOrRevoke only if signer is changed

### DIFF
--- a/.changeset/slimy-buses-deny.md
+++ b/.changeset/slimy-buses-deny.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+feat: Run validateOrRevoke only if signer is updated

--- a/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.test.ts
+++ b/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.test.ts
@@ -1,0 +1,165 @@
+import { jestRocksDB } from "../db/jestUtils.js";
+import Engine from "../engine/index.js";
+import { ValidateOrRevokeMessagesJobScheduler } from "./validateOrRevokeMessagesJob.js";
+import { FarcasterNetwork, Factories, Message, toFarcasterTime, OnChainEvent } from "@farcaster/hub-nodejs";
+import {
+  HubState,
+  IdRegisterOnChainEvent,
+  UserDataAddMessage,
+  UserDataType,
+  UserNameType,
+  UsernameProofMessage,
+  bytesToHexString,
+  bytesToUtf8String,
+} from "@farcaster/core";
+import { jest } from "@jest/globals";
+import { publicClient } from "../../test/utils.js";
+import { getHubState, putHubState } from "../../storage/db/hubState.js";
+
+const db = jestRocksDB("jobs.ValidateOrRevokeMessagesJob.test");
+
+const network = FarcasterNetwork.TESTNET;
+const fid = Factories.Fid.build();
+const fname = Factories.Fname.build();
+const signer = Factories.Ed25519Signer.build();
+const custodySigner = Factories.Eip712Signer.build();
+
+let custodyEvent: IdRegisterOnChainEvent;
+let signerEvent: OnChainEvent;
+let storageEvent: OnChainEvent;
+let castAdd: Message;
+
+let addFname: UserDataAddMessage;
+let ensNameProof: UsernameProofMessage;
+
+beforeAll(async () => {
+  const signerKey = (await signer.getSignerKey())._unsafeUnwrap();
+  const custodySignerKey = (await custodySigner.getSignerKey())._unsafeUnwrap();
+  custodyEvent = Factories.IdRegistryOnChainEvent.build({ fid }, { transient: { to: custodySignerKey } });
+  signerEvent = Factories.SignerOnChainEvent.build({ fid }, { transient: { signer: signerKey } });
+  storageEvent = Factories.StorageRentOnChainEvent.build({ fid });
+  castAdd = await Factories.CastAddMessage.create({ data: { fid, network } }, { transient: { signer } });
+
+  addFname = await Factories.UserDataAddMessage.create(
+    {
+      data: {
+        fid,
+        userDataBody: {
+          type: UserDataType.USERNAME,
+          value: bytesToUtf8String(fname)._unsafeUnwrap(),
+        },
+      },
+    },
+    { transient: { signer } },
+  );
+  const custodySignerAddress = bytesToHexString(custodySignerKey)._unsafeUnwrap();
+
+  jest.spyOn(publicClient, "getEnsAddress").mockImplementation(() => {
+    return Promise.resolve(custodySignerAddress);
+  });
+  ensNameProof = await Factories.UsernameProofMessage.create(
+    {
+      data: {
+        fid,
+        usernameProofBody: Factories.UserNameProof.build({
+          fid,
+          owner: custodySignerKey,
+          name: Factories.EnsName.build(),
+          type: UserNameType.USERNAME_TYPE_ENS_L1,
+        }),
+      },
+    },
+    { transient: { signer } },
+  );
+});
+
+describe("ValidateOrRevokeMessagesJob", () => {
+  let engine: Engine;
+  let job: ValidateOrRevokeMessagesJobScheduler;
+
+  beforeEach(async () => {
+    engine = new Engine(db, network, undefined, publicClient);
+    job = new ValidateOrRevokeMessagesJobScheduler(db, engine);
+
+    await engine.start();
+  });
+
+  afterAll(async () => {
+    await engine.stop();
+  });
+
+  test("doJobForFid checks message when no fid or lastJobTimestamp", async () => {
+    // There is nothing in the DB, so if we add a message, it should get checked.
+    await engine.mergeOnChainEvent(custodyEvent);
+    await engine.mergeOnChainEvent(signerEvent);
+    await engine.mergeOnChainEvent(storageEvent);
+
+    await engine.mergeMessage(castAdd);
+
+    const result = await job.doJobForFid(0, fid);
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toBe(1);
+  });
+
+  test("doJobForFid doesn't check message if lastJobTimestamp > signer", async () => {
+    // There is nothing in the DB, so if we add a message, it should get checked.
+    await engine.mergeOnChainEvent(custodyEvent);
+    await engine.mergeOnChainEvent(signerEvent);
+    await engine.mergeOnChainEvent(storageEvent);
+
+    await engine.mergeMessage(castAdd);
+
+    const blockTimeToFCTime = toFarcasterTime(1000 * signerEvent.blockTimestamp)._unsafeUnwrap();
+    const result = await job.doJobForFid(blockTimeToFCTime + 1, fid);
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toBe(0);
+  });
+
+  test("doJobs checks if there is empty hub state", async () => {
+    await engine.mergeOnChainEvent(custodyEvent);
+    await engine.mergeOnChainEvent(signerEvent);
+    await engine.mergeOnChainEvent(storageEvent);
+
+    await engine.mergeMessage(castAdd);
+
+    await putHubState(db, HubState.create({}));
+
+    const result = await job.doJobs();
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toBe(1);
+  });
+
+  test("Continues job from last fid and checks username message", async () => {
+    await engine.mergeOnChainEvent(custodyEvent);
+    await engine.mergeOnChainEvent(signerEvent);
+    await engine.mergeOnChainEvent(storageEvent);
+
+    await engine.mergeMessage(castAdd);
+
+    await putHubState(db, HubState.create({ validateOrRevokeState: { lastFid: fid - 1, lastJobTimestamp: 0 } }));
+
+    const result = await job.doJobs();
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toBe(1);
+
+    // Get the hub state to make sure it was written correctly
+    const hubState = await getHubState(db);
+    expect(hubState.validateOrRevokeState?.lastFid).toBe(0);
+    expect(hubState.validateOrRevokeState?.lastJobTimestamp).toBeGreaterThan(0);
+
+    // Running it again checks no messages
+    const result2 = await job.doJobs();
+    expect(result2.isOk()).toBe(true);
+    expect(result2._unsafeUnwrap()).toBe(0);
+
+    // Merge the ENS name proof
+    const result3 = await engine.mergeMessage(ensNameProof);
+    console.log(result3);
+    expect(result3.isOk()).toBe(true);
+
+    // Running it again checks the ENS name proof
+    const result4 = await job.doJobs();
+    expect(result4.isOk()).toBe(true);
+    expect(result4._unsafeUnwrap()).toBe(1);
+  });
+});

--- a/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
@@ -1,12 +1,13 @@
-import { bytesToHexString, HubAsyncResult, HubError, Message } from "@farcaster/hub-nodejs";
-import { err, ok, Result } from "neverthrow";
+import { bytesToHexString, HubAsyncResult, HubError, OnChainEvent, toFarcasterTime } from "@farcaster/hub-nodejs";
+import { err, ok, Result, ResultAsync } from "neverthrow";
 import cron from "node-cron";
 import { logger } from "../../utils/logger.js";
-import { FID_BYTES, TSHASH_LENGTH, UserMessagePostfixMax } from "../db/types.js";
+import { FID_BYTES, TSHASH_LENGTH, UserMessagePostfixMax, UserPostfix } from "../db/types.js";
 import RocksDB from "../db/rocksdb.js";
 import Engine from "../engine/index.js";
 import { makeUserKey, messageDecode } from "../db/message.js";
 import { statsd } from "../../utils/statsd.js";
+import { getHubState, putHubState } from "../../storage/db/hubState.js";
 
 export const DEFAULT_VALIDATE_AND_REVOKE_MESSAGES_CRON = "0 1 * * *"; // Every day at 01:00 UTC
 
@@ -41,10 +42,10 @@ export class ValidateOrRevokeMessagesJobScheduler {
     return this._cronTask ? "started" : "stopped";
   }
 
-  async doJobs(): HubAsyncResult<void> {
+  async doJobs(): HubAsyncResult<number> {
     if (this._running) {
       log.info({}, "ValidateOrRevokeMessagesJob already running, skipping");
-      return ok(undefined);
+      return ok(0);
     }
 
     log.info({}, "starting ValidateOrRevokeMessagesJob");
@@ -72,36 +73,158 @@ export class ValidateOrRevokeMessagesJobScheduler {
     let totalMessagesChecked = 0;
 
     const numFids = allFids.length;
-    const scheduledTimePerFidMs = (6 * 60 * 60 * 1000) / numFids; // 6 hours for all FIDs
-    log.info({ numFids, scheduledTimePerFidMs }, "ValidateOrRevokeMessagesJob: got FIDs");
+    log.info({ numFids }, "ValidateOrRevokeMessagesJob: got FIDs");
+
+    const hubStateResult = await ResultAsync.fromPromise(getHubState(this._db), (e) => e as HubError);
+    if (hubStateResult.isErr()) {
+      log.error({ errCode: hubStateResult.error.errCode }, `error getting hub state: ${hubStateResult.error.message}`);
+      return err(hubStateResult.error);
+    }
+    let hubState = hubStateResult.value;
+
+    const lastJobTimestamp = hubState.validateOrRevokeState?.lastJobTimestamp ?? 0;
+    const lastFid = hubState.validateOrRevokeState?.lastFid ?? 0;
+
+    log.info({ lastJobTimestamp, lastFid, numFids }, "ValidateOrRevokeMessagesJob: starting");
 
     for (let i = 0; i < numFids; i++) {
       const fid = allFids[i] as number;
-      const numChecked = await this.doJobForFid(fid);
-      totalMessagesChecked += numChecked.unwrapOr(0);
+
+      if (lastFid > 0 && fid < lastFid) {
+        continue;
+      }
+      const numChecked = await this.doJobForFid(lastJobTimestamp, fid);
+      // We'll alwats check for username proof messages
+      const numUsernamesChecked = await this.doUsernamesJobForFid(fid);
+
+      totalMessagesChecked += numChecked.unwrapOr(0) + numUsernamesChecked.unwrapOr(0);
 
       if (i % 1000 === 0) {
         log.info({ fid, totalMessagesChecked }, "ValidateOrRevokeMessagesJob: progress");
-      }
 
-      // If we are running ahead of schedule, sleep for a bit to let the other jobs catch up.
-      if (Date.now() - start < (i + 1) * scheduledTimePerFidMs) {
-        await new Promise((resolve) => setTimeout(resolve, scheduledTimePerFidMs));
+        // Also write the hub state to the database every 1000 FIDs, so that we can recover from
+        // unfinished job
+        const hubState = await getHubState(this._db);
+        hubState.validateOrRevokeState = {
+          lastFid: fid,
+          lastJobTimestamp,
+        };
+        await putHubState(this._db, hubState);
       }
     }
 
     const timeTakenMs = Date.now() - start;
     log.info({ timeTakenMs, numFids, totalMessagesChecked }, "finished ValidateOrRevokeMessagesJob");
+    hubState = await getHubState(this._db);
+    hubState.validateOrRevokeState = {
+      lastFid: 0,
+      lastJobTimestamp: toFarcasterTime(Date.now()).unwrapOr(0),
+    };
+    await putHubState(this._db, hubState);
 
     // StatsD metrics
     statsd().timing("validateOrRevokeMessagesJob.timeTakenMs", timeTakenMs);
     statsd().gauge("validateOrRevokeMessagesJob.totalMessagesChecked", totalMessagesChecked);
 
     this._running = false;
-    return ok(undefined);
+    return ok(totalMessagesChecked);
   }
 
-  async doJobForFid(fid: number): HubAsyncResult<number> {
+  /**
+   * Check if any signers for this FID have changed since the last time the job ran, and if so,
+   * validate or revoke any messages that are affected.
+   */
+  async doJobForFid(lastJobTimestamp: number, fid: number): HubAsyncResult<number> {
+    const prefix = makeUserKey(fid);
+
+    const allSigners: OnChainEvent[] = [];
+    let finished = false;
+    let pageToken: Uint8Array | undefined;
+
+    do {
+      // First, find if any signers have changed since the last time the job ran
+      const signers = await this._engine.getOnChainSignersByFid(fid);
+      if (signers.isErr()) {
+        log.error(
+          { errCode: signers.error.errCode },
+          `error getting on-chain signers for FID ${fid}: ${signers.error.message}`,
+        );
+        return err(signers.error);
+      }
+
+      const { events, nextPageToken } = signers.value;
+      if (!nextPageToken) {
+        finished = true;
+      } else {
+        pageToken = nextPageToken;
+      }
+      allSigners.push(...events);
+    } while (!finished);
+
+    // Find the newest signer event
+    const latestSignerEventTs = toFarcasterTime(
+      1000 *
+        allSigners.reduce((acc, signer) => {
+          return acc > signer.blockTimestamp ? acc : signer.blockTimestamp;
+        }, 0),
+    ).unwrapOr(0);
+
+    if (latestSignerEventTs < lastJobTimestamp) {
+      log.debug({ fid, latestSignerEventTs, lastJobTimestamp }, "skipping FID, no new signers");
+      return ok(0);
+    }
+
+    log.info({ fid, lastJobTimestamp, latestSignerEventTs }, "ValidateOrRevokeMessagesJob: checking FID");
+
+    let count = 0;
+    await this._db.forEachIteratorByPrefix(
+      prefix,
+      async (key, value) => {
+        if ((key as Buffer).length !== 1 + FID_BYTES + 1 + TSHASH_LENGTH) {
+          // Not a message key, so we can skip it.
+          return; // continue
+        }
+
+        // Get the UserMessagePostfix from the key, which is the 1 + 32 bytes from the start
+        const postfix = (key as Buffer).readUint8(1 + FID_BYTES);
+        if (postfix > UserMessagePostfixMax) {
+          // Not a message key, so we can skip it.
+          return; // continue
+        }
+
+        const message = Result.fromThrowable(
+          () => messageDecode(new Uint8Array(value as Buffer)),
+          (e) => e as HubError,
+        )();
+
+        if (message.isOk()) {
+          const result = await this._engine.validateOrRevokeMessage(message.value);
+          count += 1;
+          result.match(
+            (result) => {
+              if (result !== undefined) {
+                log.info({ fid, hash: bytesToHexString(message.value.hash)._unsafeUnwrap() }, "revoked message");
+              }
+            },
+            (e) => {
+              log.error({ errCode: e.errCode }, `error validating and revoking message: ${e.message}`);
+            },
+          );
+        }
+      },
+      {},
+      15 * 60 * 1000, // 15 minutes
+    );
+
+    return ok(count);
+  }
+
+  /**
+   * We'll also check for any username proof messages that need to be revoked, in case the user
+   * has changed their username/reset the ENS since the last time the job ran.
+   * We run this irrespective of the lastJobTimestamp
+   */
+  async doUsernamesJobForFid(fid: number): HubAsyncResult<number> {
     const prefix = makeUserKey(fid);
     let count = 0;
 
@@ -115,8 +238,8 @@ export class ValidateOrRevokeMessagesJobScheduler {
 
         // Get the UserMessagePostfix from the key, which is the 1 + 32 bytes from the start
         const postfix = (key as Buffer).readUint8(1 + FID_BYTES);
-        if (postfix > UserMessagePostfixMax) {
-          // Not a message key, so we can skip it.
+        if (postfix !== UserPostfix.UsernameProofMessage && postfix !== UserPostfix.UserDataMessage) {
+          // Not a user name proof key, so we can skip it.
           return; // continue
         }
 

--- a/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
@@ -118,7 +118,7 @@ export class ValidateOrRevokeMessagesJobScheduler {
     hubState = await getHubState(this._db);
     hubState.validateOrRevokeState = {
       lastFid: 0,
-      lastJobTimestamp: toFarcasterTime(Date.now()).unwrapOr(0),
+      lastJobTimestamp: toFarcasterTime(start).unwrapOr(0),
     };
     await putHubState(this._db, hubState);
 

--- a/packages/core/src/protobufs/generated/hub_state.ts
+++ b/packages/core/src/protobufs/generated/hub_state.ts
@@ -2,15 +2,94 @@
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 
+export interface ValidateOrRevokeJobState {
+  /** The (Farcaster time epoch) timestamp where the last job started */
+  lastJobTimestamp: number;
+  /** The last FID to complete successfully. If this is 0, then the last job finished successfully */
+  lastFid: number;
+}
+
 export interface HubState {
   /** uint32 last_eth_block = 1; // Deprecated */
   lastFnameProof: number;
-  /** bool syncEvents = 4; // Deprecated */
   lastL2Block: number;
+  /** bool syncEvents = 4; // Deprecated */
+  validateOrRevokeState: ValidateOrRevokeJobState | undefined;
 }
 
+function createBaseValidateOrRevokeJobState(): ValidateOrRevokeJobState {
+  return { lastJobTimestamp: 0, lastFid: 0 };
+}
+
+export const ValidateOrRevokeJobState = {
+  encode(message: ValidateOrRevokeJobState, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.lastJobTimestamp !== 0) {
+      writer.uint32(8).uint32(message.lastJobTimestamp);
+    }
+    if (message.lastFid !== 0) {
+      writer.uint32(16).uint32(message.lastFid);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): ValidateOrRevokeJobState {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseValidateOrRevokeJobState();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.lastJobTimestamp = reader.uint32();
+          continue;
+        case 2:
+          if (tag != 16) {
+            break;
+          }
+
+          message.lastFid = reader.uint32();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): ValidateOrRevokeJobState {
+    return {
+      lastJobTimestamp: isSet(object.lastJobTimestamp) ? Number(object.lastJobTimestamp) : 0,
+      lastFid: isSet(object.lastFid) ? Number(object.lastFid) : 0,
+    };
+  },
+
+  toJSON(message: ValidateOrRevokeJobState): unknown {
+    const obj: any = {};
+    message.lastJobTimestamp !== undefined && (obj.lastJobTimestamp = Math.round(message.lastJobTimestamp));
+    message.lastFid !== undefined && (obj.lastFid = Math.round(message.lastFid));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ValidateOrRevokeJobState>, I>>(base?: I): ValidateOrRevokeJobState {
+    return ValidateOrRevokeJobState.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<ValidateOrRevokeJobState>, I>>(object: I): ValidateOrRevokeJobState {
+    const message = createBaseValidateOrRevokeJobState();
+    message.lastJobTimestamp = object.lastJobTimestamp ?? 0;
+    message.lastFid = object.lastFid ?? 0;
+    return message;
+  },
+};
+
 function createBaseHubState(): HubState {
-  return { lastFnameProof: 0, lastL2Block: 0 };
+  return { lastFnameProof: 0, lastL2Block: 0, validateOrRevokeState: undefined };
 }
 
 export const HubState = {
@@ -20,6 +99,9 @@ export const HubState = {
     }
     if (message.lastL2Block !== 0) {
       writer.uint32(24).uint64(message.lastL2Block);
+    }
+    if (message.validateOrRevokeState !== undefined) {
+      ValidateOrRevokeJobState.encode(message.validateOrRevokeState, writer.uint32(42).fork()).ldelim();
     }
     return writer;
   },
@@ -45,6 +127,13 @@ export const HubState = {
 
           message.lastL2Block = longToNumber(reader.uint64() as Long);
           continue;
+        case 5:
+          if (tag != 42) {
+            break;
+          }
+
+          message.validateOrRevokeState = ValidateOrRevokeJobState.decode(reader, reader.uint32());
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -58,6 +147,9 @@ export const HubState = {
     return {
       lastFnameProof: isSet(object.lastFnameProof) ? Number(object.lastFnameProof) : 0,
       lastL2Block: isSet(object.lastL2Block) ? Number(object.lastL2Block) : 0,
+      validateOrRevokeState: isSet(object.validateOrRevokeState)
+        ? ValidateOrRevokeJobState.fromJSON(object.validateOrRevokeState)
+        : undefined,
     };
   },
 
@@ -65,6 +157,9 @@ export const HubState = {
     const obj: any = {};
     message.lastFnameProof !== undefined && (obj.lastFnameProof = Math.round(message.lastFnameProof));
     message.lastL2Block !== undefined && (obj.lastL2Block = Math.round(message.lastL2Block));
+    message.validateOrRevokeState !== undefined && (obj.validateOrRevokeState = message.validateOrRevokeState
+      ? ValidateOrRevokeJobState.toJSON(message.validateOrRevokeState)
+      : undefined);
     return obj;
   },
 
@@ -76,6 +171,10 @@ export const HubState = {
     const message = createBaseHubState();
     message.lastFnameProof = object.lastFnameProof ?? 0;
     message.lastL2Block = object.lastL2Block ?? 0;
+    message.validateOrRevokeState =
+      (object.validateOrRevokeState !== undefined && object.validateOrRevokeState !== null)
+        ? ValidateOrRevokeJobState.fromPartial(object.validateOrRevokeState)
+        : undefined;
     return message;
   },
 };

--- a/protobufs/schemas/hub_state.proto
+++ b/protobufs/schemas/hub_state.proto
@@ -1,8 +1,14 @@
 syntax = "proto3";
 
+message ValidateOrRevokeJobState {
+  uint32 last_job_timestamp = 1;  // The (Farcaster time epoch) timestamp where the last job started
+  uint32 last_fid = 2;  // The last FID to complete successfully. If this is 0, then the last job finished successfully
+}
+
 message HubState {
 //  uint32 last_eth_block = 1; // Deprecated
   uint64 last_fname_proof = 2;
   uint64 last_l2_block = 3;
 //  bool syncEvents = 4; // Deprecated
+  ValidateOrRevokeJobState validate_or_revoke_state = 5;
 }


### PR DESCRIPTION
## Motivation

The validateOrRevokeMessages job takes ~12 hours to run everyday. It is very inefficient because it checks every single message.

## Change Summary

- Check messages only if the signer has changed for an FID
- Check the username proof messages irrespective of signers

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding the `validateOrRevokeState` field to the `HubState` message and implementing the `ValidateOrRevokeMessagesJobScheduler` class. 

### Detailed summary
- Added `validateOrRevokeState` field to `HubState` message in `hub_state.proto` and `hub_state.ts`
- Implemented `ValidateOrRevokeJobState` message in `hub_state.ts`
- Added `createBaseValidateOrRevokeJobState` function in `hub_state.ts`
- Implemented encoding and decoding functions for `ValidateOrRevokeJobState` in `hub_state.ts`
- Added `doJobForFid` and `doJobs` methods to `ValidateOrRevokeMessagesJobScheduler` in `validateOrRevokeMessagesJob.ts`
- Added test cases in `validateOrRevokeMessagesJob.test.ts`

> The following files were skipped due to too many changes: `apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->