### PR TITLE
perf: discard old contact info messages early

### DIFF
--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1109,6 +1109,14 @@ export class Hub implements HubInterface {
           appVersion: content.appVersion,
           timestamp: content.timestamp,
         });
+
+    // Don't process messages that are too old
+    if (message.timestamp && message.timestamp < Date.now() - MAX_CONTACT_INFO_AGE_MS) {
+      log.debug({ message }, "contact info message is too old");
+      return false;
+    }
+
+    // Validate the signature if present
     if (content.signature && content.signer && peerId.publicKey && content.body) {
       let bytes: Uint8Array;
       if (content.dataBytes) {
@@ -1150,12 +1158,6 @@ export class Hub implements HubInterface {
       }
     } else if (this.strictContactInfoValidation) {
       log.warn({ message: content, peerId }, "provided contact info does not have a signature");
-      return false;
-    }
-
-    // Don't process messages that are too old
-    if (message.timestamp && message.timestamp < Date.now() - MAX_CONTACT_INFO_AGE_MS) {
-      log.debug({ message }, "contact info message is too old");
       return false;
     }
 


### PR DESCRIPTION
## Motivation

When processing a contact info message, the old behavior was:

1. hashing the content, verifying the signature
2. then checking the timestamp and discarding the message if it's too old

The new behavior just inverts the order of these two operations, so we avoid doing expensive work if we're going to discard the message.

Please advise on how to add a test for this, at least it doesn't break any existing tests.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the message processing in the `Hub` class of the Hubble application. The notable changes include:

- Added a check to ignore messages that are too old
- Added validation for message signatures if present
- Updated the address book for the peer

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->