### PR TITLE
fix: Run prune job in thread

### DIFF
--- a/.changeset/curvy-turkeys-allow.md
+++ b/.changeset/curvy-turkeys-allow.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Run prune job in a thread to not block NodeJS main thread

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -260,7 +260,8 @@ class Engine extends TypedEmitter<EngineEvents> {
     if (mergeResult.isOk() && limiter) {
       const timeTakenMs = Date.now() - start;
 
-      if (typeToSetPostfix(message.data?.type ?? MessageType.NONE) === UserPostfix.ReactionMessage) {
+      const messagePostFix = typeToSetPostfix(message.data?.type ?? MessageType.NONE);
+      if (messagePostFix === UserPostfix.ReactionMessage || messagePostFix === UserPostfix.UserDataMessage) {
         statsd().timing("engine.merge.rust", timeTakenMs);
       } else {
         statsd().timing("engine.merge.nodejs", timeTakenMs);

--- a/apps/hubble/src/storage/jobs/pruneMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/pruneMessagesJob.ts
@@ -85,7 +85,6 @@ export class PruneMessagesJobScheduler {
       }
 
       // Sleep for a bit avoid overloading the Merkle Trie
-
       const syncTrieQSize = this._getSyncTrieQSizeFn();
       if (syncTrieQSize > 10_000) {
         log.info({ syncTrieQSize }, "sync trie Q is large, sleeping for 30s");


### PR DESCRIPTION
## Motivation

Run the prune job in a thread so as to not block the NodeJS main thread

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR optimizes the `pruneMessagesJob` in `@farcaster/hubble` by running it in a thread to prevent blocking the NodeJS main thread.

### Detailed summary
- Moved `pool` field out of `Store` struct
- Added `messagePostFix` check in `index.ts`
- Added `once_cell` dependency in `store.rs`
- Improved error handling in `store.rs`
- Implemented threadpool for `prune_messages` in `store.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->