### PR TITLE
docs: Update legacy browser warning

### DIFF
--- a/packages/hub-nodejs/docs/README.md
+++ b/packages/hub-nodejs/docs/README.md
@@ -15,7 +15,7 @@ Note: The HTTP API is an alternate way to read/write to the Hub. Please see the 
 1. Timestamps are calculated from the [Farcaster epoch](./Utils.md#time), not the Unix epoch.
 2. Errors are handled with [a monadic pattern](./Utils.md#errors), instead of try-catch.
 3. [Ethers](https://www.npmjs.com/package/ethers) and [noble](https://www.npmjs.com/package/@noble/ed25519) are required to create new messages.
-4. Only Nodejs is supported, and browser support is a [work in progress](https://github.com/farcasterxyz/hubble/issues/573).
+4. Both Nodejs and [browser environments are supported](https://github.com/farcasterxyz/hubble/issues/573).
 5. Fixed length data is encoded in [byte formats](./Utils.md#bytes), instead of strings.
 
 There are also a few Farcaster-specific terms that are very commonly used in this package:


### PR DESCRIPTION
## Motivation

Browser support was added via https://github.com/farcasterxyz/hub-monorepo/issues/573 but this documentation was not updated to reflex those changes

## Change Summary

See above ^

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the README.md file in the hub-nodejs package. It includes changes related to error handling, required packages, and support for both Nodejs and browser environments.

### Detailed summary
- Updated support information for Nodejs and browser environments.
- Improved error handling with a monadic pattern.
- Clarified the required packages for creating new messages.
- Encoded fixed length data in byte formats for consistency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->