### PR TITLE
feat: add address to frame message

### DIFF
--- a/.changeset/perfect-cameras-relax.md
+++ b/.changeset/perfect-cameras-relax.md
@@ -1,0 +1,8 @@
+---
+"@farcaster/hub-nodejs": patch
+"@farcaster/hub-web": patch
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+Add address to frame message

--- a/apps/hubble/src/addon/src/proto/protobufs.rs
+++ b/apps/hubble/src/addon/src/proto/protobufs.rs
@@ -387,6 +387,9 @@ pub struct FrameActionBody {
     /// Chain-specific transaction ID for tx actions
     #[prost(bytes = "vec", tag = "6")]
     pub transaction_id: ::prost::alloc::vec::Vec<u8>,
+    /// Connected address for tx actions
+    #[prost(bytes = "vec", tag = "7")]
+    pub address: ::prost::alloc::vec::Vec<u8>,
 }
 impl ::prost::Name for FrameActionBody {
     const NAME: &'static str = "FrameActionBody";

--- a/apps/hubble/src/addon/src/proto/protobufs.rs
+++ b/apps/hubble/src/addon/src/proto/protobufs.rs
@@ -387,7 +387,7 @@ pub struct FrameActionBody {
     /// Chain-specific transaction ID for tx actions
     #[prost(bytes = "vec", tag = "6")]
     pub transaction_id: ::prost::alloc::vec::Vec<u8>,
-    /// Connected address for tx actions
+    /// Chain-specific address for tx actions
     #[prost(bytes = "vec", tag = "7")]
     pub address: ::prost::alloc::vec::Vec<u8>,
 }

--- a/packages/core/src/protobufs/generated/message.ts
+++ b/packages/core/src/protobufs/generated/message.ts
@@ -515,6 +515,8 @@ export interface FrameActionBody {
   state: Uint8Array;
   /** Chain-specific transaction ID for tx actions */
   transactionId: Uint8Array;
+  /** Chain-specific address for tx actions */
+  address: Uint8Array;
 }
 
 function createBaseMessage(): Message {
@@ -1778,6 +1780,7 @@ function createBaseFrameActionBody(): FrameActionBody {
     inputText: new Uint8Array(),
     state: new Uint8Array(),
     transactionId: new Uint8Array(),
+    address: new Uint8Array(),
   };
 }
 
@@ -1800,6 +1803,9 @@ export const FrameActionBody = {
     }
     if (message.transactionId.length !== 0) {
       writer.uint32(50).bytes(message.transactionId);
+    }
+    if (message.address.length !== 0) {
+      writer.uint32(58).bytes(message.address);
     }
     return writer;
   },
@@ -1853,6 +1859,13 @@ export const FrameActionBody = {
 
           message.transactionId = reader.bytes();
           continue;
+        case 7:
+          if (tag != 58) {
+            break;
+          }
+
+          message.address = reader.bytes();
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -1870,6 +1883,7 @@ export const FrameActionBody = {
       inputText: isSet(object.inputText) ? bytesFromBase64(object.inputText) : new Uint8Array(),
       state: isSet(object.state) ? bytesFromBase64(object.state) : new Uint8Array(),
       transactionId: isSet(object.transactionId) ? bytesFromBase64(object.transactionId) : new Uint8Array(),
+      address: isSet(object.address) ? bytesFromBase64(object.address) : new Uint8Array(),
     };
   },
 
@@ -1887,6 +1901,8 @@ export const FrameActionBody = {
       (obj.transactionId = base64FromBytes(
         message.transactionId !== undefined ? message.transactionId : new Uint8Array(),
       ));
+    message.address !== undefined &&
+      (obj.address = base64FromBytes(message.address !== undefined ? message.address : new Uint8Array()));
     return obj;
   },
 
@@ -1904,6 +1920,7 @@ export const FrameActionBody = {
     message.inputText = object.inputText ?? new Uint8Array();
     message.state = object.state ?? new Uint8Array();
     message.transactionId = object.transactionId ?? new Uint8Array();
+    message.address = object.address ?? new Uint8Array();
     return message;
   },
 };

