### PR TITLE
fix: Cleanup DB on destroy and reset TrieDB before catchupWithSnapshot

### DIFF
--- a/.changeset/hungry-hounds-poke.md
+++ b/.changeset/hungry-hounds-poke.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Cleanup DB directory after destroy and reset TrieDB before catchupSyncwithSnapshot

--- a/apps/hubble/src/addon/src/db/rocksdb.rs
+++ b/apps/hubble/src/addon/src/db/rocksdb.rs
@@ -159,10 +159,16 @@ impl RocksDB {
         self.close()?;
         let path = Path::new(&self.path);
 
-        rocksdb::DB::destroy(&rocksdb::Options::default(), path).map_err(|e| HubError {
-            code: "db.internal_error".to_string(),
-            message: e.to_string(),
-        })
+        let result =
+            rocksdb::DB::destroy(&rocksdb::Options::default(), path).map_err(|e| HubError {
+                code: "db.internal_error".to_string(),
+                message: e.to_string(),
+            });
+
+        // Also rm -rf the directory, ignore any errors
+        let _ = fs::remove_dir_all(path);
+
+        result
     }
 
     pub fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, HubError> {

--- a/apps/hubble/src/defaultConfig.ts
+++ b/apps/hubble/src/defaultConfig.ts
@@ -10,7 +10,7 @@ const DEFAULT_GOSSIP_PORT = 2282;
 const DEFAULT_RPC_PORT = 2283;
 const DEFAULT_HTTP_API_PORT = 2281;
 const DEFAULT_NETWORK = 3; // Farcaster Devnet
-export const DEFAULT_CATCHUP_SYNC_SNAPSHOT_MESSAGE_LIMIT = 3_000_000;
+export const DEFAULT_CATCHUP_SYNC_SNAPSHOT_MESSAGE_LIMIT = 10_000_000;
 
 export const Config = {
   /** Path to a PeerId file */

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -879,9 +879,12 @@ export class Hub implements HubInterface {
       log.info(`beginning snapshot sync in ${SHUTDOWN_GRACE_PERIOD_MS.toString()}ms - THIS WILL RESET THE DATABASE`);
       // Sleep for a bit to allow user some time to cancel the operation before we purge the DB
       await sleep(SHUTDOWN_GRACE_PERIOD_MS);
+
       // We use the item count in the trie RocksDB to determine if catchup sync is warranted.
       // However, the messages RocksDB will be cleared and replaced with the downloaded snapshot which contains both DBs.
+      rsDbDestroy(this.syncEngine.trie.getDb().rustDb);
       rsDbDestroy(this.rocksDB.rustDb);
+
       const snapshotResult = await this.snapshotSync(true);
       if (snapshotResult.isErr()) {
         log.error({ error: snapshotResult.error }, "failed to sync snapshot, falling back to diff sync");


### PR DESCRIPTION
## Motivation

Cleanup the DB directory on destroy and also reset the trieDB when we attempt to catchup sync from snapshot


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving database cleanup and synchronization in the `@farcaster/hubble` module.

### Detailed summary
- Increased `DEFAULT_CATCHUP_SYNC_SNAPSHOT_MESSAGE_LIMIT` to 10,000,000
- Added directory cleanup after destroying DB in `rocksdb.rs`
- Improved handling of DB cleanup and synchronization in `hubble.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->