### PR TITLE
fix: solana base58 instead of text decode to avoid null bytes

### DIFF
--- a/.changeset/spicy-chairs-rescue.md
+++ b/.changeset/spicy-chairs-rescue.md
@@ -1,5 +1,0 @@
----
-"@farcaster/replicator": patch
----
-
-Base 58 encode solana data

--- a/.changeset/spicy-chairs-rescue.md
+++ b/.changeset/spicy-chairs-rescue.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/replicator": patch
+---
+
+Base 58 encode solana data

--- a/apps/replicator/CHANGELOG.md
+++ b/apps/replicator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/replicator
 
+## 0.3.5
+
+### Patch Changes
+
+- ff5b8cbc: Base 58 encode solana data
+
 ## 0.3.4
 
 ### Patch Changes

--- a/apps/replicator/package.json
+++ b/apps/replicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/replicator",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Replicate Farcaster hub data into Postgres",
   "author": "",
   "license": "",

--- a/apps/replicator/src/util.ts
+++ b/apps/replicator/src/util.ts
@@ -46,6 +46,7 @@ import { AssertionError } from "./error.js";
 import { Logger } from "./log.js";
 import { threadId as workerThreadId } from "worker_threads";
 import { pid } from "process";
+import base58 from "bs58";
 
 export type StoreMessageOperation = "merge" | "delete" | "prune" | "revoke";
 
@@ -206,9 +207,9 @@ export function convertProtobufMessageBodyToJson(message: Message): MessageBodyJ
           } satisfies VerificationAddEthAddressBodyJson;
         case Protocol.SOLANA:
           return {
-            address: new TextDecoder().decode(address),
+            address: base58.encode(address),
             claimSignature: bytesToHex(claimSignature),
-            blockHash: new TextDecoder().decode(blockHash),
+            blockHash: base58.encode(blockHash),
             protocol: Protocol.SOLANA,
           } satisfies VerificationAddSolAddressBodyJson;
         default:


### PR DESCRIPTION
## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the replicator package to version 0.3.5, introducing Base58 encoding for Solana data in the util.ts file.

### Detailed summary
- Bumps replicator package version to 0.3.5
- Adds Base58 encoding for Solana data in util.ts

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->