### PR TITLE
chore: release 1.10.10

### DIFF
--- a/.changeset/curvy-turkeys-allow.md
+++ b/.changeset/curvy-turkeys-allow.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Run prune job in a thread to not block NodeJS main thread

--- a/.changeset/dry-apples-give.md
+++ b/.changeset/dry-apples-give.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-Set maximum & default page size for HTTP API requests to 1K

--- a/.changeset/fluffy-experts-sleep.md
+++ b/.changeset/fluffy-experts-sleep.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-chore: Refactor store.rs to make migrating verifications store easier

--- a/.changeset/forty-snakes-try.md
+++ b/.changeset/forty-snakes-try.md
@@ -1,5 +1,0 @@
----
-"@farcaster/replicator": patch
----
-
-updateTableMetrics is using too much postgresql CPU

--- a/.changeset/funny-tables-begin.md
+++ b/.changeset/funny-tables-begin.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-Change Docker Compose restart policy to `always`

--- a/.changeset/great-wolves-push.md
+++ b/.changeset/great-wolves-push.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-Increase read timeout for Fname Registry server requests 2.5s → 5s

--- a/.changeset/happy-birds-admire.md
+++ b/.changeset/happy-birds-admire.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Tar file before gzip to make snapshotting faster.

--- a/.changeset/healthy-masks-sort.md
+++ b/.changeset/healthy-masks-sort.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Use default page size for prune job

--- a/.changeset/many-suns-compete.md
+++ b/.changeset/many-suns-compete.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-Reduce default chunk size from 10000 to 9999

--- a/.changeset/mighty-cups-pull.md
+++ b/.changeset/mighty-cups-pull.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Move snapshot tar creation into rocksdb.rs

--- a/.changeset/new-rivers-tap.md
+++ b/.changeset/new-rivers-tap.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-bug: Migrate FNameUserNameProofByFid prefix from 25 -> 27 to resolve conflict with VerificationsByAddress

--- a/.changeset/nine-pugs-sparkle.md
+++ b/.changeset/nine-pugs-sparkle.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Catch exception if inconsistency in DB

--- a/.changeset/proud-cherries-turn.md
+++ b/.changeset/proud-cherries-turn.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-tests: Setup testing framework for rust

--- a/.changeset/sharp-donuts-deliver.md
+++ b/.changeset/sharp-donuts-deliver.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-docs: Fix broken link on docs site

--- a/.changeset/swift-bobcats-promise.md
+++ b/.changeset/swift-bobcats-promise.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-perf: Move UserData store to rust

--- a/.changeset/violet-falcons-enjoy.md
+++ b/.changeset/violet-falcons-enjoy.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Don't return '0x' for empty addresses

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @farcaster/hubble
 
+## 1.10.10
+
+### Patch Changes
+
+- 3e0f195c: fix: Run prune job in a thread to not block NodeJS main thread
+- aad4396a: Set maximum & default page size for HTTP API requests to 1K
+- aedde259: chore: Refactor store.rs to make migrating verifications store easier
+- 18800701: Change Docker Compose restart policy to `always`
+- 451ae847: Increase read timeout for Fname Registry server requests 2.5s → 5s
+- 280946d0: fix: Tar file before gzip to make snapshotting faster.
+- b51c15b2: fix: Use default page size for prune job
+- a14b0dfb: Reduce default chunk size from 10000 to 9999
+- f1eea12f: fix: Move snapshot tar creation into rocksdb.rs
+- c4ca31ef: bug: Migrate FNameUserNameProofByFid prefix from 25 -> 27 to resolve conflict with VerificationsByAddress
+- 6cb4c995: fix: Catch exception if inconsistency in DB
+- 498ec9bb: tests: Setup testing framework for rust
+- 9c5c7628: docs: Fix broken link on docs site
+- 3e3edf2d: perf: Move UserData store to rust
+- 4ec6c607: fix: Don't return '0x' for empty addresses
+
 ## 1.10.9
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.10.9",
+  "version": "1.10.10",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",

--- a/apps/replicator/CHANGELOG.md
+++ b/apps/replicator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/replicator
 
+## 0.3.6
+
+### Patch Changes
+
+- 0b1a6862: updateTableMetrics is using too much postgresql CPU
+
 ## 0.3.5
 
 ### Patch Changes

--- a/apps/replicator/package.json
+++ b/apps/replicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/replicator",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Replicate Farcaster hub data into Postgres",
   "author": "",
   "license": "",


### PR DESCRIPTION
## Motivation

Release 1.10.10

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates version numbers and includes various patches and fixes for the `@farcaster/hubble` and `@farcaster/replicator` packages.

### Detailed summary
- Updated `@farcaster/hubble` version to `1.10.10`
- Updated `@farcaster/replicator` version to `0.3.6`
- Various patches and fixes for CPU usage, HTTP API requests, Docker Compose restart policy, timeout settings, and code refactoring.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->