### PR TITLE
tests: Fix flaky test

### DIFF
--- a/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.test.ts
+++ b/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.test.ts
@@ -27,11 +27,16 @@ let castAdd: Message;
 
 let ensNameProof: UsernameProofMessage;
 
+const fakeCurrentTimestamp = 1711056649337; // 21 march 2024
+
 beforeAll(async () => {
   const signerKey = (await signer.getSignerKey())._unsafeUnwrap();
   const custodySignerKey = (await custodySigner.getSignerKey())._unsafeUnwrap();
   custodyEvent = Factories.IdRegistryOnChainEvent.build({ fid }, { transient: { to: custodySignerKey } });
-  signerEvent = Factories.SignerOnChainEvent.build({ fid }, { transient: { signer: signerKey } });
+  signerEvent = Factories.SignerOnChainEvent.build(
+    { fid, blockTimestamp: fakeCurrentTimestamp / 1000 - 1 }, // blockTimestamp is previous second
+    { transient: { signer: signerKey } },
+  );
   storageEvent = Factories.StorageRentOnChainEvent.build({ fid });
   castAdd = await Factories.CastAddMessage.create({ data: { fid, network } }, { transient: { signer } });
 
@@ -66,7 +71,7 @@ describe("ValidateOrRevokeMessagesJob", () => {
     job = new ValidateOrRevokeMessagesJobScheduler(db, engine, false);
 
     nowOrig = Date.now;
-    Date.now = () => 1711056649337; // 21 march 2024
+    Date.now = () => fakeCurrentTimestamp;
 
     await engine.start();
   });


### PR DESCRIPTION
## Motivation

Fix flaky test

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a fake current timestamp for testing purposes in the `validateOrRevokeMessagesJob.test.ts` file.

### Detailed summary
- Added a `fakeCurrentTimestamp` constant for testing purposes
- Modified the creation of `signerEvent` with a custom block timestamp
- Updated `Date.now` to return the `fakeCurrentTimestamp` for testing consistency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->