### PR TITLE
bug: Enforce protobuf oneof constraints

### DIFF
--- a/.changeset/hip-cherries-pull.md
+++ b/.changeset/hip-cherries-pull.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+bug: Enforce protobuf oneof constraints


### PR DESCRIPTION
## Motivation

When protobufs have fields that are defined `oneof`, the compiler doesn't enforce that exactly one of the fields is set. We need to manually validate these


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enforce protobuf oneof constraints in the `validateMessage` function and ensure only one body can be set in a message.

### Detailed summary
- Enforced protobuf oneof constraints in `validateMessage`
- Added validation for setting only one body in a message

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->