--- a/packages/core/src/validations.test.ts
+++ b/packages/core/src/validations.test.ts
@@ -1286,4 +1286,11 @@ describe("validateFrameActionBody", () => {
     const result = validations.validateFrameActionBody(body);
     expect(result._unsafeUnwrapErr().message).toMatch("invalid transaction ID");
   });
+  test("fails when address is too long", async () => {
+    const body = Factories.FrameActionBody.build({
+      address: Buffer.from(faker.datatype.string(65)),
+    });
+    const result = validations.validateFrameActionBody(body);
+    expect(result._unsafeUnwrapErr().message).toMatch("invalid address");
+  });
 });

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -792,6 +792,9 @@ export const validateFrameActionBody = (body: protobufs.FrameActionBody): HubRes
   if (validateBytesAsString(body.transactionId, 256).isErr()) {
     return err(new HubError("bad_request.validation_failure", "invalid transaction ID"));
   }
+  if (validateBytesAsString(body.address, 64).isErr()) {
+    return err(new HubError("bad_request.validation_failure", "invalid address"));
+  }
 
   if (body.castId !== undefined) {
     const result = validateCastId(body.castId);

--- a/packages/hub-nodejs/src/generated/message.ts
+++ b/packages/hub-nodejs/src/generated/message.ts
@@ -515,6 +515,8 @@ export interface FrameActionBody {
   state: Uint8Array;
   /** Chain-specific transaction ID for tx actions */
   transactionId: Uint8Array;
+  /** Chain-specific address for tx actions */
+  address: Uint8Array;
 }
 
 function createBaseMessage(): Message {
@@ -1778,6 +1780,7 @@ function createBaseFrameActionBody(): FrameActionBody {
     inputText: new Uint8Array(),
     state: new Uint8Array(),
     transactionId: new Uint8Array(),
+    address: new Uint8Array(),
   };
 }
 
@@ -1800,6 +1803,9 @@ export const FrameActionBody = {
     }
     if (message.transactionId.length !== 0) {
       writer.uint32(50).bytes(message.transactionId);
+    }
+    if (message.address.length !== 0) {
+      writer.uint32(58).bytes(message.address);
     }
     return writer;
   },
@@ -1853,6 +1859,13 @@ export const FrameActionBody = {
 
           message.transactionId = reader.bytes();
           continue;
+        case 7:
+          if (tag != 58) {
+            break;
+          }
+
+          message.address = reader.bytes();
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -1870,6 +1883,7 @@ export const FrameActionBody = {
       inputText: isSet(object.inputText) ? bytesFromBase64(object.inputText) : new Uint8Array(),
       state: isSet(object.state) ? bytesFromBase64(object.state) : new Uint8Array(),
       transactionId: isSet(object.transactionId) ? bytesFromBase64(object.transactionId) : new Uint8Array(),
+      address: isSet(object.address) ? bytesFromBase64(object.address) : new Uint8Array(),
     };
   },
 
@@ -1887,6 +1901,8 @@ export const FrameActionBody = {
       (obj.transactionId = base64FromBytes(
         message.transactionId !== undefined ? message.transactionId : new Uint8Array(),
       ));
+    message.address !== undefined &&
+      (obj.address = base64FromBytes(message.address !== undefined ? message.address : new Uint8Array()));
     return obj;
   },
 
@@ -1904,6 +1920,7 @@ export const FrameActionBody = {
     message.inputText = object.inputText ?? new Uint8Array();
     message.state = object.state ?? new Uint8Array();
     message.transactionId = object.transactionId ?? new Uint8Array();
+    message.address = object.address ?? new Uint8Array();
     return message;
   },
 };

