### PR TITLE
perf: Use countKeysAtPrefix for storage cache counts

### DIFF
--- a/.changeset/eight-falcons-think.md
+++ b/.changeset/eight-falcons-think.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+perf: Count keys at prefix directly instead of forEachIterator

--- a/apps/hubble/src/addon/src/lib.rs
+++ b/apps/hubble/src/addon/src/lib.rs
@@ -113,7 +113,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("dbDel", RocksDB::js_del)?;
     cx.export_function("dbCommit", RocksDB::js_commit_transaction)?;
     cx.export_function("dbSnapshotBackup", RocksDB::js_snapshot_backup)?;
-
+    cx.export_function("dbCountKeysAtPrefix", RocksDB::js_count_keys_at_prefix)?;
     cx.export_function(
         "dbForEachIteratorByPrefix",
         RocksDB::js_for_each_iterator_by_prefix,

--- a/apps/hubble/src/rustfunctions.ts
+++ b/apps/hubble/src/rustfunctions.ts
@@ -281,6 +281,10 @@ export const rsDbForEachIteratorByOpts = async (
   return !stopped && allFinished;
 };
 
+export const rsDbCountKeysAtPrefix = async (db: RustDb, prefix: Uint8Array): Promise<number> => {
+  return await lib.dbCountKeysAtPrefix.call(db, prefix);
+};
+
 export const rsCreateStoreEventHandler = (
   epoch?: number,
   last_timestamp?: number,

--- a/apps/hubble/src/storage/db/rocksdb.ts
+++ b/apps/hubble/src/storage/db/rocksdb.ts
@@ -17,6 +17,7 @@ import {
   rsDbPut,
   RustDb,
   rustErrorToHubError,
+  rsDbCountKeysAtPrefix,
 } from "../../rustfunctions.js";
 import { PageOptions } from "storage/stores/types.js";
 
@@ -181,7 +182,11 @@ class RocksDB {
   }
 
   async commit(tsx: RocksDbTransaction): Promise<void> {
-    return rsDbCommit(this._db, tsx.getKeyValues());
+    return await rsDbCommit(this._db, tsx.getKeyValues());
+  }
+
+  async countKeysAtPrefix(prefix: Buffer): Promise<number> {
+    return await rsDbCountKeysAtPrefix(this._db, prefix);
   }
 
   /**
@@ -192,7 +197,7 @@ class RocksDB {
     callback: (key: Buffer, value: Buffer | undefined) => Promise<boolean> | boolean | Promise<void> | void,
     pageOptions: PageOptions = {},
   ): Promise<boolean> {
-    return rsDbForEachIteratorByPrefix(this._db, prefix, pageOptions, callback);
+    return await rsDbForEachIteratorByPrefix(this._db, prefix, pageOptions, callback);
   }
 
   /**
@@ -203,7 +208,7 @@ class RocksDB {
     options: RocksDbIteratorOptions,
     callback: (key: Buffer | undefined, value: Buffer | undefined) => Promise<boolean> | boolean | void,
   ): Promise<boolean> {
-    return rsDbForEachIteratorByOpts(this._db, options, callback);
+    return await rsDbForEachIteratorByOpts(this._db, options, callback);
   }
 
   async approximateSize(): Promise<number> {

--- a/apps/hubble/src/storage/stores/storageCache.ts
+++ b/apps/hubble/src/storage/stores/storageCache.ts
@@ -38,7 +38,6 @@ export class StorageCache {
   private _counts: Map<string, number>;
   private _earliestTsHashes: Map<string, Uint8Array>;
   private _activeStorageSlots: Map<number, StorageSlot>;
-  private prepopulateComplete = false;
   private _pendingMessageCountScans = 0;
 
   constructor(db: RocksDB, usage?: Map<string, number>) {
@@ -107,10 +106,9 @@ export class StorageCache {
 
       // Recheck the count in case it was set by another thread (i.e. no race conditions)
       if (this._counts.get(key) === undefined) {
+        // We should maybe turn this into a LRU cache, otherwise it scales by the number
+        // of fids*set types.
         this._counts.set(key, total);
-        if (this.prepopulateComplete) {
-          log.debug({ fid, set, total }, `storage cache miss for fid: ${fid}`);
-        }
       }
 
       this._pendingMessageCountScans -= 1;


### PR DESCRIPTION
## Motivation

Instead of using a `forEachIteratorAtPrefix` which incurs FFI + JS object creation + GC overhead, directly count the keys of a prefix in rust to speed up StorageCache calculations



## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving performance in the `@farcaster/hubble` module by optimizing key counting operations.

### Detailed summary
- Introduced `rsDbCountKeysAtPrefix` function to directly count keys at a prefix in Rust
- Added `dbCountKeysAtPrefix` function in Rust to count keys with a given prefix
- Updated `countKeysAtPrefix` method in TypeScript to utilize the new Rust functions
- Refactored key counting operations for efficiency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->