### PR TITLE
feat(shuttle): add message state to handler

### DIFF
--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.2.3
+
+### Patch Changes
+
+- feat(shuttle): add message state to handler
+
 ## 0.2.2
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/shuttle/src/example-app/app.ts
+++ b/packages/shuttle/src/example-app/app.ts
@@ -11,9 +11,10 @@ import {
   EventStreamConnection,
   HubEventStreamConsumer,
   HubSubscriber,
+  MessageState,
 } from "../index"; // If you want to use this as a standalone app, replace this import with "@farcaster/shuttle"
-import { migrateToLatest } from "./migration";
-import { bytesToHexString, HubEvent, Message } from "@farcaster/hub-nodejs";
+import { AppDb, migrateToLatest, Tables } from "./db";
+import { bytesToHexString, HubEvent, isCastAddMessage, isCastRemoveMessage, Message } from "@farcaster/hub-nodejs";
 import { log } from "./log";
 import { Command } from "@commander-js/extra-typings";
 import { readFileSync } from "fs";
@@ -23,6 +24,7 @@ import url from "node:url";
 import { ok, Result } from "neverthrow";
 import { getQueue, getWorker } from "./worker";
 import { Queue } from "bullmq";
+import { farcasterTimeToDate } from "../utils";
 
 const hubId = "shuttle";
 
