### PR TITLE
fix: Fix duplicate message ttl check and reduce fname poll timeout

### DIFF
--- a/.changeset/grumpy-donkeys-allow.md
+++ b/.changeset/grumpy-donkeys-allow.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Fix gossip seen ttl check (convert to seconds first)

--- a/.changeset/lucky-radios-poke.md
+++ b/.changeset/lucky-radios-poke.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Reduce fname poll timeout so we reject username messages less often

--- a/apps/hubble/src/eth/fnameRegistryEventsProvider.ts
+++ b/apps/hubble/src/eth/fnameRegistryEventsProvider.ts
@@ -12,8 +12,8 @@ import {
 } from "@farcaster/hub-nodejs";
 import { Result } from "neverthrow";
 
-const DEFAULT_POLL_TIMEOUT_IN_MS = 30_000;
-const DEFAULT_READ_TIMEOUT_IN_MS = 10_000;
+const DEFAULT_POLL_TIMEOUT_IN_MS = 5_000;
+const DEFAULT_READ_TIMEOUT_IN_MS = 2_500;
 
 const log = logger.child({
   component: "FNameRegistryEventsProvider",

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1017,7 +1017,7 @@ export class Hub implements HubInterface {
     if (gossipMessage.timestamp) {
       // If message is older than seenTTL, we will try to merge it, but report it as invalid so it doesn't
       // propogate across the network
-      const cutOffTime = getFarcasterTime().unwrapOr(0) - GOSSIP_SEEN_TTL;
+      const cutOffTime = getFarcasterTime().unwrapOr(0) - GOSSIP_SEEN_TTL / 1000;
 
       if (gossipMessage.timestamp < cutOffTime) {
         await this.gossipNode.reportValid(msgId, peerIdFromString(source.toString()).toBytes(), false);

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -425,14 +425,26 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
 
   public addContactInfoForPeerId(peerId: PeerId, contactInfo: ContactInfoContentBody) {
     const existingPeerInfo = this.getContactInfoForPeerId(peerId.toString());
+    log.info(
+      {
+        peerInfo: contactInfo,
+        theirMessages: contactInfo.count,
+        peerNetwork: contactInfo.network,
+        peerVersion: contactInfo.hubVersion,
+        peerAppVersion: contactInfo.appVersion,
+        connectedPeers: this.getPeerCount(),
+        peerId: peerId.toString(),
+        isNew: !!existingPeerInfo,
+      },
+      "Peer ContactInfo",
+    );
+
     if (existingPeerInfo) {
       if (contactInfo.timestamp > existingPeerInfo.contactInfo.timestamp) {
-        log.debug({ peerInfo: existingPeerInfo }, "Updating peer with latest contactInfo");
         this.currentHubPeerContacts.set(peerId.toString(), { peerId, contactInfo });
       }
       return err(new HubError("bad_request.duplicate", "peer already exists"));
     } else {
-      log.info({ peerInfo: contactInfo, connectedPeers: this.getPeerCount() }, "New Peer ContactInfo");
       this.currentHubPeerContacts.set(peerId.toString(), { peerId, contactInfo });
       return ok(undefined);
     }


### PR DESCRIPTION
## Motivation

Seen TTL is in ms, but timestamp is seconds, so the duplicate check never triggered. Also reduce the fname poll timeout so we don't reject username change messages if it came in faster than the old 30 second timeout.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing issues related to gossip message handling and reducing poll timeout for fname registry events.

### Detailed summary
- Fixed a bug in gossip seen TTL check by converting it to seconds
- Reduced the poll timeout for fname registry events from 30 seconds to 5 seconds
- Reduced the read timeout for fname registry events from 10 seconds to 2.5 seconds
- Updated the calculation of cutOffTime in hubble.ts to divide GOSSIP_SEEN_TTL by 1000
- Added logging for peer contact information in syncEngine.ts

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->