### PR TITLE
fix: Increase min timeouts for PM2 configuration

### DIFF
--- a/apps/hubble/pm2.config.cjs
+++ b/apps/hubble/pm2.config.cjs
@@ -19,7 +19,11 @@ module.exports = {
       args: process.env.HUBBLE_ARGS,
       watch: false,
       log_type: "json",
+      out_file: "/dev/null",
       err_file: "/dev/stderr",
+      min_uptime: 60_000, // Min uptime before the app can be considered started
+      listen_timeout: 30_000, // Time before forcing a reload if app not listening
+      kill_timeout: 60_000, // Time before sending a final SIGKILL after attempting graceful stop
     },
   ],
 };


### PR DESCRIPTION
## Motivation

The defaults were too aggressive.

## Change Summary

Update various timeout configuration.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the PM2 configuration for the `hubble` app by adding new parameters related to uptime, listen timeout, and kill timeout.

### Detailed summary
- Added `out_file: "/dev/null"` to redirect output to null
- Added `min_uptime: 60_000` for minimum uptime before considering app started
- Added `listen_timeout: 30_000` for forcing reload if app not listening
- Added `kill_timeout: 60_000` for final SIGKILL after graceful stop

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->