### PR TITLE
perf: Move userdata store to rust

### DIFF
--- a/.changeset/swift-bobcats-promise.md
+++ b/.changeset/swift-bobcats-promise.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+perf: Move UserData store to rust

--- a/apps/hubble/src/addon/src/lib.rs
+++ b/apps/hubble/src/addon/src/lib.rs
@@ -3,7 +3,7 @@ use db::RocksDB;
 use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey, EXPANDED_SECRET_KEY_LENGTH};
 use neon::{prelude::*, types::buffer::TypedArray};
 use std::convert::TryInto;
-use store::{ReactionStore, Store};
+use store::{ReactionStore, Store, UserDataStore};
 
 mod db;
 mod logger;
@@ -142,6 +142,20 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
         "getReactionsByTarget",
         ReactionStore::js_get_reactions_by_target,
     )?;
+
+    // UserDataStore methods
+    cx.export_function("createUserDataStore", UserDataStore::create_userdata_store)?;
+    cx.export_function("getUserDataAdd", UserDataStore::js_get_userdata_add)?;
+    cx.export_function(
+        "getUserDataAddsByFid",
+        UserDataStore::js_get_user_data_adds_by_fid,
+    )?;
+    cx.export_function("getUserNameProof", UserDataStore::js_get_username_proof)?;
+    cx.export_function(
+        "getUserNameProofByFid",
+        UserDataStore::js_get_username_proof_by_fid,
+    )?;
+    cx.export_function("mergeUserNameProof", UserDataStore::js_merge_username_proof)?;
 
     Ok(())
 }

