### PR TITLE
perf: Move username proof store to rust

### DIFF
--- a/.changeset/lovely-islands-sit.md
+++ b/.changeset/lovely-islands-sit.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+perf: Move username proof store to rust

--- a/apps/hubble/src/addon/src/lib.rs
+++ b/apps/hubble/src/addon/src/lib.rs
@@ -1,4 +1,4 @@
-use crate::store::{CastStore, StoreEventHandler};
+use crate::store::{CastStore, StoreEventHandler, UsernameProofStore, VerificationStore};
 use db::RocksDB;
 use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey, EXPANDED_SECRET_KEY_LENGTH};
 use neon::{prelude::*, types::buffer::TypedArray};
@@ -183,27 +183,45 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     // VerificationStore methods
     cx.export_function(
         "createVerificationStore",
-        store::VerificationStore::create_verification_store,
+        VerificationStore::create_verification_store,
     )?;
     cx.export_function(
         "getVerificationAdd",
-        store::VerificationStore::js_get_verification_add,
+        VerificationStore::js_get_verification_add,
     )?;
     cx.export_function(
         "getVerificationAddsByFid",
-        store::VerificationStore::js_get_verification_adds_by_fid,
+        VerificationStore::js_get_verification_adds_by_fid,
     )?;
     cx.export_function(
         "getVerificationRemove",
-        store::VerificationStore::js_get_verification_remove,
+        VerificationStore::js_get_verification_remove,
     )?;
     cx.export_function(
         "getVerificationRemovesByFid",
-        store::VerificationStore::js_get_verification_removes_by_fid,
+        VerificationStore::js_get_verification_removes_by_fid,
     )?;
     cx.export_function(
         "migrateVerifications",
-        store::VerificationStore::js_migrate_verifications,
+        VerificationStore::js_migrate_verifications,
+    )?;
+
+    // Username Proof methods
+    cx.export_function(
+        "createUsernameProofStore",
+        UsernameProofStore::create_username_proof_store,
+    )?;
+    cx.export_function(
+        "getUsernameProof",
+        UsernameProofStore::js_get_username_proof,
+    )?;
+    cx.export_function(
+        "getUsernameProofsByFid",
+        UsernameProofStore::js_get_username_proofs_by_fid,
+    )?;
+    cx.export_function(
+        "getUsernameProofByFidAndName",
+        UsernameProofStore::js_get_username_proof_by_fid_and_name,
     )?;
 
     Ok(())

--- a/apps/hubble/src/addon/src/store/mod.rs
+++ b/apps/hubble/src/addon/src/store/mod.rs
@@ -5,6 +5,7 @@ pub use self::reaction_store::*;
 pub use self::store::*;
 pub use self::store_event_handler::*;
 pub use self::user_data_store::*;
+pub use self::username_proof_store::*;
 pub use self::utils::*;
 pub use self::verification_store::*;
 
@@ -16,5 +17,6 @@ mod reaction_store;
 mod store;
 mod store_event_handler;
 mod user_data_store;
+mod username_proof_store;
 mod utils;
 mod verification_store;

