### PR TITLE
fix: gossip connection timeout

### DIFF
--- a/.changeset/cold-hornets-laugh.md
+++ b/.changeset/cold-hornets-laugh.md
@@ -2,4 +2,4 @@
 "@farcaster/hubble": patch
 ---
 
-Set dial timeout when connecting to peers for gossip node (default: 2 seconds) and expose LIBP2P_CONNECT_TIMEOUT_MS environment variable
+fix: Set dial timeout when connecting to peers for gossip node (default: 2 seconds) and expose LIBP2P_CONNECT_TIMEOUT_MS environment variable

--- a/.changeset/cold-hornets-laugh.md
+++ b/.changeset/cold-hornets-laugh.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+Set dial timeout when connecting to peers for gossip node (default: 2 seconds) and expose LIBP2P_CONNECT_TIMEOUT_MS environment variable

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -596,24 +596,6 @@ app
       console.log("Please wait... This may take several minutes");
     }
 
-    const hub = hubResult.value;
-    const startResult = await ResultAsync.fromPromise(
-      hub.start(),
-      (e) => new Error("Failed to start hub", { cause: e }),
-    );
-    if (startResult.isErr()) {
-      logger.fatal(startResult.error);
-      logger.fatal({ reason: "Hub Startup failed" }, "shutting down hub");
-      try {
-        await hub.teardown();
-      } finally {
-        logger.flush();
-        process.exit(1);
-      }
-    }
-
-    process.stdin.resume();
-
     process.on("SIGINT", () => {
       handleShutdownSignal("SIGINT");
     });
@@ -637,6 +619,24 @@ app
 
       handleShutdownSignal("unhandledRejection");
     });
+
+    const hub = hubResult.value;
+    const startResult = await ResultAsync.fromPromise(
+      hub.start(),
+      (e) => new Error("Failed to start hub", { cause: e }),
+    );
+    if (startResult.isErr()) {
+      logger.fatal(startResult.error);
+      logger.fatal({ reason: "Hub Startup failed" }, "shutting down hub");
+      try {
+        await hub.teardown();
+      } finally {
+        logger.flush();
+        process.exit(1);
+      }
+    }
+
+    process.stdin.resume();
   });
 
 /*//////////////////////////////////////////////////////////////

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -19,7 +19,7 @@ import { Config as DefaultConfig } from "./defaultConfig.js";
 import { profileStorageUsed } from "./profile/profile.js";
 import { profileRPCServer } from "./profile/rpcProfile.js";
 import { profileGossipServer } from "./profile/gossipProfile.js";
-import { initializeStatsd } from "./utils/statsd.js";
+import { getStatsdInitialization, initializeStatsd } from "./utils/statsd.js";
 import os from "os";
 import { startupCheck, StartupCheckStatus } from "./utils/startupCheck.js";
 import { mainnet, optimism } from "viem/chains";
@@ -502,6 +502,7 @@ app
       rebuildSyncTrie,
       profileSync,
       resyncNameEvents: cliOptions.resyncNameEvents ?? hubConfig.resyncNameEvents ?? false,
+      statsdParams: getStatsdInitialization(),
       commitLockTimeout: cliOptions.commitLockTimeout ?? hubConfig.commitLockTimeout,
       commitLockMaxPending: cliOptions.commitLockMaxPending ?? hubConfig.commitLockMaxPending,
       adminServerEnabled: cliOptions.adminServerEnabled ?? hubConfig.adminServerEnabled,

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -65,7 +65,7 @@ import { AddrInfo } from "@chainsafe/libp2p-gossipsub/types";
 import { CheckIncomingPortsJobScheduler } from "./storage/jobs/checkIncomingPortsJob.js";
 import { NetworkConfig, applyNetworkConfig, fetchNetworkConfig } from "./network/utils/networkConfig.js";
 import { UpdateNetworkConfigJobScheduler } from "./storage/jobs/updateNetworkConfigJob.js";
-import { statsd } from "./utils/statsd.js";
+import { statsd, StatsDInitParams } from "./utils/statsd.js";
 import {
   getDbSchemaVersion,
   LATEST_DB_SCHEMA_VERSION,
@@ -174,6 +174,9 @@ export interface HubOptions {
 
   /** Rank RPCs and use the ones with best stability and latency */
   rankRpcs?: boolean;
+
+  /** StatsD parameters */
+  statsdParams?: StatsDInitParams | undefined;
 
   /** ETH mainnet RPC URL(s) */
   ethMainnetRpcUrl?: string;
