### PR TITLE
fix: expose environment variable GOSSIPSUB_IWANT_FOLLOWUP_MS, update …

### DIFF
--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -67,7 +67,7 @@
     "@aws-sdk/client-s3": "^3.400.0",
     "@aws-sdk/client-sts": "^3.398.0",
     "@aws-sdk/lib-storage": "^3.504.0",
-    "@chainsafe/libp2p-gossipsub": "6.1.0",
+    "@chainsafe/libp2p-gossipsub": "6.3.0",
     "@chainsafe/libp2p-noise": "^11.0.0 ",
     "@faker-js/faker": "~7.6.0",
     "@farcaster/hub-nodejs": "^0.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1046,13 +1046,13 @@
   resolved "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.1.tgz#62cb285669d91f88fd9fa285048dde3882f0993b"
   integrity sha512-nqSJ8u2a1Rv9FYbyI8qpDhTYujaKEyLknNrTejLYoSWmdeg+2WB7R6BZqPZYfrJzDxVi3rl6ZQuoaEvpKRZWgQ==
 
-"@chainsafe/libp2p-gossipsub@6.1.0":
-  version "6.1.0"
-  resolved "https://registry.npmjs.org/@chainsafe/libp2p-gossipsub/-/libp2p-gossipsub-6.1.0.tgz#70b34bb507d365ebc9dcd64071ccb0f4452a57f5"
-  integrity sha512-+zIPRGf2T+Qd+Hef/XbJx66FL+hbmth9sk6sr3PvQ2eolHGFwPwxSeM7fVdGWoZ7sMndUoGKUNPmO2GzbPsVQg==
+"@chainsafe/libp2p-gossipsub@6.3.0":
+  version "6.3.0"
+  resolved "https://registry.npmjs.org/@chainsafe/libp2p-gossipsub/-/libp2p-gossipsub-6.3.0.tgz#0ef8b8548a4c8307233b01dfb23bfa605df6b0e2"
+  integrity sha512-yRgMB5JpyPROjmhOeOmzJUAKci19qBEnpH80201f8JkkviUJo7+X8i3MUkammlbFg0VhaTKBT98Osbko9+rT1w==
   dependencies:
     "@libp2p/crypto" "^1.0.3"
-    "@libp2p/interface-connection" "^3.0.1"
+    "@libp2p/interface-connection" "^4.0.0"
     "@libp2p/interface-connection-manager" "^1.3.0"
     "@libp2p/interface-keys" "^1.0.3"
     "@libp2p/interface-peer-id" "^2.0.0"
@@ -1065,7 +1065,7 @@
     "@libp2p/peer-record" "^5.0.0"
     "@libp2p/pubsub" "^6.0.0"
     "@libp2p/topology" "^4.0.0"
-    "@multiformats/multiaddr" "^11.0.0"
+    "@multiformats/multiaddr" "^12.0.0"
     abortable-iterator "^4.0.2"
     denque "^1.5.0"
     it-length-prefixed "^8.0.2"


### PR DESCRIPTION

## Motivation

- Hubs experience spikes of duplicate messages 
- Duplicate messages should not propagate to application layer if seen in p2p layer
- However, high message throughput can be I/O intensive and delay propagation. Delayed messages can reduce peer scores and yield negative feedback loop.

## Change Summary

- Update update @chainsafe/libp2p-gossipsub to 6.3.0
- Expose environment variable GOSSIPSUB_IWANT_FOLLOWUP_MS
- Pass in gossipsubIWantFollowupMs parameter in gossipNodeWorker

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
