### PR TITLE
fix: Handle solana verification removes

### DIFF
--- a/.changeset/small-files-rush.md
+++ b/.changeset/small-files-rush.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+fix: Handle solana verification removes

--- a/packages/core/src/factories.ts
+++ b/packages/core/src/factories.ts
@@ -591,6 +591,11 @@ const VerificationRemoveBodyFactory = Factory.define<protobufs.VerificationRemov
         address: EthAddressFactory.build(),
         protocol: protobufs.Protocol.ETHEREUM,
       });
+    case Protocol.SOLANA:
+      return protobufs.VerificationRemoveBody.create({
+        address: SolAddressFactory.build(),
+        protocol: protobufs.Protocol.SOLANA,
+      });
     default:
       throw new Error(`Unsupported protocol [found: ${params.protocol}]`);
   }

--- a/packages/core/src/validations.test.ts
+++ b/packages/core/src/validations.test.ts
@@ -888,6 +888,11 @@ describe("validateVerificationRemoveBody", () => {
     expect(validations.validateVerificationRemoveBody(body)).toEqual(ok(body));
   });
 
+  test("solana-succeeds", () => {
+    const body = Factories.VerificationRemoveBody.build({ protocol: Protocol.SOLANA });
+    expect(validations.validateVerificationRemoveBody(body)).toEqual(ok(body));
+  });
+
   describe("fails", () => {
     let body: protobufs.VerificationRemoveBody;
     let hubErrorMessage: string;
@@ -906,12 +911,20 @@ describe("validateVerificationRemoveBody", () => {
       hubErrorMessage = "Ethereum address is missing";
     });
 
-    test("with invalid address", async () => {
+    test("with invalid eth address", async () => {
       body = Factories.VerificationRemoveBody.build({
         address: Factories.Bytes.build({}, { transient: { length: 21 } }),
         protocol: Protocol.ETHEREUM,
       });
       hubErrorMessage = "Ethereum address must be 20 bytes";
+    });
+
+    test("with invalid solana address", async () => {
+      body = Factories.VerificationRemoveBody.build({
+        address: Factories.Bytes.build({}, { transient: { length: 33 } }),
+        protocol: Protocol.SOLANA,
+      });
+      hubErrorMessage = "solana address must be 32 bytes";
     });
   });
 });

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -733,6 +733,8 @@ export const validateVerificationRemoveBody = (
   switch (body.protocol) {
     case protobufs.Protocol.ETHEREUM:
       return validateEthAddress(body.address).map(() => body);
+    case protobufs.Protocol.SOLANA:
+      return validateSolAddress(body.address).map(() => body);
     default:
       return err(new HubError("bad_request.validation_failure", "invalid verification protocol"));
   }


### PR DESCRIPTION
## Motivation

A bad validation was preventing solana verification removes. Also return solana address and block hash as base58 encoded rather than hex encoded

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on handling solana verification removes. 

### Detailed summary
- Added support for solana verification removes in factories.ts and validations.ts.
- Added tests for solana verification removes in validations.test.ts.
- Added a test for solana verification removes in engine/index.test.ts.
- Added base58ToBytes and bytesToBase58 functions in httpServer.ts.
- Updated the getVerification API in httpServer.ts to handle solana addresses.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->