### PR TITLE
fix: Disallow parallel storage scans for the same fid

### DIFF
--- a/.changeset/spicy-pens-occur.md
+++ b/.changeset/spicy-pens-occur.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Don't allow parallel storage cache scans

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -291,7 +291,7 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
       if (result.isOk()) {
         log.info({ peerIdStr, addr }, "Connected to peer from DB");
       } else {
-        log.warn({ peerIdStr, addr, error: result.error }, "Failed to connect to peer from DB");
+        log.debug({ peerIdStr, addr, error: result.error }, "Failed to connect to peer from DB");
       }
 
       // Sleep for a bit to avoid overwhelming the network

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -1166,7 +1166,6 @@ export default class Server {
         let lastEventId = 0;
         const eventListener = (event: HubEvent) => {
           if (event.id <= lastEventId) {
-            // log.warn({ event, lastEventId }, "subscribe: Out-of-order event sent on subscribe()");
             statsd().increment("rpc.subscribe.out_of_order");
           }
           lastEventId = event.id;

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -348,7 +348,6 @@ class Engine extends TypedEmitter<EngineEvents> {
     const limiter = getRateLimiterForTotalMessages(storageUnits.value * this._totalPruneSize);
     const isRateLimited = await isRateLimitedByKey(`${fid}`, limiter);
     if (isRateLimited) {
-      log.warn({ fid }, "rate limit exceeded for FID");
       return err(new HubError("unavailable", `rate limit exceeded for FID ${fid}`));
     }
 


### PR DESCRIPTION
## Motivation

If we get a lot of messages for the same Fid at the same time, we were doing parallel scans for the Fid's messages. This PR will only scan an Fid once.


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing issues related to parallel storage cache scans in the `@farcaster/hubble` package.

### Detailed summary
- Prevent parallel storage cache scans to avoid race conditions
- Updated logging levels for better debugging
- Added a sleep function to avoid network overload
- Improved handling of message count scans to prevent storage failures

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->