### PR TITLE
perf: Use threadpool while pruning old hub events

### DIFF
--- a/.changeset/perfect-points-nail.md
+++ b/.changeset/perfect-points-nail.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Prune hub events in a threadpool

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -39,7 +39,7 @@
     "test": "yarn test:ts && yarn test:rust",
     "test:ts": "yarn build:all && NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096\" jest",
     "test:rust": "cargo test --manifest-path ./src/addon/Cargo.toml",
-    "test:ci": "yarn build:all && yarn test:rust --release && ENVIRONMENT=test NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096\" jest --ci --forceExit --coverage -w 3"
+    "test:ci": "yarn build:all && yarn test:rust --release && ENVIRONMENT=test NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096\" jest --ci --forceExit --coverage -w 2"
   },
   "devDependencies": {
     "@libp2p/interface-mocks": "^9.0.0",

--- a/apps/hubble/src/addon/src/lib.rs
+++ b/apps/hubble/src/addon/src/lib.rs
@@ -115,6 +115,10 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("dbSnapshotBackup", RocksDB::js_snapshot_backup)?;
     cx.export_function("dbCountKeysAtPrefix", RocksDB::js_count_keys_at_prefix)?;
     cx.export_function(
+        "dbDeleteAllKeysInRange",
+        RocksDB::js_delete_all_keys_in_range,
+    )?;
+    cx.export_function(
         "dbForEachIteratorByPrefix",
         RocksDB::js_for_each_iterator_by_prefix,
     )?;

--- a/apps/hubble/src/rustfunctions.ts
+++ b/apps/hubble/src/rustfunctions.ts
@@ -285,6 +285,10 @@ export const rsDbCountKeysAtPrefix = async (db: RustDb, prefix: Uint8Array): Pro
   return await lib.dbCountKeysAtPrefix.call(db, prefix);
 };
 
+export const rsDbDeleteAllKeysInRange = async (db: RustDb, iteratorOpts: RocksDbIteratorOptions): Promise<boolean> => {
+  return await lib.dbDeleteAllKeysInRange.call(db, iteratorOpts);
+};
+
 export const rsCreateStoreEventHandler = (
   epoch?: number,
   last_timestamp?: number,

--- a/apps/hubble/src/storage/db/rocksdb.ts
+++ b/apps/hubble/src/storage/db/rocksdb.ts
@@ -18,6 +18,7 @@ import {
   RustDb,
   rustErrorToHubError,
   rsDbCountKeysAtPrefix,
+  rsDbDeleteAllKeysInRange,
 } from "../../rustfunctions.js";
 import { PageOptions } from "storage/stores/types.js";
 
@@ -187,6 +188,10 @@ class RocksDB {
 
   async countKeysAtPrefix(prefix: Buffer): Promise<number> {
     return await rsDbCountKeysAtPrefix(this._db, prefix);
+  }
+
+  async deleteAllKeysInRange(options: RocksDbIteratorOptions): Promise<boolean> {
+    return await rsDbDeleteAllKeysInRange(this._db, options);
   }
 
   /**

--- a/apps/hubble/src/storage/stores/storeEventHandler.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.ts
@@ -364,21 +364,12 @@ class StoreEventHandler extends TypedEmitter<StoreEvents> {
       return err(iteratorOpts.error);
     }
 
-    let error: HubError | undefined;
-    await this._db.forEachIteratorByOpts(iteratorOpts.value, async (key, _value) => {
-      const result = await ResultAsync.fromPromise(this._db.del(key as Buffer), (e) => e as HubError);
-      if (result.isErr()) {
-        error = result.error;
-        return true; // stop iteration
-      }
-      return false;
-    });
+    const result = await ResultAsync.fromPromise(
+      this._db.deleteAllKeysInRange(iteratorOpts.value),
+      (e) => e as HubError,
+    );
 
-    if (error) {
-      return err(error);
-    } else {
-      return ok(undefined);
-    }
+    return result.map((_) => {});
   }
 
   private broadcastEvent(event: HubEvent): HubResult<void> {


### PR DESCRIPTION
## Motivation

Use the threadpool while pruning old hub events


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing and optimizing hub events pruning in a threadpool. 

### Detailed summary
- Added `rsDbDeleteAllKeysInRange` function in `rustfunctions.ts`
- Updated `storeEventHandler.ts` to use `deleteAllKeysInRange`
- Modified `package.json` to change test concurrency to 2
- Updated `utils.rs` and `rocksdb.rs` for iterator options and key deletion functionality

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->