### PR TITLE
chore: Release 1.11

### DIFF
--- a/.changeset/famous-poets-speak.md
+++ b/.changeset/famous-poets-speak.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-chore: Migrate verifications store to rust

--- a/.changeset/fluffy-bulldogs-vanish.md
+++ b/.changeset/fluffy-bulldogs-vanish.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: Generate grpc rust code from protobufs

--- a/.changeset/lovely-islands-sit.md
+++ b/.changeset/lovely-islands-sit.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-perf: Move username proof store to rust

--- a/.changeset/orange-starfishes-fry.md
+++ b/.changeset/orange-starfishes-fry.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-perf: Throttle prune job

--- a/.changeset/popular-garlics-warn.md
+++ b/.changeset/popular-garlics-warn.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-perf: Migrate cast store to rust

--- a/.changeset/popular-suits-joke.md
+++ b/.changeset/popular-suits-joke.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Read data_bytes properly when pruning

--- a/.changeset/rare-carpets-itch.md
+++ b/.changeset/rare-carpets-itch.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-Migrate link store to Rust

--- a/.changeset/serious-cats-compete.md
+++ b/.changeset/serious-cats-compete.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: stats for hub restarts

--- a/.changeset/shaggy-bags-film.md
+++ b/.changeset/shaggy-bags-film.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-chore: Add rustfmt check before git commit

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @farcaster/hubble
 
+## 1.11.0
+
+### Minor Changes
+
+- chore: Release 1.11
+
+### Patch Changes
+
+- dd1a3e46: chore: Migrate verifications store to rust
+- f115bce1: feat: Generate grpc rust code from protobufs
+- 63e2abe6: perf: Move username proof store to rust
+- 70603192: perf: Throttle prune job
+- ca42eaf0: perf: Migrate cast store to rust
+- 0b523281: fix: Read data_bytes properly when pruning
+- eb2b0e1d: Migrate link store to Rust
+- cfa701c9: feat: stats for hub restarts
+- d2b2f726: chore: Add rustfmt check before git commit
+
 ## 1.10.11
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.10.11",
+  "version": "1.11.0",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -92,7 +92,7 @@ export const APP_NICKNAME = process.env["HUBBLE_NAME"] ?? "Farcaster Hub";
 export const SNAPSHOT_S3_DEFAULT_BUCKET = "download.farcaster.xyz";
 export const S3_REGION = "us-east-1";
 
-export const FARCASTER_VERSION = "2024.2.7";
+export const FARCASTER_VERSION = "2024.3.20";
 export const FARCASTER_VERSIONS_SCHEDULE: VersionSchedule[] = [
   { version: "2023.3.1", expiresAt: 1682553600000 }, // expires at 4/27/23 00:00 UTC
   { version: "2023.4.19", expiresAt: 1686700800000 }, // expires at 6/14/23 00:00 UTC
@@ -103,6 +103,7 @@ export const FARCASTER_VERSIONS_SCHEDULE: VersionSchedule[] = [
   { version: "2023.11.15", expiresAt: 1704844800000 }, // expires at 1/10/24 00:00 UTC
   { version: "2023.12.27", expiresAt: 1708473600000 }, // expires at 2/21/24 00:00 UTC
   { version: "2024.2.7", expiresAt: 1712102400000 }, // expires at 4/3/24 00:00 UTC
+  { version: "2024.3.20", expiresAt: 1715731200000 }, // expires at 5/15/24 00:00 UTC
 ];
 
 const MAX_CONTACT_INFO_AGE_MS = GOSSIP_SEEN_TTL;


### PR DESCRIPTION
## Motivation

Release 1.11

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `@farcaster/hubble` to `1.11.0`, introduces Rust migrations and optimizations, and updates `FARCASTER_VERSION` in `hubble.ts`.

### Detailed summary
- Updated `@farcaster/hubble` version to `1.11.0`
- Migrated verifications store, username proof store, cast store, link store to Rust
- Added stats for hub restarts
- Updated `FARCASTER_VERSION` in `hubble.ts` to `2024.3.20`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->