### PR TITLE
fix(hubble): reduce hub bandwidth with floodsub toggle

### DIFF
--- a/.changeset/flat-seahorses-pay.md
+++ b/.changeset/flat-seahorses-pay.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix(hubble): reduce hub bandwidth with floodsub toggle

--- a/.changeset/flat-seahorses-pay.md
+++ b/.changeset/flat-seahorses-pay.md
@@ -2,4 +2,4 @@
 "@farcaster/hubble": patch
 ---
 
-fix(hubble): reduce hub bandwidth with floodsub toggle
+fix(hubble): reduce hub bandwidth, can be toggled with GOSSIPSUB_FALLBACK_TO_FLOODSUB and GOSSIPSUB_FLOOD_PUBLISH

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -516,6 +516,8 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
             data = Buffer.from(Object.values(detail.msg.data as unknown as Record<string, number>));
           }
 
+          statsd().gauge("gossip.message_size_bytes", data.length, { topic: detail.msg.topic });
+
           const tags: { [key: string]: string } = {
             topic: detail.msg.topic,
           };

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -114,7 +114,7 @@ export class LibP2PNode {
     // default in gossipsub of 3s is not enough since hubs may experience I/O lag
     const gossipsubIWantFollowupMs = process.env["GOSSIPSUB_IWANT_FOLLOWUP_MS"]
       ? parseInt(process.env["GOSSIPSUB_IWANT_FOLLOWUP_MS"])
-      : 6 * 1000;
+      : 3 * 1000;
 
     if (options.p2pConnectTimeoutMs) {
       this._p2pConnectTimeoutMs = options.p2pConnectTimeoutMs;

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -486,9 +486,6 @@ export default class Server {
             }
 
             const response = MessagesResponse.create({ messages });
-            const data = Buffer.from(MessagesResponse.encode(response).finish());
-
-            statsd().gauge("rpc.message_size_bytes", data.length, { method: "getAllMessagesBySyncIds", peer });
             callback(null, response);
           },
           (err: HubError) => {

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -485,7 +485,11 @@ export default class Server {
               messages = messages.filter((message) => message.data !== undefined && message.hash.length > 0);
             }
 
-            callback(null, MessagesResponse.create({ messages }));
+            const response = MessagesResponse.create({ messages });
+            const data = Buffer.from(MessagesResponse.encode(response).finish());
+
+            statsd().gauge("rpc.message_size_bytes", data.length, { method: "getAllMessagesBySyncIds", peer });
+            callback(null, response);
           },
           (err: HubError) => {
             callback(toServiceError(err));


### PR DESCRIPTION
## Motivation

- Hub bandwidth usage has increased to around 400-500 KiB per second, or 40-50 GiB per day
- Needless bandwidth utilization can increase resource requirements to run Hub

## Context
- The default settings for our libp2p library publish to floodsub and subscribe to floodsub topic
- Floodsub is a p2p protocol where every message a node receives gets forwarded to all known peers in the network
- While there are benefits to Floodsub, it has significant network amplification factors and hits scalability limits as the number of hubs in the network grows

## Change Summary

- By default, disable `floodPublish` and `fallbackToFloodsub` 
- Expose environment variables `GOSSIPSUB_FALLBACK_TO_FLOODSUB` and `GOSSIPSUB_FLOOD_PUBLISH` to toggle the values for gossipsub p2p 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR reduces hub bandwidth in the `hubble` app by adding toggles for `GOSSIPSUB_FALLBACK_TO_FLOODSUB` and `GOSSIPSUB_FLOOD_PUBLISH`.

### Detailed summary
- Added toggles for `GOSSIPSUB_FALLBACK_TO_FLOODSUB` and `GOSSIPSUB_FLOOD_PUBLISH` in `gossipNode.ts`
- Refactored callback handling in `server.ts`
- Added environment variable checks for `fallbackToFloodsub` and `floodPublish` in `gossipNodeWorker.ts`
- Added stats tracking for message sizes in `gossipNodeWorker.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->