### PR TITLE
perf: Support multiple validation workers

### DIFF
--- a/.changeset/gold-beds-search.md
+++ b/.changeset/gold-beds-search.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+perf: Support multiple validation workers

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -10,6 +10,7 @@ import {
   hexStringToBytes,
   HubAsyncResult,
   HubError,
+  HubErrorCode,
   HubEvent,
   HubResult,
   isSignerOnChainEvent,
@@ -68,8 +69,30 @@ import { consumeRateLimitByKey, getRateLimiterForTotalMessages, isRateLimitedByK
 import { rsValidationMethods } from "../../rustfunctions.js";
 import { RateLimiterAbstract } from "rate-limiter-flexible";
 import { TypedEmitter } from "tiny-typed-emitter";
-import { ValidationWorkerData } from "./validation.worker.js";
-import { statsd } from "../../utils/statsd.js";
+
+export const NUM_VALIDATION_WORKERS = 2;
+
+export interface ValidationWorkerData {
+  l2RpcUrl: string;
+  ethMainnetRpcUrl: string;
+}
+
+export interface ValidationWorkerMessageWithMessage {
+  id: number;
+  message: Message;
+  errCode?: never;
+  errMessage?: never;
+}
+
+export interface ValidationWorkerMessageWithError {
+  id: number;
+  message?: never;
+  errCode: HubErrorCode;
+  errMessage: string;
+}
+
+// The type of response that the worker sends back to the main thread
+export type ValidationWorkerMessage = ValidationWorkerMessageWithMessage | ValidationWorkerMessageWithError;
 
 const log = logger.child({
   component: "Engine",
@@ -96,7 +119,8 @@ class Engine extends TypedEmitter<EngineEvents> {
   private _onchainEventsStore: OnChainEventStore;
   private _usernameProofStore: UsernameProofStore;
 
-  private _validationWorker: Worker | undefined;
+  private _validationWorkers: Worker[] | undefined;
+  private _nextValidationWorker = 0;
 
   private _validationWorkerJobId = 0;
   private _validationWorkerPromiseMap = new Map<number, (resolve: HubResult<Message>) => void>();
@@ -155,14 +179,12 @@ class Engine extends TypedEmitter<EngineEvents> {
 
     this._revokeSignerWorker.start();
 
-    if (!this._validationWorker) {
+    if (!this._validationWorkers) {
       const workerPath = "./build/storage/engine/validation.worker.js";
       try {
         if (fs.existsSync(workerPath)) {
-          this._validationWorker = new Worker(workerPath, { workerData: this.getWorkerData() });
-          log.info({ workerPath }, "created validation worker thread");
-
-          this._validationWorker.on("message", (data) => {
+          this._validationWorkers = [];
+          const validationWorkerHandler = (data: ValidationWorkerMessage) => {
             const { id, message, errCode, errMessage } = data;
             const resolve = this._validationWorkerPromiseMap.get(id);
 
@@ -176,7 +198,16 @@ class Engine extends TypedEmitter<EngineEvents> {
             } else {
               log.warn({ id }, "validation worker promise.response not found");
             }
-          });
+          };
+
+          const workerData = this.getWorkerData();
+          for (let i = 0; i < NUM_VALIDATION_WORKERS; i++) {
+            const validationWorker = new Worker(workerPath, { workerData });
+            validationWorker.on("message", validationWorkerHandler);
+            log.info({ workerPath }, "created validation worker thread");
+
+            this._validationWorkers.push(validationWorker);
+          }
         } else {
           log.warn({ workerPath }, "validation.worker.js not found, falling back to main thread");
         }
@@ -199,9 +230,12 @@ class Engine extends TypedEmitter<EngineEvents> {
 
     this._revokeSignerWorker.start();
 
-    if (this._validationWorker) {
-      await this._validationWorker.terminate();
-      this._validationWorker = undefined;
+    if (this._validationWorkers) {
+      for (const worker of this._validationWorkers) {
+        await worker.terminate();
+      }
+
+      this._validationWorkers = undefined;
       log.info("validation worker thread terminated");
     }
     log.info("engine stopped");
@@ -1037,8 +1071,11 @@ class Engine extends TypedEmitter<EngineEvents> {
     }
 
     // 6. Check message body and envelope
-    if (this._validationWorker) {
-      const worker = this._validationWorker;
+    if (this._validationWorkers) {
+      this._nextValidationWorker += 1;
+      this._nextValidationWorker = this._nextValidationWorker % this._validationWorkers.length;
+
+      const worker = this._validationWorkers[this._nextValidationWorker] as Worker;
       return new Promise<HubResult<Message>>((resolve) => {
         const id = this._validationWorkerJobId++;
         this._validationWorkerPromiseMap.set(id, resolve);

--- a/apps/hubble/src/storage/engine/validation.worker.ts
+++ b/apps/hubble/src/storage/engine/validation.worker.ts
@@ -3,11 +3,7 @@ import { rsValidationMethods } from "../../rustfunctions.js";
 import { workerData, parentPort } from "worker_threads";
 import { http, createPublicClient, fallback } from "viem";
 import { optimism, mainnet } from "viem/chains";
-
-export interface ValidationWorkerData {
-  l2RpcUrl: string;
-  ethMainnetRpcUrl: string;
-}
+import { ValidationWorkerData, ValidationWorkerMessage } from "./index.js";
 
 const config = workerData as ValidationWorkerData;
 const opMainnetRpcUrls = config.l2RpcUrl.split(",");
@@ -36,9 +32,15 @@ parentPort?.on("message", (data) => {
     const result = await validations.validateMessage(message, rsValidationMethods, publicClients);
 
     if (result.isErr()) {
-      parentPort?.postMessage({ id, errCode: result.error.errCode, errMessage: result.error.message });
+      const response: ValidationWorkerMessage = {
+        id,
+        errCode: result.error.errCode,
+        errMessage: result.error.message,
+      };
+      parentPort?.postMessage(response);
     } else {
-      parentPort?.postMessage({ id, message: result.value });
+      const response: ValidationWorkerMessage = { id, message: result.value };
+      parentPort?.postMessage(response);
     }
   })();
 });

--- a/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
@@ -191,7 +191,7 @@ export class ValidateOrRevokeMessagesJobScheduler {
       return ok(0);
     }
 
-    log.info(
+    log.debug(
       { fid, lastJobTimestamp, latestSignerEventTs, doFullScanForFid },
       "ValidateOrRevokeMessagesJob: checking FID",
     );


### PR DESCRIPTION
## Motivation

Support multiple validation workers so that we can validate messages in parallel. This is not really used yet, but will be once we start merging bundles. 

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances performance by enabling multiple validation workers in the Hubble app.

### Detailed summary
- Added support for multiple validation workers in the Hubble app for improved performance.
- Refactored validation worker handling to utilize an array of workers.
- Updated interfaces and types related to validation workers and messages.
- Improved error handling and response structure in validation worker messages.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->