### PR TITLE
chore: Update docker-compose.yml to avoid port conflicts

### DIFF
--- a/apps/hubble/docker-compose.yml
+++ b/apps/hubble/docker-compose.yml
@@ -54,8 +54,8 @@ services:
       # - '2003:2003' # Carbon line receiver
       # - '2004:2004' # Carbon pickle receiver
       # - '7002:7002' # Carbon cache query
-      - '8125:8125/udp' # StatsD
-      - '8126:8126' # StatsD admin
+      - '${STATSD_PUBLISH:-8125}:8125/udp' # StatsD
+      - '${STATSD_ADMIN_PUBLISH:-8126}:8126' # StatsD admin
     networks:
       - my-network
 


### PR DESCRIPTION
## Motivation

These ports are conflicting with things already on our systems (datadog)

## Change Summary

allow environment variable overrides

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `docker-compose.yml` file to dynamically set the StatsD and StatsD admin ports using environment variables.

### Detailed summary
- Dynamically set StatsD port using `${STATSD_PUBLISH:-8125}`
- Dynamically set StatsD admin port using `${STATSD_ADMIN_PUBLISH:-8126}`
- Removed specific port numbers for StatsD and StatsD admin

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->