### PR TITLE
fix: Deprecate raw iterators in favor of forEach iterators

### DIFF
--- a/.changeset/thin-eels-count.md
+++ b/.changeset/thin-eels-count.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Deprecate raw iterators and switch to forEach iterators

--- a/apps/hubble/src/network/sync/merkleTrie.test.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.test.ts
@@ -39,12 +39,12 @@ describe("MerkleTrie", () => {
     callback?: (i: number, key: Buffer, value: Buffer) => Promise<void>,
   ): Promise<number> => {
     let count = 0;
-    for await (const [key, value] of db.iteratorByPrefix(Buffer.from([RootPrefix.SyncMerkleTrieNode]))) {
+    await db.forEachIteratorByPrefix(Buffer.from([RootPrefix.SyncMerkleTrieNode]), async (key, value) => {
       if (callback) {
         await callback(count, key as Buffer, value as Buffer);
       }
       count++;
-    }
+    });
 
     return count;
   };

--- a/apps/hubble/src/rpc/adminServer.ts
+++ b/apps/hubble/src/rpc/adminServer.ts
@@ -128,9 +128,7 @@ export default class AdminServer {
           ];
           for (const prefix of prefixes) {
             const prefixBuffer = Buffer.from([prefix]);
-            const iterator = this.db.iteratorByPrefix(prefixBuffer);
-
-            for await (const [key] of iterator) {
+            await this.db.forEachIteratorByPrefix(prefixBuffer, async (key) => {
               const result = await ResultAsync.fromPromise(this.db.del(key as Buffer), (e) => e as HubError);
               result.match(
                 () => {
@@ -140,7 +138,7 @@ export default class AdminServer {
                   log.error({ errCode: e.errCode }, "Failed to delete key: ${e.message}");
                 },
               );
-            }
+            });
           }
           log.info(`Deleted ${deletedCount} keys from db`);
 

--- a/apps/hubble/src/storage/db/message.test.ts
+++ b/apps/hubble/src/storage/db/message.test.ts
@@ -56,10 +56,11 @@ describe("makeMessagePrimaryKey", () => {
     for (const key of [key1, key2, key3, key4, key5]) {
       await db.put(key, TRUE_VALUE);
     }
-    const dbKeys = [];
-    for await (const [key] of db.iterator({ values: false, keyAsBuffer: true })) {
-      dbKeys.push(key);
-    }
+    const dbKeys: Buffer[] = [];
+    await db.forEachIteratorByPrefix(Buffer.from([]), (key, _) => {
+      dbKeys.push(key as Buffer);
+    });
+
     expect(dbKeys).toEqual([key1, key2, key3, key4, key5]);
   });
 });

--- a/apps/hubble/src/storage/stores/castStore.test.ts
+++ b/apps/hubble/src/storage/stores/castStore.test.ts
@@ -586,15 +586,17 @@ describe("revoke", () => {
   test("deletes all keys relating to the cast", async () => {
     await store.merge(castAdd);
     const castKeys: Buffer[] = [];
-    for await (const [key] of db.iterator()) {
+    await db.forEachIterator(async (key) => {
       castKeys.push(key as Buffer);
-    }
+    });
+
     expect(castKeys.length).toBeGreaterThan(0);
     await store.revoke(castAdd);
     const castKeysAfterRevoke: Buffer[] = [];
-    for await (const [key] of db.iterator()) {
+    await db.forEachIterator(async (key) => {
       castKeysAfterRevoke.push(key as Buffer);
-    }
+    });
+
     // Two hub events left behind (one merge, one revoke)
     expect(castKeysAfterRevoke.length).toEqual(2);
   });
@@ -605,15 +607,17 @@ describe("revoke", () => {
     });
     await store.merge(cast);
     const castKeys: Buffer[] = [];
-    for await (const [key] of db.iterator()) {
+    await db.forEachIterator(async (key) => {
       castKeys.push(key as Buffer);
-    }
+    });
+
     expect(castKeys.length).toBeGreaterThan(0);
     await store.revoke(cast);
     const castKeysAfterRevoke: Buffer[] = [];
-    for await (const [key] of db.iterator()) {
+    await db.forEachIterator(async (key) => {
       castKeysAfterRevoke.push(key as Buffer);
-    }
+    });
+
     // Two hub events left behind (one merge, one revoke)
     expect(castKeysAfterRevoke.length).toEqual(2);
   });

