### PR TITLE
fix: Increase hub stream buffer size to keep up with faster hub merges

### DIFF
--- a/.changeset/ten-cooks-check.md
+++ b/.changeset/ten-cooks-check.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Increase hub stream buffer size

--- a/apps/hubble/src/rpc/bufferedStreamWriter.ts
+++ b/apps/hubble/src/rpc/bufferedStreamWriter.ts
@@ -4,7 +4,7 @@ import { err, ok } from "neverthrow";
 export const STREAM_DRAIN_TIMEOUT_MS = 10_000;
 export const SLOW_CLIENT_GRACE_PERIOD_MS = 60_000;
 // TODO: Make this configurable via CLI
-export const STREAM_MESSAGE_BUFFER_SIZE = 5_000;
+export const STREAM_MESSAGE_BUFFER_SIZE = 10_000;
 
 /**
  * A BufferedStreamWriter is a wrapper around a gRPC stream that will buffer messages when the stream is backed up.


### PR DESCRIPTION
## Motivation

Some subscribers are hitting this limit, presumably because hubs on faster hardware are merging more messages than before.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Increased the hub stream buffer size from 5,000 to 10,000 in the `bufferedStreamWriter.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->