### PR TITLE
fix: Migrate fnameUserNameProofByFid prefix 25 -> 27

### DIFF
--- a/.changeset/new-rivers-tap.md
+++ b/.changeset/new-rivers-tap.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+bug: Migrate FNameUserNameProofByFid prefix from 25 -> 27 to resolve conflict with VerificationsByAddress

--- a/apps/hubble/src/addon/src/store/message.rs
+++ b/apps/hubble/src/addon/src/store/message.rs
@@ -62,14 +62,14 @@ pub enum RootPrefix {
     /** DB Schema version */
     DBSchemaVersion = 24,
 
-    /* Used to index fname username proofs by fid */
-    FNameUserNameProofByFid = 25,
-
     /* Used to index verifications by address */
-    // VerificationByAddress = 25,
+    VerificationByAddress = 25,
 
     /* Store the connected peers */
     ConnectedPeers = 26,
+
+    /* Used to index fname username proofs by fid */
+    FNameUserNameProofByFid = 27,
 }
 
 /** Copied from the JS code */

--- a/apps/hubble/src/storage/db/migrations/9.fnameUserNameProofByFidPrefix.test.ts
+++ b/apps/hubble/src/storage/db/migrations/9.fnameUserNameProofByFidPrefix.test.ts
@@ -1,0 +1,68 @@
+import { performDbMigrations } from "./migrations.js";
+import { jestRocksDB } from "../jestUtils.js";
+import { Eip712Signer, Factories, HubError, VerificationAddAddressMessage } from "@farcaster/hub-nodejs";
+import StoreEventHandler from "../../stores/storeEventHandler.js";
+import { putOnChainEventTransaction } from "../onChainEvent.js";
+import VerificationStore from "../../stores/verificationStore.js";
+import { RootPrefix } from "../types.js";
+import { makeFidKey, makeTsHash } from "../message.js";
+import { ResultAsync } from "neverthrow";
+
+const db = jestRocksDB("fnameUserNameProofByFid.migration.test");
+
+const eventHandler = new StoreEventHandler(db);
+const set = new VerificationStore(db, eventHandler);
+
+const fid = Factories.Fid.build();
+
+let ethSigner: Eip712Signer;
+let ethSignerKey: Uint8Array;
+let verificationAdd: VerificationAddAddressMessage;
+
+describe("fnameUserNameProofByFid migration", () => {
+  beforeAll(async () => {
+    ethSigner = Factories.Eip712Signer.build();
+    ethSignerKey = (await ethSigner.getSignerKey())._unsafeUnwrap();
+
+    const rent = Factories.StorageRentOnChainEvent.build({ fid }, { transient: { units: 1 } });
+    await db.commit(putOnChainEventTransaction(db.transaction(), rent));
+
+    verificationAdd = await Factories.VerificationAddEthAddressMessage.create(
+      {
+        data: { fid, verificationAddAddressBody: { address: ethSignerKey } },
+      },
+      { transient: { ethSigner } },
+    );
+    await set.merge(verificationAdd);
+  });
+
+  test("should migrate the fnameUserNameProofByFidPrefix", async () => {
+    const tsHash = makeTsHash(verificationAdd.data.timestamp, verificationAdd.hash)._unsafeUnwrap();
+
+    // Add the FnameUserNameProofByFidPrefix key with the old (25) prefix
+    const key = Buffer.concat([Buffer.from([RootPrefix.FNameUserNameProofByFid]), makeFidKey(fid)]);
+    await db.put(key, Buffer.from(tsHash));
+
+    const success = await performDbMigrations(db, 8, 9);
+    expect(success).toBe(true);
+
+    // Expect that the key was migrated to the new (27) prefix
+    const newKey = Buffer.concat([Buffer.from([RootPrefix.FNameUserNameProofByFid]), makeFidKey(fid)]);
+    const value = await db.get(newKey);
+    expect(value).toEqual(Buffer.from(tsHash));
+
+    // Expect that the old key was deleted
+    const oldKey = Buffer.concat([Buffer.from([25]), makeFidKey(fid)]);
+    const oldValue = await ResultAsync.fromPromise(db.get(oldKey), (e) => e as HubError);
+    expect(oldValue.isErr()).toBe(true);
+    expect(oldValue._unsafeUnwrapErr().errCode).toBe("not_found");
+
+    // Expect that the verificationAddAddressMessage is still in the store
+    const verifications = await set.getVerificationAddsByFid(fid);
+    expect(verifications.messages).toHaveLength(1);
+    expect(verifications.messages[0]?.hash).toEqual(verificationAdd.hash);
+
+    const verification = await set.getVerificationAdd(fid, ethSignerKey);
+    expect(verification.hash).toEqual(verificationAdd.hash);
+  });
+});

