### PR TITLE
docs: Update docker upgrading commands

### DIFF
--- a/apps/hubble/www/docs/intro/install.md
+++ b/apps/hubble/www/docs/intro/install.md
@@ -89,8 +89,8 @@ docker compose logs -f hubble
 Navigate to `apps/hubble` in hub-monorepo and run: 
 
 ```bash
-git checkout main && git pull
-docker compose stop && docker compose up -d --force-recreate --pull always
+git fetch --tags --force && git checkout @latest  # Checkout to the latest release
+docker compose stop && docker compose up -d --force-recreate --pull always  # Stop current container and start the upgraded one
 ```
 
 ## Installing from source


### PR DESCRIPTION
## Motivation

Make sure docker container is upgraded into the release version, and aviod situations like #1727

## Change Summary

Change docker container upgrade commands in Upgrading Hubble section.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the installation process in the `install.md` file for the Hubble application. 

### Detailed summary
- Changed Git commands to fetch tags and checkout the latest release
- Added comments for clarity on stopping and starting Docker containers

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->