### PR TITLE
fix: Split the snapshot into 4GB chunks

### DIFF
--- a/.changeset/popular-dryers-walk.md
+++ b/.changeset/popular-dryers-walk.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Split the snapshot into 4GB chunks

--- a/apps/hubble/src/addon/src/db/mod.rs
+++ b/apps/hubble/src/addon/src/db/mod.rs
@@ -1,3 +1,4 @@
 pub use self::rocksdb::*;
 
+mod multi_chunk_writer;
 mod rocksdb;

--- a/apps/hubble/src/addon/src/db/multi_chunk_writer.rs
+++ b/apps/hubble/src/addon/src/db/multi_chunk_writer.rs
@@ -1,0 +1,173 @@
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use slog::{info, o};
+use std::fs::{self, File};
+use std::io::{Result, Write};
+use std::path::{Path, PathBuf};
+
+use crate::logger::LOGGER;
+
+/**
+* A writer that will write data to multiple files, creating a new file when the current one
+* reaches the max size. The files are compressed using Gzip and the individual parts are
+* named chunk_XXXX.bin where XXXX is the part number.
+*
+* The writer will create the `base_path` directory if it does not exist.
+*/
+pub(crate) struct MultiChunkWriter {
+    base_path: PathBuf,
+    current_part: usize,
+    max_size: usize,
+    current_size: usize,
+    encoder: Option<GzEncoder<File>>,
+    logger: slog::Logger,
+}
+
+impl MultiChunkWriter {
+    pub fn new(base_path: PathBuf, max_size: usize) -> Self {
+        Self {
+            base_path,
+            current_part: 0,
+            max_size,
+            current_size: 0,
+            encoder: None,
+            logger: LOGGER.new(o! ("module" => "snapshot_writer")),
+        }
+    }
+
+    fn ensure_directory_exists<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+        if !path.as_ref().exists() {
+            fs::create_dir_all(path)?;
+        }
+        Ok(())
+    }
+
+    pub fn next_part(&mut self) -> Result<()> {
+        self.ensure_directory_exists(&self.base_path)?;
+        // Finish the current part if it exists
+        self.finish()?;
+
+        self.current_part += 1;
+
+        let file_name = self
+            .base_path
+            .join(format!("chunk_{:04}.bin", self.current_part));
+        let file = File::create(&file_name)?;
+        self.encoder = Some(GzEncoder::new(file, Compression::default()));
+        self.current_size = 0;
+        Ok(())
+    }
+
+    pub fn finish(&mut self) -> Result<()> {
+        if let Some(encoder) = self.encoder.take() {
+            info!(self.logger, "Finished writing part"; "part" => self.current_part);
+
+            encoder.finish()?;
+        }
+        Ok(())
+    }
+}
+
+impl Write for MultiChunkWriter {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        if self.encoder.is_none() || (self.current_size + buf.len() > self.max_size) {
+            self.next_part()?;
+        }
+
+        if let Some(encoder) = self.encoder.as_mut() {
+            let size = encoder.write(buf)?;
+            self.current_size += size;
+            Ok(size)
+        } else {
+            Ok(0) // This should never happen
+        }
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        if let Some(encoder) = self.encoder.as_mut() {
+            encoder.flush()
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flate2::read::GzDecoder;
+    use std::io::Read as _;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_initialization_and_file_creation() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut writer = MultiChunkWriter::new(temp_dir.path().to_path_buf(), 100);
+
+        writer.write_all(b"Hello, world!").unwrap();
+        writer.finish().unwrap();
+
+        let entries = std::fs::read_dir(temp_dir.path()).unwrap();
+
+        // Collect entries and sort them to ensure we read them in the correct order
+        let mut files: Vec<_> = entries.map(|e| e.unwrap().path()).collect();
+        files.sort();
+        assert_eq!(files.len(), 1);
+
+        // Now, verify the contents of each file
+        let file = File::open(files.get(0).unwrap()).unwrap();
+        let mut gz = GzDecoder::new(file);
+        let mut contents = String::new();
+        gz.read_to_string(&mut contents).unwrap();
+
+        assert_eq!(
+            contents, "Hello, world!",
+            "File content did not match expected for file {:?}",
+            files[0]
+        );
+    }
+
+    #[test]
+    fn test_handling_maximum_size() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut writer = MultiChunkWriter::new(temp_dir.path().to_path_buf(), 5);
+
+        writer.write_all(b"12345").unwrap();
+        writer.write_all(b"67890").unwrap(); // This should trigger a new part
+        writer.finish().unwrap();
+
+        let entries = std::fs::read_dir(temp_dir.path()).unwrap();
+        // Collect entries and sort them to ensure we read them in the correct order
+        let mut files: Vec<_> = entries.map(|e| e.unwrap().path()).collect();
+        files.sort();
+        assert_eq!(files.len(), 2); // Expect two files
+
+        // Now, verify the contents of each file
+        for (index, file_path) in files.iter().enumerate() {
+            let file = File::open(file_path).unwrap();
+            let mut gz = GzDecoder::new(file);
+            let mut contents = String::new();
+            gz.read_to_string(&mut contents).unwrap();
+
+            let expected = if index == 0 { "12345" } else { "67890" };
+            assert_eq!(
+                contents, expected,
+                "File content did not match expected for file {:?}",
+                file_path
+            );
+        }
+    }
+
+    #[test]
+    fn test_directory_creation() {
+        let temp_dir = TempDir::new().unwrap();
+        let non_existent_subdir = temp_dir.path().join("subdir");
+
+        let mut writer = MultiChunkWriter::new(non_existent_subdir.clone(), 100);
+
+        writer.write_all(b"Data").unwrap();
+        writer.finish().unwrap();
+
+        assert!(non_existent_subdir.exists()); // Directory should now exist
+    }
+}

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -723,7 +723,7 @@ const s3SnapshotURL = new Command("snapshot-url")
     }
     const [url, metadata] = response.value;
     console.log(`${JSON.stringify(metadata, null, 2)}`);
