### PR TITLE
fix: Add additional checks to prevent contact info duplicates

### DIFF
--- a/.changeset/six-nails-listen.md
+++ b/.changeset/six-nails-listen.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Add additional checks to prevent contact info duplicates

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1233,7 +1233,8 @@ export class Hub implements HubInterface {
     // TODO remove this once all peers are updated past 1.6.4
     if (message.timestamp === 0) return false;
 
-    return true;
+    // Return if peer contact was newer than existing contact (prevents old gossip messages from being forwarded)
+    return result.isOk();
   }
 
   /** Since we don't know if the peer is using SSL or not, we'll attempt to get the SSL version,


### PR DESCRIPTION
## Motivation

We're treating duplicate contact info messages as valid within the seen ttl, only treat as valid if the contact info was newer than what we already had.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a bug related to duplicate contact info in the Hubble app. 

### Detailed summary
- Added additional checks to prevent contact info duplicates
- Modified the return statement to prevent old gossip messages from being forwarded
- Updated the log message for updated peer contact info

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->