### PR TITLE
fix: Resolve more deprecation warnings in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build Docker image
         id: docker-image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           cache-from: type=gha
           cache-to: type=gha,type=inline
@@ -43,7 +43,7 @@ jobs:
         run: curl -L https://github.com/fullstorydev/grpcurl/releases/download/v1.8.7/grpcurl_1.8.7_linux_arm64.tar.gz -o - | tar -xzf -
 
       - name: Check that gRPC server is running
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_seconds: 10
           retry_wait_seconds: 5


### PR DESCRIPTION
## Motivation

Missed some in 7165aabf.

## Change Summary

Update.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Docker image building and gRPC server check actions to their latest versions.

### Detailed summary
- Updated `docker/build-push-action` from v4 to v5 in `.github/workflows/ci.yml`
- Updated `nick-fields/retry` from v2 to v3 for gRPC server check action

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->