### PR TITLE
chore: v1.11.8 release

### DIFF
--- a/.changeset/popular-dryers-walk.md
+++ b/.changeset/popular-dryers-walk.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Split the snapshot into 4GB chunks

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hubble
 
+## 1.11.8
+
+### Patch Changes
+
+- cd7db2dc: fix: Split the snapshot into 4GB chunks
+
 ## 1.11.7
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.11.7",
+  "version": "1.11.8",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",


### PR DESCRIPTION
## Motivation

v 1.11.8 release with chunked snapshots


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of the `@farcaster/hubble` package to `1.11.8` and includes a patch to split snapshots into 4GB chunks.

### Detailed summary
- Updated package version to `1.11.8`
- Patched to split snapshots into 4GB chunks

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->