--- a/apps/hubble/src/storage/stores/linkStore.test.ts
+++ b/apps/hubble/src/storage/stores/linkStore.test.ts
@@ -706,15 +706,17 @@ describe("revoke", () => {
   test("deletes all keys relating to the link", async () => {
     await set.merge(linkAdd);
     const linkKeys: Buffer[] = [];
-    for await (const [key] of db.iterator()) {
+    await db.forEachIterator((key) => {
       linkKeys.push(key as Buffer);
-    }
+    });
+
     expect(linkKeys.length).toBeGreaterThan(0);
     await set.revoke(linkAdd);
     const linkKeysAfterRevoke: Buffer[] = [];
-    for await (const [key] of db.iterator()) {
+    await db.forEachIterator((key) => {
       linkKeysAfterRevoke.push(key as Buffer);
-    }
+    });
+
     // Two hub events left behind (one merge, one revoke)
     expect(linkKeysAfterRevoke.length).toEqual(2);
   });

--- a/apps/hubble/src/storage/stores/reactionStore.test.ts
+++ b/apps/hubble/src/storage/stores/reactionStore.test.ts
@@ -730,15 +730,17 @@ describe("revoke", () => {
   test("deletes all keys relating to the reaction", async () => {
     await set.merge(reactionAdd);
     const reactionKeys: Buffer[] = [];
-    for await (const [key] of db.iterator()) {
+    await db.forEachIterator((key) => {
       reactionKeys.push(key as Buffer);
-    }
+    });
+
     expect(reactionKeys.length).toBeGreaterThan(0);
     await set.revoke(reactionAdd);
     const reactionKeysAfterRevoke: Buffer[] = [];
-    for await (const [key] of db.iterator()) {
+    await db.forEachIterator((key) => {
       reactionKeysAfterRevoke.push(key as Buffer);
-    }
+    });
+
     // Two hub events left behind (one merge, one revoke)
     expect(reactionKeysAfterRevoke.length).toEqual(2);
   });
@@ -749,15 +751,17 @@ describe("revoke", () => {
     });
     await set.merge(reaction);
     const reactionKeys: Buffer[] = [];
-    for await (const [key] of db.iterator()) {
+    await db.forEachIterator((key) => {
       reactionKeys.push(key as Buffer);
-    }
+    });
+
     expect(reactionKeys.length).toBeGreaterThan(0);
     await set.revoke(reaction);
     const reactionKeysAfterRevoke: Buffer[] = [];
-    for await (const [key] of db.iterator()) {
+    await db.forEachIterator((key) => {
       reactionKeysAfterRevoke.push(key as Buffer);
-    }
+    });
+
     // Two hub events left behind (one merge, one revoke)
     expect(reactionKeysAfterRevoke.length).toEqual(2);
   });

--- a/apps/hubble/src/storage/stores/storageCache.ts
+++ b/apps/hubble/src/storage/stores/storageCache.ts
@@ -206,9 +206,12 @@ export class StorageCache {
     const value = this._earliestTsHashes.get(key);
     if (value === undefined) {
       const prefix = makeMessagePrimaryKey(fid, set);
-      const iterator = this._db.iteratorByPrefix(prefix, { values: false });
-      const [firstKey] = await iterator.next();
-      await iterator.end();
+
+      let firstKey: Buffer | undefined;
+      await this._db.forEachIteratorByPrefix(prefix, (key) => {
+        firstKey = key as Buffer;
+        return true; // Finish the iteration after the first key-value pair
+      });
 
       if (firstKey === undefined) {
         return ok(undefined);


### PR DESCRIPTION
## Motivation

In prep for the Rust migration for the DB, deprecate the raw iterators

## Change Summary

Raw iterators are very problematic, causing memory leaks and unclosed iterators. In prep for moving to Rust, switch to using exclusively the forEachIterators that handle the iteration through callbacks which are much safer and fit Rust's memory safety model. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR deprecates raw iterators and replaces them with forEach iterators in the `@farcaster/hubble` package.

### Detailed summary
- Deprecated raw iterators in favor of forEach iterators in various test files
- Replaced raw iterators with forEach iterators in storage cache, link store, cast store, reaction store, admin server, and engine files
- Modified the RocksDB class to include a private iterator method and a new forEachIteratorByOpts method

> The following files were skipped due to too many changes: `apps/hubble/src/storage/db/onChainEvent.ts`, `apps/hubble/src/storage/stores/store.ts`, `apps/hubble/src/storage/jobs/revokeMessagesBySignerJob.ts`, `apps/hubble/src/storage/db/message.ts`, `apps/hubble/src/storage/db/rocksdb.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->