### PR TITLE
chore: bump package versions

### DIFF
--- a/.changeset/hungry-boats-scream.md
+++ b/.changeset/hungry-boats-scream.md
@@ -1,6 +1,0 @@
----
-"@farcaster/replicator": patch
-"@farcaster/hubble": patch
----
-
-chore: update @farcaster/hub-nodejs

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hubble
 
+## 1.10.4
+
+### Patch Changes
+
+- addf097c: chore: update @farcaster/hub-nodejs
+
 ## 1.10.3
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",

--- a/apps/replicator/CHANGELOG.md
+++ b/apps/replicator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/replicator
 
+## 0.3.2
+
+### Patch Changes
+
+- addf097c: chore: update @farcaster/hub-nodejs
+
 ## 0.3.1
 
 ### Patch Changes

--- a/apps/replicator/package.json
+++ b/apps/replicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/replicator",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Replicate Farcaster hub data into Postgres",
   "author": "",
   "license": "",


### PR DESCRIPTION
## Change Summary

Release updated Hubble and replicator.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the versions of `@farcaster/hubble` and `@farcaster/replicator` to `1.10.4` and `0.3.2` respectively. It also includes a chore to update `@farcaster/hub-nodejs`.

### Detailed summary
- Updated `@farcaster/hubble` version to `1.10.4`
- Updated `@farcaster/replicator` version to `0.3.2`
- Chore: Updated `@farcaster/hub-nodejs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->