### PR TITLE
fix: Allow specifying custom args via pm2 initialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run Hubble
         shell: bash
-        run: docker run --name hub --detach -p2282:2282 -p2283:2283 farcasterxyz/hubble:test sh -c 'node build/cli.js identity create && node build/cli.js start --rpc-port 2283 --ip 0.0.0.0 --gossip-port 2282 --eth-mainnet-rpc-url "https://eth-mainnet.g.alchemy.com/v2/8cz__IXnQ5FK_GNYDlfooLzYhBAW7ta0" --l2-rpc-url "https://opt-mainnet.g.alchemy.com/v2/3xWX-cWV-an3IPXmVCRXX51PpQzc-8iJ" --network 3 --allowed-peers none'
+        run: docker run --name hub --detach -p2282:2282 -p2283:2283 farcasterxyz/hubble:test sh -c 'node build/cli.js identity create && HUBBLE_ARGS="start --rpc-port 2283 --ip 0.0.0.0 --gossip-port 2282 --eth-mainnet-rpc-url https://eth-mainnet.g.alchemy.com/v2/8cz__IXnQ5FK_GNYDlfooLzYhBAW7ta0 --l2-rpc-url https://opt-mainnet.g.alchemy.com/v2/3xWX-cWV-an3IPXmVCRXX51PpQzc-8iJ --network 3 --allowed-peers none" npx pm2-runtime start pm2.config.cjs'
 
       - name: Download grpcurl
         shell: bash

--- a/Dockerfile.hubble
+++ b/Dockerfile.hubble
@@ -93,5 +93,7 @@ EXPOSE 2283
 WORKDIR /home/node/app/apps/hubble
 
 # Run using pm2 as supervisor for faster recoveries on failure
-COPY --chown=node:node ./apps/hubble/pm2.config.js ./pm2.config.js
-CMD ["npx", "pm2-runtime", "pm2.config.js"]
+COPY --chown=node:node ./apps/hubble/pm2.config.cjs ./pm2.config.cjs
+ENV NODE_ARGS="--max-old-space-size=8192"
+ENV HUBBLE_ARGS="start --network 1"
+CMD ["npx", "pm2-runtime", "start", "pm2.config.cjs"]

--- a/apps/hubble/docker-compose.yml
+++ b/apps/hubble/docker-compose.yml
@@ -10,19 +10,21 @@ services:
     image: farcasterxyz/hubble:latest
     pull_policy: always
     restart: on-failure:5
-    command: [
-      "node", "--no-warnings", "--max-old-space-size=8192",  "build/cli.js", "start",
-      "--ip", "0.0.0.0",
-      "--gossip-port", "${GOSSIP_PORT:-2282}",
-      "--rpc-port", "${RPC_PORT:-2283}",   
-      "--eth-mainnet-rpc-url", "$ETH_MAINNET_RPC_URL",
-      "--l2-rpc-url", "$OPTIMISM_L2_RPC_URL",
-      "--network", "${FC_NETWORK_ID:-1}",
-      "--rpc-subscribe-per-ip-limit", "${RPC_SUBSCRIBE_PER_IP_LIMIT:-4}",
-      "-b", "${BOOTSTRAP_NODE:-/dns/nemes.farcaster.xyz/tcp/2282}",
-      "--statsd-metrics-server", "$STATSD_METRICS_SERVER",
-      "--hub-operator-fid", "${HUB_OPERATOR_FID:-0}",
-    ]
+    command: ["npx", "pm2-runtime", "start", "pm2.config.cjs"]
+    environment:
+      NODE_OPTIONS: "--no-warnings --max-old-space-size=8192"
+      HUBBLE_ARGS: >-
+        start
+        --ip 0.0.0.0
+        --gossip-port ${GOSSIP_PORT:-2282}
+        --rpc-port ${RPC_PORT:-2283}
+        --eth-mainnet-rpc-url $ETH_MAINNET_RPC_URL
+        --l2-rpc-url $OPTIMISM_L2_RPC_URL
+        --network ${FC_NETWORK_ID:-1}
+        --rpc-subscribe-per-ip-limit ${RPC_SUBSCRIBE_PER_IP_LIMIT:-4}
+        -b ${BOOTSTRAP_NODE:-/dns/nemes.farcaster.xyz/tcp/2282}
+        --statsd-metrics-server $STATSD_METRICS_SERVER
+        --hub-operator-fid ${HUB_OPERATOR_FID:-0}
     ports:
       - '${HTTPAPI_PORT:-2281}:${HTTPAPI_PORT:-2281}' # HTTP API. You can set HTTP_PORT in .env
       - '${GOSSIP_PORT:-2282}:${GOSSIP_PORT:-2282}' # Gossip. You can set GOSSIP_PORT in .env
@@ -37,7 +39,7 @@ services:
       options:
         max-size: "1g"
         max-file: "2"
-  
+
   # Start this if you want perf metrics for your hubble node. Remember to start `grafana` as well.
   statsd:
     image: graphiteapp/graphite-statsd:1.1.10-5
@@ -65,6 +67,6 @@ services:
     networks:
       - my-network
 
-networks: 
+networks:
   my-network:
- 
+

--- a/apps/hubble/pm2.config.cjs
+++ b/apps/hubble/pm2.config.cjs
@@ -11,9 +11,12 @@ module.exports = {
   apps: [
     {
       name: "hubble",
-      // First arg is implicitly `node`
-      args: "--max-old-space-size=8192 ./build/cli.js start --network 1",
-      instances: 1, // Only one hub process can access RocksDB at a time
+      script: "./build/cli.js",
+      instances: 1,
+      exec_mode: "cluster",
+      // HACK: Allows us to pass arguments in a way recognized by the CLI flag processing library we use
+      // This is only necessary when running via PM2.
+      args: process.env.HUBBLE_ARGS,
       watch: false,
       log_type: "json",
       out_file: "/dev/stdout",


### PR DESCRIPTION
## Motivation

We weren't correctly starting up when running via PM2 when we introduced this change in #1724.

## Change Summary

Update PM2 configuration to allow us to pass through command line args. While here, also fix the test that missed this error.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Docker configuration for the Hubble application to enhance performance and allow passing arguments more efficiently.

### Detailed summary
- Updated `pm2.config.js` to `pm2.config.cjs` for better argument handling
- Added environment variables `NODE_ARGS` and `HUBBLE_ARGS`
- Modified `ci.yml` to run PM2 with updated arguments
- Adjusted `docker-compose.yml` to use `pm2-runtime` with `pm2.config.cjs` and new environment variables

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->