### PR TITLE
fix: Online snapshot using rocksdb snapshot iterators

### DIFF
--- a/.changeset/giant-bobcats-perform.md
+++ b/.changeset/giant-bobcats-perform.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Create online snapshots using snapshot iterators

--- a/apps/hubble/src/addon/Cargo.lock
+++ b/apps/hubble/src/addon/Cargo.lock
@@ -11,8 +11,8 @@ dependencies = [
  "cadence",
  "chrono",
  "ed25519-dalek",
+ "flate2",
  "glob",
- "gzp",
  "hex",
  "hostname",
  "neon",
@@ -269,12 +269,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,15 +344,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,17 +360,6 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
-
-[[package]]
-name = "core_affinity"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622892f5635ce1fc38c8f16dfc938553ed64af482edb5e150bf4caedbfcb2304"
-dependencies = [
- "libc",
- "num_cpus",
- "winapi",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -570,21 +544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
- "libz-sys",
  "miniz_oxide",
-]
-
-[[package]]
-name = "flume"
-version = "0.10.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "pin-project",
- "spin",
 ]
 
 [[package]]
@@ -649,10 +609,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -666,23 +624,6 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "gzp"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c65d1899521a11810501b50b898464d133e1afc96703cff57726964cfa7baf"
-dependencies = [
- "byteorder",
- "bytes",
- "core_affinity",
- "flate2",
- "flume",
- "libdeflater",
- "libz-sys",
- "num_cpus",
- "thiserror",
-]
 
 [[package]]
 name = "h2"
@@ -927,24 +868,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
-name = "libdeflate-sys"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1f7b0817f85e2ba608892f30fbf4c9d03f3ebf9db0c952d1b7c8f7387b54785"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "libdeflater"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671e63282f642c7bcc7d292b212d5a4739fef02a77fe98429a75d308f96e7931"
-dependencies = [
- "libdeflate-sys",
-]
-
-[[package]]
 name = "libloading"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,8 +900,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
 dependencies = [
  "cc",
- "cmake",
- "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -988,16 +909,6 @@ name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
-
-[[package]]
-name = "lock_api"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -1070,15 +981,6 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom",
-]
 
 [[package]]
 name = "neon"
@@ -1454,12 +1356,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,15 +1487,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "spki"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,26 +1557,6 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3de26b0965292219b4287ff031fcba86837900fe9cd2b34ea8ad893c0953d2"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "268026685b2be38d7103e9e507c938a1fcb3d7e6eb15e87870b617bf37b6d581"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/apps/hubble/src/addon/Cargo.toml
+++ b/apps/hubble/src/addon/Cargo.toml
@@ -28,12 +28,12 @@ cadence = "1.2.0"
 slog-atomic = "3.1.0"
 walkdir = "2.5.0"
 tar = "0.4.40"
-gzp = "0.11.3"
 tonic = "0.11.0"
 tokio = {version="1.36.0", features=["macros", "rt-multi-thread"]}
 tempfile = "3.10.1"
 rand = "0.8.5"
 hex = "0.4.3"
+flate2 = "1.0.28"
 
 [build-dependencies]
 tonic-build = "0.11"

--- a/apps/hubble/src/addon/src/db/rocksdb.rs
+++ b/apps/hubble/src/addon/src/db/rocksdb.rs
@@ -1,11 +1,9 @@
 use crate::logger::LOGGER;
 use crate::statsd::statsd;
 use crate::store::{self, get_db, hub_error_to_js_throw, increment_vec_u8, HubError, PageOptions};
-use gzp::{
-    deflate::Gzip,
-    par::compress::{ParCompress, ParCompressBuilder},
-    ZWriter,
-};
+use crate::trie::merkle_trie::TRIE_DBPATH_PREFIX;
+use flate2::write::GzEncoder;
+use flate2::Compression;
 use neon::context::{Context, FunctionContext};
 use neon::handle::Handle;
 use neon::object::Object;
@@ -15,8 +13,9 @@ use neon::types::{
     Finalize, JsArray, JsBoolean, JsBox, JsBuffer, JsFunction, JsNumber, JsObject, JsPromise,
     JsString,
 };
-use rocksdb::{Options, TransactionDB};
-use slog::{info, o};
+use rocksdb::{Options, TransactionDB, DB};
+use slog::{info, o, Logger};
+use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::fs::{self, File};
 use std::path::Path;
