### PR TITLE
refactor: add tags to key statsd metrics

### DIFF
--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1423,7 +1423,6 @@ export class Hub implements HubInterface {
           error_code: e.errCode,
           message_type: type,
           source: source ?? "unknown-source",
-          fid: message.data?.fid.toString() ?? "unknown-fid",
         };
         statsd().increment("submit_message.error", 1, tags);
       },

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1067,7 +1067,6 @@ export class Hub implements HubInterface {
         const tags: { [key: string]: string } = {
           valid: reportedAsInvalid ? "false" : "true",
           error_code: result.error.errCode,
-          error_message: result.error.message,
           message_type: messageTypeToName(message.data?.type),
         };
 

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1068,7 +1068,7 @@ export class Hub implements HubInterface {
           valid: reportedAsInvalid ? "false" : "true",
           error_code: result.error.errCode,
           error_message: result.error.message,
-          message_type: message.data?.type.toString() ?? "",
+          message_type: messageTypeToName(message.data?.type),
         };
 
         statsd().increment("gossip.message_failure", 1, tags);

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1071,7 +1071,7 @@ export class Hub implements HubInterface {
           message_type: message.data?.type.toString() ?? "",
         };
 
-        statsd().increment("gossip.message_failure", tags);
+        statsd().increment("gossip.message_failure", 1, tags);
         log.info(
           {
             errCode: result.error.errCode,

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -17,7 +17,7 @@ import { peerIdFromBytes, peerIdFromString } from "@libp2p/peer-id";
 import { multiaddr, Multiaddr } from "@multiformats/multiaddr";
 import { err, ok, Result } from "neverthrow";
 import { TypedEmitter } from "tiny-typed-emitter";
-import { logger } from "../../utils/logger.js";
+import { logger, messageTypeToName } from "../../utils/logger.js";
 import { PeriodicPeerCheckScheduler } from "./periodicPeerCheck.js";
 import { GOSSIP_PROTOCOL_VERSION } from "./protocol.js";
 import { AddrInfo } from "@chainsafe/libp2p-gossipsub/types";
@@ -517,7 +517,7 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
 
           const decoded = GossipNode.decodeMessage(data);
           if (decoded.isOk()) {
-            tags["message_type"] = decoded.value.message?.data?.type.toString() ?? "unknown-message-type";
+            tags["message_type"] = messageTypeToName(decoded.value.message?.data?.type) || "unknown-message-type";
             tags["fid"] = decoded.value.message?.data?.fid.toString() ?? "unknown-fid";
           }
 

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -520,7 +520,6 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
           const decoded = GossipNode.decodeMessage(data);
           if (decoded.isOk()) {
             tags["message_type"] = messageTypeToName(decoded.value.message?.data?.type) || "unknown-message-type";
-            tags["fid"] = decoded.value.message?.data?.fid.toString() ?? "unknown-fid";
           }
 
           this.emit("message", detail.msg.topic, decoded, detail.propagationSource, detail.msgId);

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -722,5 +722,9 @@ parentPort?.on("message", async (msg: LibP2PNodeMethodGenericMessage) => {
       break;
     }
   }
-  statsd().histogram(`gossip.worker.${method}.latency_ms`, Date.now() - start);
+
+  const tags: { [key: string]: string } = {
+    method: method,
+  };
+  statsd().histogram("gossip.worker.latency_ms", Date.now() - start, 1.0, tags);
 });

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -726,5 +726,5 @@ parentPort?.on("message", async (msg: LibP2PNodeMethodGenericMessage) => {
   const tags: { [key: string]: string } = {
     method: method,
   };
-  statsd().histogram("gossip.worker.latency_ms", Date.now() - start, 1.0, tags);
+  statsd().histogram("gossip.worker.latency_ms", Date.now() - start, 1, tags);
 });


### PR DESCRIPTION
## Motivation

- StatsD metrics support tags for high cardinality multivariate data
- String interpolation is useful for local development, but can be much more difficult to graph in production

## Change Summary

- Update `gossip.message_failure`
- Update `submit_message.error`
- Update `gossip.messages`
- Update `gossip.worker.latency_ms`

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances gossip message tracking in the Hubble network by adding detailed tags for message failures and emissions.

### Detailed summary
- Added detailed tags for latency tracking in `gossipNodeWorker.ts`
- Enhanced message failure tracking with specific tags in `hubble.ts`
- Improved message tracking and decoding in `gossipNode.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->