### PR TITLE
chore: Add console command to track hub delays

### DIFF
--- a/apps/hubble/src/console/console.ts
+++ b/apps/hubble/src/console/console.ts
@@ -18,6 +18,7 @@ import { FactoriesCommand, ProtobufCommand } from "./protobufCommand.js";
 import { RpcClientCommand } from "./rpcClientCommand.js";
 import { WarpcastTestCommand } from "./warpcastTestCommand.js";
 import { SyncId } from "../network/sync/syncId.js";
+import { TrackHubDelayCommand } from "./trackHubDelayCommand.js";
 
 export const DEFAULT_RPC_CONSOLE = "127.0.0.1:2283";
 
@@ -67,6 +68,7 @@ export const startConsole = async (addressString: string, useInsecure: boolean) 
     new GenCommand(rpcClient, adminClient),
     new WarpcastTestCommand(rpcClient, adminClient),
     new AdminCommand(adminClient),
+    new TrackHubDelayCommand(rpcClient),
   ];
 
   replServer.defineCommand("help", {

--- a/apps/hubble/src/console/trackHubDelayCommand.ts
+++ b/apps/hubble/src/console/trackHubDelayCommand.ts
@@ -1,0 +1,88 @@
+import { HubEvent, HubRpcClient, SubscribeRequest, fromFarcasterTime, toFarcasterTime } from "@farcaster/hub-nodejs";
+import { ConsoleCommandInterface } from "./console.js";
+
+export class TrackHubDelayCommand implements ConsoleCommandInterface {
+  constructor(private readonly rpcClient: HubRpcClient) {}
+
+  commandName(): string {
+    return "trackHubDelay";
+  }
+  shortHelp(): string {
+    return "Track the delay between the hub's eventId timestamp and the message's timestamp";
+  }
+  help(): string {
+    return `
+    Usage: trackHubDelay()
+
+        Track the amount of delay that the connected hub is experiencing while merging messages
+    `;
+  }
+  object() {
+    return {
+      start: async () => {
+        // Create a client stream to connect to the hub
+        const request = SubscribeRequest.create({});
+        const streamResult = await this.rpcClient.subscribe(request);
+        if (streamResult.isErr()) {
+          console.error("Failed to subscribe to hub");
+          return;
+        }
+
+        // Get the stream from the result
+        const stream = streamResult.value;
+
+        let totalDelay = 0;
+        let numMessages = 0;
+
+        const interval = setInterval(() => {
+          if (numMessages > 0) {
+            console.log(
+              `Average delay: ${
+                Math.round((totalDelay * 10 ** 2) / numMessages) / 10 ** 2
+              } s from ${numMessages} messages`,
+            );
+          }
+        }, 5 * 1000);
+
+        // Listen for messages from the hub
+        stream.on("data", (hubEvent: HubEvent) => {
+          // Get the timestamp of the event
+          const eventTimestamp = hubEvent.id / 4096 / 1000;
+
+          // Get the message timeStamp
+          const messageTimestamp = hubEvent.mergeMessageBody?.message?.data?.timestamp ?? 0;
+
+          if (messageTimestamp) {
+            // Calculate the delay
+            const delay = eventTimestamp - messageTimestamp;
+            if (delay > 1000) {
+              console.log(
+                `Huge Delay: ${Math.round(delay / 1000)}s.  Message timestamp: ${new Date(
+                  fromFarcasterTime(messageTimestamp)._unsafeUnwrap(),
+                )}`,
+              );
+            } else {
+              totalDelay += delay;
+              numMessages++;
+            }
+          }
+        });
+
+        const finished = new Promise((resolve) => {
+          stream.on("close", () => {
+            resolve(true);
+          });
+          stream.on("end", () => {
+            resolve(true);
+          });
+          stream.on("error", () => {
+            resolve(true);
+          });
+        });
+
+        await finished;
+        clearInterval(interval);
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Motivation

Add a new console command to track message delays at hubs

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a new `TrackHubDelayCommand` to track delay between hub and message timestamps in the console.

### Detailed summary
- Added `TrackHubDelayCommand` to track delay in hub messages
- Subscribes to hub events and calculates delay
- Displays average delay and handles error cases

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->