### PR TITLE
fix: Handle axios errors while reporting errors

### DIFF
--- a/.changeset/lemon-tigers-swim.md
+++ b/.changeset/lemon-tigers-swim.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Handle axios errors while reporting to Datadog

--- a/apps/hubble/src/utils/diagnosticReportWorker.ts
+++ b/apps/hubble/src/utils/diagnosticReportWorker.ts
@@ -9,6 +9,7 @@ import {
 import { logger } from "./logger.js";
 import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
 import { constants as httpConstants } from "http2";
+import { Result, ResultAsync, ok } from "neverthrow";
 
 const DataDogEventAlert = {
   ERROR: "error",
@@ -92,7 +93,7 @@ parentPort?.on("message", async (message: unknown) => {
     return;
   }
 
-  let response: AxiosResponse<unknown, unknown> | null = null;
+  let response: Result<AxiosResponse<unknown, unknown>, Error> | null = null;
   switch (messageType) {
     case DiagnosticReportMessageType.Error: {
       const data = payload as DiagnosticReportMessageSpec[DiagnosticReportMessageType.Error];
@@ -108,26 +109,31 @@ parentPort?.on("message", async (message: unknown) => {
       logger.error({ type: messageType }, "Unknown diagnostic report message type");
   }
 
-  if (
-    response &&
-    !(response.status === httpConstants.HTTP_STATUS_ACCEPTED || response.status === httpConstants.HTTP_STATUS_OK)
+  if (response?.isErr()) {
+    logger.error({ error: response.error }, "Error while reporting diagnostic to Datadog");
+  } else if (
+    response?.isOk() &&
+    !(
+      response.value.status === httpConstants.HTTP_STATUS_ACCEPTED ||
+      response.value.status === httpConstants.HTTP_STATUS_OK
+    )
   ) {
     logger.error(
       {
-        status: response.status,
-        response_data: JSON.stringify(response.data),
+        status: response.value.status,
+        response_data: JSON.stringify(response.value.data),
       },
       "Failed to report diagnostic to Datadog",
     );
   }
 });
 
-const postDataDogEvent = (
+const postDataDogEvent = async (
   request: DataDogEventCreateRequest,
   config: DiagnosticReportConfig,
-): Promise<AxiosResponse> => {
+): Promise<Result<AxiosResponse, Error>> => {
   if (config.optOut) {
-    return Promise.resolve({} as AxiosResponse);
+    return Promise.resolve(ok({} as AxiosResponse));
   }
 
   const baseURL = new URL(config.reportURL);
@@ -141,10 +147,14 @@ const postDataDogEvent = (
       ...(process.env["HUB_DIAGNOSTICS_APP_KEY"] && { "DD-APP-KEY": process.env["HUB_DIAGNOSTICS_APP_KEY"] }),
     },
   };
-  return axios.post(errorURL.toString(), request, requestConfig);
+
+  return ResultAsync.fromPromise(axios.post(errorURL.toString(), request, requestConfig), (e) => e as Error);
 };
 
-export const postErrorEvent = async (error: Error, config: DiagnosticReportConfig): Promise<AxiosResponse> => {
+export const postErrorEvent = async (
+  error: Error,
+  config: DiagnosticReportConfig,
+): Promise<Result<AxiosResponse, Error>> => {
   const errorMessage: string = `[error]: ${error.message}`;
   // Check if the stack trace is available, as it might be undefined in some environments
   const stackTrace: string = error.stack ? `\n[stack_trace]:\n${error.stack}` : " [stack_trace: unavailable]";
@@ -164,7 +174,7 @@ export const postErrorEvent = async (error: Error, config: DiagnosticReportConfi
 export const postUnavailableEvent = async (
   payload: DiagnosticReportUnavailablePayload,
   config: DiagnosticReportConfig,
-) => {
+): Promise<Result<AxiosResponse, Error>> => {
   const context = payload.context ? `\n[context]:\n${JSON.stringify(payload.context, null, 2)}` : "";
   const text: string = `${payload.message}${context}`;
   const params: DataDogEventCreateRequest = {


### PR DESCRIPTION
## Motivation

Handle axios errors while reporting errors to datadog

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing axios error handling while reporting to Datadog in the `diagnosticReportWorker.ts` file.

### Detailed summary
- Updated `response` variable to use `Result` type for axios response
- Modified error handling logic based on `Result` type
- Changed return type of `postDataDogEvent` and `postErrorEvent` functions to `Result` type

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->