### PR TITLE
fix: Change out-of-order warning to statsd

### DIFF
--- a/.changeset/clean-flies-smoke.md
+++ b/.changeset/clean-flies-smoke.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Change out-of-order warning to statsd

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -1166,7 +1166,8 @@ export default class Server {
         let lastEventId = 0;
         const eventListener = (event: HubEvent) => {
           if (event.id <= lastEventId) {
-            log.warn({ event, lastEventId }, "subscribe: Out-of-order event sent on subscribe()");
+            // log.warn({ event, lastEventId }, "subscribe: Out-of-order event sent on subscribe()");
+            statsd().increment("rpc.subscribe.out_of_order");
           }
           lastEventId = event.id;
           bufferedStreamWriter.writeToStream(event);


### PR DESCRIPTION
## Motivation

Instead of logging out-of-order warnings, change them to statsd metric

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `hubble` app to fix an out-of-order warning by replacing it with a statsd increment call.

### Detailed summary
- Changed out-of-order warning to statsd increment call in `rpc/server.ts` of `hubble` app.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->