### PR TITLE
fix: Don't return '0x' for empty addresses.

### DIFF
--- a/.changeset/violet-falcons-enjoy.md
+++ b/.changeset/violet-falcons-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Don't return '0x' for empty addresses

--- a/apps/hubble/src/rpc/httpServer.ts
+++ b/apps/hubble/src/rpc/httpServer.ts
@@ -91,7 +91,11 @@ function handleResponse<M>(reply: fastify.FastifyReply, obj: StaticEncodable<M>)
   };
 }
 
-function convertB64ToHex(str: string): string {
+export function convertB64ToHex(str: string): string {
+  if (str.length === 0) {
+    return str;
+  }
+
   try {
     // Try to convert the string from base64 to hex
     const bytesBuf = Buffer.from(str, "base64");
@@ -105,7 +109,7 @@ function convertB64ToHex(str: string): string {
   }
 }
 
-function convertB64ToB58(str: string): string {
+export function convertB64ToB58(str: string): string {
   try {
     const bytesBuf = Buffer.from(str, "base64");
 

--- a/apps/hubble/src/rpc/test/httpServer.test.ts
+++ b/apps/hubble/src/rpc/test/httpServer.test.ts
@@ -1,4 +1,4 @@
-import { HttpAPIServer, protoToJSON } from "../httpServer.js";
+import { HttpAPIServer, convertB64ToB58, convertB64ToHex, protoToJSON } from "../httpServer.js";
 import { jestRocksDB } from "../../storage/db/jestUtils.js";
 import {
   bytesToBase58,
@@ -35,6 +35,7 @@ import { mergeDeepPartial } from "../../test/utils.js";
 import { publicClient } from "../../test/utils.js";
 import { IdRegisterOnChainEvent } from "@farcaster/core";
 import { APP_VERSION } from "../../hubble.js";
+import base58 from "bs58";
 
 const db = jestRocksDB("httpserver.rpc.server.test");
 const network = FarcasterNetwork.TESTNET;
@@ -87,6 +88,21 @@ describe("httpServer", () => {
     await engine.mergeOnChainEvent(custodyEvent);
     await engine.mergeOnChainEvent(signerEvent);
     await engine.mergeOnChainEvent(storageEvent);
+  });
+
+  describe("conversions", () => {
+    const buf = Buffer.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    const b64 = buf.toString("base64");
+    const b58 = base58.encode(buf);
+    const hex = `0x${buf.toString("hex")}`;
+
+    expect(convertB64ToHex("")).toEqual("");
+    expect(convertB64ToHex(b64)).toEqual(hex);
+    expect(convertB64ToHex(b64)).toEqual(bytesToHexString(buf)._unsafeUnwrap());
+
+    expect(convertB64ToB58("")).toEqual("");
+    expect(convertB64ToB58(b64)).toEqual(b58);
+    expect(convertB64ToB58(b64)).toEqual(bytesToBase58(buf)._unsafeUnwrap());
   });
 
   describe("cors", () => {


### PR DESCRIPTION
Fixes #1780

## Motivation

Don't return "0x" for empty addresses, just return "" instead

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to fix the issue of returning '0x' for empty addresses in the `convertB64ToHex` and `convertB64ToB58` functions.

### Detailed summary
- Fixed issue with returning '0x' for empty addresses
- Added export to `convertB64ToHex` and `convertB64ToB58` functions
- Added tests for conversions using base58 and hex encoding

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->