### PR TITLE
fix: ValidateOrRevoke an fid's messages every 14 days

### DIFF
--- a/.changeset/spotty-radios-flash.md
+++ b/.changeset/spotty-radios-flash.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Run full validateOrRevoke for all fids every 14 days

--- a/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.test.ts
+++ b/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.test.ts
@@ -88,6 +88,11 @@ describe("ValidateOrRevokeMessagesJob", () => {
     const result = await job.doJobForFid(0, fid);
     expect(result.isOk()).toBe(true);
     expect(result._unsafeUnwrap()).toBe(1);
+
+    // If we run it again, it checks it again
+    const result2 = await job.doJobForFid(0, fid);
+    expect(result2.isOk()).toBe(true);
+    expect(result2._unsafeUnwrap()).toBe(1);
   });
 
   test("doJobForFid checks message when fid % 14 matches", async () => {

--- a/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
@@ -8,8 +8,13 @@ import Engine from "../engine/index.js";
 import { makeUserKey, messageDecode } from "../db/message.js";
 import { statsd } from "../../utils/statsd.js";
 import { getHubState, putHubState } from "../../storage/db/hubState.js";
+import { sleep } from "../../utils/crypto.js";
 
-export const DEFAULT_VALIDATE_AND_REVOKE_MESSAGES_CRON = "0 1 * * *"; // Every day at 01:00 UTC
+export const DEFAULT_VALIDATE_AND_REVOKE_MESSAGES_CRON = "0 8 * * *"; // Every day at 08:00 UTC (midnight PST)
+
+// How much time to allocate to validating and revoking each fid.
+// 50 fids per second, which translates to 1/14th of the FIDs will be checked in just over 2 hours.
+const TIME_SCHEDULED_PER_FID_PER_S = 50;
 
 const log = logger.child({
   component: "ValidateOrRevokeMessagesJob",
@@ -107,6 +112,18 @@ export class ValidateOrRevokeMessagesJobScheduler {
             lastJobTimestamp,
           };
           await putHubState(this._db, hubState);
+        }
+
+        // Throttle the job.
+        // We run at the rate of 50 fids per second. If we are running ahead of schedule, we sleep to catch up
+        if (fid % 100 === 0) {
+          const allotedTimeMs = TIME_SCHEDULED_PER_FID_PER_S * fid * 1000;
+          const elapsedTimeMs = Date.now() - start;
+          if (allotedTimeMs > elapsedTimeMs) {
+            const sleepTimeMs = allotedTimeMs - elapsedTimeMs;
+            // Sleep for the remaining time
+            await sleep(sleepTimeMs);
+          }
         }
       }
     } while (!finished);


### PR DESCRIPTION
## Motivation

Every 14 days, check all messages of an fid and revoke any invalid ones. 


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `validateOrRevokeMessagesJob` to run a full scan for all FIDs every 14 days and adds throttling to match the schedule.

### Detailed summary
- Adjusted cron schedule for full scan every 14 days
- Implemented throttling to match the schedule
- Added logging and sleeping logic for job throttling
- Fixed test cases for job execution based on FID and timestamps

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->