### PR TITLE
fix package.json

### DIFF
--- a/.changeset/selfish-dolls-sip.md
+++ b/.changeset/selfish-dolls-sip.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Fix bad version release because of package.json

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -69,7 +69,7 @@
     "@chainsafe/libp2p-gossipsub": "6.1.0",
     "@chainsafe/libp2p-noise": "^11.0.0 ",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.11.4",
+    "@farcaster/hub-nodejs": "^0.11.5",
     "@fastify/cors": "^8.4.0",
     "@figma/hot-shots": "^9.0.0-figma.1",
     "@grpc/grpc-js": "~1.8.21",


### PR DESCRIPTION
fix missing package.json from prev commit

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `@farcaster/hubble` package to `1.10.7` to fix a bad release caused by an incorrect version in `package.json`.

### Detailed summary
- Updated `@farcaster/hubble` package version to `1.10.7` in `package.json`
- Updated dependency `@farcaster/hub-nodejs` to version `^0.11.5`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->