### PR TITLE
logs: Add `--log-individual-messages` to log indivdual submitMessage

### DIFF
--- a/.changeset/thick-files-taste.md
+++ b/.changeset/thick-files-taste.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: Add --log-individual-messages to log each submitMessage status. If disabled (default) write one line per second

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -71,6 +71,10 @@ app
   .option("-c, --config <filepath>", "Path to the config file.")
   .option("--db-name <name>", "The name of the RocksDB instance. (default: rocks.hub._default)")
   .option("--process-file-prefix <prefix>", 'Prefix for file to which hub process number is written. (default: "")')
+  .option(
+    "--log-individual-messages",
+    "Log individual submitMessage. If disabled, log one line per second (default: disabled)",
+  )
 
   // Ethereum Options
   .option("-m, --eth-mainnet-rpc-url <url>", "RPC URL of a Mainnet ETH Node (or comma separated list of URLs)")
@@ -499,6 +503,7 @@ app
 
     const options: HubOptions = {
       peerId,
+      logIndividualMessages: cliOptions.logIndividualMessages ?? hubConfig.logIndividualMessages ?? false,
       ipMultiAddr: ipMultiAddrResult.value,
       rpcServerHost: hubAddressInfo.value.address,
       announceIp: cliOptions.announceIp ?? hubConfig.announceIp,

--- a/apps/hubble/www/docs/docs/cli.md
+++ b/apps/hubble/www/docs/docs/cli.md
@@ -33,6 +33,7 @@ Hubble Options:
   -c, --config <filepath>               Path to the config file.
   --db-name <name>                      The name of the RocksDB instance. (default: rocks.hub._default)
   --process-file-prefix <prefix>        Prefix for file to which hub process number is written. (default: "")
+  --log-individual-messages             Log individual submitMessage status. If disabled, log one line per second (default: disabled)"
 
 Ethereum Options:
   -m, --eth-mainnet-rpc-url <url>       RPC URL of a Mainnet ETH Node (or comma separated list of URLs)


### PR DESCRIPTION
## Motivation

 `--log-individual-messages`  will log each individual submitMessage status. If disabled (default) will log one line per second with aggregate status


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)