--- a/packages/hub-web/src/generated/message.ts
+++ b/packages/hub-web/src/generated/message.ts
@@ -515,6 +515,8 @@ export interface FrameActionBody {
   state: Uint8Array;
   /** Chain-specific transaction ID for tx actions */
   transactionId: Uint8Array;
+  /** Chain-specific address for tx actions */
+  address: Uint8Array;
 }
 
 function createBaseMessage(): Message {
@@ -1778,6 +1780,7 @@ function createBaseFrameActionBody(): FrameActionBody {
     inputText: new Uint8Array(),
     state: new Uint8Array(),
     transactionId: new Uint8Array(),
+    address: new Uint8Array(),
   };
 }
 
@@ -1800,6 +1803,9 @@ export const FrameActionBody = {
     }
     if (message.transactionId.length !== 0) {
       writer.uint32(50).bytes(message.transactionId);
+    }
+    if (message.address.length !== 0) {
+      writer.uint32(58).bytes(message.address);
     }
     return writer;
   },
@@ -1853,6 +1859,13 @@ export const FrameActionBody = {
 
           message.transactionId = reader.bytes();
           continue;
+        case 7:
+          if (tag != 58) {
+            break;
+          }
+
+          message.address = reader.bytes();
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -1870,6 +1883,7 @@ export const FrameActionBody = {
       inputText: isSet(object.inputText) ? bytesFromBase64(object.inputText) : new Uint8Array(),
       state: isSet(object.state) ? bytesFromBase64(object.state) : new Uint8Array(),
       transactionId: isSet(object.transactionId) ? bytesFromBase64(object.transactionId) : new Uint8Array(),
+      address: isSet(object.address) ? bytesFromBase64(object.address) : new Uint8Array(),
     };
   },
 
@@ -1887,6 +1901,8 @@ export const FrameActionBody = {
       (obj.transactionId = base64FromBytes(
         message.transactionId !== undefined ? message.transactionId : new Uint8Array(),
       ));
+    message.address !== undefined &&
+      (obj.address = base64FromBytes(message.address !== undefined ? message.address : new Uint8Array()));
     return obj;
   },
 
@@ -1904,6 +1920,7 @@ export const FrameActionBody = {
     message.inputText = object.inputText ?? new Uint8Array();
     message.state = object.state ?? new Uint8Array();
     message.transactionId = object.transactionId ?? new Uint8Array();
+    message.address = object.address ?? new Uint8Array();
     return message;
   },
 };

--- a/packages/hub-web/src/generated/rpc.ts
+++ b/packages/hub-web/src/generated/rpc.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import grpcWeb from "@improbable-eng/grpc-web";
+import { grpc } from "@improbable-eng/grpc-web";
 import { BrowserHeaders } from "browser-headers";
 import { Observable } from "rxjs";
 import { share } from "rxjs/operators";
@@ -45,122 +45,122 @@ import { UserNameProof } from "./username_proof";
 
 export interface HubService {
   /** Submit Methods */
-  submitMessage(request: DeepPartial<Message>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
+  submitMessage(request: DeepPartial<Message>, metadata?: grpc.Metadata): Promise<Message>;
   /** Validation Methods */
-  validateMessage(request: DeepPartial<Message>, metadata?: grpcWeb.grpc.Metadata): Promise<ValidationResponse>;
+  validateMessage(request: DeepPartial<Message>, metadata?: grpc.Metadata): Promise<ValidationResponse>;
   /**
    * Event Methods
    * @http-api: none
    */
-  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpcWeb.grpc.Metadata): Observable<HubEvent>;
+  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpc.Metadata): Observable<HubEvent>;
   /** @http-api: events */
