### PR TITLE
chore: Set maximum & default page size for HTTP API requests to 1K

### DIFF
--- a/.changeset/dry-apples-give.md
+++ b/.changeset/dry-apples-give.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+Set maximum & default page size for HTTP API requests to 1K

--- a/apps/hubble/src/rpc/httpServer.ts
+++ b/apps/hubble/src/rpc/httpServer.ts
@@ -56,6 +56,8 @@ type StaticEncodable<T> = {
   toJSON(message: T): unknown;
 };
 
+export const MAX_PAGE_SIZE = 1000; // Global maximum limit
+
 // Get the call Object for a given method
 function getCallObject<M extends keyof HubServiceServer>(
   method: M,
@@ -191,8 +193,6 @@ type QueryPageParams = {
   pageToken?: string;
   reverse?: number | boolean;
 };
-
-export const MAX_PAGE_SIZE = 1000; // Global maximum limit
 
 function getPageOptions(query: QueryPageParams): PageOptions {
   const pageSize = query.pageSize ? parseInt(query.pageSize.toString()) : MAX_PAGE_SIZE;

--- a/apps/hubble/src/rpc/httpServer.ts
+++ b/apps/hubble/src/rpc/httpServer.ts
@@ -56,7 +56,7 @@ type StaticEncodable<T> = {
   toJSON(message: T): unknown;
 };
 
-export const MAX_PAGE_SIZE = 1000; // Global maximum limit
+export const DEFAULT_PAGE_SIZE = 1000; // Global maximum limit
 
 // Get the call Object for a given method
 function getCallObject<M extends keyof HubServiceServer>(
@@ -195,10 +195,10 @@ type QueryPageParams = {
 };
 
 function getPageOptions(query: QueryPageParams): PageOptions {
-  const pageSize = query.pageSize ? parseInt(query.pageSize.toString()) : MAX_PAGE_SIZE;
+  const pageSize = query.pageSize ? parseInt(query.pageSize.toString()) : DEFAULT_PAGE_SIZE;
 
   // Ensure the pageSize does not exceed the global maximum
-  const effectivePageSize = Math.min(pageSize, MAX_PAGE_SIZE);
+  const effectivePageSize = Math.min(pageSize, DEFAULT_PAGE_SIZE);
 
   const pageToken = query.pageToken
     ? Uint8Array.from(Buffer.from(query.pageToken.replaceAll(" ", "+"), "base64"))

--- a/apps/hubble/src/rpc/httpServer.ts
+++ b/apps/hubble/src/rpc/httpServer.ts
@@ -191,17 +191,21 @@ type QueryPageParams = {
   pageToken?: string;
   reverse?: number | boolean;
 };
+
+export const MAX_PAGE_SIZE = 1000; // Global maximum limit
+
 function getPageOptions(query: QueryPageParams): PageOptions {
-  // When passing in a page token, it's base64 encoded, so we need to decode it
-  // however, the '+' character is not valid in a url, so it gets replaced with a space
-  // and the base64 decoder doesn't like that, so we need to replace it with a '+' again
-  // before decoding
+  const pageSize = query.pageSize ? parseInt(query.pageSize.toString()) : MAX_PAGE_SIZE;
+
+  // Ensure the pageSize does not exceed the global maximum
+  const effectivePageSize = Math.min(pageSize, MAX_PAGE_SIZE);
+
   const pageToken = query.pageToken
     ? Uint8Array.from(Buffer.from(query.pageToken.replaceAll(" ", "+"), "base64"))
     : undefined;
 
   return {
-    pageSize: query.pageSize ? parseInt(query.pageSize.toString()) : undefined,
+    pageSize: effectivePageSize,
     pageToken,
     reverse: query.reverse ? true : undefined,
   };

--- a/apps/hubble/www/docs/docs/httpapi/httpapi.md
+++ b/apps/hubble/www/docs/docs/httpapi/httpapi.md
@@ -59,6 +59,8 @@ The returned `nextPageToken` is empty if there are no more pages to return.
 
 Pagination query parameters can be combined with other query parameters supported by the endpoint. For example, `/v1/casts?fid=2&pageSize=3`.
 
+All endpoints have a maximum page size of `1000`.
+
 **Example**
 
 Fetch all casts by FID `2`, fetching upto 3 casts per Page

--- a/apps/hubble/www/docs/docs/httpapi/httpapi.md
+++ b/apps/hubble/www/docs/docs/httpapi/httpapi.md
@@ -1,22 +1,27 @@
 # HTTP API
+
 Hubble serves a HTTP API on port 2281 by default.
 
 ## Using the API
-The API can be called from any programing language or browser by making a normal HTTP request. 
+
+The API can be called from any programing language or browser by making a normal HTTP request.
 
 **View the API responses in a browser**
 
-Simply open the URL in a browser 
+Simply open the URL in a browser
+
 ```url
 http://127.0.0.1:2281/v1/castsByFid?fid=2
 ```
 
 **Call the API using curl**
+
 ```bash
 curl http://127.0.0.1:2281/v1/castsByFid?fid=2
 ```
 
 **Call the API via Javascript, using the axios library**
+
 ```Javascript
 import axios from "axios";
 
@@ -26,7 +31,7 @@ const server = "http://127.0.0.1:2281";
 try {
     const response = await axios.get(`${server}/v1/castsByFid?fid=${fid}`);
 
-    console.log(`API Returned HTTP status ${response.status}`);    
+    console.log(`API Returned HTTP status ${response.status}`);
     console.log(`First Cast's text is ${response.data.messages[0].data.castAddBody.text}`);
 } catch (e) {
     // Handle errors
@@ -35,29 +40,34 @@ try {
 ```
 
 ## Response encoding
-Responses from the API are encoded as `application/json`, and can be parsed as normal JSON objects. 
+
+Responses from the API are encoded as `application/json`, and can be parsed as normal JSON objects.
 
 1. Hashes, ETH addresses, signers etc... are all encoded as hex strings starting with `0x`
 2. Signatures and other binary fields are encoded in base64
 3. Constants are encoded as their string types. For example, the `hashScheme` is encoded as `HASH_SCHEME_BLAKE3` which is equivalent to the `HASH_SCHEME_BLAKE3 = 1` from the protobuf schema.
 
 ## Timestamps
-Messages contain a timestamp, which is the _Farcaster Epoch Timestamp_ (and not the Unix Epoch). 
+
+Messages contain a timestamp, which is the _Farcaster Epoch Timestamp_ (and not the Unix Epoch).
 
 ## Paging
-Most endpoints support paging to get a large number of responses. 
+
+Most endpoints support paging to get a large number of responses.
 
 **Pagination Query Parameters**
 
-| Parameter | Description | Example |
-| --------- | ----------- | ------- |
-| pageSize | Maximum number of messages to return in a single response | `pageSize=100` |
-| reverse | Reverse the sort order, returning latest messages first | `reverse=1` |
+| Parameter | Description                                                                                                              | Example                             |
+| --------- | ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------- |
+| pageSize  | Maximum number of messages to return in a single response                                                                | `pageSize=100`                      |
+| reverse   | Reverse the sort order, returning latest messages first                                                                  | `reverse=1`                         |
 | pageToken | The page token returned by the previous query, to fetch the next page. If this parameters is empty, fetch the first page | `pageToken=AuzO1V0Dta...fStlynsGWT` |
 
-The returned `nextPageToken` is empty if there are no more pages to return. 
+The returned `nextPageToken` is empty if there are no more pages to return.
 
 Pagination query parameters can be combined with other query parameters supported by the endpoint. For example, `/v1/casts?fid=2&pageSize=3`.
+
+All endpoints have a maximum page size of `1000`.
 
 **Example**
 
@@ -65,13 +75,14 @@ Fetch all casts by FID `2`, fetching upto 3 casts per Page
 
 ```bash
 # Fetch first page
-http://127.0.0.1:2281/v1/castsByFid?fid=2&pageSize=3 
+http://127.0.0.1:2281/v1/castsByFid?fid=2&pageSize=3
 
 # Fetch next page. The pageToken is from the previous response(`response.nextPageToken`)
 http://127.0.0.1:2281/v1/castsByFid?fid=2&pageSize=3&pageToken=AuzO1V0DtaItCwwa10X6YsfStlynsGWT
 ```
 
 **Javascript Example**
+
 ```Javascript
 import axios from "axios";
 
@@ -87,9 +98,11 @@ do {
 ```
 
 ## Handling Errors
+
 If there's an API error, the HTTP status code is set to `400` or `500` as appropriate. The response is a JSON object with `detail`, `errCode` and `metadata` fields set to identify and debug the errors.
 
 **Example**
+
 ```bash
 $ curl "http://127.0.0.1:2281/v1/castById?fid=invalid"
 {
@@ -105,8 +118,11 @@ $ curl "http://127.0.0.1:2281/v1/castById?fid=invalid"
   },
 }
 ```
+
 ## CORS
+
 You can set a custom CORS header in the HTTP server by using the `--http-cors-origin` parameter when running your Hubble instance. Setting this to `*` will allow requests from any origin.
 
 ## Limitations
-The HTTP API currently does not support any of the Sync APIs that are available in the gRPC vesion. When Hubs sync with each other, they will use the gRPC APIs instead of the HTTP APIs. 
+
+The HTTP API currently does not support any of the Sync APIs that are available in the gRPC vesion. When Hubs sync with each other, they will use the gRPC APIs instead of the HTTP APIs.

--- a/apps/hubble/www/docs/docs/httpapi/httpapi.md
+++ b/apps/hubble/www/docs/docs/httpapi/httpapi.md
@@ -1,27 +1,22 @@
 # HTTP API
-
 Hubble serves a HTTP API on port 2281 by default.
 
 ## Using the API
-
-The API can be called from any programing language or browser by making a normal HTTP request.
+The API can be called from any programing language or browser by making a normal HTTP request. 
 
 **View the API responses in a browser**
 
-Simply open the URL in a browser
-
+Simply open the URL in a browser 
 ```url
 http://127.0.0.1:2281/v1/castsByFid?fid=2
 ```
 
 **Call the API using curl**
-
 ```bash
 curl http://127.0.0.1:2281/v1/castsByFid?fid=2
 ```
 
 **Call the API via Javascript, using the axios library**
-
 ```Javascript
 import axios from "axios";
 
@@ -31,7 +26,7 @@ const server = "http://127.0.0.1:2281";
 try {
     const response = await axios.get(`${server}/v1/castsByFid?fid=${fid}`);
 
-    console.log(`API Returned HTTP status ${response.status}`);
+    console.log(`API Returned HTTP status ${response.status}`);    
     console.log(`First Cast's text is ${response.data.messages[0].data.castAddBody.text}`);
 } catch (e) {
     // Handle errors
@@ -40,34 +35,29 @@ try {
 ```
 
 ## Response encoding
-
-Responses from the API are encoded as `application/json`, and can be parsed as normal JSON objects.
+Responses from the API are encoded as `application/json`, and can be parsed as normal JSON objects. 
 
 1. Hashes, ETH addresses, signers etc... are all encoded as hex strings starting with `0x`
 2. Signatures and other binary fields are encoded in base64
 3. Constants are encoded as their string types. For example, the `hashScheme` is encoded as `HASH_SCHEME_BLAKE3` which is equivalent to the `HASH_SCHEME_BLAKE3 = 1` from the protobuf schema.
 
 ## Timestamps
-
-Messages contain a timestamp, which is the _Farcaster Epoch Timestamp_ (and not the Unix Epoch).
+Messages contain a timestamp, which is the _Farcaster Epoch Timestamp_ (and not the Unix Epoch). 
 
 ## Paging
-
-Most endpoints support paging to get a large number of responses.
+Most endpoints support paging to get a large number of responses. 
 
 **Pagination Query Parameters**
 
-| Parameter | Description                                                                                                              | Example                             |
-| --------- | ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------- |
-| pageSize  | Maximum number of messages to return in a single response                                                                | `pageSize=100`                      |
-| reverse   | Reverse the sort order, returning latest messages first                                                                  | `reverse=1`                         |
+| Parameter | Description | Example |
+| --------- | ----------- | ------- |
+| pageSize | Maximum number of messages to return in a single response | `pageSize=100` |
+| reverse | Reverse the sort order, returning latest messages first | `reverse=1` |
 | pageToken | The page token returned by the previous query, to fetch the next page. If this parameters is empty, fetch the first page | `pageToken=AuzO1V0Dta...fStlynsGWT` |
 
-The returned `nextPageToken` is empty if there are no more pages to return.
+The returned `nextPageToken` is empty if there are no more pages to return. 
 
 Pagination query parameters can be combined with other query parameters supported by the endpoint. For example, `/v1/casts?fid=2&pageSize=3`.
-
-All endpoints have a maximum page size of `1000`.
 
 **Example**
 
@@ -75,14 +65,13 @@ Fetch all casts by FID `2`, fetching upto 3 casts per Page
 
 ```bash
 # Fetch first page
-http://127.0.0.1:2281/v1/castsByFid?fid=2&pageSize=3
+http://127.0.0.1:2281/v1/castsByFid?fid=2&pageSize=3 
 
 # Fetch next page. The pageToken is from the previous response(`response.nextPageToken`)
 http://127.0.0.1:2281/v1/castsByFid?fid=2&pageSize=3&pageToken=AuzO1V0DtaItCwwa10X6YsfStlynsGWT
 ```
 
 **Javascript Example**
-
 ```Javascript
 import axios from "axios";
 
@@ -98,11 +87,9 @@ do {
 ```
 
 ## Handling Errors
-
 If there's an API error, the HTTP status code is set to `400` or `500` as appropriate. The response is a JSON object with `detail`, `errCode` and `metadata` fields set to identify and debug the errors.
 
 **Example**
-
 ```bash
 $ curl "http://127.0.0.1:2281/v1/castById?fid=invalid"
 {
@@ -118,11 +105,8 @@ $ curl "http://127.0.0.1:2281/v1/castById?fid=invalid"
   },
 }
 ```
-
 ## CORS
-
 You can set a custom CORS header in the HTTP server by using the `--http-cors-origin` parameter when running your Hubble instance. Setting this to `*` will allow requests from any origin.
 
 ## Limitations
-
-The HTTP API currently does not support any of the Sync APIs that are available in the gRPC vesion. When Hubs sync with each other, they will use the gRPC APIs instead of the HTTP APIs.
+The HTTP API currently does not support any of the Sync APIs that are available in the gRPC vesion. When Hubs sync with each other, they will use the gRPC APIs instead of the HTTP APIs. 


### PR DESCRIPTION
## Motivation

Serializing JSON can be slow.

## Change Summary

Reduce the maximum size of each page, and set an explicit default.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR sets a maximum and default page size of 1K for HTTP API requests in the `@farcaster/hubble` package.

### Detailed summary
- Set maximum and default page size for HTTP API requests to 1K in `@farcaster/hubble`
- Updated pagination logic in `httpapi.md`
- Added `DEFAULT_PAGE_SIZE` constant in `httpServer.ts`
- Ensured page size does not exceed global maximum

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->