--- a/apps/hubble/src/addon/src/store/message.rs
+++ b/apps/hubble/src/addon/src/store/message.rs
@@ -63,7 +63,7 @@ pub enum RootPrefix {
     DBSchemaVersion = 24,
 
     /* Used to index fname username proofs by fid */
-    // FNameUserNameProofByFid = 25,
+    FNameUserNameProofByFid = 25,
 
     /* Used to index verifications by address */
     // VerificationByAddress = 25,

--- a/apps/hubble/src/addon/src/store/mod.rs
+++ b/apps/hubble/src/addon/src/store/mod.rs
@@ -2,10 +2,13 @@ pub use self::message::*;
 pub use self::reaction_store::*;
 pub use self::store::*;
 pub use self::store_event_handler::*;
+pub use self::user_data_store::*;
 pub use self::utils::*;
 
 mod message;
+mod name_registry_events;
 mod reaction_store;
 mod store;
 mod store_event_handler;
+mod user_data_store;
 mod utils;

--- a/apps/hubble/src/addon/src/store/name_registry_events.rs
+++ b/apps/hubble/src/addon/src/store/name_registry_events.rs
@@ -1,0 +1,83 @@
+use prost::Message;
+
+use crate::{
+    db::{RocksDB, RocksDbTransactionBatch},
+    protos::UserNameProof,
+};
+
+use super::{HubError, RootPrefix, UserPostfix};
+
+pub fn make_fname_username_proof_key(name: &[u8]) -> Vec<u8> {
+    let mut key = Vec::with_capacity(1 + 32 + 1 + 32);
+    key.push(RootPrefix::FNameUserNameProof as u8);
+    key.extend_from_slice(name);
+    key
+}
+
+pub fn make_fname_username_proof_by_fid_key(fid: u32) -> Vec<u8> {
+    let mut key = Vec::with_capacity(1 + 4 + 1 + 32);
+    key.push(RootPrefix::FNameUserNameProofByFid as u8);
+    key.extend_from_slice(&fid.to_le_bytes());
+    key
+}
+
+pub fn get_username_proof(db: &RocksDB, name: &[u8]) -> Result<Option<UserNameProof>, HubError> {
+    let key = make_fname_username_proof_key(name);
+    let buf = db.get(&key)?;
+    if buf.is_none() {
+        return Ok(None);
+    }
+
+    match UserNameProof::decode(buf.unwrap().as_slice()) {
+        Ok(proof) => Ok(Some(proof)),
+        Err(_) => Err(HubError {
+            code: "internal_error".to_string(),
+            message: "could not decode username proof".to_string(),
+        }),
+    }
+}
+
+pub fn get_fname_proof_by_fid(db: &RocksDB, fid: u32) -> Result<Option<UserNameProof>, HubError> {
+    let secondary_key = make_fname_username_proof_by_fid_key(fid);
+    let primary_key = db.get(&secondary_key)?;
+    if primary_key.is_none() {
+        return Ok(None);
+    }
+
+    let buf = db.get(primary_key.unwrap().as_slice())?;
+    if buf.is_none() {
+        return Ok(None);
+    }
+
+    match UserNameProof::decode(buf.unwrap().as_slice()) {
+        Ok(proof) => Ok(Some(proof)),
+        Err(_) => Err(HubError {
+            code: "internal_error".to_string(),
+            message: "could not decode username proof".to_string(),
+        }),
+    }
+}
+
+pub fn put_username_proof_transaction(
+    txn: &mut RocksDbTransactionBatch,
+    username_proof: &UserNameProof,
+) {
+    let buf = username_proof.encode_to_vec();
+
+    let primary_key = make_fname_username_proof_key(&username_proof.name);
+    txn.put(primary_key.clone(), buf);
+
+    let secondary_key = make_fname_username_proof_by_fid_key(username_proof.fid as u32);
+    txn.put(secondary_key, primary_key);
+}
+
+pub fn delete_username_proof_transaction(
+    txn: &mut RocksDbTransactionBatch,
+    username_proof: &UserNameProof,
+) {
+    let primary_key = make_fname_username_proof_key(&username_proof.name);
+    txn.delete(primary_key);
+
+    let secondary_key = make_fname_username_proof_by_fid_key(username_proof.fid as u32);
+    txn.delete(secondary_key);
+}

--- a/apps/hubble/src/addon/src/store/store.rs
+++ b/apps/hubble/src/addon/src/store/store.rs
@@ -85,16 +85,21 @@ pub trait StoreDef: Send + Sync {
 
     fn build_secondary_indicies(
         &self,
-        txn: &mut RocksDbTransactionBatch,
-        ts_hash: &[u8; TS_HASH_LENGTH],
-        message: &Message,
-    ) -> Result<(), HubError>;
+        _txn: &mut RocksDbTransactionBatch,
+        _ts_hash: &[u8; TS_HASH_LENGTH],
+        _message: &Message,
+    ) -> Result<(), HubError> {
+        Ok(())
+    }
+
     fn delete_secondary_indicies(
         &self,
-        txn: &mut RocksDbTransactionBatch,
-        ts_hash: &[u8; TS_HASH_LENGTH],
-        message: &Message,
-    ) -> Result<(), HubError>;
+        _txn: &mut RocksDbTransactionBatch,
+        _ts_hash: &[u8; TS_HASH_LENGTH],
+        _message: &Message,
+    ) -> Result<(), HubError> {
+        Ok(())
+    }
 
     fn find_merge_add_conflicts(&self, message: &Message) -> Result<(), HubError>;
     fn find_merge_remove_conflicts(&self, message: &Message) -> Result<(), HubError>;
