### PR TITLE
fix: Use native threadpool for merkle trie ops

### DIFF
--- a/.changeset/thirty-cows-mate.md
+++ b/.changeset/thirty-cows-mate.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Use threadpool for trie node ops


### PR DESCRIPTION
## Motivation

Use the native threadpool for expensive merkle trie ops so as to not block the main thread


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR optimizes trie node operations in `merkle_trie.rs` by implementing a threadpool for improved performance.

### Detailed summary
- Replaces direct operations with a threadpool for `trie.get_trie_node_metadata` and `trie.get_all_values` in `merkle_trie.rs`
- Ensures asynchronous execution for better performance and efficiency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->