-  getEvent(request: DeepPartial<EventRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubEvent>;
+  getEvent(request: DeepPartial<EventRequest>, metadata?: grpc.Metadata): Promise<HubEvent>;
   /**
    * Casts
    * @http-api: castById
    */
-  getCast(request: DeepPartial<CastId>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
-  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
-  getCastsByParent(request: DeepPartial<CastsByParentRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
-  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getCast(request: DeepPartial<CastId>, metadata?: grpc.Metadata): Promise<Message>;
+  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getCastsByParent(request: DeepPartial<CastsByParentRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
+  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /**
    * Reactions
    * @http-api: reactionById
    */
-  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
-  getReactionsByFid(request: DeepPartial<ReactionsByFidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpc.Metadata): Promise<Message>;
+  getReactionsByFid(request: DeepPartial<ReactionsByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /** To be deprecated */
   getReactionsByCast(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<MessagesResponse>;
   getReactionsByTarget(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<MessagesResponse>;
   /**
    * User Data
    * @http-api: none
    */
-  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
-  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpc.Metadata): Promise<Message>;
+  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /**
    * Username Proof
    * @http-api: userNameProofByName
    */
-  getUsernameProof(request: DeepPartial<UsernameProofRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<UserNameProof>;
-  getUserNameProofsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<UsernameProofsResponse>;
+  getUsernameProof(request: DeepPartial<UsernameProofRequest>, metadata?: grpc.Metadata): Promise<UserNameProof>;
+  getUserNameProofsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<UsernameProofsResponse>;
   /**
    * Verifications
    * @http-api: none
    */
-  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
-  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpc.Metadata): Promise<Message>;
+  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /**
    * OnChain Events
    * @http-api: none
    */
-  getOnChainSigner(request: DeepPartial<SignerRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEvent>;
-  getOnChainSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEventResponse>;
+  getOnChainSigner(request: DeepPartial<SignerRequest>, metadata?: grpc.Metadata): Promise<OnChainEvent>;
+  getOnChainSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<OnChainEventResponse>;
   /** @http-api: none */
-  getOnChainEvents(request: DeepPartial<OnChainEventRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEventResponse>;
+  getOnChainEvents(request: DeepPartial<OnChainEventRequest>, metadata?: grpc.Metadata): Promise<OnChainEventResponse>;
   /** @http-api: none */
-  getIdRegistryOnChainEvent(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEvent>;
+  getIdRegistryOnChainEvent(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<OnChainEvent>;
   /** @http-api: onChainIdRegistryEventByAddress */
   getIdRegistryOnChainEventByAddress(
     request: DeepPartial<IdRegistryEventByAddressRequest>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<OnChainEvent>;
   /** @http-api: storageLimitsByFid */
   getCurrentStorageLimitsByFid(
     request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<StorageLimitsResponse>;
-  getFids(request: DeepPartial<FidsRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<FidsResponse>;
+  getFids(request: DeepPartial<FidsRequest>, metadata?: grpc.Metadata): Promise<FidsResponse>;
   /**
    * Links
    * @http-api: linkById
    */
-  getLink(request: DeepPartial<LinkRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message>;
-  getLinksByFid(request: DeepPartial<LinksByFidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getLink(request: DeepPartial<LinkRequest>, metadata?: grpc.Metadata): Promise<Message>;
+  getLinksByFid(request: DeepPartial<LinksByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /** @http-api: linksByTargetFid */
-  getLinksByTarget(request: DeepPartial<LinksByTargetRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getLinksByTarget(request: DeepPartial<LinksByTargetRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /**
    * Bulk Methods
    * The Bulk methods don't have corresponding HTTP API endpoints because the
    * regular endpoints can be used to get all the messages
    * @http-api: none
    */
-  getAllCastMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getAllCastMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /** @http-api: none */
-  getAllReactionMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getAllReactionMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /** @http-api: none */
   getAllVerificationMessagesByFid(
     request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<MessagesResponse>;
   /** @http-api: none */
-  getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /** @http-api: none */
-  getAllLinkMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getAllLinkMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /** Sync Methods */
-  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubInfoResponse>;
-  getCurrentPeers(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<ContactInfoResponse>;
+  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpc.Metadata): Promise<HubInfoResponse>;
+  getCurrentPeers(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<ContactInfoResponse>;
   /** @http-api: none */
-  getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncStatusResponse>;
+  getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpc.Metadata): Promise<SyncStatusResponse>;
   /** @http-api: none */
-  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncIds>;
+  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpc.Metadata): Promise<SyncIds>;
   /** @http-api: none */
-  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpc.Metadata): Promise<MessagesResponse>;
   /** @http-api: none */
   getSyncMetadataByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<TrieNodeMetadataResponse>;
   /** @http-api: none */
   getSyncSnapshotByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<TrieNodeSnapshotResponse>;
 }
 
@@ -211,103 +211,103 @@ export class HubServiceClientImpl implements HubService {
     this.getSyncSnapshotByPrefix = this.getSyncSnapshotByPrefix.bind(this);
   }
 
-  submitMessage(request: DeepPartial<Message>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  submitMessage(request: DeepPartial<Message>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceSubmitMessageDesc, Message.fromPartial(request), metadata);
   }
 
-  validateMessage(request: DeepPartial<Message>, metadata?: grpcWeb.grpc.Metadata): Promise<ValidationResponse> {
+  validateMessage(request: DeepPartial<Message>, metadata?: grpc.Metadata): Promise<ValidationResponse> {
     return this.rpc.unary(HubServiceValidateMessageDesc, Message.fromPartial(request), metadata);
   }
 
-  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpcWeb.grpc.Metadata): Observable<HubEvent> {
+  subscribe(request: DeepPartial<SubscribeRequest>, metadata?: grpc.Metadata): Observable<HubEvent> {
     return this.rpc.invoke(HubServiceSubscribeDesc, SubscribeRequest.fromPartial(request), metadata);
   }
 
-  getEvent(request: DeepPartial<EventRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubEvent> {
+  getEvent(request: DeepPartial<EventRequest>, metadata?: grpc.Metadata): Promise<HubEvent> {
     return this.rpc.unary(HubServiceGetEventDesc, EventRequest.fromPartial(request), metadata);
   }
 
-  getCast(request: DeepPartial<CastId>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  getCast(request: DeepPartial<CastId>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetCastDesc, CastId.fromPartial(request), metadata);
   }
 
-  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getCastsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetCastsByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getCastsByParent(request: DeepPartial<CastsByParentRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getCastsByParent(request: DeepPartial<CastsByParentRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetCastsByParentDesc, CastsByParentRequest.fromPartial(request), metadata);
   }
 
-  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getCastsByMention(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetCastsByMentionDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  getReaction(request: DeepPartial<ReactionRequest>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetReactionDesc, ReactionRequest.fromPartial(request), metadata);
   }
 
-  getReactionsByFid(request: DeepPartial<ReactionsByFidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getReactionsByFid(request: DeepPartial<ReactionsByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetReactionsByFidDesc, ReactionsByFidRequest.fromPartial(request), metadata);
   }
 
   getReactionsByCast(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetReactionsByCastDesc, ReactionsByTargetRequest.fromPartial(request), metadata);
   }
 
   getReactionsByTarget(
     request: DeepPartial<ReactionsByTargetRequest>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetReactionsByTargetDesc, ReactionsByTargetRequest.fromPartial(request), metadata);
   }
 
-  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  getUserData(request: DeepPartial<UserDataRequest>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetUserDataDesc, UserDataRequest.fromPartial(request), metadata);
   }
 
-  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getUserDataByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetUserDataByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getUsernameProof(request: DeepPartial<UsernameProofRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<UserNameProof> {
+  getUsernameProof(request: DeepPartial<UsernameProofRequest>, metadata?: grpc.Metadata): Promise<UserNameProof> {
     return this.rpc.unary(HubServiceGetUsernameProofDesc, UsernameProofRequest.fromPartial(request), metadata);
   }
 
-  getUserNameProofsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<UsernameProofsResponse> {
+  getUserNameProofsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<UsernameProofsResponse> {
     return this.rpc.unary(HubServiceGetUserNameProofsByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  getVerification(request: DeepPartial<VerificationRequest>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetVerificationDesc, VerificationRequest.fromPartial(request), metadata);
   }
 
-  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getVerificationsByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetVerificationsByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getOnChainSigner(request: DeepPartial<SignerRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEvent> {
+  getOnChainSigner(request: DeepPartial<SignerRequest>, metadata?: grpc.Metadata): Promise<OnChainEvent> {
     return this.rpc.unary(HubServiceGetOnChainSignerDesc, SignerRequest.fromPartial(request), metadata);
   }
 
-  getOnChainSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEventResponse> {
+  getOnChainSignersByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<OnChainEventResponse> {
     return this.rpc.unary(HubServiceGetOnChainSignersByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getOnChainEvents(request: DeepPartial<OnChainEventRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEventResponse> {
+  getOnChainEvents(request: DeepPartial<OnChainEventRequest>, metadata?: grpc.Metadata): Promise<OnChainEventResponse> {
     return this.rpc.unary(HubServiceGetOnChainEventsDesc, OnChainEventRequest.fromPartial(request), metadata);
   }
 
-  getIdRegistryOnChainEvent(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEvent> {
+  getIdRegistryOnChainEvent(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<OnChainEvent> {
     return this.rpc.unary(HubServiceGetIdRegistryOnChainEventDesc, FidRequest.fromPartial(request), metadata);
   }
 
   getIdRegistryOnChainEventByAddress(
     request: DeepPartial<IdRegistryEventByAddressRequest>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<OnChainEvent> {
     return this.rpc.unary(
       HubServiceGetIdRegistryOnChainEventByAddressDesc,
@@ -318,80 +318,80 @@ export class HubServiceClientImpl implements HubService {
 
   getCurrentStorageLimitsByFid(
     request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<StorageLimitsResponse> {
     return this.rpc.unary(HubServiceGetCurrentStorageLimitsByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getFids(request: DeepPartial<FidsRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<FidsResponse> {
+  getFids(request: DeepPartial<FidsRequest>, metadata?: grpc.Metadata): Promise<FidsResponse> {
     return this.rpc.unary(HubServiceGetFidsDesc, FidsRequest.fromPartial(request), metadata);
   }
 
-  getLink(request: DeepPartial<LinkRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<Message> {
+  getLink(request: DeepPartial<LinkRequest>, metadata?: grpc.Metadata): Promise<Message> {
     return this.rpc.unary(HubServiceGetLinkDesc, LinkRequest.fromPartial(request), metadata);
   }
 
-  getLinksByFid(request: DeepPartial<LinksByFidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getLinksByFid(request: DeepPartial<LinksByFidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetLinksByFidDesc, LinksByFidRequest.fromPartial(request), metadata);
   }
 
-  getLinksByTarget(request: DeepPartial<LinksByTargetRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getLinksByTarget(request: DeepPartial<LinksByTargetRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetLinksByTargetDesc, LinksByTargetRequest.fromPartial(request), metadata);
   }
 
-  getAllCastMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getAllCastMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllCastMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getAllReactionMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getAllReactionMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllReactionMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
   getAllVerificationMessagesByFid(
     request: DeepPartial<FidRequest>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllVerificationMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllUserDataMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getAllLinkMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getAllLinkMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllLinkMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
-  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubInfoResponse> {
+  getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpc.Metadata): Promise<HubInfoResponse> {
     return this.rpc.unary(HubServiceGetInfoDesc, HubInfoRequest.fromPartial(request), metadata);
   }
 
-  getCurrentPeers(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<ContactInfoResponse> {
+  getCurrentPeers(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<ContactInfoResponse> {
     return this.rpc.unary(HubServiceGetCurrentPeersDesc, Empty.fromPartial(request), metadata);
   }
 
-  getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncStatusResponse> {
+  getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpc.Metadata): Promise<SyncStatusResponse> {
     return this.rpc.unary(HubServiceGetSyncStatusDesc, SyncStatusRequest.fromPartial(request), metadata);
   }
 
-  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncIds> {
+  getAllSyncIdsByPrefix(request: DeepPartial<TrieNodePrefix>, metadata?: grpc.Metadata): Promise<SyncIds> {
     return this.rpc.unary(HubServiceGetAllSyncIdsByPrefixDesc, TrieNodePrefix.fromPartial(request), metadata);
   }
 
-  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
+  getAllMessagesBySyncIds(request: DeepPartial<SyncIds>, metadata?: grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllMessagesBySyncIdsDesc, SyncIds.fromPartial(request), metadata);
   }
 
   getSyncMetadataByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<TrieNodeMetadataResponse> {
     return this.rpc.unary(HubServiceGetSyncMetadataByPrefixDesc, TrieNodePrefix.fromPartial(request), metadata);
   }
 
   getSyncSnapshotByPrefix(
     request: DeepPartial<TrieNodePrefix>,
-    metadata?: grpcWeb.grpc.Metadata,
+    metadata?: grpc.Metadata,
   ): Promise<TrieNodeSnapshotResponse> {
     return this.rpc.unary(HubServiceGetSyncSnapshotByPrefixDesc, TrieNodePrefix.fromPartial(request), metadata);
   }
@@ -1320,9 +1320,9 @@ export const HubServiceGetSyncSnapshotByPrefixDesc: UnaryMethodDefinitionish = {
 };
 
 export interface AdminService {
-  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty>;
-  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty>;
-  submitOnChainEvent(request: DeepPartial<OnChainEvent>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEvent>;
+  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty>;
+  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty>;
+  submitOnChainEvent(request: DeepPartial<OnChainEvent>, metadata?: grpc.Metadata): Promise<OnChainEvent>;
 }
 
 export class AdminServiceClientImpl implements AdminService {
@@ -1335,15 +1335,15 @@ export class AdminServiceClientImpl implements AdminService {
     this.submitOnChainEvent = this.submitOnChainEvent.bind(this);
   }
 
-  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty> {
+  rebuildSyncTrie(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty> {
     return this.rpc.unary(AdminServiceRebuildSyncTrieDesc, Empty.fromPartial(request), metadata);
   }
 
-  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<Empty> {
+  deleteAllMessagesFromDb(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<Empty> {
     return this.rpc.unary(AdminServiceDeleteAllMessagesFromDbDesc, Empty.fromPartial(request), metadata);
   }
 
-  submitOnChainEvent(request: DeepPartial<OnChainEvent>, metadata?: grpcWeb.grpc.Metadata): Promise<OnChainEvent> {
+  submitOnChainEvent(request: DeepPartial<OnChainEvent>, metadata?: grpc.Metadata): Promise<OnChainEvent> {
     return this.rpc.unary(AdminServiceSubmitOnChainEventDesc, OnChainEvent.fromPartial(request), metadata);
   }
 }
@@ -1419,7 +1419,7 @@ export const AdminServiceSubmitOnChainEventDesc: UnaryMethodDefinitionish = {
   } as any,
 };
 
-interface UnaryMethodDefinitionishR extends grpcWeb.grpc.UnaryMethodDefinition<any, any> {
+interface UnaryMethodDefinitionishR extends grpc.UnaryMethodDefinition<any, any> {
   requestStream: any;
   responseStream: any;
 }
@@ -1430,32 +1430,32 @@ interface Rpc {
   unary<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     request: any,
-    metadata: grpcWeb.grpc.Metadata | undefined,
+    metadata: grpc.Metadata | undefined,
   ): Promise<any>;
   invoke<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     request: any,
-    metadata: grpcWeb.grpc.Metadata | undefined,
+    metadata: grpc.Metadata | undefined,
   ): Observable<any>;
 }
 
 export class GrpcWebImpl {
   private host: string;
   private options: {
-    transport?: grpcWeb.grpc.TransportFactory;
-    streamingTransport?: grpcWeb.grpc.TransportFactory;
+    transport?: grpc.TransportFactory;
+    streamingTransport?: grpc.TransportFactory;
     debug?: boolean;
-    metadata?: grpcWeb.grpc.Metadata;
+    metadata?: grpc.Metadata;
     upStreamRetryCodes?: number[];
   };
 
   constructor(
     host: string,
     options: {
-      transport?: grpcWeb.grpc.TransportFactory;
-      streamingTransport?: grpcWeb.grpc.TransportFactory;
+      transport?: grpc.TransportFactory;
+      streamingTransport?: grpc.TransportFactory;
       debug?: boolean;
-      metadata?: grpcWeb.grpc.Metadata;
+      metadata?: grpc.Metadata;
       upStreamRetryCodes?: number[];
     },
   ) {
@@ -1466,21 +1466,21 @@ export class GrpcWebImpl {
   unary<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     _request: any,
-    metadata: grpcWeb.grpc.Metadata | undefined,
+    metadata: grpc.Metadata | undefined,
   ): Promise<any> {
     const request = { ..._request, ...methodDesc.requestType };
     const maybeCombinedMetadata = metadata && this.options.metadata
       ? new BrowserHeaders({ ...this.options?.metadata.headersMap, ...metadata?.headersMap })
       : metadata || this.options.metadata;
     return new Promise((resolve, reject) => {
-      grpcWeb.grpc.unary(methodDesc, {
+      grpc.unary(methodDesc, {
         request,
         host: this.host,
         metadata: maybeCombinedMetadata,
         transport: this.options.transport,
         debug: this.options.debug,
         onEnd: function (response) {
-          if (response.status === grpcWeb.grpc.Code.OK) {
+          if (response.status === grpc.Code.OK) {
             resolve(response.message!.toObject());
           } else {
             const err = new GrpcWebError(response.statusMessage, response.status, response.trailers);
@@ -1494,7 +1494,7 @@ export class GrpcWebImpl {
   invoke<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     _request: any,
-    metadata: grpcWeb.grpc.Metadata | undefined,
+    metadata: grpc.Metadata | undefined,
   ): Observable<any> {
     const upStreamCodes = this.options.upStreamRetryCodes || [];
     const DEFAULT_TIMEOUT_TIME: number = 3_000;
@@ -1504,14 +1504,14 @@ export class GrpcWebImpl {
       : metadata || this.options.metadata;
     return new Observable((observer) => {
       const upStream = (() => {
-        const client = grpcWeb.grpc.invoke(methodDesc, {
+        const client = grpc.invoke(methodDesc, {
           host: this.host,
           request,
           transport: this.options.streamingTransport || this.options.transport,
           metadata: maybeCombinedMetadata,
           debug: this.options.debug,
           onMessage: (next) => observer.next(next),
-          onEnd: (code: grpcWeb.grpc.Code, message: string, trailers: grpcWeb.grpc.Metadata) => {
+          onEnd: (code: grpc.Code, message: string, trailers: grpc.Metadata) => {
             if (code === 0) {
               observer.complete();
             } else if (upStreamCodes.includes(code)) {
@@ -1562,7 +1562,7 @@ type DeepPartial<T> = T extends Builtin ? T
   : Partial<T>;
 
 export class GrpcWebError extends tsProtoGlobalThis.Error {
-  constructor(message: string, public code: grpcWeb.grpc.Code, public metadata: grpcWeb.grpc.Metadata) {
+  constructor(message: string, public code: grpc.Code, public metadata: grpc.Metadata) {
     super(message);
   }
 }

--- a/protobufs/schemas/message.proto
+++ b/protobufs/schemas/message.proto
@@ -181,4 +181,5 @@ message FrameActionBody {
   bytes input_text = 4; // Text input from the user, if present
   bytes state = 5; // Serialized frame state value
   bytes transaction_id = 6; // Chain-specific transaction ID for tx actions
+  bytes address = 7; // Chain-specific address for tx actions
 }


### PR DESCRIPTION
## Motivation

It's useful for frames to know:

1) the current connected address, to generate transaction calldata
2) the actual address that executed a tx, in the post transaction callback

We should pass this as part of the frame message.

## Change Summary

- Add `address` field to `FrameActionBody`
- Limit length to 64 bytes.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates message schemas and validations to include a chain-specific address for transaction actions.

### Detailed summary
- Added `address` field to message schemas
- Updated validations to check address length
- Updated message serialization and deserialization functions to handle the `address` field

> The following files were skipped due to too many changes: `packages/hub-web/src/generated/rpc.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->