### PR TITLE
tests: Simplify ci tests

### DIFF
--- a/.changeset/soft-emus-chew.md
+++ b/.changeset/soft-emus-chew.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Simplify github actions test runs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,56 +50,7 @@ jobs:
           max_attempts: 10
           shell: bash
           command: ./grpcurl -plaintext -import-path protobufs/schemas -proto protobufs/schemas/rpc.proto 127.0.0.1:2283 HubService.GetInfo
-          on_retry_command: docker logs hub
-
-  analyze:
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '20'
-      
-      - name: Install Protocol Buffer Compiler
-        uses: arduino/setup-protoc@v3
-        with:
-          version: "24.4"
-
-      - name: Restore cached dependencies for Node modules.
-        id: module-cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ github.workspace }}/node_modules
-          key: ${{ runner.os }}-${{ runner.arch }}--node--20--${{ hashFiles('yarn.lock') }}
-
-      - name: Cache Cargo registry and git
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-registry-${{ hashFiles('apps/hubble/src/addon/Cargo.lock') }}
-
-      - name: Cache Cargo build artifacts
-        uses: actions/cache@v3
-        with:
-          path: ${{ github.workspace }}/apps/hubble/src/addon/target
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-build-${{ hashFiles('apps/hubble/src/addon/Cargo.lock') }}
-
-      - name: Install dependencies
-        run: yarn install
-
-      # - name: Run audit
-      #   run: yarn audit
-
-      - name: Run build
-        run: yarn build
-
-      - name: Run linter
-        run: yarn lint:ci
+          on_retry_command: docker logs hub      
 
   test:
     timeout-minutes: 10
@@ -162,6 +113,9 @@ jobs:
 
       - name: Run build
         run: yarn build
+
+      - name: Run linter
+        run: yarn lint:ci
 
       - name: Run tests
         run: yarn test:ci

--- a/apps/hubble/hubble.code-workspace
+++ b/apps/hubble/hubble.code-workspace
@@ -1,0 +1,16 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "src/addon"
+		}
+	],
+	"settings": {
+		"[apps/hubble/src/addon]": {
+		  "jest.enable": false
+		},
+		"rust-analyzer.showUnlinkedFileNotification": false
+	  }
+}

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -34,7 +34,7 @@
     "profile": "node --max-old-space-size=4096 build/cli.js profile",
     "status": "node build/cli.js status",
     "test": "yarn build:all && NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096\" jest",
-    "test:ci": "yarn build:all && ENVIRONMENT=test NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096\" jest --ci --forceExit --coverage -w 4"
+    "test:ci": "yarn build:all && ENVIRONMENT=test NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096\" jest --ci --forceExit --coverage -w 3"
   },
   "devDependencies": {
     "@libp2p/interface-mocks": "^9.0.0",


### PR DESCRIPTION
## Motivation

Simplify the tests to run linter alongside the tests instead of separate process to make maintaining `ci.yml` easier. 


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR simplifies GitHub Actions test runs and adjusts test concurrency in the `hubble` app.

### Detailed summary
- Updated `test:ci` script concurrency to `-w 3`
- Removed unnecessary steps in GitHub Actions workflow for `hubble`
- Adjusted linting script execution order

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->