### PR TITLE
feat: Build Hubble base image on Node.js 21 `slim`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
 
     strategy:
       matrix:
-        node_version: [18, 20]
+        node_version: [18, 20, 21]
 
     steps:
       - uses: actions/checkout@v3

--- a/Dockerfile.hubble
+++ b/Dockerfile.hubble
@@ -5,9 +5,7 @@
 ############## Stage 1: Create pruned version of monorepo #####################
 ###############################################################################
 
-FROM node:20.2-alpine AS prune
-
-RUN apk add --no-cache libc6-compat
+FROM node:21.6-slim AS prune
 
 USER node
 RUN mkdir /home/node/app
@@ -23,10 +21,10 @@ RUN /home/node/.yarn/bin/turbo prune --scope=@farcaster/hubble --docker
 ############## Stage 2: Build the code using a full node image ################
 ###############################################################################
 
-FROM node:20.2-alpine AS build
+FROM node:21.6-slim AS build
 
 # Needed for compilation step
-RUN apk add --no-cache libc6-compat python3 make g++ linux-headers curl
+RUN apt-get update && apt-get install -y python3 make g++ linux-headers-generic curl
 
 USER node
 RUN mkdir /home/node/app
@@ -60,10 +58,7 @@ RUN rm -rf node_modules && yarn install --production --ignore-scripts --prefer-o
 ########## Stage 3: Copy over the built code to a leaner alpine image #########
 ###############################################################################
 
-FROM node:20.2-alpine as app
-
-# Requirement for runtime metrics integrations
-RUN apk add libc6-compat
+FROM node:21.6-slim as app
 
 # Set non-root user and expose ports
 USER node


### PR DESCRIPTION
## Motivation

We're wondering if this will help reduce the number of segfaults we're seeing in production.

## Change Summary

Update base image to Node.js 21. In order to get this to build, we had to switch from Alpine to Node's `slim` variant, which is `glibc` based.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR increases Node.js support to version 21 and updates Docker images to slim variants for optimization.

### Detailed summary
- Updated Node.js versions to 21 in CI workflow
- Changed Docker base images to `node:21.6-slim` for pruning, building, and final app stages
- Replaced Alpine package installations with `apt-get` commands for slim images

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->