### PR TITLE
fix: Replace hot-shots with @figma-hotshots

### DIFF
--- a/.changeset/shaggy-knives-move.md
+++ b/.changeset/shaggy-knives-move.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/replicator": patch
+"@farcaster/hubble": patch
+---
+
+fix: Replace hot-shots with @figma/hot-shots

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -89,7 +89,7 @@
     "cli-progress": "^3.12.0",
     "commander": "~10.0.0",
     "fastify": "^4.22.0",
-    "hot-shots": "^10.0.0",
+    "@figma/hot-shots": "^9.0.0-figma.1",
     "libp2p": "0.43.4",
     "neverthrow": "~6.0.0",
     "node-cron": "~3.0.2",

--- a/apps/hubble/src/utils/statsd.ts
+++ b/apps/hubble/src/utils/statsd.ts
@@ -1,4 +1,4 @@
-import { StatsD } from "hot-shots";
+import { StatsD } from "@figma/hot-shots";
 import { logger } from "./logger.js";
 
 const log = logger.child({ module: "statsd" });

--- a/apps/replicator/package.json
+++ b/apps/replicator/package.json
@@ -34,7 +34,7 @@
     "dotenv": "^16.3.1",
     "fastify": "^4.23.2",
     "fastq": "^1.15.0",
-    "hot-shots": "^10.0.0",
+    "@figma/hot-shots": "^9.0.0-figma.1",
     "humanize-duration": "^3.30.0",
     "ioredis": "^5.3.2",
     "kysely": "^0.26.3",

--- a/apps/replicator/src/statsd.ts
+++ b/apps/replicator/src/statsd.ts
@@ -1,4 +1,4 @@
-import { StatsD } from "hot-shots";
+import { StatsD } from "@figma/hot-shots";
 import { log as parentLog } from "./log.js";
 import { AssertionError } from "./error.js";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1902,6 +1902,11 @@
     fastify-plugin "^4.0.0"
     hashlru "^2.3.0"
 
+"@figma/hot-shots@^9.0.0-figma.1":
+  version "9.0.0-figma.1"
+  resolved "https://registry.npmjs.org/@figma/hot-shots/-/hot-shots-9.0.0-figma.1.tgz#e642c65469536503de12e2ecdaa2717c96a993eb"
+  integrity sha512-tyOOM2hclLbv0lSkJg4jdR/RibsuPM5q9VHnwP6oqEKwPIMp32mHKWr01Oie4WWbDa3QB8g2Wx3VYLrjEo9HUg==
+
 "@grpc/grpc-js@~1.8.21":
   version "1.8.21"
   resolved "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.21.tgz#d282b122c71227859bf6c5866f4c40f4a2696513"
@@ -4837,13 +4842,6 @@ binary-extensions@^2.0.0:
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-bindings@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
-  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
-  dependencies:
-    file-uri-to-path "1.0.0"
-
 blessed@0.1.81:
   version "0.1.81"
   resolved "https://registry.npmjs.org/blessed/-/blessed-0.1.81.tgz#f962d687ec2c369570ae71af843256e6d0ca1129"
@@ -6449,11 +6447,6 @@ file-type@^17.1.6:
     strtok3 "^7.0.0-alpha.9"
     token-types "^5.0.0-alpha.2"
 
-file-uri-to-path@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
-  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
-
 filelist@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz#f78978a1e944775ff9e62e744424f215e58352b5"
@@ -6993,13 +6986,6 @@ hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
-
-hot-shots@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.npmjs.org/hot-shots/-/hot-shots-10.0.0.tgz#d360f9dd252da78297aca1cb08fd84a8936739c2"
-  integrity sha512-uy/uGpuJk7yuyiKRfZMBNkF1GAOX5O2ifO9rDCaX9jw8fu6eW9QeWC7WRPDI+O98frW1HQgV3+xwjWsZPECIzQ==
-  optionalDependencies:
-    unix-dgram "2.x"
 
 html-escaper@^2.0.0:
   version "2.0.2"
@@ -9324,11 +9310,6 @@ mz@^2.7.0:
     any-promise "^1.0.0"
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
-
-nan@^2.16.0:
-  version "2.17.0"
-  resolved "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz#c0150a2368a182f033e9aa5195ec76ea41a199cb"
-  integrity sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==
 
 nanoid@^4.0.0:
   version "4.0.1"
@@ -11871,14 +11852,6 @@ universalify@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
   integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
-
-unix-dgram@2.x:
-  version "2.0.6"
-  resolved "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.6.tgz#6d567b0eb6d7a9504e561532b598a46e34c5968b"
-  integrity sha512-AURroAsb73BZ6CdAyMrTk/hYKNj3DuYYEuOaB8bYMOHGKupRNScw90Q5C71tWJc3uE7dIeXRyuwN0xLLq3vDTg==
-  dependencies:
-    bindings "^1.5.0"
-    nan "^2.16.0"
 
 update-browserslist-db@^1.0.10:
   version "1.0.10"


### PR DESCRIPTION
## Motivation

Replace hot-shots with @figma/hot-shots, which removes the `unix-dgram` dependency, which doesn't seem to be maintained

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates dependencies in `@farcaster/replicator` and `@farcaster/hubble` to replace `hot-shots` with `@figma/hot-shots`.

### Detailed summary
- Replaced `hot-shots` with `@figma/hot-shots` in both apps
- Updated `@figma/hot-shots` version in `package.json`
- Updated dependencies in `yarn.lock`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->