### PR TITLE
feat: Log hub restarts

### DIFF
--- a/.changeset/serious-cats-compete.md
+++ b/.changeset/serious-cats-compete.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: stats for hub restarts

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -9,7 +9,7 @@ import { mkdir, readFile, writeFile } from "fs/promises";
 import { Result, ResultAsync } from "neverthrow";
 import { dirname, resolve } from "path";
 import { exit } from "process";
-import { APP_VERSION, FARCASTER_VERSION, Hub, HubOptions, S3_REGION } from "./hubble.js";
+import { APP_VERSION, FARCASTER_VERSION, Hub, HubOptions, HubShutdownReason, S3_REGION } from "./hubble.js";
 import { logger } from "./utils/logger.js";
 import { addressInfoFromParts, hostPortFromString, ipMultiAddrStrFromAddressInfo, parseAddress } from "./utils/p2p.js";
 import { DEFAULT_RPC_CONSOLE, startConsole } from "./console/console.js";
@@ -157,10 +157,28 @@ app
       logger.flush();
 
       logger.warn(`signal '${signalName}' received`);
+      let shutdownReason: HubShutdownReason;
+      switch (signalName) {
+        case "SIGTERM":
+          shutdownReason = HubShutdownReason.SIG_TERM;
+          break;
+        case "uncaughtException":
+          shutdownReason = HubShutdownReason.EXCEPTION;
+          break;
+        case "unhandledRejection":
+          shutdownReason = HubShutdownReason.EXCEPTION;
+          break;
+        case "S3SnapshotUpload":
+          shutdownReason = HubShutdownReason.SELF_TERMINATED;
+          break;
+        default:
+          shutdownReason = HubShutdownReason.UNKNOWN;
+      }
+
       if (!isExiting) {
         isExiting = true;
         hub
-          .teardown()
+          .teardown(shutdownReason)
           .then(() => {
             logger.info("Hub stopped gracefully");
             process.exit(0);
@@ -627,7 +645,7 @@ app
       logger.fatal(startResult.error);
       logger.fatal({ reason: "Hub Startup failed" }, "shutting down hub");
       try {
-        await hub.teardown();
+        await hub.teardown(HubShutdownReason.EXCEPTION);
       } finally {
         logger.flush();
         process.exit(1);

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -731,7 +731,7 @@ export class Hub implements HubInterface {
     // When we startup, we write into the DB that we have not yet cleanly shutdown. And when we do
     // shutdown, we'll write "true" to this key, indicating that we've cleanly shutdown.
     // This way, when starting up, we'll know if the previous shutdown was clean or not.
-    await this.writeHubCleanShutdown(false);
+    await this.writeHubCleanShutdown(false, HubShutdownReason.UNKNOWN);
   }
 
   /** Apply the new the network config. Will return true if the Hub should exit */
@@ -1543,7 +1543,7 @@ export class Hub implements HubInterface {
       (e) => e as HubError,
     );
     if (shutdownResult.isErr()) {
-      return shutdownResult;
+      return err(shutdownResult.error);
     }
     const shutdownReason = shutdownResult.value[1] ?? -1;
     const cleanShutdown = shutdownResult.value[0] === 1;
@@ -1557,7 +1557,7 @@ export class Hub implements HubInterface {
     statsd().increment("hub.restart", 1, tags);
     logger.info({ clean: cleanShutdown, reason: shutdownReason, unexpected }, "Hub restarted");
 
-    return cleanShutdown;
+    return ok(cleanShutdown);
   }
 
   async getDbNetwork(): HubAsyncResult<FarcasterNetwork | undefined> {

--- a/apps/hubble/src/storage/jobs/checkFarcasterVersionJob.ts
+++ b/apps/hubble/src/storage/jobs/checkFarcasterVersionJob.ts
@@ -1,7 +1,7 @@
 import { HubAsyncResult } from "@farcaster/hub-nodejs";
 import { ok } from "neverthrow";
 import cron from "node-cron";
-import { Hub } from "../../hubble.js";
+import { Hub, HubShutdownReason } from "../../hubble.js";
 import { logger } from "../../utils/logger.js";
 import { getMinFarcasterVersion } from "../../utils/versions.js";
 
@@ -42,7 +42,7 @@ export class CheckFarcasterVersionJobScheduler {
 
     if (minVersion.isErr()) {
       log.info({}, "Farcaster version expired, shutting down hub");
-      await this._hub.stop();
+      await this._hub.stop(HubShutdownReason.SELF_TERMINATED);
     }
 
     return ok(undefined);

--- a/apps/hubble/src/storage/jobs/updateNetworkConfigJob.ts
+++ b/apps/hubble/src/storage/jobs/updateNetworkConfigJob.ts
@@ -1,5 +1,5 @@
 import cron from "node-cron";
-import { Hub, HubInterface } from "../../hubble.js";
+import { Hub, HubShutdownReason } from "../../hubble.js";
 import { logger } from "../../utils/logger.js";
 import { HubAsyncResult } from "@farcaster/core";
 import { fetchNetworkConfig } from "../../network/utils/networkConfig.js";
@@ -51,7 +51,7 @@ export class UpdateNetworkConfigJobScheduler {
 
     if (shouldRestart) {
       log.info({}, "Network config restart signal");
-      await this._hub.stop(false);
+      await this._hub.stop(HubShutdownReason.SELF_TERMINATED, false);
       await this._hub.start();
     }
 

--- a/apps/hubble/src/test/e2e/hubbleNetwork.test.ts
+++ b/apps/hubble/src/test/e2e/hubbleNetwork.test.ts
@@ -1,6 +1,6 @@
-import { Factories, FarcasterNetwork, Message, bytesToHexString } from "@farcaster/hub-nodejs";
-import { deployStorageRegistry, testClient } from "../utils.js";
-import { Hub, HubOptions, randomDbName } from "../../hubble.js";
+import { bytesToHexString, Factories, FarcasterNetwork, Message } from "@farcaster/hub-nodejs";
+import { deployStorageRegistry } from "../utils.js";
+import { Hub, HubOptions, HubShutdownReason, randomDbName } from "../../hubble.js";
 import { localHttpUrl } from "../constants.js";
 import { sleep, sleepWhile } from "../../utils/crypto.js";
 import { DB_DIRECTORY } from "../../storage/db/rocksdb.js";
@@ -132,8 +132,8 @@ describe("hubble gossip and sync tests", () => {
         const result2 = await hub2.engine.getCast(fid, castAdd2.hash);
         expect(result2.isOk()).toBeTruthy();
       } finally {
-        await hub1?.stop();
-        await hub2?.stop();
+        await hub1?.stop(HubShutdownReason.SELF_TERMINATED);
+        await hub2?.stop(HubShutdownReason.SELF_TERMINATED);
       }
     },
     100 * TEST_TIMEOUT_SHORT,

--- a/apps/hubble/src/test/e2e/hubbleStartup.test.ts
+++ b/apps/hubble/src/test/e2e/hubbleStartup.test.ts
@@ -1,6 +1,6 @@
 import { Factories, FarcasterNetwork, bytesToHexString } from "@farcaster/hub-nodejs";
 import { deployStorageRegistry } from "../utils.js";
-import { Hub, HubOptions, randomDbName } from "../../hubble.js";
+import { Hub, HubOptions, HubShutdownReason, randomDbName } from "../../hubble.js";
 import { localHttpUrl } from "../constants.js";
 import { sleep } from "../../utils/crypto.js";
 import { DB_DIRECTORY } from "../../storage/db/rocksdb.js";
@@ -72,7 +72,7 @@ describe("hubble startup tests", () => {
         const hubState = await hub.getHubState();
         expect(hubState.isOk()).toBe(true);
       } finally {
-        await hub?.teardown();
+        await hub?.teardown(HubShutdownReason.SELF_TERMINATED);
       }
     },
     TEST_TIMEOUT_SHORT,


### PR DESCRIPTION
## Motivation

Log reason for hub restarts

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces hub restart stats and enhances hub shutdown handling in the `@farcaster/hubble` package.

### Detailed summary
- Added `HubShutdownReason` enum for shutdown reasons
- Updated shutdown handling in various job schedulers and tests
- Improved shutdown logic in the `Hub` class for graceful exits

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->