@@ -470,69 +469,6 @@ impl RocksDB {
             .map(|metadata| metadata.len()) // Extract the file size.
             .sum() // Sum the sizes.
     }
-
-    pub fn create_tar_backup(&self, input_dir: &str) -> Result<String, HubError> {
-        if self.db.read().unwrap().is_some() {
-            return Err(HubError {
-                code: "db.open".to_string(),
-                message: "Can't create a Tar backup while DB is open".to_string(),
-            });
-        }
-
-        let base_name = Path::new(input_dir)
-            .file_name()
-            .map(|s| s.to_string_lossy().to_string())
-            .unwrap_or(".".to_string());
-
-        let output_file_path = format!(
-            "{}-{}.tar",
-            input_dir,
-            chrono::Local::now().format("%Y-%m-%d-%s")
-        );
-
-        let start = std::time::SystemTime::now();
-        info!(self.logger, "Creating tarball for directory: {}", input_dir; 
-            o!("output_file_path" => &output_file_path, "base_name" => &base_name));
-
-        let tar_file = File::create(&output_file_path)?;
-        let mut tar = Builder::new(tar_file);
-
-        tar.append_dir_all(base_name, input_dir)?;
-
-        tar.finish()?;
-
-        let metadata = fs::metadata(&output_file_path)?;
-        let time_taken = start.elapsed().expect("Time went backwards");
-
-        info!(
-            self.logger,
-            "Tarball created: path = {}, size = {} bytes, time taken = {:?}",
-            output_file_path,
-            metadata.len(),
-            time_taken
-        );
-
-        Ok(output_file_path)
-    }
-
-    pub fn create_tar_gzip(input_tar: &str) -> Result<String, HubError> {
-        let output_gz_path = format!("{}.gz", input_tar);
-
-        let mut tar_file = File::open(input_tar)?;
-        let gz_file = File::create(&output_gz_path)?;
-        // let mut gz_encoder = GzEncoder::new(gz_file, Compression::default());
-        let mut parz: ParCompress<Gzip> = ParCompressBuilder::new().from_writer(gz_file);
-
-        std::io::copy(&mut tar_file, &mut parz)?;
-
-        parz.finish().map_err(|e| HubError {
-            code: "db.internal_error".to_string(),
-            message: format!("Error creating gzip file: {}", e.to_string()),
-        })?;
-        fs::remove_file(input_tar)?;
-
-        Ok(output_gz_path)
-    }
 }
 
 impl RocksDB {
@@ -563,26 +499,6 @@ impl RocksDB {
         let result = db.approximate_size();
 
         Ok(cx.number(result as f64))
-    }
-
-    pub fn js_create_tar_backup(mut cx: FunctionContext) -> JsResult<JsPromise> {
-        let db = get_db(&mut cx)?;
-        let input_dir = db.location();
-
-        let channel = cx.channel();
-        let (deferred, promise) = cx.promise();
-
-        // Spawn a new thread to create the tarball
-        std::thread::spawn(move || {
-            let result = db.create_tar_backup(&input_dir);
-
-            deferred.settle_with(&channel, move |mut tcx| match result {
-                Ok(output_path) => Ok(tcx.string(output_path)),
-                Err(e) => hub_error_to_js_throw(&mut tcx, e),
-            });
-        });
-
-        Ok(promise)
     }
 
     pub fn js_create_tar_gzip(mut cx: FunctionContext) -> JsResult<JsPromise> {
@@ -891,6 +807,190 @@ impl RocksDB {
         let channel = cx.channel();
         let (deferred, promise) = cx.promise();
         deferred.settle_with(&channel, move |mut cx| Ok(cx.boolean(result.unwrap())));
+
+        Ok(promise)
+    }
+}
+
+impl RocksDB {
+    pub fn create_tar_gzip(input_tar: &str) -> Result<String, HubError> {
+        let output_gz_path = format!("{}.gz", input_tar);
+
+        let mut tar_file = File::open(input_tar)?;
+        let gz_file = File::create(&output_gz_path)?;
+
+        // Set up the GzEncoder for gzip compression with default compression level
+        let mut encoder = GzEncoder::new(gz_file, Compression::default());
+        std::io::copy(&mut tar_file, &mut encoder)?;
+
+        encoder.finish().map_err(|e| HubError {
+            code: "db.internal_error".to_string(),
+            message: format!("Error creating gzip file: {}", e.to_string()),
+        })?;
+        fs::remove_file(input_tar)?;
+
+        Ok(output_gz_path)
+    }
+
+    fn create_tar(logger: &Logger, input_dir: &str) -> Result<String, HubError> {
+        let base_name = Path::new(input_dir)
+            .file_name()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or(".".to_string());
+
+        let output_file_path = format!(
+            "{}-{}.tar",
+            base_name,
+            chrono::Local::now().format("%Y-%m-%d-%s")
+        );
+
+        let start = std::time::SystemTime::now();
+        info!(logger, "Creating tarball for directory: {}", input_dir; 
+            o!("output_file_path" => &output_file_path, "base_name" => &base_name));
+
+        let tar_file = File::create(&output_file_path)?;
+        let mut tar = Builder::new(tar_file);
+
+        tar.append_dir_all(base_name, input_dir)?;
+        tar.finish()?;
+
+        let metadata = fs::metadata(&output_file_path)?;
+        let time_taken = start.elapsed().expect("Time went backwards");
+
+        info!(
+            logger,
+            "Tarball created: path = {}, size = {} bytes, time taken = {:?}",
+            output_file_path,
+            metadata.len(),
+            time_taken
+        );
+
+        Ok(output_file_path)
+    }
+
+    fn snapshot_backup(main_db: Arc<RocksDB>, trie_db: Arc<RocksDB>) -> Result<String, HubError> {
+        let main_logger = LOGGER.new(o! ("component" => "RocksDBSnapshotBackup"));
+        let main_db_path = main_db.location();
+
+        let main_backup_path = Path::new(&format!(
+            "{}-{}.backup",
+            main_db_path,
+            chrono::Local::now().format("%Y-%m-%d-%s")
+        ))
+        .join("rocks.hub._default");
+
+        // rm -rf this path if it exists
+        if main_backup_path.exists() {
+            fs::remove_dir_all(&main_backup_path).map_err(|e| HubError {
+                code: "db.internal_error".to_string(),
+                message: e.to_string(),
+            })?;
+        }
+
+        let triedb_backup_path = main_backup_path.join(TRIE_DBPATH_PREFIX);
+
+        let main_backup_path = main_backup_path.into_os_string().into_string().unwrap();
+        let triedb_backup_path = triedb_backup_path.into_os_string().into_string().unwrap();
+
+        let start = std::time::SystemTime::now();
+        info!(main_logger, "Creating snapshot for main DB: {}", main_db_path; 
+        o!("output_file_path_main" => &main_backup_path, "output_file_path_trie" => &triedb_backup_path));
+
+        let backup_main = DB::open_default(&main_backup_path)
+            .map_err(|e| HubError::internal_db_error(&e.to_string()))?;
+        let backup_trie = DB::open_default(&triedb_backup_path)
+            .map_err(|e| HubError::internal_db_error(&e.to_string()))?;
+
+        let logger = main_logger.clone();
+        let main_backup_thread = std::thread::spawn(move || {
+            let main_db = main_db.db();
+            let main_db_snapshot = main_db.as_ref().unwrap().snapshot();
+
+            let iterator = main_db_snapshot.iterator(rocksdb::IteratorMode::Start);
+            let mut count = 0;
+            for item in iterator {
+                let (key, value) = item.unwrap();
+                backup_main.put(key, value).unwrap();
+
+                count += 1;
+                if count % 1_000_000 == 0 {
+                    backup_main.flush().unwrap();
+                    info!(logger, "mainDb Snapshot backup progress: {}", count);
+                }
+            }
+
+            info!(logger, "mainDB Snapshot backup completed: {}", count);
+            drop(main_db_snapshot);
+            drop(backup_main);
+        });
+
+        let logger = main_logger.clone();
+        let trie_backup_thread = std::thread::spawn(move || {
+            let trie_db = trie_db.db();
+            let trie_db_snapshot = trie_db.as_ref().unwrap().snapshot();
+
+            let iterator = trie_db_snapshot.iterator(rocksdb::IteratorMode::Start);
+            let mut count = 0;
+            for item in iterator {
+                let (key, value) = item.unwrap();
+                backup_trie.put(key, value).unwrap();
+
+                count += 1;
+                if count % 1_000_000 == 0 {
+                    backup_trie.flush().unwrap();
+                    info!(logger, "trieDb Snapshot backup progress: {}", count);
+                }
+            }
+
+            info!(logger, "trieDB Snapshot backup completed: {}", count);
+            drop(trie_db_snapshot);
+            drop(backup_trie);
+        });
+
+        main_backup_thread.join().unwrap();
+        trie_backup_thread.join().unwrap();
+
+        info!(
+            main_logger,
+            "Full DB Snapshot Backup created: path = {}, time taken = {:?}",
+            main_backup_path,
+            start.elapsed().expect("Time went backwards")
+        );
+
+        let tar_path = Self::create_tar(&main_logger, &main_backup_path)?;
+        let tar_gz_path = Self::create_tar_gzip(&tar_path)?;
+        info!(
+            main_logger,
+            "Full DB Snapshot Backup tar.gz created: path = {}", tar_gz_path,
+        );
+
+        // rm -rf the backup path
+        fs::remove_dir_all(&main_backup_path).map_err(|e| HubError {
+            code: "db.internal_error".to_string(),
+            message: e.to_string(),
+        })?;
+
+        Ok(tar_gz_path)
+    }
+
+    pub fn js_snapshot_backup(mut cx: FunctionContext) -> JsResult<JsPromise> {
+        let main_db_handle = cx.argument::<JsBox<Arc<RocksDB>>>(0)?;
+        let main_db = (**main_db_handle.borrow()).clone();
+        let trie_db_handle = cx.argument::<JsBox<Arc<RocksDB>>>(1)?;
+        let trie_db = (**trie_db_handle.borrow()).clone();
+
+        let channel = cx.channel();
+        let (deferred, promise) = cx.promise();
+
+        // Spawn a new thread to create the tarball
+        std::thread::spawn(move || {
+            let result = Self::snapshot_backup(main_db, trie_db);
+
+            deferred.settle_with(&channel, move |mut tcx| match result {
+                Ok(output_path) => Ok(tcx.string(output_path)),
+                Err(e) => hub_error_to_js_throw(&mut tcx, e),
+            });
+        });
 
         Ok(promise)
     }

--- a/apps/hubble/src/addon/src/db/rocksdb.rs
+++ b/apps/hubble/src/addon/src/db/rocksdb.rs
@@ -820,7 +820,7 @@ impl RocksDB {
         let gz_file = File::create(&output_gz_path)?;
 
         // Set up the GzEncoder for gzip compression with default compression level
-        let mut encoder = GzEncoder::new(gz_file, Compression::default());
+        let mut encoder = GzEncoder::new(gz_file, Compression::fast());
         std::io::copy(&mut tar_file, &mut encoder)?;
 
         encoder.finish().map_err(|e| HubError {

--- a/apps/hubble/src/addon/src/lib.rs
+++ b/apps/hubble/src/addon/src/lib.rs
@@ -103,8 +103,6 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("createDb", RocksDB::js_create_db)?;
     cx.export_function("dbOpen", RocksDB::js_open)?;
     cx.export_function("dbApproximateSize", RocksDB::js_approximate_size)?;
-    cx.export_function("dbCreateTarBackup", RocksDB::js_create_tar_backup)?;
-    cx.export_function("dbCreateTarGzip", RocksDB::js_create_tar_gzip)?;
     cx.export_function("dbClear", RocksDB::js_clear)?;
     cx.export_function("dbClose", RocksDB::js_close)?;
     cx.export_function("dbDestroy", RocksDB::js_destroy)?;
@@ -114,6 +112,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("dbPut", RocksDB::js_put)?;
     cx.export_function("dbDel", RocksDB::js_del)?;
     cx.export_function("dbCommit", RocksDB::js_commit_transaction)?;
+    cx.export_function("dbSnapshotBackup", RocksDB::js_snapshot_backup)?;
 
     cx.export_function(
         "dbForEachIteratorByPrefix",

--- a/apps/hubble/src/addon/src/store/store.rs
+++ b/apps/hubble/src/addon/src/store/store.rs
@@ -41,6 +41,13 @@ impl HubError {
             message: error_message.to_string(),
         }
     }
+
+    pub fn internal_db_error(error_message: &str) -> HubError {
+        HubError {
+            code: "db.internal_error".to_string(),
+            message: error_message.to_string(),
+        }
+    }
 }
 
 impl Display for HubError {

--- a/apps/hubble/src/addon/src/trie/merkle_trie.rs
+++ b/apps/hubble/src/addon/src/trie/merkle_trie.rs
@@ -28,7 +28,7 @@ use std::{
     },
 };
 
-const TRIE_DBPATH_PREFIX: &str = "trieDb";
+pub const TRIE_DBPATH_PREFIX: &str = "trieDb";
 const TRIE_UNLOAD_THRESHOLD: u64 = 10_000;
 
 #[derive(Debug)]

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -588,19 +588,6 @@ app
       );
     }
 
-    if (options.enableSnapshotToS3) {
-      // Set the Hub to exit (and be automatically restarted) so that the snapshot is uploaded
-      // before the Hub starts syncing
-      // Calculate and set a timeout to run at 9:10 am UTC (2:10 am PST)
-      const millisTill9 = millisTillRestart();
-      logger.info({ millisTill9 }, "Scheduling Hub to exit at 9:10 am UTC to upload snapshot to S3");
-
-      setTimeout(async () => {
-        logger.info("Exiting Hub to upload snapshot to S3");
-        handleShutdownSignal("S3SnapshotUpload");
-      }, millisTill9);
-    }
-
     await startupCheck.rpcCheck(options.ethMainnetRpcUrl, mainnet, "L1");
     await startupCheck.rpcCheck(options.l2RpcUrl, optimism, "L2", options.l2ChainId);
 
@@ -910,16 +897,6 @@ app.parse(process.argv);
 ///////////////////////////////////////////////////////////////
 //                        UTILS
 ///////////////////////////////////////////////////////////////
-function millisTillRestart(): number {
-  // Calculate the number of milliseconds until 9:10 am UTC (2:10 am PST)
-  const now = new Date();
-  const timeAt9 = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 9, 10, 0, 0).getTime();
-
-  const millisTill9Tomorrow = timeAt9 + 24 * 60 * 60 * 1000 - now.getTime();
-  const millisTill9Today = timeAt9 - now.getTime();
-
-  return millisTill9Today > 0 ? millisTill9Today : millisTill9Tomorrow;
-}
 
 // Verify that we have access to the AWS credentials.
 // Either via environment variables or via the AWS credentials file

--- a/apps/hubble/src/rustfunctions.ts
+++ b/apps/hubble/src/rustfunctions.ts
@@ -116,14 +116,6 @@ export const rsApproximateSize = (db: RustDb): number => {
   return lib.dbApproximateSize.call(db);
 };
 
-export const rsCreateTarBackup = (db: RustDb): Promise<string> => {
-  return lib.dbCreateTarBackup.call(db);
-};
-
-export const rsCreateTarGzip = (filePath: string): Promise<string> => {
-  return lib.dbCreateTarGzip(filePath);
-};
-
 export const rsDbClear = (db: RustDb) => {
   return lib.dbClear.call(db);
 };
@@ -160,6 +152,10 @@ export const rsDbDel = async (db: RustDb, key: Uint8Array): Promise<void> => {
 
 export const rsDbCommit = async (db: RustDb, keyValues: DbKeyValue[]): Promise<void> => {
   return await lib.dbCommit.call(db, keyValues);
+};
+
+export const rsDbSnapshotBackup = async (mainDb: RustDb, trieDb: RustDb): Promise<string> => {
+  return await lib.dbSnapshotBackup(mainDb, trieDb);
 };
 
 /**

--- a/apps/hubble/src/storage/jobs/dbSnapshotBackupJob.ts
+++ b/apps/hubble/src/storage/jobs/dbSnapshotBackupJob.ts
@@ -1,0 +1,196 @@
+import { FarcasterNetwork, HubAsyncResult, HubError } from "@farcaster/hub-nodejs";
+import { ResultAsync, err, ok } from "neverthrow";
+import cron from "node-cron";
+import { logger } from "../../utils/logger.js";
+import { rsDbSnapshotBackup } from "../../rustfunctions.js";
+import RocksDB from "../../storage/db/rocksdb.js";
+import { MerkleTrie } from "../../network/sync/merkleTrie.js";
+import { uploadToS3 } from "../../utils/snapshot.js";
+import SyncEngine from "../../network/sync/syncEngine.js";
+import { S3Client, ListObjectsV2Command, DeleteObjectsCommand } from "@aws-sdk/client-s3";
+import fs from "fs";
+import { HubOptions, S3_REGION, SNAPSHOT_S3_DEFAULT_BUCKET } from "../../hubble.js";
+
+export const DEFAULT_DB_SNAPSHOT_BACKUP_JOB_CRON = "15 2 * * *"; // 2:15 am everyday
+
+const log = logger.child({
+  component: "DbSnapshotJob",
+});
+
+type SchedulerStatus = "started" | "stopped";
+
+export class DbSnapshotBackupJobScheduler {
+  private _cronTask?: cron.ScheduledTask;
+  private _running = false;
+
+  private _mainDb: RocksDB;
+  private _trieDb: RocksDB;
+  private _syncEngine: SyncEngine;
+  private _options: HubOptions;
+
+  constructor(mainDb: RocksDB, trieDb: RocksDB, syncEngine: SyncEngine, options: HubOptions) {
+    this._mainDb = mainDb;
+    this._trieDb = trieDb;
+    this._syncEngine = syncEngine;
+    this._options = options;
+  }
+
+  start(cronSchedule?: string) {
+    this._cronTask = cron.schedule(cronSchedule ?? DEFAULT_DB_SNAPSHOT_BACKUP_JOB_CRON, () => this.doJobs(), {
+      timezone: "Etc/UTC",
+    });
+  }
+
+  stop() {
+    if (this._cronTask) {
+      this._cronTask.stop();
+    }
+  }
+
+  status(): SchedulerStatus {
+    return this._cronTask ? "started" : "stopped";
+  }
+
+  async doJobs(): HubAsyncResult<void> {
+    if (!this._options.enableSnapshotToS3) {
+      return ok(undefined);
+    }
+
+    if (this._running) {
+      log.info({}, "Db Snapshot Backup job already running, skipping");
+      return ok(undefined);
+    }
+
+    log.info({}, "starting Db Snapshot Backup job");
+    const start = Date.now();
+
+    // Back up the DB before opening it
+    const tarGzResult = await ResultAsync.fromPromise(
+      rsDbSnapshotBackup(this._mainDb.rustDb, this._trieDb.rustDb),
+      (e) => e as Error,
+    );
+
+    if (tarGzResult.isOk()) {
+      const messageCount = await this._syncEngine.trie.items();
+
+      // If snapshot to S3 flag is explicitly set, we throw an error if message count is zero,
+      // since it would be atypical to set this flag when there are no messages in the trie
+      if (messageCount <= 0) {
+        log.error("no messages found in sync engine trie, cannot upload snapshot");
+        throw new HubError("unavailable", "no messages found in sync engine trie, snapshot upload failed");
+      }
+
+      // Upload to S3. Run this in the background so we don't block startup.
+      setTimeout(async () => {
+        log.info({ messageCount }, "uploading snapshot to S3");
+        const s3Result = await uploadToS3(
+          this._options.network,
+          tarGzResult.value,
+          this._options.s3SnapshotBucket,
+          messageCount,
+        );
+        if (s3Result.isErr()) {
+          log.error({ error: s3Result.error, errMsg: s3Result.error.message }, "failed to upload snapshot to S3");
+        }
+
+        // Delete the tar file, ignore errors
+        fs.unlink(tarGzResult.value, () => {});
+
+        // Cleanup old files from S3
+        this.deleteOldSnapshotsFromS3();
+      }, 10);
+    } else {
+      log.error({ error: tarGzResult.error }, "failed to create tar backup for S3");
+    }
+
+    log.info({ timeTakenMs: Date.now() - start }, "finished Db Snapshot Backup job");
+    this._running = false;
+
+    return ok(undefined);
+  }
+
+  async deleteOldSnapshotsFromS3(): HubAsyncResult<void> {
+    try {
+      const fileListResult = await this.listS3Snapshots();
+
+      if (!fileListResult.isOk()) {
+        return err(new HubError("unavailable.network_failure", fileListResult.error.message));
+      }
+
+      if (fileListResult.value.length < 2) {
+        log.warn({ fileList: fileListResult.value }, "Not enough snapshot files to delete");
+        return ok(undefined);
+      }
+
+      const oneMonthAgo = new Date();
+      oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
+
+      const oldFiles = fileListResult.value
+        .filter((file) => (file.LastModified ? new Date(file.LastModified) < oneMonthAgo : false))
+        .slice(0, 10);
+
+      if (oldFiles.length === 0) {
+        return ok(undefined);
+      }
+
+      log.warn({ oldFiles }, "Deleting old snapshot files from S3");
+
+      const s3Bucket = this._options.s3SnapshotBucket ?? SNAPSHOT_S3_DEFAULT_BUCKET;
+      const deleteParams = {
+        Bucket: s3Bucket,
+        Delete: {
+          Objects: oldFiles.map((file) => ({ Key: file.Key })),
+        },
+      };
+
+      const s3 = new S3Client({
+        region: S3_REGION,
+      });
+
+      await s3.send(new DeleteObjectsCommand(deleteParams));
+      return ok(undefined);
+    } catch (e: unknown) {
+      return err(new HubError("unavailable.network_failure", (e as Error).message));
+    }
+  }
+
+  async listS3Snapshots(): HubAsyncResult<
+    Array<{
+      Key: string | undefined;
+      Size: number | undefined;
+      LastModified: Date | undefined;
+    }>
+  > {
+    const network = FarcasterNetwork[this._options.network].toString();
+
+    const s3 = new S3Client({
+      region: S3_REGION,
+    });
+
+    // Note: We get the snapshots across all DB_SCHEMA versions
+    // when determining which snapshots to delete, we only delete snapshots from the current DB_SCHEMA version
+    const s3Bucket = this._options.s3SnapshotBucket ?? SNAPSHOT_S3_DEFAULT_BUCKET;
+    const params = {
+      Bucket: s3Bucket,
+      Prefix: `snapshots/${network}/`,
+    };
+
+    try {
+      const response = await s3.send(new ListObjectsV2Command(params));
+
+      if (response.Contents) {
+        return ok(
+          response.Contents.map((item) => ({
+            Key: item.Key,
+            Size: item.Size,
+            LastModified: item.LastModified,
+          })),
+        );
+      } else {
+        return ok([]);
+      }
+    } catch (e: unknown) {
+      return err(new HubError("unavailable.network_failure", (e as Error).message));
+    }
+  }
+}

--- a/apps/hubble/src/storage/jobs/dbSnapshotBackupJob.ts
+++ b/apps/hubble/src/storage/jobs/dbSnapshotBackupJob.ts
@@ -4,7 +4,6 @@ import cron from "node-cron";
 import { logger } from "../../utils/logger.js";
 import { rsDbSnapshotBackup } from "../../rustfunctions.js";
 import RocksDB from "../../storage/db/rocksdb.js";
-import { MerkleTrie } from "../../network/sync/merkleTrie.js";
 import { uploadToS3 } from "../../utils/snapshot.js";
 import SyncEngine from "../../network/sync/syncEngine.js";
 import { S3Client, ListObjectsV2Command, DeleteObjectsCommand } from "@aws-sdk/client-s3";


### PR DESCRIPTION
## Motivation

Do an online backup/snapshot using rocksdb snapshot iterators instead of restarting the hub.


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `@farcaster/hubble` package with a fix for creating online snapshots using snapshot iterators.

### Detailed summary
- Added `pub` visibility to a constant in `merkle_trie.rs`
- Added a new function `internal_db_error` in `store.rs`
- Updated dependencies in `Cargo.toml`
- Removed functions related to tar backup and gzip in `lib.rs`
- Added a new function `dbSnapshotBackup` in `lib.rs`
- Updated functions related to tar backup and gzip in `rustfunctions.ts`
- Added a new function `rsDbSnapshotBackup` in `dbSnapshotBackupJob.ts`
- Added new imports and functions related to snapshot backup job in `dbSnapshotBackupJob.ts`
- Updated `Cargo.lock` to include the `flate2` dependency

> The following files were skipped due to too many changes: `apps/hubble/src/addon/Cargo.lock`, `apps/hubble/src/hubble.ts`, `apps/hubble/src/addon/src/db/rocksdb.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->