### PR TITLE
tests: Cleanup after tests

### DIFF
--- a/.changeset/purple-buses-invent.md
+++ b/.changeset/purple-buses-invent.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+tests: Cleanup after tests properly

--- a/apps/hubble/src/addon/src/db/rocksdb.rs
+++ b/apps/hubble/src/addon/src/db/rocksdb.rs
@@ -1165,7 +1165,13 @@ mod tests {
 
     #[test]
     fn test_count_keys_at_prefix() {
-        let db = crate::db::RocksDB::new("/tmp/testdb").unwrap();
+        let tmp_path = tempfile::tempdir()
+            .unwrap()
+            .path()
+            .as_os_str()
+            .to_string_lossy()
+            .to_string();
+        let db = crate::db::RocksDB::new(&tmp_path).unwrap();
         db.open().unwrap();
 
         // Add some keys
@@ -1197,5 +1203,8 @@ mod tests {
         // Count keys at prefix with a specific prefix that doesn't exist
         let count = db.count_keys_at_prefix(b"key201");
         assert_eq!(count.unwrap(), 0);
+
+        // Cleanup
+        db.destroy().unwrap();
     }
 }

--- a/apps/hubble/src/test/e2e/hubbleNetwork.test.ts
+++ b/apps/hubble/src/test/e2e/hubbleNetwork.test.ts
@@ -49,7 +49,7 @@ describe("hubble gossip and sync tests", () => {
     };
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await fnameServer.stop();
 
     // rm -rf the rocksdb directory

--- a/apps/hubble/src/test/e2e/hubbleStartup.test.ts
+++ b/apps/hubble/src/test/e2e/hubbleStartup.test.ts
@@ -49,7 +49,7 @@ describe("hubble startup tests", () => {
     };
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await fnameServer.stop();
 
     // rm -rf the rocksdb directory


### PR DESCRIPTION
## Motivation

Cleanup properly after tests

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates test cleanup procedures and improves resource management in the `hubble` app. 

### Detailed summary
- Updated test cleanup from `afterAll` to `afterEach`
- Improved resource handling in `hubbleNetwork.test.ts` and `hubbleStartup.test.ts`
- Added resource cleanup in `rocksdb.rs` test module

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->