### PR TITLE
chore: release packages

### DIFF
--- a/.changeset/perfect-cameras-relax.md
+++ b/.changeset/perfect-cameras-relax.md
@@ -1,8 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
-"@farcaster/hub-web": patch
-"@farcaster/core": patch
-"@farcaster/hubble": patch
----
-
-Add address to frame message

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hubble
 
+## 1.10.11
+
+### Patch Changes
+
+- 22615b3c: Add address to frame message
+- Updated dependencies [22615b3c]
+  - @farcaster/hub-nodejs@0.11.7
+
 ## 1.10.10
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.10.10",
+  "version": "1.10.11",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -71,7 +71,7 @@
     "@chainsafe/libp2p-gossipsub": "6.1.0",
     "@chainsafe/libp2p-noise": "^11.0.0 ",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.11.6",
+    "@farcaster/hub-nodejs": "^0.11.7",
     "@fastify/cors": "^8.4.0",
     "@figma/hot-shots": "^9.0.0-figma.1",
     "@grpc/grpc-js": "~1.8.21",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/core
 
+## 0.14.7
+
+### Patch Changes
+
+- 22615b3c: Add address to frame message
+
 ## 0.14.6
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hub-nodejs
 
+## 0.11.7
+
+### Patch Changes
+
+- 22615b3c: Add address to frame message
+- Updated dependencies [22615b3c]
+  - @farcaster/core@0.14.7
+
 ## 0.11.6
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@farcaster/core": "0.14.6",
+    "@farcaster/core": "0.14.7",
     "@grpc/grpc-js": "~1.8.21",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"

--- a/packages/hub-web/CHANGELOG.md
+++ b/packages/hub-web/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hub-web
 
+## 0.8.5
+
+### Patch Changes
+
+- 22615b3c: Add address to frame message
+- Updated dependencies [22615b3c]
+  - @farcaster/core@0.14.7
+
 ## 0.8.4
 
 ### Patch Changes

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-web",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -28,7 +28,7 @@
     "ts-proto": "^1.146.0"
   },
   "dependencies": {
-    "@farcaster/core": "^0.14.5",
+    "@farcaster/core": "^0.14.7",
     "@improbable-eng/grpc-web": "^0.15.0",
     "rxjs": "^7.8.0"
   }


### PR DESCRIPTION
## Change Summary

Add `address` field to frame messages.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates version numbers in various packages to `0.14.7`, `0.8.5`, and `1.10.11`, and includes changes related to dependencies and address addition to frame message.

### Detailed summary
- Bumped versions to `0.14.7`, `0.8.5`, and `1.10.11`
- Added address to frame message
- Updated dependencies in different packages

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->