### PR TITLE
chore: Release v1.10.7

### DIFF
--- a/.changeset/empty-ties-do.md
+++ b/.changeset/empty-ties-do.md
@@ -1,9 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
-"@farcaster/hub-web": patch
-"@farcaster/replicator": patch
-"@farcaster/core": patch
-"@farcaster/hubble": patch
----
-
-perf: Move DB and Reactions store to rust

--- a/.changeset/smooth-donkeys-repeat.md
+++ b/.changeset/smooth-donkeys-repeat.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Log directly from worker threads

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @farcaster/hubble
 
+## 1.10.7
+
+### Patch Changes
+
+- 5a1764d8: perf: Move DB and Reactions store to rust
+- ac861b12: fix: Log directly from worker threads
+- Updated dependencies [5a1764d8]
+  - @farcaster/hub-nodejs@0.11.5
+
 ## 1.10.6
 
 ### Patch Changes

--- a/apps/replicator/CHANGELOG.md
+++ b/apps/replicator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/replicator
 
+## 0.3.3
+
+### Patch Changes
+
+- 5a1764d8: perf: Move DB and Reactions store to rust
+- Updated dependencies [5a1764d8]
+  - @farcaster/hub-nodejs@0.11.5
+
 ## 0.3.2
 
 ### Patch Changes

--- a/apps/replicator/package.json
+++ b/apps/replicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/replicator",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Replicate Farcaster hub data into Postgres",
   "author": "",
   "license": "",
@@ -28,7 +28,7 @@
     "@bull-board/api": "^5.8.4",
     "@bull-board/fastify": "^5.8.4",
     "@commander-js/extra-typings": "^11.0.0",
-    "@farcaster/hub-nodejs": "^0.11.3",
+    "@farcaster/hub-nodejs": "^0.11.5",
     "@figma/hot-shots": "^9.0.0-figma.1",
     "bullmq": "^4.11.4",
     "commander": "^11.0.0",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/core
 
+## 0.14.5
+
+### Patch Changes
+
+- 5a1764d8: perf: Move DB and Reactions store to rust
+
 ## 0.14.4
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hub-nodejs
 
+## 0.11.5
+
+### Patch Changes
+
+- 5a1764d8: perf: Move DB and Reactions store to rust
+- Updated dependencies [5a1764d8]
+  - @farcaster/core@0.14.5
+
 ## 0.11.4
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@farcaster/core": "0.14.4",
+    "@farcaster/core": "0.14.5",
     "@grpc/grpc-js": "~1.8.21",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"

--- a/packages/hub-web/CHANGELOG.md
+++ b/packages/hub-web/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hub-web
 
+## 0.8.4
+
+### Patch Changes
+
+- 5a1764d8: perf: Move DB and Reactions store to rust
+- Updated dependencies [5a1764d8]
+  - @farcaster/core@0.14.5
+
 ## 0.8.3
 
 ### Patch Changes

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-web",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -28,7 +28,7 @@
     "ts-proto": "^1.146.0"
   },
   "dependencies": {
-    "@farcaster/core": "^0.14.4",
+    "@farcaster/core": "^0.14.5",
     "@improbable-eng/grpc-web": "^0.15.0",
     "rxjs": "^7.8.0"
   }


### PR DESCRIPTION
## Motivation

v 1.10.7 release of Hubble

## Change Summary

- Move reactions store to Rust
- RocksDB upgraded to 8.10

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)