-    console.log(`Download at: ${url}`);
+    console.log(`Download chunks under directory at: ${url}`);
     exit(0);
   });
 

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -937,41 +937,33 @@ export class Hub implements HubInterface {
             );
 
             let prevVersion = 0;
-            let latestSnapshotKey;
+            let latestSnapshotKeyBase;
+            let latestChunks: string[] = [];
             do {
               const response = await axios.get(
                 `https://${s3Bucket}/${this.getSnapshotFolder(prevVersion)}/latest.json`,
               );
-              const { key } = response.data;
+              const { keyBase, chunks } = response.data;
 
-              if (!key) {
+              if (!keyBase) {
                 log.error(
                   { data: response.data, folder: this.getSnapshotFolder(prevVersion) },
                   "No latest snapshot name found in latest.json",
                 );
                 prevVersion += 1;
               } else {
-                latestSnapshotKey = key as string;
+                latestSnapshotKeyBase = keyBase as string;
+                latestChunks = chunks as string[];
                 break;
               }
             } while (prevVersion < LATEST_DB_SCHEMA_VERSION);
 
-            if (!latestSnapshotKey) {
+            if (!latestSnapshotKeyBase) {
               resolve(err(new HubError("unavailable", "No latest snapshot name found in latest.json")));
               return;
             } else {
-              log.info({ latestSnapshotKey }, "found latest S3 snapshot");
+              log.info({ latestSnapshotKeyBase }, "found latest S3 snapshot");
             }
-
-            const snapshotUrl = `https://${s3Bucket}/${latestSnapshotKey}`;
-            const response2 = await axios.get(snapshotUrl, {
-              responseType: "stream",
-            });
-            const totalSize = parseInt(response2.headers["content-length"], 10);
-
-            let downloadedSize = 0;
-            log.info({ totalSize }, "Getting snapshot...");
-            progressBar = addProgressBar("Getting snapshot", totalSize);
 
             const handleError = (e: Error) => {
               log.error({ error: e }, "Error extracting snapshot");
@@ -979,8 +971,11 @@ export class Hub implements HubInterface {
               resolve(err(new HubError("unavailable", "Error extracting snapshot")));
             };
 
-            const gunzip = zlib.createGunzip();
             const parseStream = new tar.Parse();
+            const gunzip = zlib.createGunzip();
+            gunzip.pipe(parseStream);
+
+            gunzip.on("error", handleError);
 
             // We parse the tar file and extract it into the DB location, which might be different
             // than the location it was originally created in. So, we transform the top-level
@@ -1004,25 +999,37 @@ export class Hub implements HubInterface {
               resolve(ok(true));
             });
 
-            let lastDownloadedSize = 0;
-            response2.data
-              .on("error", handleError)
-              // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-              .on("data", (chunk: any) => {
-                const largeChunk = 1024 * 1024 * 1024;
+            log.info({ numChunks: latestChunks.length }, "Getting snapshot chunks...");
+            progressBar = addProgressBar("Getting snapshot", latestChunks.length * 100);
 
-                downloadedSize += chunk.length;
-                progressBar?.update(downloadedSize);
+            let chunkCount = 0;
+            for (const chunk of latestChunks) {
+              let downloadedSize = 0;
+              chunkCount += 1;
+              log.info({ chunkCount, totalChunks: latestChunks.length }, "Downloading snapshot chunks...");
 
-                if (downloadedSize - lastDownloadedSize > largeChunk) {
-                  log.info({ downloadedSize, totalSize }, "Downloading snapshot...");
-                  lastDownloadedSize = downloadedSize;
-                }
-              })
-              .pipe(gunzip)
-              .on("error", handleError)
-              .pipe(parseStream)
-              .on("error", handleError);
+              const chunkUrl = `https://${s3Bucket}/${latestSnapshotKeyBase}/${chunk}`;
+              const chunkResponse = await axios.get(chunkUrl, {
+                responseType: "stream",
+              });
+              const totalSize = parseInt(chunkResponse.headers["content-length"], 10);
+
+              await new Promise((resolve) => {
+                chunkResponse.data
+                  .on("error", handleError)
+                  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+                  .on("data", (dataChunk: any) => {
+                    downloadedSize += dataChunk.length;
+                    progressBar?.update((chunkCount - 1) * 100 + (downloadedSize * 100) / totalSize);
+                  })
+                  .on("end", () => {
+                    resolve(true);
+                  })
+                  .pipe(gunzip, { end: false });
+              });
+            }
+
+            gunzip.end();
           } else {
             resolve(ok(false));
           }

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1020,7 +1020,7 @@ export class Hub implements HubInterface {
                   // biome-ignore lint/suspicious/noExplicitAny: <explanation>
                   .on("data", (dataChunk: any) => {
                     downloadedSize += dataChunk.length;
-                    progressBar?.update((chunkCount - 1) * 100 + (downloadedSize * 100) / totalSize);
+                    progressBar?.update(Math.round((chunkCount - 1) * 100 + (downloadedSize * 100) / totalSize));
                   })
                   .on("end", () => {
                     resolve(true);

--- a/apps/hubble/src/network/sync/merkleTrie.test.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.test.ts
@@ -135,7 +135,8 @@ describe("MerkleTrie", () => {
         blockTimestamp: event1.blockTimestamp,
         fid: event1.fid,
         txIndex: event1.txIndex,
-        logIndex: event1.logIndex + 1,
+        // make sure only last byte is different
+        logIndex: event1.logIndex + (event1.logIndex % 256 === 255 ? -1 : +1),
       });
       const syncId1 = SyncId.fromOnChainEvent(event1);
       const syncId2 = SyncId.fromOnChainEvent(event2);

--- a/apps/hubble/src/storage/db/migrations/migrations.ts
+++ b/apps/hubble/src/storage/db/migrations/migrations.ts
@@ -46,7 +46,7 @@ migrations.set(7, async (db: RocksDB) => {
   return await clearAdminResets(db);
 });
 
-migrations.set(8, async (db: RocksDB) => {
+migrations.set(8, async (_db: RocksDB) => {
   /**
    * This is the rust DB migration. There's no actual migration
    * to be done, but we set a new version to mark the migration
@@ -56,6 +56,16 @@ migrations.set(8, async (db: RocksDB) => {
 
 migrations.set(9, async (db: RocksDB) => {
   return await fnameUserNameProofByFidPrefix(db);
+});
+
+migrations.set(10, async (_db: RocksDB) => {
+  /**
+   * This is the snapshot chunking migration. There's no actual migration
+   * to be done, but we set a new version to mark the migration so that snapshots
+   * will work correctly (i.e. the snapshot metadata will be correctly fetched
+   * by compatible versions of the hub)
+   */
+  return true;
 });
 
 // To Add a new migration

--- a/apps/hubble/src/storage/jobs/dbSnapshotBackupJob.ts
+++ b/apps/hubble/src/storage/jobs/dbSnapshotBackupJob.ts
@@ -93,8 +93,8 @@ export class DbSnapshotBackupJobScheduler {
           messageCount,
         );
         if (s3Result.isOk()) {
-          // Delete the tar file, ignore errors
-          fs.unlink(tarGzResult.value, () => {});
+          // Delete the tar file chunks directory, ignore errors
+          fs.rmdirSync(tarGzResult.value);
 
           // Cleanup old files from S3
           this.deleteOldSnapshotsFromS3();

--- a/apps/hubble/src/storage/jobs/dbSnapshotBackupJob.ts
+++ b/apps/hubble/src/storage/jobs/dbSnapshotBackupJob.ts
@@ -85,7 +85,6 @@ export class DbSnapshotBackupJobScheduler {
 
       // Upload to S3. Run this in the background so we don't block startup.
       setTimeout(async () => {
-        log.info({ messageCount }, "uploading snapshot to S3");
         const s3Result = await uploadToS3(
           this._options.network,
           tarGzResult.value,

--- a/apps/hubble/src/utils/snapshot.ts
+++ b/apps/hubble/src/utils/snapshot.ts
@@ -16,7 +16,7 @@ export type SnapshotMetadata = Partial<DbStats> & {
 };
 
 export const isValidSnapshotMetadata = (data: Record<string, unknown>): data is SnapshotMetadata => {
-  return data["key"] !== undefined && data["timestamp"] !== undefined && data["serverDate"] !== undefined;
+  return data["keyBase"] !== undefined && data["timestamp"] !== undefined && data["serverDate"] !== undefined;
 };
 
 export const fetchSnapshotMetadata = async (snapshotPrefixURI: string): HubAsyncResult<SnapshotMetadata> => {

--- a/apps/hubble/src/utils/snapshot.ts
+++ b/apps/hubble/src/utils/snapshot.ts
@@ -9,7 +9,8 @@ import { Upload } from "@aws-sdk/lib-storage";
 import { logger } from "./logger.js";
 
 export type SnapshotMetadata = Partial<DbStats> & {
-  key: string;
+  keyBase: string;
+  chunks: string[];
   timestamp: number;
   serverDate: string;
 };
@@ -63,7 +64,7 @@ export const snapshotURLAndMetadata = async (
     return err(response.error);
   }
   const data: SnapshotMetadata = response.value;
-  return ok([`https://${s3Bucket}/${data.key}`, data]);
+  return ok([`https://${s3Bucket}/${data.keyBase}`, data]);
 };
 export const snapshotURL = (
   fcNetwork: FarcasterNetwork,
@@ -75,46 +76,67 @@ export const snapshotURL = (
 
 export const uploadToS3 = async (
   fcNetwork: FarcasterNetwork,
-  filePath: string,
+  chunkedDirPath: string,
   s3Bucket: string = SNAPSHOT_S3_DEFAULT_BUCKET,
   messageCount?: number,
 ): HubAsyncResult<string> => {
-  let start = Date.now();
+  const startTimestamp = Date.now();
   const s3 = new S3Client({
     region: S3_REGION,
   });
 
   // The AWS key is "snapshots/{network}/{DB_SCHEMA_VERSION}/snapshot-{yyyy-mm-dd}-{timestamp}.tar.gz"
-  const key = `${snapshotDirectory(fcNetwork)}/snapshot-${new Date().toISOString().split("T")[0]}-${Math.floor(
-    Date.now() / 1000,
-  )}.tar.gz`;
+  const keyBase = `${snapshotDirectory(fcNetwork)}/snapshot-${
+    new Date(startTimestamp).toISOString().split("T")[0]
+  }-${Math.floor(startTimestamp / 1000)}.tar.gz`;
 
-  start = Date.now();
-  logger.info({ filePath, key, bucket: s3Bucket }, "Uploading snapshot to S3");
+  logger.info({ chunkedDirPath, keyBase, s3Bucket }, "Uploading snapshot to S3");
 
-  const fileStream = fs.createReadStream(filePath);
-  fileStream.on("error", function (err) {
-    logger.error(`S3 File Error: ${err}`);
-  });
+  // Read all the chunks files in the chunkedDirPath and upload them to S3
 
-  // The targz should be uploaded via multipart upload to S3
-  const targzParams = new Upload({
-    client: s3,
-    params: {
-      Bucket: s3Bucket,
-      Key: key,
-      Body: fileStream,
-    },
-    queueSize: 4, // 4 concurrent uploads
-    partSize: 1000 * 1024 * 1024, // 1 GB
-  });
+  // Get all the files in the directory
+  const files = fs.readdirSync(chunkedDirPath);
+  files.sort();
 
-  // NOTE: The sync engine type `DbStats` does not match the type in packages/core used by SnapshotMetadata.
-  //       As a result, ensure keys match core package `DbStats`, NOT sync engine `DbStats`
+  // Upload each file to S3
+  for (const file of files) {
+    const key = `${keyBase}/${file}`;
+    const filePath = `${chunkedDirPath}/${file}`;
+
+    const fileStream = fs.createReadStream(filePath);
+    fileStream.on("error", function (err) {
+      logger.error(`S3 File Error: ${err}`);
+    });
+
+    // The chunks should be uploaded via multipart upload to S3
+    const chunkUploadParams = new Upload({
+      client: s3,
+      params: {
+        Bucket: s3Bucket,
+        Key: key,
+        Body: fileStream,
+      },
+      queueSize: 4, // 4 concurrent uploads
+      partSize: 1000 * 1024 * 1024, // 1 GB
+    });
+
+    chunkUploadParams.on("httpUploadProgress", (progress) => {
+      logger.info({ progress }, "Uploading snapshot to S3 - progress");
+    });
+
+    try {
+      await chunkUploadParams.done();
+      logger.info({ key, file, timeTakenMs: Date.now() - startTimestamp }, "Snapshot chunk uploaded to S3");
+    } catch (e: unknown) {
+      return err(new HubError("unavailable.network_failure", (e as Error).message));
+    }
+  }
+
   const metadata: SnapshotMetadata = {
-    key,
-    timestamp: Date.now(),
-    serverDate: new Date().toISOString(),
+    keyBase,
+    chunks: files,
+    timestamp: startTimestamp,
+    serverDate: new Date(startTimestamp).toISOString(),
     ...(messageCount && { numMessages: messageCount }),
   };
 
@@ -124,15 +146,11 @@ export const uploadToS3 = async (
     Body: JSON.stringify(metadata, null, 2),
   };
 
-  targzParams.on("httpUploadProgress", (progress) => {
-    logger.info({ progress }, "Uploading snapshot to S3 - progress");
-  });
-
   try {
-    await targzParams.done();
+    logger.info({ latestJsonParams, metadata }, "Preparing latest.json for uploading to S3");
     await s3.send(new PutObjectCommand(latestJsonParams));
-    logger.info({ key, timeTakenMs: Date.now() - start }, "Snapshot uploaded to S3");
-    return ok(key);
+    logger.info({}, "Snapshot latest.json uploaded to S3");
+    return ok(keyBase);
   } catch (e: unknown) {
     return err(new HubError("unavailable.network_failure", (e as Error).message));
   }


### PR DESCRIPTION
## Motivation

To avoid the snapshot .tar.gz from becoming too big, we split it into 4GB chunks


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus:
Implement snapshot chunking, improve snapshot download logging, and enhance error handling in the Hub application.

### Detailed summary:
- Split snapshot into 4GB chunks for efficient storage
- Update snapshot download log message
- Implement chunked snapshot writing for backups
- Improve error handling during snapshot upload
- Modify snapshot metadata key to `keyBase`

> The following files were skipped due to too many changes: `apps/hubble/src/utils/snapshot.ts`, `apps/hubble/src/hubble.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->