--- a/apps/hubble/src/storage/db/migrations/9.fnameUserNameProofByFidPrefix.ts
+++ b/apps/hubble/src/storage/db/migrations/9.fnameUserNameProofByFidPrefix.ts
@@ -1,0 +1,36 @@
+/**
+ * Up until now, the RootPrefix.FNameUserNameProofByFid and RootPrefix.VerificationByAddress both
+ * had the value of 25. This migration will change the value of RootPrefix.FNameUserNameProofByFid to 27
+ *
+ */
+
+import { logger } from "../../../utils/logger.js";
+import RocksDB from "../rocksdb.js";
+import { FID_BYTES, RootPrefix } from "../types.js";
+
+const log = logger.child({ component: "FNameUserNameProofByFidPrefixMigration" });
+
+export async function fnameUserNameProofByFidPrefix(db: RocksDB): Promise<boolean> {
+  log.info({}, "Starting fname user name proof by fid prefix migration");
+  let count = 0;
+  const start = Date.now();
+
+  await db.forEachIteratorByPrefix(Buffer.from([25]), async (key, value) => {
+    if (!key || !value) {
+      return;
+    }
+
+    // If the key is exactly 5 bytes long, then that means it was the FnameUserNameProofByFid key
+    // and not the VerificationByAddress key
+    if (key.length === 1 + FID_BYTES) {
+      const newKey = Buffer.from([RootPrefix.FNameUserNameProofByFid, ...key.slice(1)]);
+      await db.put(newKey, value);
+      await db.del(key);
+
+      count += 1;
+    }
+  });
+
+  log.info({ count, duration: Date.now() - start }, "Finished fname user name proof by fid prefix migration");
+  return true;
+}

--- a/apps/hubble/src/storage/db/migrations/migrations.ts
+++ b/apps/hubble/src/storage/db/migrations/migrations.ts
@@ -1,16 +1,17 @@
 import { Result, ResultAsync } from "neverthrow";
 import RocksDB from "../rocksdb.js";
 import { logger } from "../../../utils/logger.js";
+import { RootPrefix } from "../types.js";
+import rocksdb from "../rocksdb.js";
+import { HubAsyncResult, HubError } from "@farcaster/hub-nodejs";
 import { usernameProofIndexMigration } from "./1.usernameproof.js";
 import { fnameProofIndexMigration } from "./2.fnameproof.js";
 import { clearEventsMigration } from "./3.clearEvents.js";
 import { uniqueVerificationsMigration } from "./4.uniqueVerifications.js";
 import { fnameSyncIds } from "./5.fnameSyncIds.js";
 import { oldContractEvents } from "./6.oldContractEvents.js";
-import { HubAsyncResult, HubError } from "@farcaster/hub-nodejs";
-import { RootPrefix } from "../types.js";
-import rocksdb from "../rocksdb.js";
 import { clearAdminResets } from "./7.clearAdminResets.js";
+import { fnameUserNameProofByFidPrefix } from "./9.fnameUserNameProofByFidPrefix.js";
 
 type MigrationFunctionType = (db: RocksDB) => Promise<boolean>;
 const migrations = new Map<number, MigrationFunctionType>();
@@ -51,6 +52,10 @@ migrations.set(8, async (db: RocksDB) => {
    * to be done, but we set a new version to mark the migration
    */
   return true;
+});
+
+migrations.set(9, async (db: RocksDB) => {
+  return await fnameUserNameProofByFidPrefix(db);
 });
 
 // To Add a new migration

--- a/apps/hubble/src/storage/db/types.ts
+++ b/apps/hubble/src/storage/db/types.ts
@@ -70,14 +70,14 @@ export enum RootPrefix {
   /** DB Schema version */
   DBSchemaVersion = 24,
 
-  /* Used to index fname username proofs by fid */
-  FNameUserNameProofByFid = 25,
-
   /* Used to index verifications by address */
   VerificationByAddress = 25,
 
   /* Store the connected peers */
   ConnectedPeers = 26,
+
+  /* Used to index fname username proofs by fid */
+  FNameUserNameProofByFid = 27,
 }
 
 /**


### PR DESCRIPTION
## Motivation

 Up until now, the RootPrefix.FNameUserNameProofByFid and RootPrefix.VerificationByAddress both had the value of 25. This migration will change the value of RootPrefix.FNameUserNameProofByFid to 27

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)
