### PR TITLE
fix: increase shuttle hub client timeout limit

### DIFF
--- a/.changeset/plenty-badgers-boil.md
+++ b/.changeset/plenty-badgers-boil.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+fix: increase hub timeout limit

--- a/packages/shuttle/src/shuttle/hubSubscriber.ts
+++ b/packages/shuttle/src/shuttle/hubSubscriber.ts
@@ -73,7 +73,7 @@ export class BaseHubSubscriber extends HubSubscriber {
 
   private _waitForReadyHubClient(): Promise<Result<void, unknown>> {
     return new Promise((resolve) => {
-      this.hubClient?.$.waitForReady(Date.now() + 500, (e) => {
+      this.hubClient?.$.waitForReady(Date.now() + 5000, (e) => {
         return e ? resolve(err(e)) : resolve(ok(undefined));
       });
     });


### PR DESCRIPTION
## Motivation

When trying to run the shuttle example using a remote hub, the hub client connection times out and the program fails to start.

## Change Summary

Update the hub client connection timeout to be 5000ms, similar to other examples in the codebase.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR increases the timeout limit for the hub in the `shuttle` package to fix potential issues with hub connectivity.

### Detailed summary
- Increased the timeout limit for the hub from 500ms to 5000ms in `hubSubscriber.ts` to ensure better hub connectivity.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->