### PR TITLE
docs: Fix display of install instructions

### DIFF
--- a/apps/hubble/www/docs/intro/install.md
+++ b/apps/hubble/www/docs/intro/install.md
@@ -38,9 +38,14 @@ cd ~/hubble && ./hubble.sh upgrade
 
 ## Install via Docker
 
-Hubble can also be set up by running the docker image directly. To do this: 
+Hubble can also be set up by running the docker image directly. To do this:
 
-1. Check out the latest release locally: `git clone -c advice.detachedHead=false -b @latest https://github.com/farcasterxyz/hub-monorepo.git`
+1. Check out the latest release locally:
+
+```bash
+git clone -c advice.detachedHead=false -b @latest https://github.com/farcasterxyz/hub-monorepo.git
+```
+
 2. From the root of this folder navigate to `apps/hubble`
 3. Generate your identity key pair with docker compose.
 


### PR DESCRIPTION
## Motivation

Make it easier to copy+paste.

## Change Summary

Switch to syntax highlighted code.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the installation instructions in the `install.md` file for setting up Hubble via Docker. 

### Detailed summary
- Added a step to check out the latest release locally using `git clone` command.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->