### PR TITLE
Revert "chore: release hubble 1.11.1"

### DIFF
--- a/.changeset/hip-cherries-pull.md
+++ b/.changeset/hip-cherries-pull.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+bug: Enforce protobuf oneof constraints

--- a/.changeset/six-bats-grab.md
+++ b/.changeset/six-bats-grab.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat(hubble): update s3 snapshot metadata to include database statistics, and add snapshot-url command

--- a/.changeset/spotty-radios-flash.md
+++ b/.changeset/spotty-radios-flash.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Run full validateOrRevoke for all fids every 14 days

--- a/.changeset/violet-peas-relax.md
+++ b/.changeset/violet-peas-relax.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat(hubble): Add support for using S3 snapshot for "catch up" sync.

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @farcaster/hubble
 
-## 1.11.1
-
-### Patch Changes
-
-- e30297b9: bug: Enforce protobuf oneof constraints
-- c678742f: feat(hubble): update s3 snapshot metadata to include database statistics, and add snapshot-url command
-- 751ed729: fix: Run full validateOrRevoke for all fids every 14 days
-- 935246bd: feat(hubble): Add support for using S3 snapshot for "catch up" sync.
-- @farcaster/hub-nodejs@0.11.8
-
 ## 1.11.0
 
 ### Minor Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.11.1",
+  "version": "1.11.0",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -74,7 +74,7 @@
     "@chainsafe/libp2p-gossipsub": "6.1.0",
     "@chainsafe/libp2p-noise": "^11.0.0 ",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.11.8",
+    "@farcaster/hub-nodejs": "^0.11.7",
     "@fastify/cors": "^8.4.0",
     "@figma/hot-shots": "^9.0.0-figma.1",
     "@grpc/grpc-js": "~1.8.21",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @farcaster/core
 
-## 0.14.8
-
-### Patch Changes
-
-- e30297b9: bug: Enforce protobuf oneof constraints
-
 ## 0.14.7
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.14.8",
+  "version": "0.14.7",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @farcaster/hub-nodejs
 
-## 0.11.8
-
-### Patch Changes
-
-- Updated dependencies [e30297b9]
-  - @farcaster/core@0.14.8
-
 ## 0.11.7
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.11.8",
+  "version": "0.11.7",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@farcaster/core": "0.14.8",
+    "@farcaster/core": "0.14.7",
     "@grpc/grpc-js": "~1.8.21",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"


### PR DESCRIPTION
Reverts farcasterxyz/hub-monorepo#1838

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating versions and adding features related to the `@farcaster/hubble` package.

### Detailed summary
- Added feature to run full validation every 14 days
- Enforced protobuf oneof constraints
- Added support for using S3 snapshot for "catch up" sync
- Updated S3 snapshot metadata with database statistics
- Updated versions of `@farcaster/core` and `@farcaster/hub-nodejs` to `0.14.7` and `0.11.7` respectively

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->