### PR TITLE
fix: Log gossipnode worker heap stats

### DIFF
--- a/.changeset/plenty-cooks-decide.md
+++ b/.changeset/plenty-cooks-decide.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Log memory usage every 60s

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -765,6 +765,15 @@ export class Hub implements HubInterface {
     // shutdown, we'll write "true" to this key, indicating that we've cleanly shutdown.
     // This way, when starting up, we'll know if the previous shutdown was clean or not.
     await this.writeHubCleanShutdown(false, HubShutdownReason.UNKNOWN);
+
+    // Set up a timer to log the memory usage every minute
+    setInterval(() => {
+      const memoryData = process.memoryUsage();
+      statsd().gauge("memory.rss", memoryData.rss);
+      statsd().gauge("memory.heap_total", memoryData.heapTotal);
+      statsd().gauge("memory.heap_used", memoryData.heapUsed);
+      statsd().gauge("memory.external", memoryData.external);
+    }, 60 * 1000);
   }
 
   /** Apply the new the network config. Will return true if the Hub should exit */

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -226,7 +226,7 @@ export class LibP2PNode {
       statsd().gauge("memory.gossipworker.heap_total", memoryData.heapTotal);
       statsd().gauge("memory.gossipworker.heap_used", memoryData.heapUsed);
       statsd().gauge("memory.gossipworker.external", memoryData.external);
-    }, 10 * 1000);
+    }, 60 * 1000);
   }
 
   async isStarted(): Promise<boolean> {

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -217,6 +217,16 @@ export class LibP2PNode {
   async start() {
     await this._node?.start();
     this.registerEventListeners();
+
+    // Send memory usage stats to statsd every 10 seconds
+    setInterval(() => {
+      const memoryData = process.memoryUsage();
+
+      statsd().gauge("memory.gossipworker.rss", memoryData.rss);
+      statsd().gauge("memory.gossipworker.heap_total", memoryData.heapTotal);
+      statsd().gauge("memory.gossipworker.heap_used", memoryData.heapUsed);
+      statsd().gauge("memory.gossipworker.external", memoryData.external);
+    }, 10 * 1000);
   }
 
   async isStarted(): Promise<boolean> {

--- a/apps/hubble/src/storage/jobs/gossipContactInfoJob.ts
+++ b/apps/hubble/src/storage/jobs/gossipContactInfoJob.ts
@@ -2,7 +2,6 @@ import cron from "node-cron";
 import { HubInterface } from "../../hubble.js";
 import { logger } from "../../utils/logger.js";
 import { HubAsyncResult } from "@farcaster/core";
-import { statsd } from "../../utils/statsd.js";
 
 const log = logger.child({
   component: "GossipContactInfo",
@@ -38,11 +37,6 @@ export class GossipContactInfoJobScheduler {
 
   async doJobs(): HubAsyncResult<void> {
     log.info({}, "starting gossip contact info job");
-    const memoryData = process.memoryUsage();
-    statsd().gauge("memory.rss", memoryData.rss);
-    statsd().gauge("memory.heap_total", memoryData.heapTotal);
-    statsd().gauge("memory.heap_used", memoryData.heapUsed);
-    statsd().gauge("memory.external", memoryData.external);
 
     return await this._hub.gossipContactInfo();
   }

--- a/apps/hubble/src/utils/snapshot.ts
+++ b/apps/hubble/src/utils/snapshot.ts
@@ -90,7 +90,7 @@ export const uploadToS3 = async (
   )}.tar.gz`;
 
   start = Date.now();
-  logger.info({ filePath, key, bucket: s3Bucket }, "progress uploading snapshot to S3");
+  logger.info({ filePath, key, bucket: s3Bucket }, "Uploading snapshot to S3");
 
   const fileStream = fs.createReadStream(filePath);
   fileStream.on("error", function (err) {
@@ -125,7 +125,7 @@ export const uploadToS3 = async (
   };
 
   targzParams.on("httpUploadProgress", (progress) => {
-    logger.info({ progress }, "Uploading snapshot to S3");
+    logger.info({ progress }, "Uploading snapshot to S3 - progress");
   });
 
   try {


### PR DESCRIPTION
## Motivation

Log heap usage of main and gossip worker thread every 60s

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR optimizes memory usage logging in the Hubble app by adding interval-based statsd logging and updating logger messages.

### Detailed summary
- Added interval-based memory usage logging to `gossipNodeWorker.ts` and `hubble.ts`
- Updated logger messages in `snapshot.ts` and `gossipContactInfoJob.ts`
- Modified data type in `merkle_trie.rs` for memory optimization

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->