### PR TITLE
fix: Don't fail CI if upload coverage fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,3 +138,4 @@ jobs:
 
       - name: Upload coverage results
         uses: codecov/codecov-action@v4
+        continue-on-error: true


### PR DESCRIPTION
## Motivation

Don't fail CI if uploading coverage fails

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the CI workflow to upload coverage results with the `codecov/codecov-action@v4` action and adds the `continue-on-error: true` option.

### Detailed summary
- Updated CI workflow to upload coverage results
- Added `continue-on-error: true` option to the codecov action

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->