### PR TITLE
fix: Calculate sleep time correctly for throttling validateOrRevoke job

### DIFF
--- a/.changeset/thick-phones-boil.md
+++ b/.changeset/thick-phones-boil.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Calculate sleep time correctly for throttling validateOrRevoke job

--- a/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
@@ -14,7 +14,7 @@ export const DEFAULT_VALIDATE_AND_REVOKE_MESSAGES_CRON = "0 12 * * *"; // Every 
 
 // How much time to allocate to validating and revoking each fid.
 // 50 fids per second, which translates to 1/14th of the FIDs will be checked in just over 2 hours.
-const TIME_SCHEDULED_PER_FID_PER_S = 50;
+const TIME_SCHEDULED_PER_FID_MS = 1000 / 50;
 
 const log = logger.child({
   component: "ValidateOrRevokeMessagesJob",
@@ -117,7 +117,7 @@ export class ValidateOrRevokeMessagesJobScheduler {
         // Throttle the job.
         // We run at the rate of 50 fids per second. If we are running ahead of schedule, we sleep to catch up
         if (fid % 100 === 0) {
-          const allotedTimeMs = TIME_SCHEDULED_PER_FID_PER_S * fid * 1000;
+          const allotedTimeMs = fid * TIME_SCHEDULED_PER_FID_MS;
           const elapsedTimeMs = Date.now() - start;
           if (allotedTimeMs > elapsedTimeMs) {
             const sleepTimeMs = allotedTimeMs - elapsedTimeMs;


### PR DESCRIPTION
## Motivation

Bugfix to calculate throttling speed correctly for validate or revoke job


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the calculation of sleep time for throttling in the `ValidateOrRevokeMessagesJob` to ensure accurate job scheduling.

### Detailed summary
- Updated `TIME_SCHEDULED_PER_FID_MS` calculation for accurate job timing
- Adjusted sleep time calculation based on fid processing progress

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->