@@ -55,8 +57,9 @@ export class App implements MessageHandler {
 
   async handleMessageMerge(
     message: Message,
-    _txn: DB,
+    txn: DB,
     operation: StoreMessageOperation,
+    state: MessageState,
     isNew: boolean,
     wasMissed: boolean,
   ): Promise<void> {
@@ -64,8 +67,34 @@ export class App implements MessageHandler {
       // Message was already in the db, no-op
       return;
     }
+
+    const appDB = txn as unknown as AppDb; // Need this to make typescript happy, not clean way to "inherit" table types
+
+    // Example of how to materialize casts into a separate table. Insert casts into a separate table, and mark them as deleted when removed
+    // Note that since we're relying on "state", this can sometimes be invoked twice. e.g. when a CastRemove is merged, this call will be invoked 2 twice:
+    // castAdd, operation=delete, state=deleted (the cast that the remove is removing)
+    // castRemove, operation=merge, state=deleted (the actual remove message)
+    const isCastMessage = isCastAddMessage(message) || isCastRemoveMessage(message);
+    if (isCastMessage && state === "created") {
+      await appDB
+        .insertInto("casts")
+        .values({
+          fid: message.data.fid,
+          hash: message.hash,
+          text: message.data.castAddBody?.text || "",
+          timestamp: farcasterTimeToDate(message.data.timestamp) || new Date(),
+        })
+        .execute();
+    } else if (isCastMessage && state === "deleted") {
+      await appDB
+        .updateTable("casts")
+        .set({ deletedAt: farcasterTimeToDate(message.data.timestamp) || new Date() })
+        .where("hash", "=", message.hash)
+        .execute();
+    }
+
     const messageDesc = wasMissed ? `missed message (${operation})` : `message (${operation})`;
-    log.info(`Stored ${messageDesc} ${bytesToHexString(message.hash)._unsafeUnwrap()} (type ${message.data?.type})`);
+    log.info(`${state} ${messageDesc} ${bytesToHexString(message.hash)._unsafeUnwrap()} (type ${message.data?.type})`);
   }
 
   async start() {

--- a/packages/shuttle/src/example-app/migrations/002_casts.ts
+++ b/packages/shuttle/src/example-app/migrations/002_casts.ts
@@ -1,0 +1,24 @@
+import { Kysely, sql } from "kysely";
+
+// biome-ignore lint/suspicious/noExplicitAny: legacy code, avoid using ignore for new code
+export const up = async (db: Kysely<any>) => {
+  // Casts -------------------------------------------------------------------------------------
+  await db.schema
+    .createTable("casts")
+    .addColumn("id", "uuid", (col) => col.defaultTo(sql`generate_ulid()`))
+    .addColumn("createdAt", "timestamptz", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("updatedAt", "timestamptz", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("deletedAt", "timestamptz")
+    .addColumn("timestamp", "timestamptz", (col) => col.notNull())
+    .addColumn("fid", "bigint", (col) => col.notNull())
+    .addColumn("hash", "bytea", (col) => col.notNull())
+    .addColumn("text", "text", (col) => col.notNull())
+    .execute();
+
+  await db.schema
+    .createIndex("casts_fid_timestamp_index")
+    .on("casts")
+    .columns(["fid", "timestamp"])
+    .where(sql.ref("deleted_at"), "is", null) // Only index active (non-deleted) casts
+    .execute();
+};

--- a/packages/shuttle/src/shuttle/hubEventProcessor.ts
+++ b/packages/shuttle/src/shuttle/hubEventProcessor.ts
@@ -1,13 +1,21 @@
 import {
   HubEvent,
+  isCastAddMessage,
+  isCastRemoveMessage,
+  isLinkAddMessage,
+  isLinkRemoveMessage,
   isMergeMessageHubEvent,
   isPruneMessageHubEvent,
+  isReactionAddMessage,
+  isReactionRemoveMessage,
   isRevokeMessageHubEvent,
+  isVerificationAddAddressMessage,
+  isVerificationRemoveMessage,
   Message,
 } from "@farcaster/hub-nodejs";
 import { DB } from "./db";
 import { MessageProcessor } from "./messageProcessor";
-import { MessageHandler, StoreMessageOperation } from "./";
+import { MessageHandler, MessageState, StoreMessageOperation } from "./";
 import { log } from "../log";
 
 export class HubEventProcessor {
@@ -44,12 +52,50 @@ export class HubEventProcessor {
         await Promise.all(
           deletedMessages.map(async (deletedMessage) => {
             const isNew = await MessageProcessor.storeMessage(deletedMessage, trx, "delete", log);
-            await handler.handleMessageMerge(deletedMessage, trx, "delete", isNew, wasMissed);
+            const state = this.getMessageState(deletedMessage, "delete");
+            await handler.handleMessageMerge(deletedMessage, trx, "delete", state, isNew, wasMissed);
           }),
         );
       }
       const isNew = await MessageProcessor.storeMessage(message, trx, operation, log);
-      await handler.handleMessageMerge(message, trx, operation, isNew, wasMissed);
+      const state = this.getMessageState(message, operation);
+      await handler.handleMessageMerge(message, trx, operation, state, isNew, wasMissed);
     });
+  }
+
+  public static getMessageState(message: Message, operation: StoreMessageOperation): MessageState {
+    const isAdd = operation === "merge";
+    // Casts
+    if (isAdd && isCastAddMessage(message)) {
+      return "created";
+    } else if ((isAdd && isCastRemoveMessage(message)) || (!isAdd && isCastAddMessage(message))) {
+      return "deleted";
+    }
+    // Links
+    if (isAdd && isLinkAddMessage(message)) {
+      return "created";
+    } else if ((isAdd && isLinkRemoveMessage(message)) || (!isAdd && isLinkAddMessage(message))) {
+      return "deleted";
+    }
+    // Reactions
+    if (isAdd && isReactionAddMessage(message)) {
+      return "created";
+    } else if ((isAdd && isReactionRemoveMessage(message)) || (!isAdd && isReactionAddMessage(message))) {
+      return "deleted";
+    }
+    // Verifications
+    if (isAdd && isVerificationAddAddressMessage(message)) {
+      return "created";
+    } else if (
+      (isAdd && isVerificationRemoveMessage(message)) ||
+      (!isAdd && isVerificationAddAddressMessage(message))
+    ) {
+      return "deleted";
+    }
+
+    // The above are 2p sets, so we have the consider whether they are add or remove messages to determine the state
+    // The rest are 1p sets, so we can just check the operation
+
+    return isAdd ? "created" : "deleted";
   }
 }

--- a/packages/shuttle/src/shuttle/index.ts
+++ b/packages/shuttle/src/shuttle/index.ts
@@ -11,6 +11,7 @@ export * from "./messageReconciliation";
 export * from "./eventStream";
 
 export type StoreMessageOperation = "merge" | "delete" | "revoke" | "prune";
+export type MessageState = "created" | "deleted";
 
 export type ProcessResult = {
   skipped: boolean;
@@ -21,12 +22,15 @@ export type ProcessResult = {
 // - if wasMissed is true, then the package provides no guarantees about the ordering (it is possible to receive an add
 //      after a remove, your app needs to handle the CRDT resolution). We will provide a way to handle this in the future.
 // - If the same messages is received multiple times, isNew will be set to false for all but the first time
+// - state is a user friendly translation of the impact of the message to the CRDT set (e.g. a "merge" of a remove message
+// is semantically a delete of the existing add, and state will be set to "deleted" in that case)
 
 export interface MessageHandler {
   handleMessageMerge(
     message: Message,
     txn: DB,
     operation: StoreMessageOperation,
+    state: MessageState,
     isNew: boolean,
     wasMissed: boolean,
   ): Promise<void>;


### PR DESCRIPTION
## Motivation

Add example of how to materialize casts to a separate table and add MessageState to the message handler to simplify reasoning about what happened to the message.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to introduce a new `MessageState` to the `MessageHandler` interface and implement its usage in the `HubEventProcessor`.

### Detailed summary
- Added `MessageState` enum to represent message states in the `MessageHandler` interface.
- Implemented `MessageState` handling in the `HubEventProcessor`.
- Added new tables and migration logic in the example app.
- Updated message handling in the `App` class.
- Updated tests and imports accordingly.

> The following files were skipped due to too many changes: `packages/shuttle/src/shuttle.integration.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->