### PR TITLE
fix: Increase read timeout for Fname Registry server requests 2.5s → 5s

### DIFF
--- a/.changeset/great-wolves-push.md
+++ b/.changeset/great-wolves-push.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+Increase read timeout for Fname Registry server requests 2.5s → 5s

--- a/apps/hubble/src/eth/fnameRegistryEventsProvider.ts
+++ b/apps/hubble/src/eth/fnameRegistryEventsProvider.ts
@@ -13,7 +13,7 @@ import {
 import { Result } from "neverthrow";
 
 const DEFAULT_POLL_TIMEOUT_IN_MS = 5_000;
-const DEFAULT_READ_TIMEOUT_IN_MS = 2_500;
+const DEFAULT_READ_TIMEOUT_IN_MS = 5_000;
 
 const log = logger.child({
   component: "FNameRegistryEventsProvider",


### PR DESCRIPTION

## Motivation

Fixes #1784. (or at least reduces frequency substantially)

## Change Summary

Increase timeout.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `DEFAULT_READ_TIMEOUT_IN_MS` value in `fnameRegistryEventsProvider.ts` from 2,500 to 5,000.

### Detailed summary
- Updated `DEFAULT_READ_TIMEOUT_IN_MS` value from 2,500 to 5,000

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->