### PR TITLE
docs: Update install instructions

### DIFF
--- a/apps/hubble/www/docs/intro/install.md
+++ b/apps/hubble/www/docs/intro/install.md
@@ -40,7 +40,7 @@ cd ~/hubble && ./hubble.sh upgrade
 
 Hubble can also be set up by running the docker image directly. To do this: 
 
-1. Check out the [hub-monorepo](https://github.com/farcasterxyz/hub-monorepo) locally.
+1. Check out the latest release locally: `git clone -c advice.detachedHead=false -b @latest https://github.com/farcasterxyz/hub-monorepo.git`
 2. From the root of this folder navigate to `apps/hubble`
 3. Generate your identity key pair with docker compose.
 


### PR DESCRIPTION
## Motivation

Avoids situations like what was reported in https://github.com/farcasterxyz/hub-monorepo/issues/1727

## Change Summary

Update the clone command.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the installation instructions in `install.md` for setting up Hubble by checking out the latest release of the `hub-monorepo` repository directly.

### Detailed summary
- Updated the command to check out the latest release of `hub-monorepo` repository.
- Improved clarity in the installation instructions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->