### PR TITLE
feat(shuttle): support prune, revokes and deletes

### DIFF
--- a/packages/hub-shuttle/CHANGELOG.md
+++ b/packages/hub-shuttle/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/hub-shuttle
 
+## 0.1.6
+
+### Patch Changes
+
+- feat(shuttle): support prune, revokes and deletes
+- 1051b3dd: feat: Support redis streams for scalability and add reconciliation workers
+
 ## 0.1.5
 
 ### Patch Changes

--- a/packages/hub-shuttle/package.json
+++ b/packages/hub-shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-shuttle",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-shuttle/src/example-app/app.ts
+++ b/packages/hub-shuttle/src/example-app/app.ts
@@ -56,7 +56,7 @@ export class App implements MessageHandler {
   async handleMessageMerge(
     message: Message,
     _txn: DB,
-    _operation: StoreMessageOperation,
+    operation: StoreMessageOperation,
     isNew: boolean,
     wasMissed: boolean,
   ): Promise<void> {
@@ -64,7 +64,7 @@ export class App implements MessageHandler {
       // Message was already in the db, no-op
       return;
     }
-    const messageDesc = wasMissed ? "missed message" : "message";
+    const messageDesc = wasMissed ? `missed message (${operation})` : `message (${operation})`;
     log.info(`Stored ${messageDesc} ${bytesToHexString(message.hash)._unsafeUnwrap()} (type ${message.data?.type})`);
   }
 

--- a/packages/hub-shuttle/src/shuttle.integration.test.ts
+++ b/packages/hub-shuttle/src/shuttle.integration.test.ts
@@ -17,6 +17,8 @@ let db: DB;
 let subscriber: FakeHubSubscriber;
 let redis: RedisClient;
 
+const signer = Factories.Ed25519Signer.build();
+
 const POSTGRES_URL = process.env["POSTGRES_URL"] || "postgres://shuttle:password@localhost:6541";
 const REDIS_URL = process.env["REDIS_URL"] || "localhost:16379";
 
@@ -24,20 +26,33 @@ class FakeHubSubscriber extends HubSubscriber implements MessageHandler {
   public override async start(fromId?: number): Promise<void> {}
   public override stop(): void {}
   public override destroy(): void {}
+  public messageCallbacks: (
+    | ((message: Message, operation: StoreMessageOperation, isNew: boolean, wasMissed: boolean) => void)
+    | undefined
+  )[] = [];
 
   public override async processHubEvent(event: HubEvent): Promise<boolean> {
-    this.emit("event", event);
+    await HubEventProcessor.processHubEvent(db, event, subscriber);
     return true;
   }
 
+  addMessageCallback(
+    callback?: (message: Message, operation: StoreMessageOperation, isNew: boolean, wasMissed: boolean) => void,
+  ) {
+    this.messageCallbacks.push(callback);
+  }
+
   async handleMessageMerge(
-    _message: Message,
+    message: Message,
     _txn: DB,
-    _operation: StoreMessageOperation,
-    _isNew: boolean,
-    _wasMissed: boolean,
+    operation: StoreMessageOperation,
+    isNew: boolean,
+    wasMissed: boolean,
   ): Promise<void> {
-    // noop
+    const callback = this.messageCallbacks.shift();
+    if (callback) {
+      callback(message, operation, isNew, wasMissed);
+    }
   }
 }
 
@@ -65,20 +80,152 @@ afterAll(async () => {
 describe("shuttle", () => {
   beforeEach(() => {
     subscriber = new FakeHubSubscriber();
-    subscriber.on("event", async (event) => {
-      await HubEventProcessor.processHubEvent(db, event, subscriber);
-    });
+  });
+
+  afterEach(() => {
+    // Ensure that all callbacks are called
+    expect(subscriber.messageCallbacks).toHaveLength(0);
   });
 
   test("replicates hubs events to database tables", async () => {
-    const signer = Factories.Ed25519Signer.build();
     const message = await Factories.CastAddMessage.create({}, { transient: { signer } });
-    expect(message.signature).toHaveLength(64);
     await subscriber.processHubEvent(
       HubEvent.create({ id: 10, type: HubEventType.MERGE_MESSAGE, mergeMessageBody: { message } }),
     );
     // count messages table and expect it to be 1
     const hash = await db.selectFrom("messages").select("hash").executeTakeFirstOrThrow();
     expect(Buffer.from(hash.hash)).toEqual(Buffer.from(message.hash));
+  });
+
+  test("message handler callback is invoked correctly", async () => {
+    const message = await Factories.CastAddMessage.create({}, { transient: { signer } });
+
+    subscriber.addMessageCallback((msg, operation, isNew, wasMissed) => {
+      expect(msg.hash).toEqual(message.hash);
+      expect(operation).toEqual("merge");
+      expect(isNew).toEqual(true);
+      expect(wasMissed).toEqual(false);
+    });
+    await subscriber.processHubEvent(
+      HubEvent.create({ id: 100, type: HubEventType.MERGE_MESSAGE, mergeMessageBody: { message } }),
+    );
+
+    // When same message is inserted again, it should still be called, but isNew should be false
+    subscriber.addMessageCallback((msg, operation, isNew, wasMissed) => {
+      expect(msg.hash).toEqual(message.hash);
+      expect(operation).toEqual("merge");
+      expect(isNew).toEqual(false);
+      expect(wasMissed).toEqual(false);
+    });
+    await subscriber.processHubEvent(
+      HubEvent.create({ id: 101, type: HubEventType.MERGE_MESSAGE, mergeMessageBody: { message } }),
+    );
+  });
+
+  test("marks messages as deleted", async () => {
+    const addMessage = await Factories.CastAddMessage.create({}, { transient: { signer } });
+    const removeMessage = await Factories.CastRemoveMessage.create(
+      { data: { fid: addMessage.data.fid, castRemoveBody: { targetHash: addMessage.hash } } },
+      { transient: { signer } },
+    );
+
+    // We expect 3 callbacks, one for the add, one for the delete of the add, and one for the remove, in that order
+    subscriber.addMessageCallback((msg, operation, isNew, wasMissed) => {
+      expect(operation).toEqual("merge");
+      expect(msg.hash).toEqual(addMessage.hash);
+      expect(isNew).toEqual(true);
+    });
+    subscriber.addMessageCallback((msg, operation, isNew, wasMissed) => {
+      expect(operation).toEqual("delete");
+      expect(msg.hash).toEqual(addMessage.hash);
+      // isNew is true becaue the message was updated in the db
+      expect(isNew).toEqual(true);
+    });
+    subscriber.addMessageCallback((msg, operation, isNew, wasMissed) => {
+      expect(operation).toEqual("merge");
+      expect(msg.hash).toEqual(removeMessage.hash);
+      expect(isNew).toEqual(true);
+    });
+
+    await subscriber.processHubEvent(
+      HubEvent.create({ id: 1, type: HubEventType.MERGE_MESSAGE, mergeMessageBody: { message: addMessage } }),
+    );
+    await subscriber.processHubEvent(
+      HubEvent.create({
+        id: 2,
+        type: HubEventType.MERGE_MESSAGE,
+        mergeMessageBody: { message: removeMessage, deletedMessages: [addMessage] },
+      }),
+    );
+
+    const addMessageInDb = await db
+      .selectFrom("messages")
+      .select(["hash", "deletedAt"])
+      .where("hash", "=", addMessage.hash)
+      .executeTakeFirstOrThrow();
+    expect(Buffer.from(addMessageInDb.hash)).toEqual(Buffer.from(addMessage.hash));
+    expect(addMessageInDb.deletedAt).not.toBeNull();
+
+    const removeMessageInDb = await db
+      .selectFrom("messages")
+      .select(["hash", "deletedAt"])
+      .where("hash", "=", removeMessage.hash)
+      .executeTakeFirstOrThrow();
+    expect(Buffer.from(removeMessageInDb.hash)).toEqual(Buffer.from(removeMessage.hash));
+    expect(removeMessageInDb.deletedAt).toBeNull();
+  });
+
+  test("marks messages as pruned", async () => {
+    const addMessage = await Factories.ReactionAddMessage.create({}, { transient: { signer } });
+    subscriber.addMessageCallback((msg, operation, isNew, wasMissed) => {
+      expect(operation).toEqual("merge");
+      expect(msg.hash).toEqual(addMessage.hash);
+      expect(isNew).toEqual(true);
+    });
+    subscriber.addMessageCallback((msg, operation, isNew, wasMissed) => {
+      expect(operation).toEqual("prune");
+      expect(msg.hash).toEqual(addMessage.hash);
+      expect(isNew).toEqual(true);
+    });
+    await subscriber.processHubEvent(
+      HubEvent.create({ id: 1, type: HubEventType.MERGE_MESSAGE, mergeMessageBody: { message: addMessage } }),
+    );
+    await subscriber.processHubEvent(
+      HubEvent.create({ id: 2, type: HubEventType.PRUNE_MESSAGE, pruneMessageBody: { message: addMessage } }),
+    );
+    const addMessageInDb = await db
+      .selectFrom("messages")
+      .select(["hash", "prunedAt"])
+      .where("hash", "=", addMessage.hash)
+      .executeTakeFirstOrThrow();
+    expect(Buffer.from(addMessageInDb.hash)).toEqual(Buffer.from(addMessage.hash));
+    expect(addMessageInDb.prunedAt).not.toBeNull();
+  });
+
+  test("marks messages as revoked", async () => {
+    const addMessage = await Factories.LinkAddMessage.create({}, { transient: { signer } });
+    subscriber.addMessageCallback((msg, operation, isNew, wasMissed) => {
+      expect(operation).toEqual("merge");
+      expect(msg.hash).toEqual(addMessage.hash);
+      expect(isNew).toEqual(true);
+    });
+    subscriber.addMessageCallback((msg, operation, isNew, wasMissed) => {
+      expect(operation).toEqual("revoke");
+      expect(msg.hash).toEqual(addMessage.hash);
+      expect(isNew).toEqual(true);
+    });
+    await subscriber.processHubEvent(
+      HubEvent.create({ id: 1, type: HubEventType.MERGE_MESSAGE, mergeMessageBody: { message: addMessage } }),
+    );
+    await subscriber.processHubEvent(
+      HubEvent.create({ id: 2, type: HubEventType.REVOKE_MESSAGE, revokeMessageBody: { message: addMessage } }),
+    );
+    const addMessageInDb = await db
+      .selectFrom("messages")
+      .select(["hash", "revokedAt"])
+      .where("hash", "=", addMessage.hash)
+      .executeTakeFirstOrThrow();
+    expect(Buffer.from(addMessageInDb.hash)).toEqual(Buffer.from(addMessage.hash));
+    expect(addMessageInDb.revokedAt).not.toBeNull();
   });
 });

--- a/packages/hub-shuttle/src/shuttle/hubEventProcessor.ts
+++ b/packages/hub-shuttle/src/shuttle/hubEventProcessor.ts
@@ -1,25 +1,55 @@
-import { HubEvent, isMergeMessageHubEvent, MergeMessageHubEvent, Message } from "@farcaster/hub-nodejs";
+import {
+  HubEvent,
+  isMergeMessageHubEvent,
+  isPruneMessageHubEvent,
+  isRevokeMessageHubEvent,
+  Message,
+} from "@farcaster/hub-nodejs";
 import { DB } from "./db";
 import { MessageProcessor } from "./messageProcessor";
-import { MessageHandler } from "./";
+import { MessageHandler, StoreMessageOperation } from "./";
 import { log } from "../log";
 
 export class HubEventProcessor {
   static async processHubEvent(db: DB, event: HubEvent, handler: MessageHandler) {
     if (isMergeMessageHubEvent(event)) {
-      const mergedMessage = event.mergeMessageBody.message;
-      await this.processMergeMessage(db, mergedMessage, handler);
+      await this.processMessage(
+        db,
+        event.mergeMessageBody.message,
+        handler,
+        "merge",
+        event.mergeMessageBody.deletedMessages,
+      );
+    } else if (isRevokeMessageHubEvent(event)) {
+      await this.processMessage(db, event.revokeMessageBody.message, handler, "revoke");
+    } else if (isPruneMessageHubEvent(event)) {
+      await this.processMessage(db, event.pruneMessageBody.message, handler, "prune");
     }
   }
 
   static async handleMissingMessage(db: DB, message: Message, handler: MessageHandler) {
-    await this.processMergeMessage(db, message, handler, true);
+    await this.processMessage(db, message, handler, "merge", [], true);
   }
 
-  private static async processMergeMessage(db: DB, message: Message, handler: MessageHandler, wasMissed = false) {
+  private static async processMessage(
+    db: DB,
+    message: Message,
+    handler: MessageHandler,
+    operation: StoreMessageOperation,
+    deletedMessages: Message[] = [],
+    wasMissed = false,
+  ) {
     await db.transaction().execute(async (trx) => {
-      const isNew = await MessageProcessor.storeMessage(message, trx, "merge", log);
-      await handler.handleMessageMerge(message, trx, "merge", isNew, wasMissed);
+      if (deletedMessages.length > 0) {
+        await Promise.all(
+          deletedMessages.map(async (deletedMessage) => {
+            const isNew = await MessageProcessor.storeMessage(deletedMessage, trx, "delete", log);
+            await handler.handleMessageMerge(deletedMessage, trx, "delete", isNew, wasMissed);
+          }),
+        );
+      }
+      const isNew = await MessageProcessor.storeMessage(message, trx, operation, log);
+      await handler.handleMessageMerge(message, trx, operation, isNew, wasMissed);
     });
   }
 }

--- a/packages/hub-shuttle/src/shuttle/hubSubscriber.ts
+++ b/packages/hub-shuttle/src/shuttle/hubSubscriber.ts
@@ -167,14 +167,14 @@ export class EventStreamHubSubscriber extends BaseHubSubscriber {
     hubClient: HubClient,
     eventStream: EventStreamConnection,
     redis: RedisClient,
-    source: string,
+    shardKey: string,
     log: Logger,
     eventTypes?: HubEventType[],
   ) {
     super(label, hubClient.client, log, eventTypes);
     this.eventStream = eventStream;
     this.redis = redis;
-    this.streamKey = `hub:${hubClient.host}:evt:msg:${source}`;
+    this.streamKey = `hub:${hubClient.host}:evt:msg:${shardKey}`;
     this.eventsToAdd = [];
   }
 

--- a/packages/hub-shuttle/src/shuttle/index.ts
+++ b/packages/hub-shuttle/src/shuttle/index.ts
@@ -20,7 +20,7 @@ export type ProcessResult = {
 // - Messages can be assumed to be processes in the same order as they were recieved by the hub as long as wasMissed in false
 // - if wasMissed is true, then the package provides no guarantees about the ordering (it is possible to receive an add
 //      after a remove, your app needs to handle the CRDT resolution). We will provide a way to handle this in the future.
-// - The package will not process the same message twice
+// - If the same messages is received multiple times, isNew will be set to false for all but the first time
 
 export interface MessageHandler {
   handleMessageMerge(


### PR DESCRIPTION
## Motivation

Handle prunes, revokes and deletes

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `@farcaster/hub-shuttle` package to version `0.1.6`, introducing support for redis streams, reconciliation workers, and handling of messages based on operation types.

### Detailed summary
- Updated package version to `0.1.6`
- Added support for redis streams and reconciliation workers
- Refactored message handling based on operation types

> The following files were skipped due to too many changes: `packages/hub-shuttle/src/shuttle.integration.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->