### PR TITLE
fix: Use default page size for prune job

### DIFF
--- a/.changeset/healthy-masks-sort.md
+++ b/.changeset/healthy-masks-sort.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Use default page size for prune job

--- a/apps/hubble/src/storage/jobs/pruneMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/pruneMessagesJob.ts
@@ -69,7 +69,7 @@ export class PruneMessagesJobScheduler {
     let finished = false;
     let pageToken: Uint8Array | undefined;
     do {
-      const fidsPage = await this._engine.getFids({ pageToken, pageSize: 100 });
+      const fidsPage = await this._engine.getFids({ pageToken });
       if (fidsPage.isErr()) {
         return err(fidsPage.error);
       }


### PR DESCRIPTION
## Motivation

Use default page size for prune job so we don't unnecessarily page. This was causing 100% CPU for a short time. 


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)
