### PR TITLE
perf: Use threadpool for getMany

### DIFF
--- a/.changeset/proud-feet-draw.md
+++ b/.changeset/proud-feet-draw.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+perf: Use threadpool to getMany


### PR DESCRIPTION
## Motivation

Use the thread pool to `getMany`, since it doesn't block the main thread. 


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves performance by utilizing a threadpool for fetching multiple values in `rocksdb.rs`.

### Detailed summary
- Utilizes a threadpool to fetch multiple values in `rocksdb.rs`
- Restructures code to use threadpool for better performance
- Updates promise handling for asynchronous execution

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->