### PR TITLE
chore: Release 1.11.6

### DIFF
--- a/.changeset/fair-lions-compete.md
+++ b/.changeset/fair-lions-compete.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-chore: Run validateOrRevoke once a month

--- a/.changeset/hungry-hounds-poke.md
+++ b/.changeset/hungry-hounds-poke.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Cleanup DB directory after destroy and reset TrieDB before catchupSyncwithSnapshot

--- a/.changeset/proud-feet-draw.md
+++ b/.changeset/proud-feet-draw.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-perf: Use threadpool to getMany

--- a/.changeset/purple-buses-invent.md
+++ b/.changeset/purple-buses-invent.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-tests: Cleanup after tests properly

--- a/.changeset/swift-eggs-sparkle.md
+++ b/.changeset/swift-eggs-sparkle.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-chore: update catchup sync with snapshot default to true

--- a/.changeset/wet-crabs-travel.md
+++ b/.changeset/wet-crabs-travel.md
@@ -1,8 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
-"@farcaster/hub-web": patch
-"@farcaster/core": patch
-"@farcaster/hubble": patch
----
-
-feat: Add gossip MessageBundles

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @farcaster/hubble
 
+## 1.11.6
+
+### Patch Changes
+
+- 6b4ea835: chore: Run validateOrRevokeMessagesJob once a month for each fid
+- f1ffdd73: fix: Cleanup DB directory after destroy and reset TrieDB before catchupSyncwithSnapshot
+- ce3f4241: perf: Use threadpool to getMany
+- 86566b15: tests: Cleanup after tests properly
+- 36191e5a: chore: update catchup sync with snapshot default to true
+- 5ca5a4a5: feat: Add gossip MessageBundles
+- Updated dependencies [5ca5a4a5]
+  - @farcaster/hub-nodejs@0.11.9
+
 ## 1.11.5
 
 ### Patch Changes
@@ -25,7 +38,7 @@
   - Add CLI flag `--diagnostic-report-url <url>`, and environment variables `HUB_DIAGNOSTICS_API_KEY`, `HUB_DIAGNOSTICS_APP_KEY` environment variables to pass in configurable DataDog-compatible URL and authorization tokens.
 
   fix(hubble): Add `L2_RPC_AUTHORIZATION_HEADER` environment variable for use with L2 RPC URLs that require authorization headers for access.
-  
+
 ## 1.11.4
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.11.5",
+  "version": "1.11.6",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -74,7 +74,7 @@
     "@chainsafe/libp2p-gossipsub": "6.1.0",
     "@chainsafe/libp2p-noise": "^11.0.0 ",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.11.8",
+    "@farcaster/hub-nodejs": "^0.11.9",
     "@fastify/cors": "^8.4.0",
     "@figma/hot-shots": "^9.0.0-figma.1",
     "@grpc/grpc-js": "~1.8.21",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/core
 
+## 0.14.9
+
+### Patch Changes
+
+- 5ca5a4a5: feat: Add gossip MessageBundles
+
 ## 0.14.8
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.14.8",
+  "version": "0.14.9",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hub-nodejs
 
+## 0.11.9
+
+### Patch Changes
+
+- 5ca5a4a5: feat: Add gossip MessageBundles
+- Updated dependencies [5ca5a4a5]
+  - @farcaster/core@0.14.9
+
 ## 0.11.8
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@farcaster/core": "0.14.8",
+    "@farcaster/core": "0.14.9",
     "@grpc/grpc-js": "~1.8.21",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"

--- a/packages/hub-web/CHANGELOG.md
+++ b/packages/hub-web/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hub-web
 
+## 0.8.6
+
+### Patch Changes
+
+- 5ca5a4a5: feat: Add gossip MessageBundles
+- Updated dependencies [5ca5a4a5]
+  - @farcaster/core@0.14.9
+
 ## 0.8.5
 
 ### Patch Changes

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-web",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -28,7 +28,7 @@
     "ts-proto": "^1.146.0"
   },
   "dependencies": {
-    "@farcaster/core": "^0.14.7",
+    "@farcaster/core": "^0.14.9",
     "@improbable-eng/grpc-web": "^0.15.0",
     "rxjs": "^7.8.0"
   }


### PR DESCRIPTION
## Motivation

v 1.11.6 release


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates version numbers and dependencies across multiple packages. 

### Detailed summary
- Updated version to `0.14.9` in `@farcaster/core`
- Updated version to `0.8.6` in `@farcaster/hub-web`
- Updated version to `0.11.9` in `@farcaster/hub-nodejs`
- Updated version to `1.11.6` in `@farcaster/hubble`
- Added gossip `MessageBundles` feature

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->