### PR TITLE
fix: Fix hub crash from bad message data submit

### DIFF
--- a/.changeset/itchy-fireants-wink.md
+++ b/.changeset/itchy-fireants-wink.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Fix hub crash from bad message data submit

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1365,8 +1365,9 @@ export class Hub implements HubInterface {
   /* -------------------------------------------------------------------------- */
 
   async submitMessage(submittedMessage: Message, source?: HubSubmitSource): HubAsyncResult<number> {
-    // If this is a dup, don't bother processing it
-    if (await isMessageInDB(this.rocksDB, submittedMessage)) {
+    // If this is a dup, don't bother processing it. Only do this for gossip messages since rpc messages
+    // haven't been validated yet
+    if (source === "gossip" && (await isMessageInDB(this.rocksDB, submittedMessage))) {
       log.debug({ source }, "submitMessage rejected: Message already exists");
       return err(new HubError("bad_request.duplicate", "message has already been merged"));
     }

--- a/apps/hubble/src/storage/db/message.ts
+++ b/apps/hubble/src/storage/db/message.ts
@@ -135,7 +135,12 @@ export const getMessage = async <T extends Message>(
 };
 
 export const isMessageInDB = async (db: RocksDB, message: Message): Promise<boolean> => {
-  const exists = await ResultAsync.fromPromise(db.get(makeMessagePrimaryKeyFromMessage(message)), (e) => e);
+  const exists = await ResultAsync.fromPromise(
+    (async () => {
+      return db.get(makeMessagePrimaryKeyFromMessage(message));
+    })(),
+    (e) => e,
+  );
   return exists.isOk() && exists.value.length > 0;
 };
 

--- a/apps/hubble/src/test/e2e/hubbleNetwork.test.ts
+++ b/apps/hubble/src/test/e2e/hubbleNetwork.test.ts
@@ -106,8 +106,8 @@ describe("hubble gossip and sync tests", () => {
         // Submit the message to hub1 via rpc, so it is gossip'd to hub2
         expect(await hub1.submitMessage(castAdd, "rpc")).toBeTruthy();
 
-        // Submitting it again should return false, as it is already in the db
-        const errResult = await hub1.submitMessage(castAdd, "rpc");
+        // Submitting it again (via gossip) should return false, as it is already in the db
+        const errResult = await hub1.submitMessage(castAdd, "gossip");
         expect(errResult.isErr()).toBeTruthy();
         expect(errResult._unsafeUnwrapErr().errCode).toEqual("bad_request.duplicate");
 


### PR DESCRIPTION
## Motivation

Hub crashes in some cases when invalid messages are submitted via rpc.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes a bug in the `hubble` app where duplicate messages were incorrectly processed, specifically addressing crashes caused by bad message data submission.

### Detailed summary
- Improved error handling for duplicate messages in `hubble`
- Updated message submission source validation
- Enhanced logging for rejected message submissions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->