### PR TITLE
fix(shuttle): ack the correct group name to fix stale bug

### DIFF
--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.2.2
+
+### Patch Changes
+
+- fix: ack the correct group name to fix stale bug
+
 ## 0.2.1
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/shuttle/src/shuttle/eventStream.ts
+++ b/packages/shuttle/src/shuttle/eventStream.ts
@@ -320,7 +320,7 @@ export class HubEventStreamConsumer {
 
           if (eventIdsProcessed.length) {
             const startTime = Date.now();
-            await this.stream.ack(this.streamKey, GROUP_NAME, eventIdsProcessed);
+            await this.stream.ack(this.streamKey, this.groupName, eventIdsProcessed);
             statsd.timing("hub.event.stream.ack_time", Date.now() - startTime, {
               hub: this.hub.host,
               source: this.shardKey,
@@ -364,7 +364,7 @@ export class HubEventStreamConsumer {
       source: this.shardKey,
     });
 
-    await inBatchesOf(events, MESSAGE_PROCESSING_CONCURRENCY, async (batchedEvents) => {
+    await inBatchesOf(events, this.messageProcessingConcurrency, async (batchedEvents) => {
       const eventIdsProcessed: string[] = [];
       await Promise.allSettled(
         batchedEvents.map((event) =>


### PR DESCRIPTION
## Motivation

We were not using the right consumer group when acking messages. Which leads to messages being processed via processStale. 

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates `@farcaster/shuttle` to version 0.2.2, fixing a bug related to group name acknowledgment in the event stream.

### Detailed summary
- Updated package version to 0.2.2
- Fixed bug by acknowledging correct group name in event stream
- Modified the acknowledgment of group names in event stream processing to use instance properties instead of constants

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->