### PR TITLE
fix: throttle triedb migration

### DIFF
--- a/apps/hubble/src/network/sync/merkleTrie.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.ts
@@ -271,7 +271,7 @@ class MerkleTrie {
     if (!(process.env["NODE_ENV"] === "test" || process.env["CI"])) {
       setTimeout(async () => {
         await this.doMigrate();
-      }, 1000);
+      }, 5 * 60 * 1000);
     }
 
     return this.callMethod("initialize");
@@ -373,7 +373,7 @@ class MerkleTrie {
       }
 
       // Wait a bit before continuing
-      await sleep(1000);
+      await sleep(2000);
 
       keys = [];
       values = [];


### PR DESCRIPTION
## Motivation

Throttle the trie db migration. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to increase the timeout duration for a migration process in `merkleTrie.ts` and adjust the sleep duration before continuing the process.

### Detailed summary
- Increased timeout duration for migration process from 1 second to 5 minutes
- Adjusted sleep duration before continuing process from 1 second to 2 seconds

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->