@@ -692,6 +695,7 @@ export class Hub implements HubInterface {
       applicationScoreCap: this.options.applicationScoreCap,
       strictNoSign: this.strictNoSign,
       connectToDbPeers: this.options.connectToDbPeers,
+      statsdParams: this.options.statsdParams,
     });
 
     await this.registerEventHandlers();

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1060,6 +1060,7 @@ export class Hub implements HubInterface {
           await this.gossipNode.reportValid(msgId, peerIdFromString(source.toString()).toBytes(), true);
         }
       } else {
+        statsd().increment(`gossip.message_failure.${result.error.errCode}`);
         log.info(
           {
             errCode: result.error.errCode,

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -22,7 +22,7 @@ import { PeriodicPeerCheckScheduler } from "./periodicPeerCheck.js";
 import { GOSSIP_PROTOCOL_VERSION } from "./protocol.js";
 import { AddrInfo } from "@chainsafe/libp2p-gossipsub/types";
 import { PeerScoreThresholds } from "@chainsafe/libp2p-gossipsub/score";
-import { statsd } from "../../utils/statsd.js";
+import { statsd, StatsDInitParams } from "../../utils/statsd.js";
 import { createFromProtobuf, exportToProtobuf } from "@libp2p/peer-id-factory";
 import EventEmitter from "events";
 import RocksDB from "../../storage/db/rocksdb.js";
@@ -79,6 +79,8 @@ export interface NodeOptions {
   connectToDbPeers?: boolean | undefined;
   /** The maximum amount of time to dial a peer in libp2p network in milliseconds */
   p2pConnectTimeoutMs?: number | undefined;
+  /** StatsD parameters */
+  statsdParams?: StatsDInitParams | undefined;
 }
 
 // A common return type for several methods on the libp2p node.
@@ -510,10 +512,6 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
           } else {
             data = Buffer.from(Object.values(detail.msg.data as unknown as Record<string, number>));
           }
-          const t = Date.now();
-          console.log(
-            JSON.stringify({ time: t, msgId: detail.msgId, topic: detail.msg.topic, msg: "Received gossip" }),
-          );
 
           this.emit(
             "message",

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -34,6 +34,10 @@ export const MAX_MESSAGE_QUEUE_SIZE = 100_000;
 /** The TTL for messages in the seen cache */
 export const GOSSIP_SEEN_TTL = 1000 * 60 * 5;
 
+/** The maximum amount of time to dial a peer in libp2p network in milliseconds */
+export const LIBP2P_CONNECT_TIMEOUT_MS = 2000;
+export const ENV_LIBP2P_CONNECT_TIMEOUT_MS = "LIBP2P_CONNECT_TIMEOUT_MS";
+
 const log = logger.child({ component: "GossipNode" });
 const workerLog = logger.child({ component: "GossipNodeWorker" });
 
@@ -73,6 +77,8 @@ export interface NodeOptions {
   strictNoSign?: boolean | undefined;
   /** Whether to connect to peers that were remembered in the DB */
   connectToDbPeers?: boolean | undefined;
+  /** The maximum amount of time to dial a peer in libp2p network in milliseconds */
+  p2pConnectTimeoutMs?: number | undefined;
 }
 
 // A common return type for several methods on the libp2p node.

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -504,6 +504,11 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
           } else {
             data = Buffer.from(Object.values(detail.msg.data as unknown as Record<string, number>));
           }
+          const t = Date.now();
+          console.log(
+            JSON.stringify({ time: t, msgId: detail.msgId, topic: detail.msg.topic, msg: "Received gossip" }),
+          );
+
           this.emit(
             "message",
             detail.msg.topic,

--- a/apps/hubble/src/network/sync/merkleTrie.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.ts
@@ -12,7 +12,7 @@ import {
   UserMessagePostfixMax,
 } from "../../storage/db/types.js";
 import { logger } from "../../utils/logger.js";
-import { getStatusdInitialization } from "../../utils/statsd.js";
+import { getStatsdInitialization } from "../../utils/statsd.js";
 import { messageDecode } from "../../storage/db/message.js";
 
 /**
@@ -113,7 +113,7 @@ class MerkleTrie {
     } else {
       const workerPath = new URL("../../../build/network/sync/merkleTrieWorker.js", import.meta.url);
       this._worker = new Worker(workerPath, {
-        workerData: { statsdInitialization: getStatusdInitialization(), dbPath: this._db.location },
+        workerData: { statsdInitialization: getStatsdInitialization(), dbPath: this._db.location },
       });
     }
 

--- a/apps/hubble/src/utils/statsd.ts
+++ b/apps/hubble/src/utils/statsd.ts
@@ -30,7 +30,7 @@ export function statsd(): StatsD {
 
 let statsdInitialization: StatsDInitParams | undefined;
 
-export function getStatusdInitialization(): StatsDInitParams | undefined {
+export function getStatsdInitialization(): StatsDInitParams | undefined {
   return statsdInitialization;
 }
 


### PR DESCRIPTION
## Motivation

- Hub nodes experienced significant delays from when a message was received and when it was validated in worker thread.
- Large amounts of p2p connection attempts can cause backlog congestion as it may exhaust file descriptor or TCP connection limits
- We observed large number of connection attempts that took 30 seconds, which seem to cause worker thread congestion
![image](https://github.com/farcasterxyz/hub-monorepo/assets/3589723/5d46383f-5c4e-485a-aedc-95c83b7db32f)


## Change Summary

- Expose `LIBP2P_CONNECT_TIMEOUT_MS` environment variable to set dial timeout when connecting to peers
- Set default connection timeout to `2 seconds` instead of `30 seconds`
- Add statsd metrics for gossip worker method latency: `gossip.worker.${method}.latency_ms` 
- Fix small bug where signal handlers were initialized after hub started - this can cause ungraceful termination and corruption issues on first sync

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving libp2p connection timeouts and exposing environment variables for configuration. 

### Detailed summary
- Set dial timeout for gossip node connections
- Expose `LIBP2P_CONNECT_TIMEOUT_MS` environment variable
- Update StatsD initialization in various files

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->