### PR TITLE
fix: add missing db and redis exports to hub-shuttle

### DIFF
--- a/.changeset/eleven-suits-eat.md
+++ b/.changeset/eleven-suits-eat.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hub-shuttle": patch
+---
+
+fix: add missing db and redis exports to hub-shuttle

--- a/packages/hub-shuttle/src/index.ts
+++ b/packages/hub-shuttle/src/index.ts
@@ -1,5 +1,7 @@
 export * from "./shuttle/interfaces";
 export * from "./shuttle/db";
+export * from "./shuttle/redis";
+export * from "./shuttle/hub";
 export * from "./shuttle/hubSubscriber";
 export * from "./shuttle/hubEventProcessor";
 export * from "./shuttle/messageProcessor";


### PR DESCRIPTION
## Motivation

Unable to use `getHubClient` and `RedisClient` from the `hub-shuttle` package.

## Change Summary

Added exports for `db.ts` and `redis.ts` to hub-shuttle's `index.ts`

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes missing exports in `hub-shuttle` package. 

### Detailed summary
- Added missing `db` and `redis` exports to `hub-shuttle`
- Exported `hub` from `index.ts` in `hub-shuttle` package

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->