### PR TITLE
perf: Throttle prune job

### DIFF
--- a/.changeset/orange-starfishes-fry.md
+++ b/.changeset/orange-starfishes-fry.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+perf: Throttle prune job

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -471,7 +471,7 @@ export class Hub implements HubInterface {
     this.adminServer = new AdminServer(this, this.rocksDB, this.engine, this.syncEngine, options.rpcAuth);
 
     // Setup job schedulers/workers
-    this.pruneMessagesJobScheduler = new PruneMessagesJobScheduler(this.engine, () => this.syncEngine.syncTrieQSize);
+    this.pruneMessagesJobScheduler = new PruneMessagesJobScheduler(this.engine);
     this.periodSyncJobScheduler = new PeriodicSyncJobScheduler(this, this.syncEngine);
     this.pruneEventsJobScheduler = new PruneEventsJobScheduler(this.engine);
     this.checkFarcasterVersionJobScheduler = new CheckFarcasterVersionJobScheduler(this);

--- a/apps/hubble/src/storage/jobs/pruneMessagesJob.test.ts
+++ b/apps/hubble/src/storage/jobs/pruneMessagesJob.test.ts
@@ -19,7 +19,7 @@ import { makeTsHash } from "../../storage/db/message.js";
 const db = jestRocksDB("jobs.pruneMessagesJob.test");
 
 const engine = new Engine(db, FarcasterNetwork.TESTNET);
-const scheduler = new PruneMessagesJobScheduler(engine, () => 0);
+const scheduler = new PruneMessagesJobScheduler(engine);
 
 // Use farcaster timestamp
 const seedMessagesFromTimestamp = async (engine: Engine, fid: number, signer: Ed25519Signer, timestamp: number) => {

--- a/apps/hubble/src/storage/jobs/pruneMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/pruneMessagesJob.ts
@@ -91,12 +91,12 @@ export class PruneMessagesJobScheduler {
         // 2. Don't overload the DB or Sync Trie, causing spikes in latency
         if (fid % 100 === 0) {
           // See if we are running ahead of schedule
-          const scheduledTime = TIME_SCHEDULED_PER_FID_MS * fid;
-          const elapsedTime = Date.now() - start;
-          if (scheduledTime > elapsedTime) {
-            const sleepTime = scheduledTime - elapsedTime;
+          const allotedTimeMs = TIME_SCHEDULED_PER_FID_MS * fid;
+          const elapsedTimeMs = Date.now() - start;
+          if (allotedTimeMs > elapsedTimeMs) {
+            const sleepTimeMs = allotedTimeMs - elapsedTimeMs;
             // Sleep for the remaining time
-            await sleep(sleepTime);
+            await sleep(sleepTimeMs);
           }
         }
       }


### PR DESCRIPTION
## Motivation

The prune job is running too fast, causing spikes in merge latency. This PR throttles the job

## Change Summary

  // We prune at the rate of 1000 fids per second. If we are running ahead of schedule, we sleep to catch up
  // We do this so that:
  // 1. Each fid is pruned at the same time at every hub, reducing thrash
  // 2. Don't overload the DB or Sync Trie, causing spikes in latency

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to improve the performance of the prune job in the `@farcaster/hubble` module.

### Detailed summary
- Throttled the prune job to avoid overloading the system
- Removed unnecessary parameter in `PruneMessagesJobScheduler` constructor
- Added logic to sleep and catch up if pruning is ahead of schedule

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->