### PR TITLE
fix: Adjust nightly validateOrRevoke job time to run earlier

### DIFF
--- a/.changeset/hip-monkeys-compare.md
+++ b/.changeset/hip-monkeys-compare.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Adjust nightly validateOrRevoke job time to run earlier

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -254,7 +254,6 @@ class Engine extends TypedEmitter<EngineEvents> {
       }
     }
 
-    const start = Date.now();
     const mergeResult = await this.mergeMessageToStore(message);
 
     if (mergeResult.isOk() && limiter) {

--- a/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
@@ -10,7 +10,7 @@ import { statsd } from "../../utils/statsd.js";
 import { getHubState, putHubState } from "../../storage/db/hubState.js";
 import { sleep } from "../../utils/crypto.js";
 
-export const DEFAULT_VALIDATE_AND_REVOKE_MESSAGES_CRON = "0 12 * * *"; // Every day at 12:00 UTC (4 am PST)
+export const DEFAULT_VALIDATE_AND_REVOKE_MESSAGES_CRON = "10 8 * * *"; // Every day at 8:10 UTC (00:10 am PST)
 
 // How much time to allocate to validating and revoking each fid.
 // 50 fids per second, which translates to 1/14th of the FIDs will be checked in just over 2 hours.


### PR DESCRIPTION
## Motivation

Adjust the nightly job to run ~4 hours earlier so it finishes before morning peak traffic

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)
