### PR TITLE
add check for SKIP_CRONTAB=true

### DIFF
--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -5,7 +5,7 @@
 # itself in the process.
 
 # Define the version of this script
-CURRENT_VERSION="4"
+CURRENT_VERSION="5"
 
 REPO="farcasterxyz/hub-monorepo"
 RAWFILE_BASE="https://raw.githubusercontent.com/$REPO"
@@ -360,6 +360,12 @@ setup_crontab() {
         exit 1
     fi
 
+    # skip installing crontab if SKIP_CRONTAB is set to anything
+    if [ "${SKIP_CRONTAB:-}" = "true" ]; then
+        echo "✅ SKIP_CRONTAB is 'true'. Skipping crontab setup."
+        return 0
+    fi
+
     # If the crontab was installed for the current user (instead of root) then
     # remove it
     if [[ "$(uname)" == "Linux" ]]; then
@@ -614,5 +620,7 @@ if [ $# -eq 0 ] || [ "$1" == "help" ]; then
     echo "  up       Start Hubble and Grafana dashboard"
     echo "  down     Stop Hubble and Grafana dashboard"
     echo "  help     Show this help"
+    echo ""
+    echo "export SKIP_CRONTAB=true to skip installing the autoupgrade crontab"
     exit 0
 fi

--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -360,9 +360,9 @@ setup_crontab() {
         exit 1
     fi
 
-    # skip installing crontab if SKIP_CRONTAB is set to anything
-    if [ "${SKIP_CRONTAB:-}" = "true" ]; then
-        echo "✅ SKIP_CRONTAB is 'true'. Skipping crontab setup."
+    # skip installing crontab if SKIP_CRONTAB is set to anything in the .env
+    if key_exists "SKIP_CRONTAB"; then
+        echo "✅ SKIP_CRONTAB exists in .env. Skipping crontab setup."
         return 0
     fi
 
@@ -621,6 +621,6 @@ if [ $# -eq 0 ] || [ "$1" == "help" ]; then
     echo "  down     Stop Hubble and Grafana dashboard"
     echo "  help     Show this help"
     echo ""
-    echo "export SKIP_CRONTAB=true to skip installing the autoupgrade crontab"
+    echo "add SKIP_CRONTAB=true to your .env to skip installing the autoupgrade crontab"
     exit 0
 fi


### PR DESCRIPTION
## Motivation

We handle our upgrades manually.

## Change Summary

Add a check for `SKIP_CRONTAB=true` into the upgrade script.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR increases the version of the script to 5 and introduces a feature to skip installing the autoupgrade crontab by setting `SKIP_CRONTAB` in the `.env` file.

### Detailed summary
- Updated `CURRENT_VERSION` to "5"
- Added check to skip crontab setup if `SKIP_CRONTAB` is set in `.env`
- Display message when skipping crontab setup
- Updated help message to include instructions for skipping crontab installation

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->