### PR TITLE
perf: Use threadpool for grpc queries

### DIFF
--- a/.changeset/silly-readers-accept.md
+++ b/.changeset/silly-readers-accept.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+perf: Run long gRPC queries in a threadpool.

--- a/apps/hubble/src/addon/src/store/reaction_store.rs
+++ b/apps/hubble/src/addon/src/store/reaction_store.rs
@@ -1,15 +1,16 @@
 use super::{
-    hub_error_to_js_throw, make_cast_id_key, make_fid_key, make_user_key, message,
+    deferred_settle_messages, hub_error_to_js_throw, make_cast_id_key, make_fid_key, make_user_key,
+    message,
     store::{Store, StoreDef},
-    utils::{encode_messages_to_js_object, get_page_options, get_store},
+    utils::{get_page_options, get_store},
     HubError, IntoU8, MessagesPage, PageOptions, RootPrefix, StoreEventHandler, UserPostfix,
     PAGE_SIZE_MAX, TS_HASH_LENGTH,
 };
-use crate::protos::message_data;
 use crate::{
     db::{RocksDB, RocksDbTransactionBatch},
     protos::{self, reaction_body::Target, Message, MessageType, ReactionBody, ReactionType},
 };
+use crate::{protos::message_data, THREAD_POOL};
 use neon::{
     context::{Context, FunctionContext},
     result::JsResult,
@@ -454,17 +455,14 @@ impl ReactionStore {
         let reaction_type = cx.argument::<JsNumber>(1).unwrap().value(&mut cx) as i32;
 
         let page_options = get_page_options(&mut cx, 2)?;
-
-        let messages =
-            match Self::get_reaction_adds_by_fid(&store, fid, reaction_type, &page_options) {
-                Ok(messages) => messages,
-                Err(e) => return hub_error_to_js_throw(&mut cx, e),
-            };
-
         let channel = cx.channel();
         let (deferred, promise) = cx.promise();
-        deferred.settle_with(&channel, move |mut cx| {
-            encode_messages_to_js_object(&mut cx, messages)
+
+        THREAD_POOL.lock().unwrap().execute(move || {
+            let messages =
+                ReactionStore::get_reaction_adds_by_fid(&store, fid, reaction_type, &page_options);
+
+            deferred_settle_messages(deferred, &channel, messages);
         });
 
         Ok(promise)
@@ -500,21 +498,18 @@ impl ReactionStore {
         let reaction_type = cx.argument::<JsNumber>(1).unwrap().value(&mut cx) as i32;
 
         let page_options = get_page_options(&mut cx, 2)?;
-
-        let messages = match ReactionStore::get_reaction_removes_by_fid(
-            &store,
-            fid,
-            reaction_type,
-            &page_options,
-        ) {
-            Ok(messages) => messages,
-            Err(e) => return hub_error_to_js_throw(&mut cx, e),
-        };
-
         let channel = cx.channel();
         let (deferred, promise) = cx.promise();
-        deferred.settle_with(&channel, move |mut cx| {
-            encode_messages_to_js_object(&mut cx, messages)
+
+        THREAD_POOL.lock().unwrap().execute(move || {
+            let messages = ReactionStore::get_reaction_removes_by_fid(
+                &store,
+                fid,
+                reaction_type,
+                &page_options,
+            );
+
+            deferred_settle_messages(deferred, &channel, messages);
         });
 
         Ok(promise)
@@ -607,20 +602,18 @@ impl ReactionStore {
 
         let page_options = get_page_options(&mut cx, 3)?;
 
-        let messages = match ReactionStore::get_reactions_by_target(
-            &store,
-            &target,
-            reaction_type,
-            &page_options,
-        ) {
-            Ok(messages) => messages,
-            Err(e) => return hub_error_to_js_throw(&mut cx, e),
-        };
-
         let channel = cx.channel();
         let (deferred, promise) = cx.promise();
-        deferred.settle_with(&channel, move |mut cx| {
-            encode_messages_to_js_object(&mut cx, messages)
+
+        THREAD_POOL.lock().unwrap().execute(move || {
+            let messages = ReactionStore::get_reactions_by_target(
+                &store,
+                &target,
+                reaction_type,
+                &page_options,
+            );
+
+            deferred_settle_messages(deferred, &channel, messages);
         });
 
         Ok(promise)


### PR DESCRIPTION
## Motivation

Some grpc queries were being executed in the main thread, and so when there was a lot of queries, the main thread would get locked up, causing the grpc health check to sometimes fail because the main thread didn't respond in time.

This PR offloads some of the work of the queries, so as long as the server is healthy, it can immediately respond to healthchecks. In addition, this PR allows the servers to serve more clients/queries. 



## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to improve performance by running long gRPC queries in a threadpool.

### Detailed summary
- Added `deferred_settle_messages` function to handle settling promises with messages
- Moved gRPC query handling to a threadpool for improved performance

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->