### PR TITLE
fix(replicator): updateTableMetrics is using too much postgresql CPU

### DIFF
--- a/.changeset/forty-snakes-try.md
+++ b/.changeset/forty-snakes-try.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/replicator": patch
+---
+
+updateTableMetrics is using too much postgresql CPU

--- a/apps/replicator/src/db.ts
+++ b/apps/replicator/src/db.ts
@@ -15,6 +15,7 @@ import {
   QueryNode,
   ColumnType,
   MigrationInfo,
+  sql,
 } from "kysely";
 import Cursor from "pg-cursor";
 import { Pool, types } from "pg";
@@ -560,6 +561,16 @@ export async function stream<DB, UT extends keyof DB, TB extends keyof DB, O>(
     }
   } catch (e) {
     throw extendStackTrace(e, new Error(), query);
+  }
+}
+
+export function getEstimateOfTablesRowCount(db: DB, tablesToMonitor: Array<keyof Tables>) {
+  try {
+    return sql<{ tableName: string; estimate: number }>`SELECT relname AS table_name, reltuples AS estimate
+               FROM pg_class
+               WHERE relname IN (${sql.join(tablesToMonitor)})`.execute(db);
+  } catch (e) {
+    throw extendStackTrace(e, new Error());
   }
 }
 

--- a/apps/replicator/src/hubReplicator.ts
+++ b/apps/replicator/src/hubReplicator.ts
@@ -1,9 +1,8 @@
 import { HubEvent, HubEventType, HubRpcClient, OnChainEvent, isHubError } from "@farcaster/hub-nodejs";
 import humanizeDuration from "humanize-duration";
 import { Redis, RedisKey } from "ioredis";
-import { sql } from "kysely";
 import { Logger } from "pino";
-import { DB, Tables, executeTakeFirstOrThrow, executeTx } from "./db.js";
+import { DB, Tables, getEstimateOfTablesRowCount, executeTx } from "./db.js";
 import { AssertionError } from "./error.js";
 import { HubSubscriber } from "./hubSubscriber.js";
 import { BackfillFidData } from "./jobs/backfillFidData.js";
@@ -61,33 +60,26 @@ export class HubReplicator {
   }
 
   private async updateTableMetrics() {
-    const stats = await executeTakeFirstOrThrow(
-      this.db.selectNoFrom(({ selectFrom }) =>
-        (
-          [
-            "chainEvents",
-            "fids",
-            "signers",
-            "usernameProofs",
-            "fnames",
-            "messages",
-            "casts",
-            "reactions",
-            "links",
-            "verifications",
-            "userData",
-            "storageAllocations",
-          ] satisfies Array<keyof Tables>
-        ).map((tableName) =>
-          selectFrom(tableName)
-            .select(({ fn }) => fn.coalesce(fn.countAll<number>(), sql<number>`0`).as(tableName))
-            .as(tableName),
-        ),
-      ),
-    );
-
-    for (const [tableName, count] of Object.entries(stats)) {
-      statsd().gauge(`db.${tableName}.rows`, count as number);
+    const tablesToMonitor: Array<keyof Tables> = [
+      "chainEvents",
+      "fids",
+      "signers",
+      "usernameProofs",
+      "fnames",
+      "messages",
+      "casts",
+      "reactions",
+      "links",
+      "verifications",
+      "userData",
+      "storageAllocations",
+    ];
+    const stats = await getEstimateOfTablesRowCount(this.db, tablesToMonitor);
+    for (const row of stats.rows) {
+      if (row.estimate < 0) {
+        row.estimate = 0;
+      }
+      statsd().gauge(`db.${row.tableName}.rows`, row.estimate as number);
     }
   }
 

--- a/apps/replicator/src/hubReplicator.ts
+++ b/apps/replicator/src/hubReplicator.ts
@@ -11,6 +11,7 @@ import { ProcessHubEvent } from "./jobs/processHubEvent.js";
 import { processOnChainEvent } from "./processors/onChainEvent.js";
 import { statsd } from "./statsd.js";
 import { sleep } from "./util.js";
+import { STATSD_HOST } from "./env.js";
 
 export class HubReplicator {
   private eventsSubscriber: HubSubscriber;
@@ -39,9 +40,11 @@ export class HubReplicator {
   }
 
   public async start() {
-    setInterval(() => {
-      this.updateTableMetrics();
-    }, 5_000);
+    if (STATSD_HOST) {
+      setInterval(() => {
+        this.updateTableMetrics();
+      }, 5_000);
+    }
     await this.backfill();
   }
 


### PR DESCRIPTION
## Motivation

the [updateTableMetrics function](https://github.com/farcasterxyz/hub-monorepo/blob/ac861b1236029acbb007456a3f53647d875030d2/apps/replicator/src/hubReplicator.ts#L43) is planned to be called every 5 seconds and each call uses an average of 2.82 minutes of CPU on a gcp 2VCPU / 8 GB RAM instance.
That's not sustainable and a waste of CPU.

Fixes #1763.

## Change Summary

* Stop counting the rows if STATSD_HOST is undefined
* Using [estimates](https://wiki.postgresql.org/wiki/Count_estimate) instead of count(*)

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR optimizes `updateTableMetrics` in `hubReplicator.ts` to reduce PostgreSQL CPU usage by using table row count estimates.

### Detailed summary
- Added `getEstimateOfTablesRowCount` function in `db.ts` to fetch table row count estimates
- Updated `updateTableMetrics` in `hubReplicator.ts` to use row count estimates for monitoring tables

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->