### PR TITLE
feat(hubble): update s3 snapshot metadata to include database statistics

### DIFF
--- a/.changeset/six-bats-grab.md
+++ b/.changeset/six-bats-grab.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat(hubble): update s3 snapshot metadata to include database statistics, and add snapshot-url command

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -27,6 +27,7 @@
     "lint:rust": "cargo fmt --manifest-path ./src/addon/Cargo.toml",
     "lint:ci": "yarn lint:customjs && biome ci src/",
     "lint:customjs": "node scripts/linter.cjs",
+		"snapshot-url": "node --no-warnings build/cli.js snapshot-url",
     "start": "node --max-old-space-size=8192 --no-warnings build/cli.js start",
     "identity": "node --no-warnings build/cli.js identity",
     "dbreset": "node build/cli.js dbreset",

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -27,7 +27,7 @@
     "lint:rust": "cargo fmt --manifest-path ./src/addon/Cargo.toml",
     "lint:ci": "yarn lint:customjs && biome ci src/",
     "lint:customjs": "node scripts/linter.cjs",
-		"snapshot-url": "node --no-warnings build/cli.js snapshot-url",
+    "snapshot-url": "node --no-warnings build/cli.js snapshot-url",
     "start": "node --max-old-space-size=8192 --no-warnings build/cli.js start",
     "identity": "node --no-warnings build/cli.js identity",
     "dbreset": "node build/cli.js dbreset",

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -644,9 +644,10 @@ app
 const s3SnapshotURL = new Command("snapshot-url")
   .description("Print latest snapshot URL and metadata from S3")
   .option("-n --network <network>", "ID of the Farcaster Network (default: 1 (mainnet))", parseNetwork)
