### PR TITLE
chore: release hubble 1.11.1

### DIFF
--- a/.changeset/hip-cherries-pull.md
+++ b/.changeset/hip-cherries-pull.md
@@ -1,6 +1,0 @@
----
-"@farcaster/core": patch
-"@farcaster/hubble": patch
----
-
-bug: Enforce protobuf oneof constraints

--- a/.changeset/six-bats-grab.md
+++ b/.changeset/six-bats-grab.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat(hubble): update s3 snapshot metadata to include database statistics, and add snapshot-url command

--- a/.changeset/spotty-radios-flash.md
+++ b/.changeset/spotty-radios-flash.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Run full validateOrRevoke for all fids every 14 days

--- a/.changeset/violet-peas-relax.md
+++ b/.changeset/violet-peas-relax.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat(hubble): Add support for using S3 snapshot for "catch up" sync.

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @farcaster/hubble
 
+## 1.11.1
+
+### Patch Changes
+
+- e30297b9: bug: Enforce protobuf oneof constraints
+- c678742f: feat(hubble): update s3 snapshot metadata to include database statistics, and add snapshot-url command
+- 751ed729: fix: Run full validateOrRevoke for all fids every 14 days
+- 935246bd: feat(hubble): Add support for using S3 snapshot for "catch up" sync.
+- @farcaster/hub-nodejs@0.11.8
+
 ## 1.11.0
 
 ### Minor Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -74,7 +74,7 @@
     "@chainsafe/libp2p-gossipsub": "6.1.0",
     "@chainsafe/libp2p-noise": "^11.0.0 ",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.11.7",
+    "@farcaster/hub-nodejs": "^0.11.8",
     "@fastify/cors": "^8.4.0",
     "@figma/hot-shots": "^9.0.0-figma.1",
     "@grpc/grpc-js": "~1.8.21",

--- a/apps/hubble/src/network/sync/merkleTrie.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.ts
@@ -209,6 +209,9 @@ class MerkleTrie {
     // MerkleTrie has rocksdb instance, however the merkle trie worker
     // uses a separate instance under trieDb prefix which needs to be used here instead.
     const location = `${path.basename(trie._db.location)}/${TrieDBPathPrefix}`;
+    if (!fs.existsSync(path.basename(`.rocks/${location}`))) {
+      return ok(0);
+    }
     const db = new RocksDB(location);
     if (!db) {
       return err(new HubError("unavailable", "RocksDB not provided"));

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/core
 
+## 0.14.8
+
+### Patch Changes
+
+- e30297b9: bug: Enforce protobuf oneof constraints
+
 ## 0.14.7
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.14.7",
+  "version": "0.14.8",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/hub-nodejs
 
+## 0.11.8
+
+### Patch Changes
+
+- Updated dependencies [e30297b9]
+  - @farcaster/core@0.14.8
+
 ## 0.11.7
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@farcaster/core": "0.14.7",
+    "@farcaster/core": "0.14.8",
     "@grpc/grpc-js": "~1.8.21",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"


### PR DESCRIPTION
## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates version numbers and dependencies in multiple packages, including bug fixes and feature enhancements.

### Detailed summary
- Updated `@farcaster/core` and `@farcaster/hub-nodejs` versions
- Bug fix enforcing protobuf oneof constraints
- Added support for using S3 snapshot for "catch up" sync
- Updated dependencies in `hub-nodejs` package
- Updated version numbers in `hubble` package to 1.11.1

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->