### PR TITLE
fix: Read data_bytes properly when pruning

### DIFF
--- a/.changeset/popular-suits-joke.md
+++ b/.changeset/popular-suits-joke.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Read data_bytes properly when pruning

--- a/apps/hubble/src/addon/src/store/username_proof_store.rs
+++ b/apps/hubble/src/addon/src/store/username_proof_store.rs
@@ -97,13 +97,6 @@ impl StoreDef for UsernameProofStoreDef {
         }
 
         let data = message.data.as_ref().unwrap();
-        if data.body.is_none() {
-            return Err(HubError {
-                code: "bad_request.validation_failure".to_string(),
-                message: "Message body is missing".to_string(),
-            });
-        }
-
         if let Some(Body::UsernameProofBody(body)) = &data.body {
             if body.name.len() == 0 {
                 return Err(HubError {
@@ -121,7 +114,7 @@ impl StoreDef for UsernameProofStoreDef {
         } else {
             Err(HubError {
                 code: "bad_request.validation_failure".to_string(),
-                message: "Message body is missing".to_string(),
+                message: "Message body is missing or incorrect".to_string(),
             })
         }
     }
@@ -140,13 +133,6 @@ impl StoreDef for UsernameProofStoreDef {
         }
 
         let data = message.data.as_ref().unwrap();
-        if data.body.is_none() {
-            return Err(HubError {
-                code: "bad_request.validation_failure".to_string(),
-                message: "Message body is missing".to_string(),
-            });
-        }
-
         if let Some(Body::UsernameProofBody(body)) = &data.body {
             if body.name.len() == 0 {
                 return Err(HubError {
@@ -161,7 +147,7 @@ impl StoreDef for UsernameProofStoreDef {
         } else {
             Err(HubError {
                 code: "bad_request.validation_failure".to_string(),
-                message: "Message body is missing".to_string(),
+                message: "Message data body is missing or incorrect".to_string(),
             })
         }
     }
@@ -180,19 +166,12 @@ impl StoreDef for UsernameProofStoreDef {
         }
 
         let data = message.data.as_ref().unwrap();
-        if data.body.is_none() {
-            return Err(HubError {
-                code: "bad_request.validation_failure".to_string(),
-                message: "Message body is missing".to_string(),
-            });
-        }
-
         let name = match &data.body {
             Some(Body::UsernameProofBody(body)) => &body.name,
             _ => {
                 return Err(HubError {
                     code: "bad_request.validation_failure".to_string(),
-                    message: "Message body is missing".to_string(),
+                    message: "Message data body is missing".to_string(),
                 })
             }
         };

--- a/apps/hubble/src/addon/src/store/verification_store.rs
+++ b/apps/hubble/src/addon/src/store/verification_store.rs
@@ -1,5 +1,6 @@
 use super::{
-    get_message, hub_error_to_js_throw, make_fid_key, make_ts_hash, make_user_key, read_fid_key,
+    get_message, hub_error_to_js_throw, make_fid_key, make_ts_hash, make_user_key, message_decode,
+    read_fid_key,
     store::{Store, StoreDef},
     utils::{self, encode_messages_to_js_object, get_page_options, get_store},
     HubError, MessagesPage, PageOptions, RootPrefix, StoreEventHandler, UserPostfix, FID_BYTES,
@@ -444,7 +445,7 @@ impl VerificationStore {
         fid: u32,
         page_options: &PageOptions,
     ) -> Result<MessagesPage, HubError> {
-        store.get_removes_by_fid(fid, page_options, Some(|message: &Message| true))
+        store.get_removes_by_fid(fid, page_options, Some(|_message: &Message| true))
     }
 
     pub fn js_get_verification_removes_by_fid(mut cx: FunctionContext) -> JsResult<JsPromise> {
@@ -482,7 +483,7 @@ impl VerificationStore {
                         return Ok(false); // Ignore non-verification messages
                     }
 
-                    let message = match Message::decode(value) {
+                    let message = match message_decode(value) {
                         Ok(message) => message,
                         Err(_) => return Ok(false), // Ignore invalid messages
                     };

--- a/apps/hubble/src/eth/fnameRegistryEventsProvider.ts
+++ b/apps/hubble/src/eth/fnameRegistryEventsProvider.ts
@@ -154,7 +154,7 @@ export class FNameRegistryEventsProvider {
     try {
       return await this.client.getTransfers(params);
     } catch (err) {
-      log.error(err, `Failed to get transfers ${params}`);
+      log.error({ err, params }, "Failed to get transfers from fname registry");
       return [];
     }
   }

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -282,7 +282,7 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
       if (result.isOk()) {
         log.info({ peerIdStr, addr }, "Connected to peer from DB");
       } else {
-        log.error({ peerIdStr, addr, error: result.error }, "Failed to connect to peer from DB");
+        log.warn({ peerIdStr, addr, error: result.error }, "Failed to connect to peer from DB");
       }
 
       // Sleep for a bit to avoid overwhelming the network


### PR DESCRIPTION
## Motivation

When pruning, read the data_bytes properly to avoid warnings


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)
