### PR TITLE
fix: Use UTC for job scheduling

### DIFF
--- a/.changeset/new-ties-appear.md
+++ b/.changeset/new-ties-appear.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Use UTC for jobs scheduler

--- a/apps/hubble/src/storage/jobs/checkIncomingPortsJob.ts
+++ b/apps/hubble/src/storage/jobs/checkIncomingPortsJob.ts
@@ -24,7 +24,9 @@ export class CheckIncomingPortsJobScheduler {
 
   start(cronSchedule?: string) {
     const defaultSchedule = "15 * * * *"; // Every hour at :15
-    this._cronTask = cron.schedule(cronSchedule ?? defaultSchedule, () => this.doJobs());
+    this._cronTask = cron.schedule(cronSchedule ?? defaultSchedule, () => this.doJobs(), {
+      timezone: "Etc/UTC",
+    });
   }
 
   stop() {

--- a/apps/hubble/src/storage/jobs/gossipContactInfoJob.ts
+++ b/apps/hubble/src/storage/jobs/gossipContactInfoJob.ts
@@ -21,7 +21,9 @@ export class GossipContactInfoJobScheduler {
   start(cronSchedule?: string) {
     const randomMinute = Math.floor(Math.random() * 60);
     const defaultSchedule = `${randomMinute} */2 * * *`; // Every 2 hours at a random minute
-    this._cronTask = cron.schedule(cronSchedule ?? defaultSchedule, () => this.doJobs());
+    this._cronTask = cron.schedule(cronSchedule ?? defaultSchedule, () => this.doJobs(), {
+      timezone: "Etc/UTC",
+    });
   }
 
   stop() {

--- a/apps/hubble/src/storage/jobs/pruneEventsJob.ts
+++ b/apps/hubble/src/storage/jobs/pruneEventsJob.ts
@@ -21,7 +21,9 @@ export class PruneEventsJobScheduler {
   }
 
   start(cronSchedule?: string) {
-    this._cronTask = cron.schedule(cronSchedule ?? DEFAULT_PRUNE_EVENTS_JOB_CRON, () => this.doJobs());
+    this._cronTask = cron.schedule(cronSchedule ?? DEFAULT_PRUNE_EVENTS_JOB_CRON, () => this.doJobs(), {
+      timezone: "Etc/UTC",
+    });
   }
 
   stop() {

--- a/apps/hubble/src/storage/jobs/pruneMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/pruneMessagesJob.ts
@@ -23,7 +23,9 @@ export class PruneMessagesJobScheduler {
   }
 
   start(cronSchedule?: string) {
-    this._cronTask = cron.schedule(cronSchedule ?? DEFAULT_PRUNE_MESSAGES_JOB_CRON, () => this.doJobs());
+    this._cronTask = cron.schedule(cronSchedule ?? DEFAULT_PRUNE_MESSAGES_JOB_CRON, () => this.doJobs(), {
+      timezone: "Etc/UTC",
+    });
 
     // Log the DB Size at startup
     setTimeout(() => {

--- a/apps/hubble/src/storage/jobs/revokeMessagesBySignerJob.ts
+++ b/apps/hubble/src/storage/jobs/revokeMessagesBySignerJob.ts
@@ -8,7 +8,7 @@ import {
 import { blake3 } from "@noble/hashes/blake3";
 import { err, ok, Result, ResultAsync } from "neverthrow";
 import { TypedEmitter } from "tiny-typed-emitter";
-import RocksDB, { Iterator } from "../db/rocksdb.js";
+import RocksDB from "../db/rocksdb.js";
 import { logger } from "../../utils/logger.js";
 import { RootPrefix } from "../db/types.js";
 import Engine from "../engine/index.js";

--- a/apps/hubble/src/storage/jobs/updateNetworkConfigJob.ts
+++ b/apps/hubble/src/storage/jobs/updateNetworkConfigJob.ts
@@ -21,7 +21,9 @@ export class UpdateNetworkConfigJobScheduler {
 
   start(cronSchedule?: string) {
     const defaultSchedule = "59 * * * *"; // Every hour at :59
-    this._cronTask = cron.schedule(cronSchedule ?? defaultSchedule, () => this.doJobs());
+    this._cronTask = cron.schedule(cronSchedule ?? defaultSchedule, () => this.doJobs(), {
+      timezone: "Etc/UTC",
+    });
   }
 
   stop() {

--- a/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
@@ -29,7 +29,9 @@ export class ValidateOrRevokeMessagesJobScheduler {
   }
 
   start(cronSchedule?: string) {
-    this._cronTask = cron.schedule(cronSchedule ?? DEFAULT_VALIDATE_AND_REVOKE_MESSAGES_CRON, () => this.doJobs());
+    this._cronTask = cron.schedule(cronSchedule ?? DEFAULT_VALIDATE_AND_REVOKE_MESSAGES_CRON, () => this.doJobs(), {
+      timezone: "Etc/UTC",
+    });
   }
 
   stop() {


### PR DESCRIPTION
## Motivation

Use UTC to schedule jobs

## Change Summary

- Schedule jobs like pruning at UTC, so all hubs prune at approx the same time and no hub has extra/missing messages

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates jobs schedulers in multiple files to use UTC timezone for consistency.

### Detailed summary
- Updated jobs schedulers in `pruneEventsJob.ts`, `checkIncomingPortsJob.ts`, `validateOrRevokeMessagesJob.ts`, `updateNetworkConfigJob.ts`, `pruneMessagesJob.ts`, and `gossipContactInfoJob.ts` to use UTC timezone for consistency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->