### PR TITLE
docs: Add warning about running `docker compose up` from latest `main`

### DIFF
--- a/apps/hubble/docker-compose.yml
+++ b/apps/hubble/docker-compose.yml
@@ -2,6 +2,11 @@
 #
 # See https://www.thehubble.xyz/intro/install.html#installing-hubble for full
 # instructions.
+#
+# WARNING: Running `docker compose up` from the latest commit on the main
+# branch may not work. Make sure to check out the latest tagged release first:
+#
+#   git fetch --tags --force && git checkout @latest && docker compose up
 
 version: '3.9'
 
@@ -69,4 +74,3 @@ services:
 
 networks:
   my-network:
-


### PR DESCRIPTION
## Motivation

Avoids confusion like that in https://github.com/farcasterxyz/hub-monorepo/issues/1727

## Change Summary

Add a note to the top of the compose file.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a warning to `docker-compose.yml` advising to use the latest tagged release before running `docker compose up`.

### Detailed summary
- Added a warning message in `docker-compose.yml` advising to checkout the latest tagged release before running `docker compose up`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->