### PR TITLE
fix(hubble): path checking for num items

### DIFF
--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -575,6 +575,7 @@ export class Hub implements HubInterface {
             );
           }
           const messageCount = messages.isErr() ? -1 : messages.value;
+          log.info({ messageCount }, "uploading snapshot to S3");
           const s3Result = await uploadToS3(
             this.options.network,
             tarResult.value,

--- a/apps/hubble/src/network/sync/merkleTrie.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.ts
@@ -209,12 +209,13 @@ class MerkleTrie {
     // MerkleTrie has rocksdb instance, however the merkle trie worker
     // uses a separate instance under trieDb prefix which needs to be used here instead.
     const location = `${path.basename(trie._db.location)}/${TrieDBPathPrefix}`;
-    if (!fs.existsSync(location)) {
-      return ok(0);
-    }
     const db = new RocksDB(location);
     if (!db) {
       return err(new HubError("unavailable", "RocksDB not provided"));
+    }
+    const isEmptyDir = await fs.promises.readdir(path.resolve(db.location)).then((files) => files.length === 0);
+    if (isEmptyDir) {
+      return ok(0);
     }
 
     let wasOpen = true;

--- a/apps/hubble/src/utils/snapshot.ts
+++ b/apps/hubble/src/utils/snapshot.ts
@@ -82,7 +82,13 @@ export const uploadToS3 = async (
   messageCount?: number,
 ): HubAsyncResult<string> => {
   let start = Date.now();
-  logger.info({ tarFilePath }, "Creating tar.gz file ...");
+  logger.info(
+    {
+      tarFilePath,
+      message_count: messageCount ?? -1,
+    },
+    "Creating tar.gz file ...",
+  );
 
   // First, gzip the file. Do it in rust, which can run the CPU intensive gzip in a separate thread
   const gzipResult = await ResultAsync.fromPromise(rsCreateTarGzip(tarFilePath), rustErrorToHubError);


### PR DESCRIPTION
## Motivation

- Path resolution was not working correctly, returning 0 for rocksdb path since rocksdb creates its own subdirectory on instantiation

## Change Summary

- Fix path resolution to check if directory empty 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances logging and handles empty directories more efficiently in the Hubble application.

### Detailed summary
- Added logging with message count when creating tar.gz file
- Improved handling of empty directories in RocksDB
- Refactored logic for uploading snapshot to S3

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->