+  .option("-b --s3-snapshot-bucket <bucket>", "The S3 bucket that holds snapshot(s)")
   .action(async (options) => {
     const network = farcasterNetworkFromJSON(options.network ?? FarcasterNetwork.MAINNET);
-    const response = await snapshotURL(network, 0);
+    const response = await snapshotURL(network, 0, options.s3SnapshotBucket);
     if (response.isErr()) {
       console.error("error fetching snapshot data", response.error);
       exit(1);

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -1,4 +1,4 @@
-import { FarcasterNetwork } from "@farcaster/hub-nodejs";
+import { FarcasterNetwork, farcasterNetworkFromJSON } from "@farcaster/hub-nodejs";
 import { peerIdFromString } from "@libp2p/peer-id";
 import { PeerId } from "@libp2p/interface-peer-id";
 import { createEd25519PeerId, createFromProtobuf, exportToProtobuf } from "@libp2p/peer-id-factory";
@@ -27,6 +27,7 @@ import { finishAllProgressBars } from "./utils/progressBars.js";
 import { MAINNET_BOOTSTRAP_PEERS } from "./bootstrapPeers.mainnet.js";
 import { STSClient, GetCallerIdentityCommand } from "@aws-sdk/client-sts";
 import axios from "axios";
+import { snapshotURL } from "./utils/snapshot.js";
 
 /** A CLI to accept options from the user and start the Hub */
 
@@ -636,6 +637,27 @@ app
 
     process.stdin.resume();
   });
+
+/*//////////////////////////////////////////////////////////////
+                          SNAPSHOT-URL COMMAND
+//////////////////////////////////////////////////////////////*/
+const s3SnapshotURL = new Command("snapshot-url")
+  .description("Print latest snapshot URL and metadata from S3")
+  .option("-n --network <network>", "ID of the Farcaster Network (default: 1 (mainnet))", parseNetwork)
+  .action(async (options) => {
+    const network = farcasterNetworkFromJSON(options.network ?? FarcasterNetwork.MAINNET);
+    const response = await snapshotURL(network, 0);
+    if (response.isErr()) {
+      console.error("error fetching snapshot data", response.error);
+      exit(1);
+    }
+    const [url, metadata] = response.value;
+    console.log(`${JSON.stringify(metadata, null, 2)}`);
+    console.log(`Download at: ${url}`);
+    exit(0);
+  });
+
+app.addCommand(s3SnapshotURL);
 
 /*//////////////////////////////////////////////////////////////
                         IDENTITY COMMAND

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -27,7 +27,7 @@ import { finishAllProgressBars } from "./utils/progressBars.js";
 import { MAINNET_BOOTSTRAP_PEERS } from "./bootstrapPeers.mainnet.js";
 import { STSClient, GetCallerIdentityCommand } from "@aws-sdk/client-sts";
 import axios from "axios";
-import { snapshotURL } from "./utils/snapshot.js";
+import { snapshotURLAndMetadata } from "./utils/snapshot.js";
 
 /** A CLI to accept options from the user and start the Hub */
 
@@ -647,7 +647,7 @@ const s3SnapshotURL = new Command("snapshot-url")
   .option("-b --s3-snapshot-bucket <bucket>", "The S3 bucket that holds snapshot(s)")
   .action(async (options) => {
     const network = farcasterNetworkFromJSON(options.network ?? FarcasterNetwork.MAINNET);
-    const response = await snapshotURL(network, 0, options.s3SnapshotBucket);
+    const response = await snapshotURLAndMetadata(network, 0, options.s3SnapshotBucket);
     if (response.isErr()) {
       console.error("error fetching snapshot data", response.error);
       exit(1);

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1657,7 +1657,7 @@ export class Hub implements HubInterface {
       partSize: 1000 * 1024 * 1024, // 1 GB
     });
 
-    const messageCount = await MerkleTrie.numItems(this.rocksDB);
+    const messageCount = await MerkleTrie.numItems(this.syncEngine.trie);
     if (messageCount.isErr()) {
       return err(messageCount.error);
     }

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -796,7 +796,7 @@ export class Hub implements HubInterface {
             let latestSnapshotKey;
             do {
               const response = await axios.get(
-                `https://download.farcaster.xyz/${this.getSnapshotFolder(prevVersion)}/latest.json`,
+                `https://${this.options.s3SnapshotBucket}/${this.getSnapshotFolder(prevVersion)}/latest.json`,
               );
               const { key } = response.data;
 
@@ -819,7 +819,7 @@ export class Hub implements HubInterface {
               log.info({ latestSnapshotKey }, "found latest S3 snapshot");
             }
 
-            const snapshotUrl = `https://download.farcaster.xyz/${latestSnapshotKey}`;
+            const snapshotUrl = `https://${this.options.s3SnapshotBucket}/${latestSnapshotKey}`;
             const response2 = await axios.get(snapshotUrl, {
               responseType: "stream",
             });
@@ -1638,7 +1638,7 @@ export class Hub implements HubInterface {
     )}.tar.gz`;
 
     start = Date.now();
-    log.info({ filePath, key }, "Uploading snapshot to S3");
+    log.info({ filePath, key, bucket: this.options.s3SnapshotBucket }, "Uploading snapshot to S3");
 
     const fileStream = fs.createReadStream(filePath);
     fileStream.on("error", function (err) {

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -84,6 +84,7 @@ import OnChainEventStore from "./storage/stores/onChainEventStore.js";
 import { ensureMessageData, isMessageInDB } from "./storage/db/message.js";
 import { getFarcasterTime } from "@farcaster/core";
 import { SnapshotMetadata } from "./utils/snapshot.js";
+import { MerkleTrie } from "./network/sync/merkleTrie.js";
 
 export type HubSubmitSource = "gossip" | "rpc" | "eth-provider" | "l2-provider" | "sync" | "fname-registry";
 
@@ -1653,17 +1654,13 @@ export class Hub implements HubInterface {
       partSize: 1000 * 1024 * 1024, // 1 GB
     });
 
-    // NOTE: db stats requires sync trie and database to be initialized, otherwise there may be zero values
-    const dbStats = await this.syncEngine.getDbStats();
     // NOTE: The sync engine type `DbStats` does not match the type in packages/core used by SnapshotMetadata.
     //       As a result, avoid spread operator and instead pass in each attribute explicitly.
     const metadata: SnapshotMetadata = {
       key,
       timestamp: Date.now(),
       serverDate: new Date().toISOString(),
-      numMessages: dbStats.numItems,
-      numFidEvents: dbStats.numFids,
-      numFnameEvents: dbStats.numFnames,
+      numMessages: MerkleTrie.numItems(),
     };
 
     const latestJsonParams = {

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1653,6 +1653,7 @@ export class Hub implements HubInterface {
       partSize: 1000 * 1024 * 1024, // 1 GB
     });
 
+    // NOTE: db stats requires sync trie and database to be initialized, otherwise there may be zero values
     const dbStats = await this.syncEngine.getDbStats();
     // NOTE: The sync engine type `DbStats` does not match the type in packages/core used by SnapshotMetadata.
     //       As a result, avoid spread operator and instead pass in each attribute explicitly.

--- a/apps/hubble/src/network/sync/merkleTrie.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.ts
@@ -198,6 +198,10 @@ class MerkleTrie {
     return result;
   }
 
+  public static numItems(): number {
+    return 0;
+  }
+
   public async stop(): Promise<void> {
     await this.callMethod("stop");
     this._worker.removeAllListeners("message");

--- a/apps/hubble/src/network/sync/merkleTrie.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.ts
@@ -207,7 +207,9 @@ class MerkleTrie {
       return err(new HubError("unavailable", "RocksDB not provided"));
     }
 
+    let wasOpen = true;
     if (db.status !== "open") {
+      wasOpen = false;
       await db.open();
     }
 
@@ -218,7 +220,11 @@ class MerkleTrie {
       }
 
       const root = TrieNode.deserialize(rootBytes);
-      db.close();
+      // If db was open prior to this method call, leave it open after the method call.
+      // Otherwise, close the db.
+      if (!wasOpen) {
+        db.close();
+      }
       return ok(root.items);
     }
 

--- a/apps/hubble/src/utils/snapshot.ts
+++ b/apps/hubble/src/utils/snapshot.ts
@@ -1,0 +1,55 @@
+import { DbStats, FarcasterNetwork, HubAsyncResult, HubError } from "@farcaster/core";
+import { LATEST_DB_SCHEMA_VERSION } from "../storage/db/migrations/migrations.js";
+import axios from "axios";
+import { err, ok } from "neverthrow";
+
+export type SnapshotMetadata = Partial<DbStats> & {
+  key: string;
+  timestamp: number;
+  serverDate: string;
+};
+
+export const isValidSnapshotMetadata = (data: Record<string, unknown>): data is SnapshotMetadata => {
+  return data["key"] !== undefined && data["timestamp"] !== undefined && data["serverDate"] !== undefined;
+};
+
+export const fetchSnapshotMetadata = async (snapshotPrefixURI: string): HubAsyncResult<SnapshotMetadata> => {
+  const latestJSON = `${snapshotPrefixURI}/latest.json`;
+  const response = await axios.get(latestJSON);
+  if (response.status !== 200) {
+    return err(
+      new HubError(
+        "unavailable.network_failure",
+        `Failed to get latest snapshot from ${latestJSON} [${response.status}]`,
+      ),
+    );
+  }
+  if (!isValidSnapshotMetadata(response.data)) {
+    return err(
+      new HubError(
+        "bad_request.validation_failure",
+        `Invalid snapshot metadata from ${latestJSON} [${JSON.stringify(response.data)}]`,
+      ),
+    );
+  }
+  return ok(response.data as SnapshotMetadata);
+};
+
+export const snapshotURL = async (
+  fcNetwork: FarcasterNetwork,
+  prevVersionCounter?: number,
+): HubAsyncResult<[string, SnapshotMetadata]> => {
+  const dirPath = snapshotDirectoryPath(fcNetwork, prevVersionCounter);
+  const response = await fetchSnapshotMetadata(dirPath);
+  if (response.isErr()) {
+    return err(response.error);
+  }
+  const data: SnapshotMetadata = response.value;
+  return ok([`https://download.farcaster.xyz/${data.key}`, data]);
+};
+export const snapshotDirectoryPath = (fcNetwork: FarcasterNetwork, prevVersionCounter?: number): string => {
+  const network = FarcasterNetwork[fcNetwork].toString();
+  return `https://download.farcaster.xyz/snapshots/${network}/DB_SCHEMA_${
+    LATEST_DB_SCHEMA_VERSION - (prevVersionCounter ?? 0)
+  }`;
+};

--- a/apps/hubble/src/utils/snapshot.ts
+++ b/apps/hubble/src/utils/snapshot.ts
@@ -1,7 +1,8 @@
 import { DbStats, FarcasterNetwork, HubAsyncResult, HubError } from "@farcaster/core";
 import { LATEST_DB_SCHEMA_VERSION } from "../storage/db/migrations/migrations.js";
 import axios from "axios";
-import { err, ok } from "neverthrow";
+import { err, ok, ResultAsync } from "neverthrow";
+import { SNAPSHOT_S3_DEFAULT_BUCKET } from "../hubble.js";
 
 export type SnapshotMetadata = Partial<DbStats> & {
   key: string;
@@ -15,41 +16,52 @@ export const isValidSnapshotMetadata = (data: Record<string, unknown>): data is 
 
 export const fetchSnapshotMetadata = async (snapshotPrefixURI: string): HubAsyncResult<SnapshotMetadata> => {
   const latestJSON = `${snapshotPrefixURI}/latest.json`;
-  const response = await axios.get(latestJSON);
-  if (response.status !== 200) {
+  const response = await ResultAsync.fromPromise(axios.get(latestJSON, { timeout: 2 * 1000 }), (error) => {
+    return new HubError("unavailable.network_failure", `Failed to get latest snapshot from ${latestJSON} [${error}]`);
+  });
+
+  if (response.isErr()) {
+    return err(response.error);
+  }
+
+  const result = response.value;
+  if (result.status !== 200) {
     return err(
       new HubError(
         "unavailable.network_failure",
-        `Failed to get latest snapshot from ${latestJSON} [${response.status}]`,
+        `Failed to get latest snapshot from ${latestJSON} [${result.status}]`,
       ),
     );
   }
-  if (!isValidSnapshotMetadata(response.data)) {
+  if (!isValidSnapshotMetadata(result.data)) {
     return err(
       new HubError(
         "bad_request.validation_failure",
-        `Invalid snapshot metadata from ${latestJSON} [${JSON.stringify(response.data)}]`,
+        `Invalid snapshot metadata from ${latestJSON} [${JSON.stringify(result.data)}]`,
       ),
     );
   }
-  return ok(response.data as SnapshotMetadata);
+  return ok(result.data as SnapshotMetadata);
 };
 
 export const snapshotURL = async (
   fcNetwork: FarcasterNetwork,
   prevVersionCounter?: number,
+  s3Bucket: string = SNAPSHOT_S3_DEFAULT_BUCKET,
 ): HubAsyncResult<[string, SnapshotMetadata]> => {
-  const dirPath = snapshotDirectoryPath(fcNetwork, prevVersionCounter);
+  const dirPath = snapshotDirectoryPath(fcNetwork, prevVersionCounter, s3Bucket);
   const response = await fetchSnapshotMetadata(dirPath);
   if (response.isErr()) {
     return err(response.error);
   }
   const data: SnapshotMetadata = response.value;
-  return ok([`https://download.farcaster.xyz/${data.key}`, data]);
+  return ok([`https://${s3Bucket}/${data.key}`, data]);
 };
-export const snapshotDirectoryPath = (fcNetwork: FarcasterNetwork, prevVersionCounter?: number): string => {
+export const snapshotDirectoryPath = (
+  fcNetwork: FarcasterNetwork,
+  prevVersionCounter?: number,
+  s3Bucket: string = SNAPSHOT_S3_DEFAULT_BUCKET,
+): string => {
   const network = FarcasterNetwork[fcNetwork].toString();
-  return `https://download.farcaster.xyz/snapshots/${network}/DB_SCHEMA_${
-    LATEST_DB_SCHEMA_VERSION - (prevVersionCounter ?? 0)
-  }`;
+  return `https://${s3Bucket}/snapshots/${network}/DB_SCHEMA_${LATEST_DB_SCHEMA_VERSION - (prevVersionCounter ?? 0)}`;
 };

--- a/apps/hubble/src/utils/snapshot.ts
+++ b/apps/hubble/src/utils/snapshot.ts
@@ -2,7 +2,13 @@ import { DbStats, FarcasterNetwork, HubAsyncResult, HubError } from "@farcaster/
 import { LATEST_DB_SCHEMA_VERSION } from "../storage/db/migrations/migrations.js";
 import axios from "axios";
 import { err, ok, ResultAsync } from "neverthrow";
-import { SNAPSHOT_S3_DEFAULT_BUCKET } from "../hubble.js";
+import { S3_REGION, SNAPSHOT_S3_DEFAULT_BUCKET } from "../hubble.js";
+import { rsCreateTarGzip, rustErrorToHubError } from "../rustfunctions.js";
+import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import fs from "fs";
+import { Upload } from "@aws-sdk/lib-storage";
+import { MerkleTrie } from "../network/sync/merkleTrie.js";
+import { logger } from "./logger.js";
 
 export type SnapshotMetadata = Partial<DbStats> & {
   key: string;
@@ -44,12 +50,16 @@ export const fetchSnapshotMetadata = async (snapshotPrefixURI: string): HubAsync
   return ok(result.data as SnapshotMetadata);
 };
 
-export const snapshotURL = async (
+export const snapshotDirectory = (fcNetwork: FarcasterNetwork, prevVersionCounter?: number): string => {
+  const network = FarcasterNetwork[fcNetwork].toString();
+  return `snapshots/${network}/DB_SCHEMA_${LATEST_DB_SCHEMA_VERSION - (prevVersionCounter ?? 0)}`;
+};
+export const snapshotURLAndMetadata = async (
   fcNetwork: FarcasterNetwork,
   prevVersionCounter?: number,
   s3Bucket: string = SNAPSHOT_S3_DEFAULT_BUCKET,
 ): HubAsyncResult<[string, SnapshotMetadata]> => {
-  const dirPath = snapshotDirectoryPath(fcNetwork, prevVersionCounter, s3Bucket);
+  const dirPath = snapshotURL(fcNetwork, prevVersionCounter, s3Bucket);
   const response = await fetchSnapshotMetadata(dirPath);
   if (response.isErr()) {
     return err(response.error);
@@ -57,11 +67,87 @@ export const snapshotURL = async (
   const data: SnapshotMetadata = response.value;
   return ok([`https://${s3Bucket}/${data.key}`, data]);
 };
-export const snapshotDirectoryPath = (
+export const snapshotURL = (
   fcNetwork: FarcasterNetwork,
   prevVersionCounter?: number,
   s3Bucket: string = SNAPSHOT_S3_DEFAULT_BUCKET,
 ): string => {
-  const network = FarcasterNetwork[fcNetwork].toString();
-  return `https://${s3Bucket}/snapshots/${network}/DB_SCHEMA_${LATEST_DB_SCHEMA_VERSION - (prevVersionCounter ?? 0)}`;
+  return `https://${s3Bucket}/${snapshotDirectory(fcNetwork, prevVersionCounter)}`;
+};
+
+export const uploadToS3 = async (
+  fcNetwork: FarcasterNetwork,
+  tarFilePath: string,
+  s3Bucket: string = SNAPSHOT_S3_DEFAULT_BUCKET,
+  messageCount?: number,
+): HubAsyncResult<string> => {
+  let start = Date.now();
+  logger.info({ tarFilePath }, "Creating tar.gz file ...");
+
+  // First, gzip the file. Do it in rust, which can run the CPU intensive gzip in a separate thread
+  const gzipResult = await ResultAsync.fromPromise(rsCreateTarGzip(tarFilePath), rustErrorToHubError);
+  if (gzipResult.isErr()) {
+    logger.error({ error: gzipResult.error }, "Error creating tar.gz file");
+    return err(gzipResult.error);
+  }
+
+  logger.info({ timeTakenMs: Date.now() - start, gzipResult }, "Finished creating tar.gz file created");
+  const filePath = gzipResult.value;
+
+  const s3 = new S3Client({
+    region: S3_REGION,
+  });
+
+  // The AWS key is "snapshots/{network}/{DB_SCHEMA_VERSION}/snapshot-{yyyy-mm-dd}-{timestamp}.tar.gz"
+  const key = `${snapshotDirectory(fcNetwork)}/snapshot-${new Date().toISOString().split("T")[0]}-${Math.floor(
+    Date.now() / 1000,
+  )}.tar.gz`;
+
+  start = Date.now();
+  logger.info({ filePath, key, bucket: s3Bucket }, "Uploading snapshot to S3");
+
+  const fileStream = fs.createReadStream(filePath);
+  fileStream.on("error", function (err) {
+    logger.error(`S3 File Error: ${err}`);
+  });
+
+  // The targz should be uploaded via multipart upload to S3
+  const targzParams = new Upload({
+    client: s3,
+    params: {
+      Bucket: s3Bucket,
+      Key: key,
+      Body: fileStream,
+    },
+    queueSize: 4, // 4 concurrent uploads
+    partSize: 1000 * 1024 * 1024, // 1 GB
+  });
+
+  // NOTE: The sync engine type `DbStats` does not match the type in packages/core used by SnapshotMetadata.
+  //       As a result, ensure keys match core package `DbStats`, NOT sync engine `DbStats`
+  const metadata: SnapshotMetadata = {
+    key,
+    timestamp: Date.now(),
+    serverDate: new Date().toISOString(),
+    ...(messageCount && { numMessages: messageCount }),
+  };
+
+  const latestJsonParams = {
+    Bucket: s3Bucket,
+    Key: `${snapshotDirectory(fcNetwork)}/latest.json`,
+    Body: JSON.stringify(metadata, null, 2),
+  };
+
+  targzParams.on("httpUploadProgress", (progress) => {
+    logger.info({ progress }, "Uploading snapshot to S3");
+  });
+
+  try {
+    await targzParams.done();
+    await s3.send(new PutObjectCommand(latestJsonParams));
+    logger.info({ key, timeTakenMs: Date.now() - start }, "Snapshot uploaded to S3");
+    return ok(key);
+  } catch (e: unknown) {
+    return err(new HubError("unavailable.network_failure", (e as Error).message));
+  }
 };

--- a/apps/hubble/www/docs/docs/cli.md
+++ b/apps/hubble/www/docs/docs/cli.md
@@ -156,3 +156,14 @@ Options:
   --insecure          Allow insecure connections to the RPC server (default: false)
   -h, --help          display help for command
 ```
+
+### snapshot-url
+```
+Usage: hub snapshot-url [options]
+
+Print latest snapshot URL and metadata from S3
+
+Options:
+  -n --network <network>  ID of the Farcaster Network (default: 1 (mainnet))
+  -h, --help              display help for command
+```


### PR DESCRIPTION
## Motivation

- As part of improvements to scaling Hub sync, we want to use snapshots more often
- Determining whether to use s3 snapshot for catch up sync requires additional information in metadata JSON

## Change Summary

- Update s3 snapshot metadata to include database statistics 
- Add `snapshot-url` command to print latest snapshot URL for convenience
  - Within `apps/hubble` run `yarn snapshot-url` or `node build/cli.js snapshot-url`

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context


Confirmed upload and download working

```
{"level":30,"time":1710985820939,"pid":5242,"hostname":"mbp.local","component":"Hub","progress":{"loaded":10485760000,"total":24114175697,"part":10,"Key":"snapshots/MAINNET/DB_SCHEMA_9/snapshot-2024-03-21-1710983283.tar.gz","Bucket":"test-bucket"},"msg":"Uploading snapshot to S3"}
{"level":30,"time":1710985925021,"pid":5242,"hostname":"mbp.local","component":"Hub","progress":{"loaded":11534336000,"total":24114175697,"part":11,"Key":"snapshots/MAINNET/DB_SCHEMA_9/snapshot-2024-03-21-1710983283.tar.gz","Bucket":"test-bucket"},"msg":"Uploading snapshot to S3"}
{"level":30,"time":1710986006718,"pid":5242,"hostname":"mbp.local","component":"Hub","progress":{"loaded":12582912000,"total":24114175697,"part":12,"Key":"snapshots/MAINNET/DB_SCHEMA_9/snapshot-2024-03-21-1710983283.tar.gz","Bucket":"test-bucket"},"msg":"Uploading snapshot to S3"}
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `hubble` app by adding a `snapshot-url` command to retrieve S3 snapshot metadata and statistics. It also includes improvements for snapshot handling and network synchronization.

### Detailed summary
- Added `snapshot-url` command to retrieve S3 snapshot metadata
- Updated snapshot handling logic with metadata and statistics
- Improved network synchronization with Merkle Trie enhancements

> The following files were skipped due to too many changes: `apps/hubble/src/utils/snapshot.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->