### PR TITLE
chore: additional logging for invalid messages

### DIFF
--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1063,10 +1063,14 @@ export class Hub implements HubInterface {
         log.info(
           {
             errCode: result.error.errCode,
+            errMsg: result.error.message,
             peerId: source.toString(),
             origin: peerIdResult.value,
             hash: bytesToHexString(message.hash).unwrapOr(""),
+            fid: message.data?.fid,
+            type: message.data?.type,
             gossipDelay: gossipMessageDelay,
+            valid: !reportedAsInvalid,
             msgId,
           },
           "Received bad gossip message from peer",
@@ -1083,7 +1087,7 @@ export class Hub implements HubInterface {
       return result.map(() => undefined);
     } else if (gossipMessage.contactInfoContent) {
       const result = await this.handleContactInfo(peerIdResult.value, gossipMessage.contactInfoContent);
-      this.gossipNode.reportValid(msgId, peerIdFromString(source.toString()).toBytes(), result);
+      await this.gossipNode.reportValid(msgId, peerIdFromString(source.toString()).toBytes(), result);
       return ok(undefined);
     } else {
       return err(new HubError("bad_request.invalid_param", "invalid message type"));


### PR DESCRIPTION
## Motivation

Add some more logs for duplicate and delayed messages

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on improving the handling of gossip messages in the `Hub` class.

### Detailed summary:
- Added `errMsg`, `fid`, and `type` properties to the gossip message object.
- Updated the `handleContactInfo` method to handle contact info content.
- Changed the `reportValid` method to be awaited when reporting valid gossip messages.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->