### PR TITLE
chore: release 1.10.9

### DIFF
--- a/.changeset/large-hotels-watch.md
+++ b/.changeset/large-hotels-watch.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Handle latestBlock properly when sending to API

--- a/.changeset/soft-emus-chew.md
+++ b/.changeset/soft-emus-chew.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Simplify github actions test runs

--- a/.changeset/sweet-geckos-sip.md
+++ b/.changeset/sweet-geckos-sip.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Add approximate_size for DB

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @farcaster/hubble
 
+## 1.10.9
+
+### Patch Changes
+
+- 4a0fa6f4: fix: Handle latestBlock properly when sending to API
+- 48d49b2e: fix: Simplify github actions test runs
+- b302d3f4: fix: Add approximate_size for DB
+- 6d765651: fix: hub crash on contract events
+
 ## 1.10.8
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.10.8",
+  "version": "1.10.9",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",


### PR DESCRIPTION
## Motivation

Release hub crash fix

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `@farcaster/hubble` to `1.10.9` with various bug fixes and improvements.

### Detailed summary
- Patched handling of `latestBlock` in API
- Simplified GitHub Actions test runs
- Added `approximate_size` for DB
- Fixed hub crash on contract events

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->