### PR TITLE
fix: add support for windows file paths in hub-shuttle example app

### DIFF
--- a/.changeset/nine-bobcats-exist.md
+++ b/.changeset/nine-bobcats-exist.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hub-shuttle": patch
+---
+
+fix: add support for windows file paths in example hub-shuttle app

--- a/packages/hub-shuttle/src/app/app.ts
+++ b/packages/hub-shuttle/src/app/app.ts
@@ -11,6 +11,7 @@ import { Command } from "@commander-js/extra-typings";
 import { readFileSync } from "fs";
 import { BACKFILL_FIDS, HUB_HOST, HUB_SSL, POSTGRES_URL, REDIS_URL } from "./env";
 import * as process from "node:process";
+import url from "node:url";
 import { MessageReconciliation } from "../shuttle/messageReconciliation";
 import { MessageHandler, StoreMessageOperation } from "../shuttle/interfaces";
 
@@ -89,7 +90,7 @@ export class App implements MessageHandler {
 }
 
 //If the module is being run directly, start the shuttle
-if (import.meta.url.endsWith(process.argv[1] || "")) {
+if (import.meta.url.endsWith(url.pathToFileURL(process.argv[1] || "").toString())) {
   async function start() {
     log.info(`Creating app connecting to: ${POSTGRES_URL}, ${REDIS_URL}, ${HUB_HOST}`);
     const app = App.create(POSTGRES_URL, REDIS_URL, HUB_HOST, HUB_SSL);


### PR DESCRIPTION
## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

The hub-shuttle example fails to run on windows because the conditional that checks if the file is being run directly fails due to windows file paths not matching node file paths e.g.

```ts
console.log(import.meta.url);
console.log(process.argv[1]);
console.log(url.pathToFileURL(process.argv[1]).toString())
console.log(url.pathToFileURL("").toString())

// file:///C:/Users/stephan/environments/opencast-shuttle/src/app/app.ts
// C:\Users\stephan\environments\opencast-shuttle\src\app\app.ts
// file:///C:/Users/stephan/environments/opencast-shuttle/src/app/app.ts
// file:///C:/Users/stephan/environments/opencast-shuttle
```

## Change Summary

Use the `node:url` package's `pathToFileURL` method to ensure file paths have the correct format.

I have confirmed the behaviour remains the same on mac.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing support for Windows file paths in the `hub-shuttle` example app.

### Detailed summary
- Fixed support for Windows file paths in the `hub-shuttle` example app
- Updated the usage of `url` module to handle file paths in `App` class

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->