### PR TITLE
fix: bs58 dependency

### DIFF
--- a/.changeset/grumpy-camels-rescue.md
+++ b/.changeset/grumpy-camels-rescue.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/core": patch
+---
+
+fix: add bs58 dependency

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,8 @@
     "@noble/curves": "^1.0.0",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0",
-    "viem": "^1.12.2"
+    "viem": "^1.12.2",
+    "bs58": "^5.0.0"
   },
   "scripts": {
     "build": "tsup --config tsup.config.ts",


### PR DESCRIPTION
## Motivation

`bs58` was added as a dependency of `@farcaster/hubble` but should be a dependency of `@farcaster/core`.

## Change Summary

Add `bs58` to `@farcaster/core` dependencies.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a missing dependency in the `@farcaster/core` package by adding `bs58`.

### Detailed summary
- Added `bs58` dependency to `@farcaster/core` package.json
- Updated the version of `bs58` to "^5.0.0"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->