### PR TITLE
chore: set repository urls for npm

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,10 @@
     "dist"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/core"
+  },
   "dependencies": {
     "@noble/curves": "^1.0.0",
     "@noble/hashes": "^1.3.0",

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -15,6 +15,10 @@
     "dist"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/hub-nodejs"
+  },
   "dependencies": {
     "@farcaster/core": "0.14.8",
     "@grpc/grpc-js": "~1.8.21",

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -15,6 +15,10 @@
     "dist"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/hub-web"
+  },
   "scripts": {
     "build": "tsup --config tsup.config.ts",
     "clean": "rimraf ./dist",


### PR DESCRIPTION
## Motivation

Adds a url from the npm package to the github repository for the convenience of developers. Some developers may only come across the package as a dependency, and have no easy way to find the github of farcaster from the npm packages.

Before
<img width="1207" alt="Screenshot 2024-03-23 at 11 47 41" src="https://github.com/farcasterxyz/hub-monorepo/assets/614768/09126757-6f8a-4695-b685-6488bedcffb9">
After
<img width="104" alt="Screenshot 2024-03-23 at 11 50 20" src="https://github.com/farcasterxyz/hub-monorepo/assets/614768/25c0c792-7d52-412d-a1ea-785682633e02">

## Change Summary

Adds the `repository` field to the `package.json` of three published packages. I don't believe a changeset is needed.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add repository URLs to the `package.json` files of `hub-nodejs`, `core`, and `hub-web` packages.

### Detailed summary
- Added repository URLs for `hub-nodejs`, `core`, and `hub-web` packages in their `package.json` files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->