### PR TITLE
fix: Remove DB_RESET_TOKEN

### DIFF
--- a/.changeset/wicked-eels-cheat.md
+++ b/.changeset/wicked-eels-cheat.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Remove DB_RESET_TOKEN

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -340,31 +340,6 @@ app
       rpcRateLimit = hubConfig.rpcRateLimit;
     }
 
-    // Check if the DB_RESET_TOKEN env variable is set. If it is, we might need to reset the DB.
-    let resetDB = false;
-    const dbResetToken = process.env["DB_RESET_TOKEN"];
-    if (dbResetToken) {
-      // Read the contents of the "db_reset_token.txt" file, and if the number is
-      // different from the DB_RESET_TOKEN env variable, then we should reset the DB
-      const dbResetTokenFile = `${processFileDir}/db_reset_token.txt`;
-      let dbResetTokenFileContents = "";
-      try {
-        dbResetTokenFileContents = fs.readFileSync(dbResetTokenFile, "utf8").trim();
-      } catch (err) {
-        // Ignore error
-      }
-
-      if (dbResetTokenFileContents !== dbResetToken) {
-        // Write the new token to the file
-        fs.mkdirSync(processFileDir, { recursive: true });
-        fs.writeFileSync(dbResetTokenFile, dbResetToken);
-
-        // Reset the DB
-        logger.warn({ dbResetTokenFileContents, dbResetToken }, "Resetting DB since DB_RESET_TOKEN was set");
-        resetDB = true;
-      }
-    }
-
     // Metrics
     const statsDServer = cliOptions.statsdMetricsServer ?? hubConfig.statsdMetricsServer;
     if (statsDServer) {
@@ -523,7 +498,7 @@ app
       rpcRateLimit,
       rpcSubscribePerIpLimit: cliOptions.rpcSubscribePerIpLimit ?? hubConfig.rpcSubscribePerIpLimit,
       rocksDBName: cliOptions.dbName ?? hubConfig.dbName,
-      resetDB,
+      resetDB: false,
       rebuildSyncTrie,
       profileSync,
       resyncNameEvents: cliOptions.resyncNameEvents ?? hubConfig.resyncNameEvents ?? false,


### PR DESCRIPTION
## Motivation

Remove the DB_RESET_TOKEN env var as a way to reset the DB
Use the `dbreset` command instead. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an issue related to the `DB_RESET_TOKEN` environment variable in the `hubble` app.

### Detailed summary
- Removes the usage of `DB_RESET_TOKEN` and related logic in `cli.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->