### PR TITLE
chore: replicator v0.3.7

### DIFF
--- a/.changeset/witty-pants-pay.md
+++ b/.changeset/witty-pants-pay.md
@@ -1,5 +1,0 @@
----
-"@farcaster/replicator": patch
----
-
-fix(replicator): handle Hub errors in backfill

--- a/apps/replicator/CHANGELOG.md
+++ b/apps/replicator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/replicator
 
+## 0.3.7
+
+### Patch Changes
+
+- 02bca881: fix(replicator): handle Hub errors in backfill
+
 ## 0.3.6
 
 ### Patch Changes

--- a/apps/replicator/package.json
+++ b/apps/replicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/replicator",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Replicate Farcaster hub data into Postgres",
   "author": "",
   "license": "",


### PR DESCRIPTION
## Motivation

- Release replicator v0.3.7

## Change Summary

- 02bca881: fix(replicator): handle Hub errors in backfill

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
