### PR TITLE
fix: Change restart policy to `always`

### DIFF
--- a/.changeset/funny-tables-begin.md
+++ b/.changeset/funny-tables-begin.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+Change Docker Compose restart policy to `always`

--- a/apps/hubble/docker-compose.yml
+++ b/apps/hubble/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   hubble:
     image: farcasterxyz/hubble:latest
     pull_policy: always
-    restart: on-failure:5
+    restart: always
     command: ["npx", "pm2-runtime", "start", "pm2.config.cjs"]
     environment:
       NODE_OPTIONS: "--no-warnings --max-old-space-size=8192"


### PR DESCRIPTION
## Motivation

Now that we're running via PM2, add another layer of protection by ensuring we always restart the container if it isn't explicitly stopped.

Closes #1647.

## Change Summary

Change policy to `always`.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to change the Docker Compose restart policy to `always` for the `@farcaster/hubble` app.

### Detailed summary
- Changed Docker Compose restart policy to `always` in `apps/hubble/docker-compose.yml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->