### PR TITLE
fix: update diagnostics reports to prefix tags with fid and peer_id

### DIFF
--- a/.changeset/large-bobcats-destroy.md
+++ b/.changeset/large-bobcats-destroy.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: update diagnostics reports to prefix tags with fid and peer_id

--- a/apps/hubble/src/utils/diagnosticReportWorker.ts
+++ b/apps/hubble/src/utils/diagnosticReportWorker.ts
@@ -149,13 +149,17 @@ export const postErrorEvent = async (error: Error, config: DiagnosticReportConfi
   // Check if the stack trace is available, as it might be undefined in some environments
   const stackTrace: string = error.stack ? `\n[stack_trace]:\n${error.stack}` : " [stack_trace: unavailable]";
   const text: string = `${errorMessage}${stackTrace}`;
-
+  const tags: string[] = [
+    "type:error",
+    ...((config.fid && [`fid:${config.fid.toString(10)}`]) || []),
+    ...((config.peerId && [`peer_id:${config.peerId}`]) || []),
+  ];
   const params: DataDogEventCreateRequest = {
     alertType: DataDogEventAlert.ERROR,
     title: error.name,
     text: text,
     priority: DataDogEventPriority.NORMAL,
-    tags: ["error", ...((config.fid && [String(config.fid)]) || []), ...((config.peerId && [config.peerId]) || [])],
+    tags: tags,
   };
 
   return postDataDogEvent(params, config);
@@ -167,15 +171,16 @@ export const postUnavailableEvent = async (
 ) => {
   const context = payload.context ? `\n[context]:\n${JSON.stringify(payload.context, null, 2)}` : "";
   const text: string = `${payload.message}${context}`;
+  const tags: string[] = [
+    "type:unavailable",
+    ...((config.fid && [`fid:${config.fid.toString(10)}`]) || []),
+    ...((config.peerId && [`peer_id:${config.peerId}`]) || []),
+  ];
   const params: DataDogEventCreateRequest = {
     title: payload.method,
     text: text,
     priority: DataDogEventPriority.NORMAL,
-    tags: [
-      "unavailable",
-      ...((config.fid && [String(config.fid)]) || []),
-      ...((config.peerId && [config.peerId]) || []),
-    ],
+    tags: tags,
   };
 
   return postDataDogEvent(params, config);


### PR DESCRIPTION
## Motivation

- For some reason DataDog ignores and omits the FID tag when it's just a "string-ified" number
- When it's `fid:${fid.toString(10)}` it works
- Add prefixes to fid and peer_id and type for consistency

## Change Summary

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates `diagnosticReportWorker.ts` in `@farcaster/hubble` to prefix tags with `fid` and `peer_id`.

### Detailed summary
- Added `fid` and `peer_id` prefix to tags in `postDataDogEvent` function
- Added `type:error` and `type:unavailable` tags for error and unavailable events respectively

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->