### PR TITLE
chore: Run ValidateOrRevokeMessages job once a month for an fid

### DIFF
--- a/.changeset/fair-lions-compete.md
+++ b/.changeset/fair-lions-compete.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+chore: Run validateOrRevoke once a month

--- a/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.test.ts
+++ b/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.test.ts
@@ -95,7 +95,7 @@ describe("ValidateOrRevokeMessagesJob", () => {
     expect(result2._unsafeUnwrap()).toBe(1);
   });
 
-  test("doJobForFid checks message when fid % 14 matches", async () => {
+  test("doJobForFid checks message when fid % 28 matches", async () => {
     // There is nothing in the DB, so if we add a message, it should get checked.
     await engine.mergeOnChainEvent(custodyEvent);
     await engine.mergeOnChainEvent(signerEvent);

--- a/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
@@ -10,10 +10,10 @@ import { statsd } from "../../utils/statsd.js";
 import { getHubState, putHubState } from "../../storage/db/hubState.js";
 import { sleep } from "../../utils/crypto.js";
 
-export const DEFAULT_VALIDATE_AND_REVOKE_MESSAGES_CRON = "10 8 * * *"; // Every day at 8:10 UTC (00:10 am PST)
+export const DEFAULT_VALIDATE_AND_REVOKE_MESSAGES_CRON = "10 20 * * *"; // Every day at 20:10 UTC (00:10 pm PST)
 
 // How much time to allocate to validating and revoking each fid.
-// 50 fids per second, which translates to 1/14th of the FIDs will be checked in just over 2 hours.
+// 50 fids per second, which translates to 1/28th of the FIDs will be checked in just over 2 hours.
 const TIME_SCHEDULED_PER_FID_MS = 1000 / 50;
 
 const log = logger.child({
@@ -184,8 +184,8 @@ export class ValidateOrRevokeMessagesJobScheduler {
         }, 0),
     ).unwrapOr(0);
 
-    // Every 14 days, we do a full scan of all messages for this FID, to make sure we don't miss anything
-    const doFullScanForFid = fid % 14 === new Date(Date.now()).getDate() % 14;
+    // Every 28 days, we do a full scan of all messages for this FID, to make sure we don't miss anything
+    const doFullScanForFid = fid % 28 === new Date(Date.now()).getDate() % 28;
 
     if (!doFullScanForFid && latestSignerEventTs < lastJobTimestamp) {
       return ok(0);


### PR DESCRIPTION
## Motivation

- The ValidateOrRevoke messages job is normally run if the signers change, but we also run once a month for backup (used to be 14 days)
- Run the job during low-traffic time

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `validateOrRevokeMessagesJob` to run once a month instead of every day, and adjusts the fid calculation to check 1/28th instead of 1/14th.

### Detailed summary
- Updated cron schedule to run `validateOrRevokeMessagesJob` once a month.
- Changed fid calculation to check 1/28th of the FIDs.
- Updated test to reflect fid % 28 matching.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->