### PR TITLE
perf: LRU cache for activeSigner and IdRegistry

### DIFF
--- a/.changeset/sour-yaks-protect.md
+++ b/.changeset/sour-yaks-protect.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+perf: Add LRU Cache for active signer and ID registry events

--- a/apps/hubble/src/rpc/test/messageService.test.ts
+++ b/apps/hubble/src/rpc/test/messageService.test.ts
@@ -26,6 +26,10 @@ let syncEngine: SyncEngine;
 let server: Server;
 let client: HubRpcClient;
 
+beforeEach(async () => {
+  engine.clearCaches();
+});
+
 beforeAll(async () => {
   syncEngine = new SyncEngine(hub, db);
   await syncEngine.start();

--- a/apps/hubble/src/rpc/test/signerService.test.ts
+++ b/apps/hubble/src/rpc/test/signerService.test.ts
@@ -39,7 +39,7 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
-  engine.clearCache();
+  engine.clearCaches();
 });
 
 afterAll(async () => {

--- a/apps/hubble/src/storage/db/migrations/3.clearEvents.test.ts
+++ b/apps/hubble/src/storage/db/migrations/3.clearEvents.test.ts
@@ -21,6 +21,7 @@ describe("clearEvents migration", () => {
 
     const success = await performDbMigrations(db, 2, 3);
     expect(success).toBe(true);
+    store.clearCaches();
 
     await expect(store.getIdRegisterEventByFid(event1.fid)).rejects.toThrow("NotFound");
   });
@@ -36,6 +37,7 @@ describe("clearEvents migration", () => {
 
       const success = await performDbMigrations(db, 2, 3);
       expect(success).toBe(true);
+      store.clearCaches();
 
       await expect(store.getIdRegisterEventByFid(event.fid)).resolves.toEqual(event);
     } finally {

--- a/apps/hubble/src/storage/engine/index.test.ts
+++ b/apps/hubble/src/storage/engine/index.test.ts
@@ -97,7 +97,7 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
-  engine.clearCache();
+  engine.clearCaches();
   engine.setSolanaVerifications(false);
 });
 

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -211,8 +211,8 @@ class Engine extends TypedEmitter<EngineEvents> {
     return this._db;
   }
 
-  clearCache() {
-    this._onchainEventsStore.clearActiveSignerCache();
+  clearCaches() {
+    this._onchainEventsStore.clearCaches();
   }
 
   get solanaVerficationsEnabled(): boolean {

--- a/apps/hubble/src/utils/lruCache.test.ts
+++ b/apps/hubble/src/utils/lruCache.test.ts
@@ -1,0 +1,94 @@
+import { LRUCache } from "./lruCache.js";
+
+describe("lruCache", () => {
+  test("cur/prev cache should work", async () => {
+    const cache = new LRUCache<string, string>(2);
+
+    const a = await cache.get("a", async () => "a");
+    expect(a).toEqual("a");
+
+    // Getting a again should not call the get method
+    const a2 = await cache.get("a", async () => "not_called");
+    expect(a2).toEqual("a");
+
+    const b = await cache.get("b", async () => "b");
+    expect(b).toEqual("b");
+
+    // Since cache size is 2, both keys should be in the cache
+    const a3 = await cache.get("a", async () => "not_called");
+    expect(a3).toEqual("a");
+    const b3 = await cache.get("b", async () => "not_called");
+    expect(b3).toEqual("b");
+
+    // Now adding a new key should evict the oldest key
+    const c = await cache.get("c", async () => "c");
+    expect(c).toEqual("c");
+
+    // a and b are now in the "prev" cache
+    const a4 = await cache.get("a", async () => "not_called");
+    expect(a4).toEqual("a");
+
+    // a and c are now in the current cache and "b" is in the "prev" cache. Calling this will
+    // actually call the get method
+    const b4 = await cache.get("b", async () => "b4");
+    expect(b4).toEqual("b4");
+
+    // Clear the cache
+    cache.clear();
+
+    // Cache should be empty
+    const a5 = await cache.get("a", async () => "a5");
+    expect(a5).toEqual("a5");
+
+    const b5 = await cache.get("b", async () => "b5");
+    expect(b5).toEqual("b5");
+  });
+
+  test("invalidate should work", async () => {
+    const cache = new LRUCache<string, string>(2);
+
+    const a = await cache.get("a", async () => "a");
+    expect(a).toEqual("a");
+
+    const b = await cache.get("b", async () => "b");
+    expect(b).toEqual("b");
+
+    cache.invalidate("a");
+
+    const a2 = await cache.get("a", async () => "a2");
+    expect(a2).toEqual("a2");
+
+    const b2 = await cache.get("b", async () => "b2");
+    expect(b2).toEqual("b");
+  });
+
+  test("old keys should be evicted", async () => {
+    const cache = new LRUCache<string, string>(2);
+
+    const a = await cache.get("a", async () => "a");
+    expect(a).toEqual("a");
+
+    const b = await cache.get("b", async () => "b");
+    expect(b).toEqual("b");
+
+    const c = await cache.get("c", async () => "c");
+    expect(c).toEqual("c");
+
+    const d = await cache.get("d", async () => "d");
+    expect(d).toEqual("d");
+
+    const e = await cache.get("e", async () => "e");
+    expect(e).toEqual("e");
+
+    // Now a and b should be evicted
+    const a3 = await cache.get("a", async () => "a3");
+    expect(a3).toEqual("a3");
+
+    const b3 = await cache.get("b", async () => "b3");
+    expect(b3).toEqual("b3");
+
+    // Now current is "b3" and prev is "e" and "a3"
+    const e2 = await cache.get("e", async () => "not_called");
+    expect(e2).toEqual("e");
+  });
+});

--- a/apps/hubble/src/utils/lruCache.ts
+++ b/apps/hubble/src/utils/lruCache.ts
@@ -1,0 +1,71 @@
+/**
+ * A simple LRU cache implementation that uses a double-buffer to store the keys and values.
+ *
+ * The "current" buffer is used to store the most recently accessed keys and values. When the
+ * "current" buffer is full, the existing "prev" buffer is dropped, (dropping the least used
+ * keys), the current buffer is moved to the "prev" buffer and a new "current" buffer is created.
+ *
+ * The "get" method also accepts a function that will be called if the key is not found in the cache.
+ *
+ * If a key is not found in the current buffer, but it is in the "prev" buffer, it is moved to the
+ * current buffer.
+ */
+export class LRUCache<K, T> {
+  current: Map<K, T>;
+  prev: Map<K, T>;
+
+  private maxSize: number;
+
+  constructor(maxSize: number) {
+    this.maxSize = maxSize;
+    this.current = new Map();
+    this.prev = new Map();
+  }
+
+  /**
+   * Get the value associated with the given key. If the key is not found in the cache, the
+   * provided function is called to get the value.
+   *
+   * If the get functon throws, the key is not added to the cache.
+   * and this function will throw the same error.
+   *
+   * @param key The key to lookup
+   * @param fn The function to call if the key is not found in the cache
+   */
+  async get(key: K, fn: () => Promise<T> | T): Promise<T> {
+    // First check if we need to rotate the buffers
+    if (this.current.size >= this.maxSize) {
+      // Rotate the buffers
+      this.prev = this.current;
+      this.current = new Map();
+    }
+
+    let value = this.current.get(key);
+    if (value === undefined) {
+      value = this.prev.get(key);
+      if (value !== undefined) {
+        this.prev.delete(key);
+        this.current.set(key, value);
+      } else {
+        value = await fn();
+        this.current.set(key, value);
+      }
+    }
+
+    return value;
+  }
+
+  /**
+   * Invalidate the given key in the cache.
+   */
+  invalidate(key: K): void {
+    this.current.delete(key);
+    this.prev.delete(key);
+  }
+
+  /** Clear */
+  clear(): void {
+    this.current.clear();
+    this.prev.clear();
+  }
+}


### PR DESCRIPTION
## Motivation

Every validateMessage gets the IdRegistry event and Active Signer. While we were caching signers, we weren't caching the immutable IdRegistry event, which was causing 2 DB gets per validateMessage. 

Cache both these in a new LRUCache


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving performance by adding an LRU Cache for active signers and ID registry events.

### Detailed summary
- Added LRU Cache implementation for caching active signers and ID registry events
- Updated cache clearing methods in the OnChainEventStore class
- Implemented cache retrieval logic in OnChainEventStore methods for active signers and ID registry events
- Added tests for the LRU Cache implementation in the `lruCache.test.ts` file

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->