### PR TITLE
fix: Reduce default chunk size from 10000 to 9999

### DIFF
--- a/.changeset/many-suns-compete.md
+++ b/.changeset/many-suns-compete.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+Reduce default chunk size from 10000 to 9999

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -34,7 +34,7 @@ const PEER_ID_FILENAME = "id.protobuf";
 const DEFAULT_PEER_ID_DIR = "./.hub";
 const DEFAULT_PEER_ID_FILENAME = `default_${PEER_ID_FILENAME}`;
 const DEFAULT_PEER_ID_LOCATION = `${DEFAULT_PEER_ID_DIR}/${DEFAULT_PEER_ID_FILENAME}`;
-const DEFAULT_CHUNK_SIZE = 10000;
+const DEFAULT_CHUNK_SIZE = 9999; // Infura doesn't like chunk sizes >= 10000
 const DEFAULT_FNAME_SERVER_URL = "https://fnames.farcaster.xyz";
 
 const DEFAULT_HTTP_API_PORT = 2281;


### PR DESCRIPTION
## Motivation

This allows the default settings to work with Infura, which doesn't like chunk sizes >= 10000.

Fixes #1703.

## Change Summary

Decrease default chunk size to 9999.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR reduces the default chunk size in `@farcaster/hubble` from 10000 to 9999 to accommodate Infura's restrictions.

### Detailed summary
- Updated default chunk size to 9999 in `apps/hubble/src/cli.ts`


> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->