### PR TITLE
chore: update catchup sync with snapshot default to true

### DIFF
--- a/.changeset/swift-eggs-sparkle.md
+++ b/.changeset/swift-eggs-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+chore: update catchup sync with snapshot default to true

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -134,7 +134,7 @@ app
   .option("--enable-snapshot-to-s3", "Enable daily snapshots to be uploaded to S3. (default: disabled)")
   .option("--s3-snapshot-bucket <bucket>", "The S3 bucket to upload snapshots to")
   .option("--disable-snapshot-sync", "Disable syncing from snapshots. (default: enabled)")
-  .option("--catchup-sync-with-snapshot [boolean]", "Enable catchup sync with snapshot. (default: disabled)")
+  .option("--catchup-sync-with-snapshot [boolean]", "Enable catchup sync with snapshot. (default: enabled)")
   .option(
     "--catchup-sync-snapshot-message-limit <number>",
     `Difference in message count before triggering snapshot sync. (default: ${DEFAULT_CATCHUP_SYNC_SNAPSHOT_MESSAGE_LIMIT})`,

--- a/apps/hubble/src/defaultConfig.ts
+++ b/apps/hubble/src/defaultConfig.ts
@@ -59,7 +59,7 @@ export const Config = {
   /** Catchup sync with snapshot
    * NOTE: Catchup sync using snapshot WILL RESET THE DATABASE
    */
-  catchupSyncWithSnapshot: false,
+  catchupSyncWithSnapshot: true,
   /**
    * Message limit - when exceeded, trigger catchup sync using snapshot
    * NOTE: Catchup sync using snapshot WILL RESET THE DATABASE


### PR DESCRIPTION
## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the catchup sync with snapshot feature in the `@farcaster/hubble` package to default to true.

### Detailed summary
- Updated `catchupSyncWithSnapshot` default value to `true` in `defaultConfig.ts`
- Updated help text for `--catchup-sync-with-snapshot` option in `cli.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->