@@ -145,6 +150,10 @@ impl Store {
 
     pub fn db(&self) -> Arc<RocksDB> {
         self.db.clone()
+    }
+
+    pub fn event_handler(&self) -> Arc<StoreEventHandler> {
+        self.store_event_handler.clone()
     }
 
     pub fn postfix(&self) -> u8 {

--- a/apps/hubble/src/addon/src/store/user_data_store.rs
+++ b/apps/hubble/src/addon/src/store/user_data_store.rs
@@ -1,0 +1,395 @@
+use super::{
+    bytes_compare, encode_messages_to_js_object, get_page_options, get_store,
+    hub_error_to_js_throw, make_user_key,
+    name_registry_events::{
+        delete_username_proof_transaction, get_fname_proof_by_fid, get_username_proof,
+        put_username_proof_transaction,
+    },
+    store::{Store, StoreDef},
+    HubError, MessagesPage, PageOptions, StoreEventHandler, UserPostfix,
+};
+use crate::protos::{hub_event, message_data, HubEvent, HubEventType, UserDataBody};
+use crate::{
+    db::{RocksDB, RocksDbTransactionBatch},
+    protos::{self, Message, MessageType},
+};
+use neon::types::{buffer::TypedArray, JsBox, JsBuffer};
+use neon::{
+    context::{Context, FunctionContext},
+    result::JsResult,
+    types::{JsNumber, JsPromise},
+};
+use prost::Message as _;
+use std::{borrow::Borrow, sync::Arc};
+
+pub struct UserDataStoreDef {
+    prune_size_limit: u32,
+}
+
+impl StoreDef for UserDataStoreDef {
+    fn postfix(&self) -> u8 {
+        UserPostfix::UserDataMessage as u8
+    }
+
+    fn add_message_type(&self) -> u8 {
+        MessageType::UserDataAdd as u8
+    }
+
+    fn remove_message_type(&self) -> u8 {
+        MessageType::None as u8
+    }
+
+    fn is_add_type(&self, message: &Message) -> bool {
+        message.signature_scheme == protos::SignatureScheme::Ed25519 as i32
+            && message.data.is_some()
+            && message.data.as_ref().unwrap().r#type == MessageType::UserDataAdd as i32
+            && message.data.as_ref().unwrap().body.is_some()
+    }
+
+    fn is_remove_type(&self, _message: &Message) -> bool {
+        false
+    }
+
+    fn find_merge_add_conflicts(&self, _message: &Message) -> Result<(), HubError> {
+        // No conflicts
+        Ok(())
+    }
+
+    fn find_merge_remove_conflicts(&self, _message: &Message) -> Result<(), HubError> {
+        Err(HubError {
+            code: "bad_request.invalid_param".to_string(),
+            message: "UserDataStoree doesn't support merging removes".to_string(),
+        })
+    }
+
+    fn make_add_key(&self, message: &Message) -> Result<Vec<u8>, HubError> {
+        let user_data_body = match message.data.as_ref().unwrap().body.as_ref().unwrap() {
+            message_data::Body::UserDataBody(body) => body,
+            _ => {
+                return Err(HubError {
+                    code: "bad_request.invalid_param".to_string(),
+                    message: "UserDataAdd message missing body".to_string(),
+                })
+            }
+        };
+
+        let key = Self::make_user_data_adds_key(
+            message.data.as_ref().unwrap().fid as u32,
+            user_data_body.r#type,
+        );
+        Ok(key)
+    }
+
+    fn make_remove_key(&self, _message: &Message) -> Result<Vec<u8>, HubError> {
+        Err(HubError {
+            code: "bad_request.invalid_param".to_string(),
+            message: "removes not supported".to_string(),
+        })
+    }
+
+    fn get_prune_size_limit(&self) -> u32 {
+        self.prune_size_limit
+    }
+}
+
+impl UserDataStoreDef {
+    /**
+     * Generates unique keys used to store or fetch UserDataAdd messages in the UserDataAdd set index
+     *
+     * @param fid farcaster id of the user who created the message
+     * @param dataType type of data being added
+     * @returns RocksDB key of the form <root_prefix>:<fid>:<user_postfix>:<dataType?>
+     */
+    fn make_user_data_adds_key(fid: u32, data_type: i32) -> Vec<u8> {
+        let mut key = Vec::with_capacity(33 + 1 + 1);
+
+        key.extend_from_slice(&make_user_key(fid));
+        key.push(UserPostfix::UserDataAdds as u8);
+        if data_type > 0 {
+            key.push(data_type as u8);
+        }
+
+        key
+    }
+}
+
+pub struct UserDataStore {}
+
+impl UserDataStore {
+    pub fn new(
+        db: Arc<RocksDB>,
+        store_event_handler: Arc<StoreEventHandler>,
+        prune_size_limit: u32,
+    ) -> Store {
+        Store::new_with_store_def(
+            db,
+            store_event_handler,
+            Box::new(UserDataStoreDef { prune_size_limit }),
+        )
+    }
+
+    pub fn create_userdata_store(mut cx: FunctionContext) -> JsResult<JsBox<Arc<Store>>> {
+        let db_js_box = cx.argument::<JsBox<Arc<RocksDB>>>(0)?;
+        let db = (**db_js_box.borrow()).clone();
+
+        // Read the StoreEventHandler
+        let store_event_handler_js_box = cx.argument::<JsBox<Arc<StoreEventHandler>>>(1)?;
+        let store_event_handler = (**store_event_handler_js_box.borrow()).clone();
+
+        // Read the prune size limit and prune time limit from the options
+        let prune_size_limit = cx
+            .argument::<JsNumber>(2)
+            .map(|n| n.value(&mut cx) as u32)?;
+
+        Ok(cx.boxed(Arc::new(UserDataStore::new(
+            db,
+            store_event_handler,
+            prune_size_limit,
+        ))))
+    }
+
+    pub fn get_user_data_add(
+        store: &Store,
+        fid: u32,
+        r#type: i32,
+    ) -> Result<Option<protos::Message>, HubError> {
+        let partial_message = protos::Message {
+            data: Some(protos::MessageData {
+                fid: fid as u64,
+                r#type: MessageType::UserDataAdd as i32,
+                body: Some(protos::message_data::Body::UserDataBody(UserDataBody {
+                    r#type,
+                    ..Default::default()
+                })),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        store.get_add(&partial_message)
+    }
+
+    pub fn js_get_userdata_add(mut cx: FunctionContext) -> JsResult<JsPromise> {
+        let channel = cx.channel();
+
+        let store = get_store(&mut cx)?;
+
+        let fid = cx.argument::<JsNumber>(0)?.value(&mut cx) as u32;
+        let r#type = cx.argument::<JsNumber>(1)?.value(&mut cx) as i32;
+
+        let result = match Self::get_user_data_add(&store, fid, r#type) {
+            Ok(Some(message)) => message.encode_to_vec(),
+            Ok(None) => cx.throw_error(format!(
+                "{}/{}",
+                "not_found", "NotFound: UserDataAdd message not found"
+            ))?,
+            Err(e) => return hub_error_to_js_throw(&mut cx, e),
+        };
+
+        let (deferred, promise) = cx.promise();
+        deferred.settle_with(&channel, move |mut cx| {
+            let mut js_buffer = cx.buffer(result.len())?;
+            js_buffer.as_mut_slice(&mut cx).copy_from_slice(&result);
+            Ok(js_buffer)
+        });
+
+        Ok(promise)
+    }
+
+    pub fn get_user_data_adds_by_fid(
+        store: &Store,
+        fid: u32,
+        page_options: &PageOptions,
+    ) -> Result<MessagesPage, HubError> {
+        store.get_adds_by_fid(fid, page_options, Some(|_message: &Message| true))
+    }
+
+    pub fn js_get_user_data_adds_by_fid(mut cx: FunctionContext) -> JsResult<JsPromise> {
+        let store = get_store(&mut cx)?;
+
+        let fid = cx.argument::<JsNumber>(0)?.value(&mut cx) as u32;
+        let page_options = get_page_options(&mut cx, 1)?;
+
+        let messages = match Self::get_user_data_adds_by_fid(&store, fid, &page_options) {
+            Ok(messages) => messages,
+            Err(e) => return hub_error_to_js_throw(&mut cx, e),
+        };
+
+        let channel = cx.channel();
+        let (deferred, promise) = cx.promise();
+        deferred.settle_with(&channel, move |mut cx| {
+            encode_messages_to_js_object(&mut cx, messages)
+        });
+
+        Ok(promise)
+    }
+
+    pub fn get_username_proof(
+        store: &Store,
+        name: &[u8],
+    ) -> Result<Option<protos::UserNameProof>, HubError> {
+        get_username_proof(&store.db(), name)
+    }
+
+    pub fn js_get_username_proof(mut cx: FunctionContext) -> JsResult<JsPromise> {
+        let store = get_store(&mut cx)?;
+        let name_buffer = cx.argument::<JsBuffer>(0)?;
+        let name = name_buffer.as_slice(&mut cx);
+
+        let result = match Self::get_username_proof(&store, &name) {
+            Ok(Some(proof)) => proof.encode_to_vec(),
+            Ok(None) => cx.throw_error(format!(
+                "{}/{}",
+                "not_found", "NotFound: UserDataAdd message not found"
+            ))?,
+            Err(e) => return hub_error_to_js_throw(&mut cx, e),
+        };
+
+        let (deferred, promise) = cx.promise();
+        let channel = cx.channel();
+        deferred.settle_with(&channel, move |mut cx| {
+            let mut js_buffer = cx.buffer(result.len())?;
+            js_buffer.as_mut_slice(&mut cx).copy_from_slice(&result);
+            Ok(js_buffer)
+        });
+
+        Ok(promise)
+    }
+
+    pub fn get_username_proof_by_fid(
+        store: &Store,
+        fid: u32,
+    ) -> Result<Option<protos::UserNameProof>, HubError> {
+        get_fname_proof_by_fid(&store.db(), fid)
+    }
+
+    pub fn js_get_username_proof_by_fid(mut cx: FunctionContext) -> JsResult<JsPromise> {
+        let store = get_store(&mut cx)?;
+        let fid = cx.argument::<JsNumber>(0)?.value(&mut cx) as u32;
+
+        let result = match Self::get_username_proof_by_fid(&store, fid) {
+            Ok(Some(proof)) => proof.encode_to_vec(),
+            Ok(None) => cx.throw_error(format!(
+                "{}/{}",
+                "not_found", "NotFound: UserDataAdd message not found"
+            ))?,
+            Err(e) => return hub_error_to_js_throw(&mut cx, e),
+        };
+
+        let (deferred, promise) = cx.promise();
+        let channel = cx.channel();
+        deferred.settle_with(&channel, move |mut cx| {
+            let mut js_buffer = cx.buffer(result.len())?;
+            js_buffer.as_mut_slice(&mut cx).copy_from_slice(&result);
+            Ok(js_buffer)
+        });
+
+        Ok(promise)
+    }
+
+    pub fn merge_username_proof(
+        store: &Store,
+        username_proof: &protos::UserNameProof,
+    ) -> Result<Vec<u8>, HubError> {
+        let existing_proof = get_username_proof(&store.db(), &username_proof.name)?;
+
+        if existing_proof.is_some() {
+            let cmp =
+                Self::username_proof_compare(existing_proof.as_ref().unwrap(), username_proof);
+
+            if cmp == 0 {
+                return Err(HubError {
+                    code: "bad_request.duplicate".to_string(),
+                    message: "username proof already exists".to_string(),
+                });
+            }
+            if cmp > 0 {
+                return Err(HubError {
+                    code: "bad_request.conflict".to_string(),
+                    message: "event conflicts with a more recent UserNameProof".to_string(),
+                });
+            }
+        }
+
+        if existing_proof.is_none() && username_proof.fid == 0 {
+            return Err(HubError {
+                code: "bad_request.conflict".to_string(),
+                message: "proof does not exist".to_string(),
+            });
+        }
+
+        let mut txn = RocksDbTransactionBatch::new();
+        if username_proof.fid == 0 {
+            delete_username_proof_transaction(&mut txn, username_proof);
+        } else {
+            put_username_proof_transaction(&mut txn, username_proof);
+        }
+
+        let mut hub_event = HubEvent {
+            r#type: HubEventType::MergeUsernameProof as i32,
+            body: Some(hub_event::Body::MergeUsernameProofBody(
+                protos::MergeUserNameProofBody {
+                    username_proof: Some(username_proof.clone()),
+                    deleted_username_proof: existing_proof,
+                    username_proof_message: None,
+                    deleted_username_proof_message: None,
+                },
+            )),
+            id: 0,
+        };
+        let id = store
+            .event_handler()
+            .commit_transaction(&mut txn, &mut hub_event)?;
+
+        store.db().commit(txn)?;
+
+        hub_event.id = id;
+        let hub_event_bytes = hub_event.encode_to_vec();
+
+        Ok(hub_event_bytes)
+    }
+
+    pub fn js_merge_username_proof(mut cx: FunctionContext) -> JsResult<JsPromise> {
+        let store = get_store(&mut cx)?;
+
+        let username_proof_buffer = cx.argument::<JsBuffer>(0)?;
+        let username_proof = protos::UserNameProof::decode(username_proof_buffer.as_slice(&mut cx));
+
+        let result = if username_proof.is_err() {
+            let e = username_proof.unwrap_err();
+            Err(HubError {
+                code: "bad_request.validation_failure".to_string(),
+                message: e.to_string(),
+            })
+        } else {
+            Self::merge_username_proof(store.as_ref(), &username_proof.unwrap())
+        };
+
+        let channel = cx.channel();
+        let (deferred, promise) = cx.promise();
+        deferred.settle_with(&channel, move |mut cx| match result {
+            Ok(hub_event_bytes) => {
+                let mut js_buffer = cx.buffer(hub_event_bytes.len())?;
+                js_buffer
+                    .as_mut_slice(&mut cx)
+                    .copy_from_slice(&hub_event_bytes);
+                Ok(js_buffer)
+            }
+            Err(e) => cx.throw_error(format!("{}/{}", e.code, e.message)),
+        });
+        // });
+
+        Ok(promise)
+    }
+
+    fn username_proof_compare(a: &protos::UserNameProof, b: &protos::UserNameProof) -> i8 {
+        if a.timestamp < b.timestamp {
+            return -1;
+        }
+        if a.timestamp > b.timestamp {
+            return 1;
+        }
+
+        bytes_compare(&a.signature, &b.signature)
+    }
+}

--- a/apps/hubble/src/rustfunctions.ts
+++ b/apps/hubble/src/rustfunctions.ts
@@ -370,3 +370,37 @@ export const rsGetReactionsByTarget = async (
 ): Promise<RustMessagesPage> => {
   return await lib.getReactionsByTarget.call(store, targetCastIdBytes, targetUrl, type, pageOptions);
 };
+
+export const rsCreateUserDataStore = (
+  db: RustDb,
+  eventHandler: RustStoreEventHandler,
+  pruneSizeLimit: number,
+): RustDynStore => {
+  const store = lib.createUserDataStore(db, eventHandler, pruneSizeLimit);
+
+  return store as RustDynStore;
+};
+
+export const rsGetUserDataAdd = async (store: RustDynStore, fid: number, dataType: number): Promise<Buffer> => {
+  return await lib.getUserDataAdd.call(store, fid, dataType);
+};
+
+export const rsGetUserDataAddsByFid = async (
+  store: RustDynStore,
+  fid: number,
+  pageOptions: PageOptions,
+): Promise<RustMessagesPage> => {
+  return await lib.getUserDataAddsByFid.call(store, fid, pageOptions);
+};
+
+export const rsGetUserNameProof = async (store: RustDynStore, name: Uint8Array): Promise<Buffer> => {
+  return await lib.getUserNameProof.call(store, name);
+};
+
+export const rsGetUserNameProofByFid = async (store: RustDynStore, fid: number): Promise<Buffer> => {
+  return await lib.getUserNameProofByFid.call(store, fid);
+};
+
+export const rsMergeUserNameProof = async (store: RustDynStore, usernameProof: Uint8Array): Promise<Buffer> => {
+  return await lib.mergeUserNameProof.call(store, usernameProof);
+};

--- a/apps/hubble/src/storage/stores/reactionStore.ts
+++ b/apps/hubble/src/storage/stores/reactionStore.ts
@@ -1,8 +1,5 @@
 import {
   CastId,
-  HubAsyncResult,
-  HubError,
-  HubEvent,
   Message,
   ReactionAddMessage,
   ReactionRemoveMessage,
@@ -11,157 +8,27 @@ import {
   getDefaultStoreLimit,
 } from "@farcaster/hub-nodejs";
 import {
-  RustDynStore,
   rsCreateReactionStore,
-  rsGetAllMessagesByFid,
-  rsGetMessage,
   rsGetReactionAdd,
   rsGetReactionAddsByFid,
   rsGetReactionRemove,
   rsGetReactionRemovesByFid,
   rsGetReactionsByTarget,
-  rsMerge,
-  rsPruneMessages,
-  revoke,
   rustErrorToHubError,
 } from "../../rustfunctions.js";
 import StoreEventHandler from "./storeEventHandler.js";
 import { MessagesPage, PageOptions, StorePruneOptions } from "./types.js";
-import { UserMessagePostfix, UserPostfix } from "../db/types.js";
-import { ResultAsync, err, ok } from "neverthrow";
+import { UserPostfix } from "../db/types.js";
+import { ResultAsync } from "neverthrow";
 import RocksDB from "storage/db/rocksdb.js";
+import { RustStoreBase } from "./rustStoreBase.js";
 
-class ReactionStore {
-  private rustReactionStore: RustDynStore;
-  protected _eventHandler: StoreEventHandler;
-
-  private _postfix: UserMessagePostfix;
-  private _pruneSizeLimit: number;
-
+class ReactionStore extends RustStoreBase<ReactionAddMessage, ReactionRemoveMessage> {
   constructor(db: RocksDB, eventHandler: StoreEventHandler, options: StorePruneOptions = {}) {
-    this._pruneSizeLimit = options.pruneSizeLimit ?? this.PRUNE_SIZE_LIMIT_DEFAULT;
+    const pruneSizeLimit = options.pruneSizeLimit ?? getDefaultStoreLimit(StoreType.REACTIONS);
+    const rustReactionStore = rsCreateReactionStore(db.rustDb, eventHandler.getRustStoreEventHandler(), pruneSizeLimit);
 
-    this.rustReactionStore = rsCreateReactionStore(
-      db.rustDb,
-      eventHandler.getRustStoreEventHandler(),
-      this._pruneSizeLimit,
-    );
-
-    this._postfix = UserPostfix.ReactionMessage;
-    this._eventHandler = eventHandler;
-  }
-
-  protected get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return getDefaultStoreLimit(StoreType.REACTIONS);
-  }
-
-  get pruneSizeLimit(): number {
-    return this._pruneSizeLimit;
-  }
-
-  async merge(message: Message): Promise<number> {
-    const prunableResult = await this._eventHandler.isPrunable(
-      // biome-ignore lint/suspicious/noExplicitAny: legacy code, avoid using ignore for new code
-      message as any,
-      this._postfix,
-      this.pruneSizeLimit,
-    );
-    if (prunableResult.isErr()) {
-      throw prunableResult.error;
-    } else if (prunableResult.value) {
-      throw new HubError("bad_request.prunable", "message would be pruned");
-    }
-
-    // Encode the message to bytes
-    const messageBytes = Message.encode(message).finish();
-    const result = await ResultAsync.fromPromise(rsMerge(this.rustReactionStore, messageBytes), rustErrorToHubError);
-    if (result.isErr()) {
-      throw result.error;
-    }
-
-    // Read the result bytes as a HubEvent
-    const resultBytes = new Uint8Array(result.value);
-    const hubEvent = HubEvent.decode(resultBytes);
-
-    void this._eventHandler.processRustCommitedTransaction(hubEvent);
-    return hubEvent.id;
-  }
-
-  async revoke(message: Message): HubAsyncResult<number> {
-    const messageBytes = Message.encode(message).finish();
-    const result = await ResultAsync.fromPromise(revoke(this.rustReactionStore, messageBytes), rustErrorToHubError);
-    if (result.isErr()) {
-      return err(result.error);
-    }
-
-    const resultBytes = new Uint8Array(result.value);
-    const hubEvent = HubEvent.decode(resultBytes);
-
-    void this._eventHandler.processRustCommitedTransaction(hubEvent);
-    return ok(hubEvent.id);
-  }
-
-  async pruneMessages(fid: number): HubAsyncResult<number[]> {
-    const cachedCount = await this._eventHandler.getCacheMessageCount(fid, this._postfix, false);
-    const units = await this._eventHandler.getCurrentStorageUnitsForFid(fid);
-
-    // Require storage cache to be synced to prune
-    if (cachedCount.isErr()) {
-      return err(cachedCount.error);
-    }
-
-    if (units.isErr()) {
-      return err(units.error);
-    }
-
-    // Return immediately if there are no messages to prune
-    if (cachedCount.value === 0) {
-      return ok([]);
-    }
-
-    const result = await ResultAsync.fromPromise(
-      rsPruneMessages(this.rustReactionStore, fid, cachedCount.value, units.value),
-      rustErrorToHubError,
-    );
-    if (result.isErr()) {
-      return err(result.error);
-    }
-
-    // Read the result bytes as an array of HubEvents
-    const commits = [];
-    for (const resultBytes of result.value) {
-      const hubEvent = HubEvent.decode(new Uint8Array(resultBytes));
-      commits.push(hubEvent.id);
-      void this._eventHandler.processRustCommitedTransaction(hubEvent);
-    }
-
-    return ok(commits);
-  }
-
-  async getMessage(fid: number, set: UserMessagePostfix, tsHash: Uint8Array): Promise<Message> {
-    const message_bytes = await ResultAsync.fromPromise(
-      rsGetMessage(this.rustReactionStore, fid, set, tsHash),
-      rustErrorToHubError,
-    );
-    if (message_bytes.isErr()) {
-      throw message_bytes.error;
-    }
-
-    return Message.decode(new Uint8Array(message_bytes.value));
-  }
-
-  async getAllMessagesByFid(
-    fid: number,
-    pageOptions: PageOptions = {},
-  ): Promise<MessagesPage<ReactionAddMessage | ReactionRemoveMessage>> {
-    const messages_page = await rsGetAllMessagesByFid(this.rustReactionStore, fid, pageOptions);
-
-    const messages =
-      messages_page.messageBytes?.map((message_bytes) => {
-        return Message.decode(new Uint8Array(message_bytes)) as ReactionAddMessage | ReactionRemoveMessage;
-      }) ?? [];
-
-    return { messages, nextPageToken: messages_page.nextPageToken };
+    super(db, rustReactionStore, UserPostfix.ReactionMessage, eventHandler, pruneSizeLimit);
   }
 
   async getReactionAdd(fid: number, type: ReactionType, target: CastId | string): Promise<ReactionAddMessage> {
@@ -175,7 +42,7 @@ class ReactionStore {
     }
 
     const result = await ResultAsync.fromPromise(
-      rsGetReactionAdd(this.rustReactionStore, fid, type, targetCastId, targetUrl),
+      rsGetReactionAdd(this._rustStore, fid, type, targetCastId, targetUrl),
       rustErrorToHubError,
     );
     if (result.isErr()) {
@@ -195,7 +62,7 @@ class ReactionStore {
     }
 
     const result = await ResultAsync.fromPromise(
-      rsGetReactionRemove(this.rustReactionStore, fid, type, targetCastId, targetUrl),
+      rsGetReactionRemove(this._rustStore, fid, type, targetCastId, targetUrl),
       rustErrorToHubError,
     );
     if (result.isErr()) {
@@ -209,7 +76,7 @@ class ReactionStore {
     type?: ReactionType,
     pageOptions?: PageOptions,
   ): Promise<MessagesPage<ReactionAddMessage>> {
-    const messages_page = await rsGetReactionAddsByFid(this.rustReactionStore, fid, type ?? 0, pageOptions ?? {});
+    const messages_page = await rsGetReactionAddsByFid(this._rustStore, fid, type ?? 0, pageOptions ?? {});
 
     const messages =
       messages_page.messageBytes?.map((message_bytes) => {
@@ -224,7 +91,7 @@ class ReactionStore {
     type?: ReactionType,
     pageOptions?: PageOptions,
   ): Promise<MessagesPage<ReactionRemoveMessage>> {
-    const message_page = await rsGetReactionRemovesByFid(this.rustReactionStore, fid, type ?? 0, pageOptions ?? {});
+    const message_page = await rsGetReactionRemovesByFid(this._rustStore, fid, type ?? 0, pageOptions ?? {});
 
     const messages =
       message_page.messageBytes?.map((message_bytes) => {
@@ -256,7 +123,7 @@ class ReactionStore {
     }
 
     const message_page = await rsGetReactionsByTarget(
-      this.rustReactionStore,
+      this._rustStore,
       targetCastId,
       targetUrl,
       type ?? ReactionType.NONE,


### PR DESCRIPTION
## Motivation

Move the UserData store to rust

## Change Summary

- userdata store to rust
- Refactor typescript code to make migrating stores easy

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on optimizing performance by moving the `UserData` store to Rust. 

### Detailed summary
- Moved `UserData` store to Rust for performance improvement.
- Added methods to interact with `UserDataStore`.
- Updated key generation and retrieval functions for `UserNameProof` in the store.
- Implemented common methods for all Rust stores in a base class.

> The following files were skipped due to too many changes: `apps/hubble/src/storage/stores/rustStoreBase.ts`, `apps/hubble/src/storage/stores/reactionStore.ts`, `apps/hubble/src/storage/stores/userDataStore.ts`, `apps/hubble/src/addon/src/store/user_data_store.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->