### PR TITLE
fix: Use pageSize=1 to get first key in iterator

### DIFF
--- a/.changeset/young-rivers-jog.md
+++ b/.changeset/young-rivers-jog.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Use pagesize=1 when scanning for first key

--- a/apps/hubble/src/addon/src/store/store.rs
+++ b/apps/hubble/src/addon/src/store/store.rs
@@ -709,6 +709,8 @@ impl Store {
         let mut count = cached_count;
         let prune_size_limit = self.store_def.get_prune_size_limit();
 
+        let mut txn = self.db.txn();
+
         let prefix = &make_message_primary_key(fid, self.store_def.postfix(), None);
         self.db.for_each_iterator_by_prefix_unbounded(
             prefix,
@@ -721,7 +723,6 @@ impl Store {
                 // Value is a message, so try to decode it
                 let message = message_decode(value)?;
 
-                let mut txn = self.db.txn();
                 if self.store_def.is_add_type(&message) {
                     let ts_hash =
                         make_ts_hash(message.data.as_ref().unwrap().timestamp, &message.hash)?;
@@ -738,7 +739,6 @@ impl Store {
                     .store_event_handler
                     .commit_transaction(&mut txn, &mut hub_event)?;
 
-                self.db.commit(txn)?;
                 count -= 1;
 
                 hub_event.id = id;
@@ -748,6 +748,7 @@ impl Store {
             },
         )?;
 
+        self.db.commit(txn)?;
         Ok(pruned_events)
     }
 

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -31,7 +31,7 @@ import { RootPrefix } from "../../storage/db/types.js";
 import { sleep } from "../../utils/crypto.js";
 
 /** The maximum number of pending merge messages before we drop new incoming gossip or sync messages. */
-export const MAX_MESSAGE_QUEUE_SIZE = 100_000;
+export const MAX_MESSAGE_QUEUE_SIZE = 5000;
 /** The TTL for messages in the seen cache */
 export const GOSSIP_SEEN_TTL = 1000 * 60 * 5;
 

--- a/apps/hubble/src/storage/stores/storageCache.ts
+++ b/apps/hubble/src/storage/stores/storageCache.ts
@@ -179,10 +179,14 @@ export class StorageCache {
       const prefix = makeMessagePrimaryKey(fid, set);
 
       let firstKey: Buffer | undefined;
-      await this._db.forEachIteratorByPrefix(prefix, (key) => {
-        firstKey = key as Buffer;
-        return true; // Finish the iteration after the first key-value pair
-      });
+      await this._db.forEachIteratorByPrefix(
+        prefix,
+        (key) => {
+          firstKey = key as Buffer;
+          return true; // Finish the iteration after the first key-value pair
+        },
+        { pageSize: 1 },
+      );
 
       if (firstKey === undefined) {
         return ok(undefined);


### PR DESCRIPTION
## Motivation

Some assorted perf fixes:
- Use pageSize =1 when getting just the first key
- Limit merge queue to 5000 items. If there is a merge queue, which should skip messages
- When pruning, prune all messages in a single Tx instead of multiple transactions


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving efficiency in scanning for the first key and reducing message queue size in the Hubble application.

### Detailed summary
- Reduced `MAX_MESSAGE_QUEUE_SIZE` to 5000 in `gossipNode.ts`
- Modified key scanning to use `pageSize=1` in `storageCache.ts`
- Refactored transaction handling in `store.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->