### PR TITLE
Update Neynar in bootstrapPeers.mainnet.ts

### DIFF
--- a/apps/hubble/src/bootstrapPeers.mainnet.ts
+++ b/apps/hubble/src/bootstrapPeers.mainnet.ts
@@ -3,6 +3,5 @@ export const MAINNET_BOOTSTRAP_PEERS = [
   "/dns/hoyt.farcaster.xyz/tcp/2282",
   "/dns/lamia.farcaster.xyz/tcp/2282",
   "/dns/nemes.farcaster.xyz/tcp/2282",
-  "/dns/elen.hubs.neynar.com/tcp/2282",
-  "/dns/tari.hubs.neynar.com/tcp/2282",
+  "/dns/bootstrap.neynar.com/tcp/2282",
 ];


### PR DESCRIPTION
We had to rearrange our domains to make this work with our load balancer

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the bootstrap peers for the mainnet in the Hubble app.

### Detailed summary
- Updated bootstrap peers for mainnet in `bootstrapPeers.mainnet.ts`
- Removed `/dns/elen.hubs.neynar.com/tcp/2282` and `/dns/tari.hubs.neynar.com/tcp/2282`
- Added `/dns/bootstrap.neynar.com/tcp/2282` as a new bootstrap peer

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->