--- a/apps/hubble/src/addon/src/store/username_proof_store.rs
+++ b/apps/hubble/src/addon/src/store/username_proof_store.rs
@@ -1,0 +1,547 @@
+use super::{
+    get_message, hub_error_to_js_throw, make_fid_key, make_user_key, read_fid_key,
+    store::{Store, StoreDef},
+    utils::{self, encode_messages_to_js_object, get_page_options, get_store},
+    HubError, IntoU8, MessagesPage, PageOptions, RootPrefix, StoreEventHandler, UserPostfix,
+    TS_HASH_LENGTH,
+};
+use crate::protos::{
+    hub_event, message_data::Body, HubEvent, HubEventType, MergeUserNameProofBody, UserNameType,
+};
+use crate::{
+    db::{RocksDB, RocksDbTransactionBatch},
+    protos::{self, Message, MessageType},
+};
+use neon::{
+    context::{Context, FunctionContext},
+    result::JsResult,
+    types::{buffer::TypedArray, JsBox, JsBuffer, JsNumber, JsPromise},
+};
+use prost::Message as _;
+use std::{borrow::Borrow as _, sync::Arc};
+
+pub struct UsernameProofStoreDef {
+    prune_size_limit: u32,
+}
+
+impl StoreDef for UsernameProofStoreDef {
+    fn postfix(&self) -> u8 {
+        UserPostfix::UsernameProofMessage.as_u8()
+    }
+
+    fn add_message_type(&self) -> u8 {
+        MessageType::UsernameProof.into_u8()
+    }
+
+    fn make_add_key(&self, message: &Message) -> Result<Vec<u8>, HubError> {
+        if message.data.is_none() {
+            return Err(HubError {
+                code: "bad_request.validation_failure".to_string(),
+                message: "Message data is missing".to_string(),
+            });
+        }
+
+        let data = message.data.as_ref().unwrap();
+        if data.body.is_none() {
+            return Err(HubError {
+                code: "bad_request.validation_failure".to_string(),
+                message: "Message body is missing".to_string(),
+            });
+        }
+
+        let name = match &data.body {
+            Some(Body::UsernameProofBody(body)) => &body.name,
+            _ => {
+                return Err(HubError {
+                    code: "bad_request.validation_failure".to_string(),
+                    message: "Message body is missing".to_string(),
+                })
+            }
+        };
+
+        Ok(Self::make_username_proof_by_fid_key(
+            message.data.as_ref().unwrap().fid as u32,
+            name,
+        ))
+    }
+
+    fn remove_type_supported(&self) -> bool {
+        false
+    }
+
+    fn make_remove_key(&self, _message: &Message) -> Result<Vec<u8>, HubError> {
+        Err(HubError {
+            code: "bad_request.validation_failure".to_string(),
+            message: "Remove not supported".to_string(),
+        })
+    }
+
+    fn is_add_type(&self, message: &Message) -> bool {
+        message.signature_scheme == protos::SignatureScheme::Ed25519 as i32
+            && message.data.is_some()
+            && message.data.as_ref().unwrap().r#type == MessageType::UsernameProof.into_u8() as i32
+            && message.data.as_ref().unwrap().body.is_some()
+    }
+
+    fn build_secondary_indices(
+        &self,
+        txn: &mut RocksDbTransactionBatch,
+        _ts_hash: &[u8; TS_HASH_LENGTH],
+        message: &Message,
+    ) -> Result<(), HubError> {
+        if message.data.is_none() {
+            return Err(HubError {
+                code: "bad_request.validation_failure".to_string(),
+                message: "Message data is missing".to_string(),
+            });
+        }
+
+        let data = message.data.as_ref().unwrap();
+        if data.body.is_none() {
+            return Err(HubError {
+                code: "bad_request.validation_failure".to_string(),
+                message: "Message body is missing".to_string(),
+            });
+        }
+
+        if let Some(Body::UsernameProofBody(body)) = &data.body {
+            if body.name.len() == 0 {
+                return Err(HubError {
+                    code: "bad_request.invalid_param".to_string(),
+                    message: "name empty".to_string(),
+                });
+            }
+
+            let by_name_key = Self::make_username_proof_by_name_key(&body.name);
+            txn.put(
+                by_name_key,
+                make_fid_key(message.data.as_ref().unwrap().fid as u32),
+            );
+            Ok(())
+        } else {
+            Err(HubError {
+                code: "bad_request.validation_failure".to_string(),
+                message: "Message body is missing".to_string(),
+            })
+        }
+    }
+
+    fn delete_secondary_indices(
+        &self,
+        txn: &mut RocksDbTransactionBatch,
+        _ts_hash: &[u8; TS_HASH_LENGTH],
+        message: &Message,
+    ) -> Result<(), HubError> {
+        if message.data.is_none() {
+            return Err(HubError {
+                code: "bad_request.validation_failure".to_string(),
+                message: "Message data is missing".to_string(),
+            });
+        }
+
+        let data = message.data.as_ref().unwrap();
+        if data.body.is_none() {
+            return Err(HubError {
+                code: "bad_request.validation_failure".to_string(),
+                message: "Message body is missing".to_string(),
+            });
+        }
+
+        if let Some(Body::UsernameProofBody(body)) = &data.body {
+            if body.name.len() == 0 {
+                return Err(HubError {
+                    code: "bad_request.invalid_param".to_string(),
+                    message: "name empty".to_string(),
+                });
+            }
+
+            let by_name_key = Self::make_username_proof_by_name_key(&body.name);
+            txn.delete(by_name_key);
+            Ok(())
+        } else {
+            Err(HubError {
+                code: "bad_request.validation_failure".to_string(),
+                message: "Message body is missing".to_string(),
+            })
+        }
+    }
+
+    fn get_merge_conflicts(
+        &self,
+        db: &RocksDB,
+        message: &Message,
+        ts_hash: &[u8; TS_HASH_LENGTH],
+    ) -> Result<Vec<Message>, HubError> {
+        if message.data.is_none() {
+            return Err(HubError {
+                code: "bad_request.validation_failure".to_string(),
+                message: "Message data is missing".to_string(),
+            });
+        }
+
+        let data = message.data.as_ref().unwrap();
+        if data.body.is_none() {
+            return Err(HubError {
+                code: "bad_request.validation_failure".to_string(),
+                message: "Message body is missing".to_string(),
+            });
+        }
+
+        let name = match &data.body {
+            Some(Body::UsernameProofBody(body)) => &body.name,
+            _ => {
+                return Err(HubError {
+                    code: "bad_request.validation_failure".to_string(),
+                    message: "Message body is missing".to_string(),
+                })
+            }
+        };
+
+        let mut conflicts = Vec::new();
+        let by_name_key = Self::make_username_proof_by_name_key(name);
+
+        let fid_result = db.get(by_name_key.as_slice());
+        if let Ok(Some(fid_bytes)) = fid_result {
+            let fid = read_fid_key(&fid_bytes);
+            if fid > 0 {
+                let existing_add_key = Self::make_username_proof_by_fid_key(fid, name);
+                if let Ok(existing_message_ts_hash) = db.get(existing_add_key.as_slice()) {
+                    if let Ok(Some(existing_message)) = get_message(
+                        db,
+                        fid,
+                        self.postfix(),
+                        &utils::vec_to_u8_24(&existing_message_ts_hash)?,
+                    ) {
+                        let message_compare = self.message_compare(
+                            self.add_message_type(),
+                            &existing_message_ts_hash.unwrap().to_vec(),
+                            self.add_message_type(),
+                            &ts_hash.to_vec(),
+                        );
+
+                        if message_compare > 0 {
+                            return Err(HubError {
+                                code: "bad_request.conflict".to_string(),
+                                message: "message conflicts with a more recent add".to_string(),
+                            });
+                        }
+                        if message_compare == 0 {
+                            return Err(HubError {
+                                code: "bad_request.duplicate".to_string(),
+                                message: "message has already been merged".to_string(),
+                            });
+                        }
+                        conflicts.push(existing_message);
+                    }
+                }
+            }
+        }
+
+        Ok(conflicts)
+    }
+
+    fn remove_message_type(&self) -> u8 {
+        MessageType::None.into_u8()
+    }
+
+    fn is_remove_type(&self, _message: &Message) -> bool {
+        false
+    }
+
+    fn find_merge_add_conflicts(&self, _db: &RocksDB, _message: &Message) -> Result<(), HubError> {
+        Ok(())
+    }
+
+    fn find_merge_remove_conflicts(
+        &self,
+        _db: &RocksDB,
+        _message: &Message,
+    ) -> Result<(), HubError> {
+        return Err(HubError {
+            code: "bad_request.validation_failure".to_string(),
+            message: "Username Proof store does not support removes".to_string(),
+        });
+    }
+
+    fn get_prune_size_limit(&self) -> u32 {
+        self.prune_size_limit
+    }
+
+    fn revoke_event_args(&self, message: &Message) -> HubEvent {
+        let username_proof_body = match &message.data {
+            Some(message_data) => match &message_data.body {
+                Some(Body::UsernameProofBody(username_proof_body)) => {
+                    Some(username_proof_body.clone())
+                }
+                _ => None,
+            },
+            _ => None,
+        };
+
+        HubEvent {
+            r#type: HubEventType::MergeUsernameProof as i32,
+            body: Some(hub_event::Body::MergeUsernameProofBody(
+                MergeUserNameProofBody {
+                    username_proof: None,
+                    deleted_username_proof: username_proof_body,
+                    username_proof_message: None,
+                    deleted_username_proof_message: Some(message.clone()),
+                },
+            )),
+            id: 0,
+        }
+    }
+
+    fn merge_event_args(&self, message: &Message, merge_conflicts: Vec<Message>) -> HubEvent {
+        let username_proof_body = match &message.data {
+            Some(message_data) => match &message_data.body {
+                Some(Body::UsernameProofBody(username_proof_body)) => {
+                    Some(username_proof_body.clone())
+                }
+                _ => None,
+            },
+            _ => None,
+        };
+
+        let (deleted_proof_body, deleted_message) = if merge_conflicts.len() > 0 {
+            match &merge_conflicts[0].data {
+                Some(message_data) => match &message_data.body {
+                    Some(Body::UsernameProofBody(username_proof_body)) => (
+                        Some(username_proof_body.clone()),
+                        Some(merge_conflicts[0].clone()),
+                    ),
+                    _ => (None, None),
+                },
+                _ => (None, None),
+            }
+        } else {
+            (None, None)
+        };
+
+        HubEvent {
+            r#type: HubEventType::MergeUsernameProof as i32,
+            body: Some(hub_event::Body::MergeUsernameProofBody(
+                MergeUserNameProofBody {
+                    username_proof: username_proof_body,
+                    deleted_username_proof: deleted_proof_body,
+                    username_proof_message: Some(message.clone()),
+                    deleted_username_proof_message: deleted_message,
+                },
+            )),
+            id: 0,
+        }
+    }
+
+    fn prune_event_args(&self, message: &Message) -> HubEvent {
+        self.revoke_event_args(message)
+    }
+}
+
+impl UsernameProofStoreDef {
+    fn make_username_proof_by_name_key(name: &Vec<u8>) -> Vec<u8> {
+        let mut key = Vec::with_capacity(1 + name.len());
+
+        key.push(RootPrefix::UserNameProofByName as u8);
+        key.extend(name);
+
+        key
+    }
+
+    fn make_username_proof_by_fid_key(fid: u32, name: &Vec<u8>) -> Vec<u8> {
+        let mut key = Vec::with_capacity(1 + 4 + 1 + name.len());
+
+        key.extend_from_slice(&make_user_key(fid));
+        key.push(UserPostfix::UserNameProofAdds.as_u8());
+        key.extend(name);
+
+        key
+    }
+}
+
+pub struct UsernameProofStore {}
+
+impl UsernameProofStore {
+    pub fn new(
+        db: Arc<RocksDB>,
+        store_event_handler: Arc<StoreEventHandler>,
+        prune_size_limit: u32,
+    ) -> Store {
+        Store::new_with_store_def(
+            db,
+            store_event_handler,
+            Box::new(UsernameProofStoreDef { prune_size_limit }),
+        )
+    }
+
+    pub fn get_username_proof(
+        store: &Store,
+        name: &Vec<u8>,
+        name_type: u8,
+    ) -> Result<Option<protos::Message>, HubError> {
+        if name_type != UserNameType::UsernameTypeEnsL1 as u8 {
+            return Err(HubError {
+                code: "bad_request".to_string(),
+                message: format!(
+                    "Unsupported username type {}. Only ENS L1 is supported",
+                    name_type as u8
+                ),
+            });
+        }
+
+        let by_name_key = UsernameProofStoreDef::make_username_proof_by_name_key(name);
+        let fid_result = store.db().get(by_name_key.as_slice())?;
+        if fid_result.is_none() {
+            return Err(HubError {
+                code: "not_found".to_string(),
+                message: format!(
+                    "NotFound: Username proof not found for name {}",
+                    String::from_utf8_lossy(name)
+                ),
+            });
+        }
+
+        let fid = read_fid_key(&fid_result.unwrap());
+        let partial_message = protos::Message {
+            data: Some(protos::MessageData {
+                fid: fid as u64,
+                body: Some(protos::message_data::Body::UsernameProofBody(
+                    protos::UserNameProof {
+                        name: name.clone(),
+                        ..Default::default()
+                    },
+                )),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        store.get_add(&partial_message)
+    }
+
+    pub fn js_get_username_proof(mut cx: FunctionContext) -> JsResult<JsPromise> {
+        let channel = cx.channel();
+
+        let store = get_store(&mut cx)?;
+
+        let name = cx.argument::<JsBuffer>(0)?.as_slice(&cx).to_vec();
+        let name_type = cx.argument::<JsNumber>(1)?.value(&mut cx) as u8;
+
+        let result = match Self::get_username_proof(&store, &name, name_type) {
+            Ok(Some(message)) => message.encode_to_vec(),
+            Ok(None) => cx.throw_error(format!(
+                "{}/{} for {}",
+                "not_found",
+                "NotFound: usernameproof not found for {}",
+                String::from_utf8_lossy(&name)
+            ))?,
+            Err(e) => return hub_error_to_js_throw(&mut cx, e),
+        };
+
+        let (deferred, promise) = cx.promise();
+        deferred.settle_with(&channel, move |mut cx| {
+            let mut js_buffer = cx.buffer(result.len())?;
+            js_buffer.as_mut_slice(&mut cx).copy_from_slice(&result);
+            Ok(js_buffer)
+        });
+
+        Ok(promise)
+    }
+
+    pub fn get_username_proofs_by_fid(
+        store: &Store,
+        fid: u32,
+        page_options: &PageOptions,
+    ) -> Result<MessagesPage, HubError> {
+        store.get_adds_by_fid(fid, page_options, Some(|_message: &Message| true))
+    }
+
+    pub fn js_get_username_proofs_by_fid(mut cx: FunctionContext) -> JsResult<JsPromise> {
+        let channel = cx.channel();
+
+        let store = get_store(&mut cx)?;
+
+        let fid = cx.argument::<JsNumber>(0)?.value(&mut cx) as u32;
+        let page_options = get_page_options(&mut cx, 1)?;
+
+        let messages = match Self::get_username_proofs_by_fid(&store, fid, &page_options) {
+            Ok(page) => page,
+            Err(e) => return hub_error_to_js_throw(&mut cx, e),
+        };
+
+        let (deferred, promise) = cx.promise();
+        deferred.settle_with(&channel, move |mut cx| {
+            encode_messages_to_js_object(&mut cx, messages)
+        });
+
+        Ok(promise)
+    }
+
+    pub fn get_username_proof_by_fid_and_name(
+        store: &Store,
+        name: &Vec<u8>,
+        fid: u32,
+    ) -> Result<Option<protos::Message>, HubError> {
+        let partial_message = protos::Message {
+            data: Some(protos::MessageData {
+                fid: fid as u64,
+                body: Some(protos::message_data::Body::UsernameProofBody(
+                    protos::UserNameProof {
+                        name: name.clone(),
+                        ..Default::default()
+                    },
+                )),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        store.get_add(&partial_message)
+    }
+
+    pub fn js_get_username_proof_by_fid_and_name(mut cx: FunctionContext) -> JsResult<JsPromise> {
+        let channel = cx.channel();
+
+        let store = get_store(&mut cx)?;
+
+        let fid = cx.argument::<JsNumber>(0)?.value(&mut cx) as u32;
+        let name = cx.argument::<JsBuffer>(1)?.as_slice(&cx).to_vec();
+
+        let result = match Self::get_username_proof_by_fid_and_name(&store, &name, fid) {
+            Ok(Some(message)) => message.encode_to_vec(),
+            Ok(None) => cx.throw_error(format!(
+                "{}/{} for {}",
+                "not_found",
+                "NotFound: usernameproof not found for {}",
+                String::from_utf8_lossy(&name)
+            ))?,
+            Err(e) => return hub_error_to_js_throw(&mut cx, e),
+        };
+
+        let (deferred, promise) = cx.promise();
+        deferred.settle_with(&channel, move |mut cx| {
+            let mut js_buffer = cx.buffer(result.len())?;
+            js_buffer.as_mut_slice(&mut cx).copy_from_slice(&result);
+            Ok(js_buffer)
+        });
+
+        Ok(promise)
+    }
+
+    pub fn create_username_proof_store(mut cx: FunctionContext) -> JsResult<JsBox<Arc<Store>>> {
+        let db_js_box = cx.argument::<JsBox<Arc<RocksDB>>>(0)?;
+        let db = (**db_js_box.borrow()).clone();
+
+        let store_event_handler_js_box = cx.argument::<JsBox<Arc<StoreEventHandler>>>(1)?;
+        let store_event_handler = (**store_event_handler_js_box.borrow()).clone();
+
+        let prune_size_limit = cx
+            .argument::<JsNumber>(2)
+            .map(|n| n.value(&mut cx) as u32)?;
+
+        Ok(cx.boxed(Arc::new(Self::new(
+            db,
+            store_event_handler,
+            prune_size_limit,
+        ))))
+    }
+}

--- a/apps/hubble/src/addon/src/store/verification_store.rs
+++ b/apps/hubble/src/addon/src/store/verification_store.rs
@@ -416,7 +416,7 @@ impl VerificationStore {
         fid: u32,
         page_options: &PageOptions,
     ) -> Result<MessagesPage, HubError> {
-        store.get_adds_by_fid(fid, page_options, Some(|message: &Message| true))
+        store.get_adds_by_fid(fid, page_options, Some(|_message: &Message| true))
     }
 
     pub fn js_get_verification_adds_by_fid(mut cx: FunctionContext) -> JsResult<JsPromise> {
@@ -621,7 +621,7 @@ impl VerificationStore {
             .argument::<JsNumber>(2)
             .map(|n| n.value(&mut cx) as u32)?;
 
-        Ok(cx.boxed(Arc::new(VerificationStore::new(
+        Ok(cx.boxed(Arc::new(Self::new(
             db,
             store_event_handler,
             prune_size_limit,

--- a/apps/hubble/src/rustfunctions.ts
+++ b/apps/hubble/src/rustfunctions.ts
@@ -504,6 +504,38 @@ export const rsGetVerificationRemovesByFid = async (
 export const rsMigrateVerifications = async (store: RustDynStore): Promise<{ total: number; duplicates: number }> => {
   return await lib.migrateVerifications.call(store);
 };
+
+/** Username Proofs store */
+export const rsCreateUsernameProofStore = (
+  db: RustDb,
+  eventHandler: RustStoreEventHandler,
+  pruneSizeLimit: number,
+): RustDynStore => {
+  const store = lib.createUsernameProofStore(db, eventHandler, pruneSizeLimit);
+
+  return store as RustDynStore;
+};
+
+export const rsGetUsernameProof = async (store: RustDynStore, name: Uint8Array, type: number): Promise<Buffer> => {
+  return await lib.getUsernameProof.call(store, name, type);
+};
+
+export const rsGetUsernameProofsByFid = async (
+  store: RustDynStore,
+  fid: number,
+  pageOptions: PageOptions,
+): Promise<RustMessagesPage> => {
+  return await lib.getUsernameProofsByFid.call(store, fid, pageOptions);
+};
+
+export const rsGetUsernameProofByFidAndName = async (
+  store: RustDynStore,
+  fid: number,
+  name: Uint8Array,
+): Promise<Buffer> => {
+  return await lib.getUsernameProofByFidAndName.call(store, fid, name);
+};
+
 export namespace rsLinkStore {
   export const CreateLinkStore = (
     db: RustDb,

--- a/apps/hubble/src/storage/stores/usernameProofStore.test.ts
+++ b/apps/hubble/src/storage/stores/usernameProofStore.test.ts
@@ -75,7 +75,7 @@ describe("usernameProofStore", () => {
       const proof = await set.getUsernameProof(fname, UserNameType.USERNAME_TYPE_ENS_L1);
       expect(proof).toEqual(newProof);
 
-      const rawProof = await set.getAdd({ data: { fid, usernameProofBody: { name: fname } } });
+      const rawProof = await set.getUsernameProofByFidAndName(fid, fname);
       expect(rawProof).toEqual(newProof);
     });
 
@@ -90,7 +90,7 @@ describe("usernameProofStore", () => {
       const proof = await set.getUsernameProof(fname, UserNameType.USERNAME_TYPE_ENS_L1);
       expect(proof).toEqual(newProof);
 
-      await expect(set.getAdd({ data: { fid, usernameProofBody: { name: fname } } })).rejects.toThrowError("NotFound");
+      await expect(set.getUsernameProofByFidAndName(fid, fname)).rejects.toThrowError("NotFound");
     });
 
     test("does not replace existing proof for name if timestamp is older", async () => {

--- a/apps/hubble/src/storage/stores/usernameProofStore.ts
+++ b/apps/hubble/src/storage/stores/usernameProofStore.ts
@@ -1,63 +1,35 @@
 import {
   getDefaultStoreLimit,
-  HubAsyncResult,
-  HubError,
-  HubEventType,
-  isUsernameProofMessage,
-  MessageType,
   StoreType,
   UserNameProof,
   UsernameProofMessage,
   UserNameType,
 } from "@farcaster/hub-nodejs";
-import { err, ok, ResultAsync } from "neverthrow";
-import { RootPrefix, UserMessagePostfix, UserPostfix } from "../db/types.js";
-import { Store } from "./store.js";
-import { RocksDbTransaction } from "../db/rocksdb.js";
-import { makeFidKey, makeTsHash, makeUserKey, readFidKey } from "../db/message.js";
-import { HubEventArgs } from "./storeEventHandler.js";
+import { ResultAsync } from "neverthrow";
+import { UserPostfix } from "../db/types.js";
+import { Message } from "@farcaster/hub-nodejs";
+import {
+  rsCreateUsernameProofStore,
+  rsGetUsernameProof,
+  rsGetUsernameProofByFidAndName,
+  rsGetUsernameProofsByFid,
+  rustErrorToHubError,
+} from "../../rustfunctions.js";
+import StoreEventHandler from "./storeEventHandler.js";
+import { StorePruneOptions } from "./types.js";
+import RocksDB from "storage/db/rocksdb.js";
+import { RustStoreBase } from "./rustStoreBase.js";
 
-/**
- * Generates a unique key used to store a UsernameProof Message
- *
- * @param fid the fid of the user who created the link
- * @param name
- * @returns RocksDB index key of the form <RootPrefix>:<fid?>:<tsHash?>
- */
-const makeUserNameProofByFidKey = (fid: number, name: Uint8Array): Buffer => {
-  return Buffer.concat([makeUserKey(fid), Buffer.from([UserPostfix.UserNameProofAdds]), Buffer.from(name)]);
-};
+class UsernameProofStore extends RustStoreBase<UsernameProofMessage, never> {
+  constructor(db: RocksDB, eventHandler: StoreEventHandler, options: StorePruneOptions = {}) {
+    const pruneSizeLimit = options.pruneSizeLimit ?? getDefaultStoreLimit(StoreType.USERNAME_PROOFS);
+    const rustUsernameProofStore = rsCreateUsernameProofStore(
+      db.rustDb,
+      eventHandler.getRustStoreEventHandler(),
+      pruneSizeLimit,
+    );
 
-const makeUserNameProofByNameKey = (name: Uint8Array): Buffer => {
-  return Buffer.concat([Buffer.from([RootPrefix.UserNameProofByName]), Buffer.from(name)]);
-};
-
-class UsernameProofStore extends Store<UsernameProofMessage, never> {
-  override _postfix: UserMessagePostfix = UserPostfix.UsernameProofMessage;
-
-  override makeAddKey(msg: UsernameProofMessage) {
-    return makeUserNameProofByFidKey(msg.data.fid, msg.data.usernameProofBody.name) as Buffer;
-  }
-
-  override makeRemoveKey(_: never): Buffer {
-    throw new Error("removes not supported");
-  }
-
-  override async findMergeAddConflicts(_message: UsernameProofMessage): HubAsyncResult<void> {
-    return ok(undefined);
-  }
-
-  override async findMergeRemoveConflicts(_message: never): HubAsyncResult<void> {
-    throw new Error("removes not supported");
-  }
-
-  override _isAddType = isUsernameProofMessage;
-  override _isRemoveType = undefined;
-  override _addMessageType = MessageType.USERNAME_PROOF;
-  override _removeMessageType = undefined;
-
-  protected override get PRUNE_SIZE_LIMIT_DEFAULT() {
-    return getDefaultStoreLimit(StoreType.USERNAME_PROOFS);
+    super(db, rustUsernameProofStore, UserPostfix.UsernameProofMessage, eventHandler, pruneSizeLimit);
   }
 
   /**
@@ -68,148 +40,34 @@ class UsernameProofStore extends Store<UsernameProofMessage, never> {
    * @param type the type of the name to find (fname or ens)
    */
   async getUsernameProof(name: Uint8Array, type: UserNameType): Promise<UsernameProofMessage> {
-    if (type === UserNameType.USERNAME_TYPE_ENS_L1) {
-      const byNameKey = makeUserNameProofByNameKey(name);
-      const fid = readFidKey(await this._db.get(byNameKey));
-      if (fid === undefined) {
-        throw new HubError("not_found", `username proof not found for name: ${name.toString()}`);
-      }
-      return this.getAdd({ data: { fid, usernameProofBody: { name: name } } });
+    const result = await ResultAsync.fromPromise(rsGetUsernameProof(this._rustStore, name, type), rustErrorToHubError);
+    if (result.isErr()) {
+      throw result.error;
     }
-    throw new HubError("bad_request", `unsupported username type: ${type}`);
+    return Message.decode(new Uint8Array(result.value)) as UsernameProofMessage;
   }
 
   /** Finds all UserNameProof messages for an fid */
   async getUsernameProofsByFid(fid: number): Promise<UserNameProof[]> {
-    const proofMessages = await this.getAddsByFid({ data: { fid } }, { pageSize: 25 });
-    const result: UserNameProof[] = [];
-    for (const proofMessage of proofMessages.messages) {
-      result.push(proofMessage.data.usernameProofBody);
-    }
-    return result;
+    const messages_page = await rsGetUsernameProofsByFid(this._rustStore, fid, {});
+
+    const messages =
+      messages_page.messageBytes?.map((messageBytes) => {
+        return Message.decode(new Uint8Array(messageBytes)) as UsernameProofMessage;
+      }) ?? [];
+
+    return messages.map((message) => message.data.usernameProofBody);
   }
 
-  override async buildSecondaryIndices(txn: RocksDbTransaction, message: UsernameProofMessage): HubAsyncResult<void> {
-    const tsHash = makeTsHash(message.data.timestamp, message.hash);
-
-    if (tsHash.isErr()) {
-      return err(tsHash.error);
+  async getUsernameProofByFidAndName(fid: number, name: Uint8Array): Promise<UsernameProofMessage> {
+    const result = await ResultAsync.fromPromise(
+      rsGetUsernameProofByFidAndName(this._rustStore, fid, name),
+      rustErrorToHubError,
+    );
+    if (result.isErr()) {
+      throw result.error;
     }
-
-    const name = message.data.usernameProofBody.name;
-
-    if (name.length === 0) {
-      return err(new HubError("bad_request.invalid_param", "name empty"));
-    }
-
-    // Puts the fid into the byTarget index
-    const byNameKey = makeUserNameProofByNameKey(name);
-    txn.put(byNameKey, makeFidKey(message.data.fid));
-
-    return ok(undefined);
-  }
-  override async deleteSecondaryIndices(txn: RocksDbTransaction, message: UsernameProofMessage): HubAsyncResult<void> {
-    const name = message.data.usernameProofBody.name;
-
-    if (name.length === 0) {
-      return err(new HubError("bad_request.invalid_param", "name empty"));
-    }
-
-    // Delete the message key from byName index
-    const byNameKey = makeUserNameProofByNameKey(name);
-    txn.del(byNameKey);
-
-    return ok(undefined);
-  }
-
-  override async getMergeConflicts(message: UsernameProofMessage): HubAsyncResult<UsernameProofMessage[]> {
-    const validateResult = await this.validateAdd(message);
-
-    if (validateResult.isErr()) {
-      return err(validateResult.error);
-    }
-
-    const checkResult = await this.findMergeAddConflicts(message);
-
-    if (checkResult.isErr()) {
-      return err(checkResult.error);
-    }
-
-    const conflicts: UsernameProofMessage[] = [];
-
-    const byNameKey = makeUserNameProofByNameKey(message.data.usernameProofBody.name);
-    const fidResult = await ResultAsync.fromPromise(this._db.get(byNameKey), () => undefined);
-    if (fidResult.isOk()) {
-      const fid = readFidKey(fidResult.value);
-      if (fid !== undefined) {
-        const existingMessage = await this.getAdd({
-          data: {
-            fid,
-            usernameProofBody: { name: message.data.usernameProofBody.name },
-          },
-        });
-        const tsHash = makeTsHash(message.data.timestamp, message.hash);
-        const existingTsHash = makeTsHash(existingMessage.data.timestamp, existingMessage.hash);
-
-        if (tsHash.isErr() || existingTsHash.isErr()) {
-          throw new HubError("bad_request", "failed to make tsHash");
-        }
-
-        const messageCompare = this.messageCompare(
-          this._addMessageType,
-          existingTsHash.value,
-          this._addMessageType,
-          tsHash.value,
-        );
-        if (messageCompare > 0) {
-          return err(new HubError("bad_request.conflict", "message conflicts with a more recent add"));
-        } else if (messageCompare === 0) {
-          return err(new HubError("bad_request.duplicate", "message has already been merged"));
-        } else {
-          conflicts.push(existingMessage);
-        }
-      }
-    }
-    return ok(conflicts);
-  }
-
-  protected override mergeEventArgs(
-    mergedMessage: UsernameProofMessage,
-    mergeConflicts: UsernameProofMessage[],
-  ): HubEventArgs {
-    return {
-      type: HubEventType.MERGE_USERNAME_PROOF,
-      mergeUsernameProofBody: {
-        usernameProof: mergedMessage.data.usernameProofBody,
-        deletedUsernameProof: mergeConflicts[0]?.data.usernameProofBody,
-        usernameProofMessage: mergedMessage,
-        deletedUsernameProofMessage: mergeConflicts[0],
-      },
-    };
-  }
-
-  protected override pruneEventArgs(prunedMessage: UsernameProofMessage): HubEventArgs {
-    return {
-      type: HubEventType.MERGE_USERNAME_PROOF,
-      mergeUsernameProofBody: {
-        usernameProof: undefined,
-        deletedUsernameProof: prunedMessage.data.usernameProofBody,
-        usernameProofMessage: undefined,
-        deletedUsernameProofMessage: prunedMessage,
-      },
-    };
-  }
-
-  protected override revokeEventArgs(message: UsernameProofMessage): HubEventArgs {
-    return {
-      type: HubEventType.MERGE_USERNAME_PROOF,
-      mergeUsernameProofBody: {
-        usernameProof: undefined,
-        deletedUsernameProof: message.data.usernameProofBody,
-        usernameProofMessage: undefined,
-        deletedUsernameProofMessage: message,
-      },
-    };
+    return Message.decode(new Uint8Array(result.value)) as UsernameProofMessage;
   }
 }
 


### PR DESCRIPTION
## Motivation

Move the username proof store to rust.


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on moving the username proof store to Rust for performance improvement.

### Detailed summary
- Moved username proof store to Rust for performance enhancement
- Updated functions to interact with the new username proof store
- Added Rust functions to create, get, and manage username proofs

> The following files were skipped due to too many changes: `apps/hubble/src/storage/stores/usernameProofStore.ts`, `apps/hubble/src/addon/src/store/username_proof_store.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->