### PR TITLE
perf: Disable WAL when creating snapshot

### DIFF
--- a/.changeset/silver-timers-collect.md
+++ b/.changeset/silver-timers-collect.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+perf: Disable WAL when generating snapshots

--- a/apps/hubble/src/addon/Cargo.lock
+++ b/apps/hubble/src/addon/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
  "ed25519-dalek",
  "flate2",
  "glob",
+ "gzp",
  "hex",
  "hostname",
  "neon",
@@ -269,6 +270,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +351,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,6 +376,17 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "core_affinity"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622892f5635ce1fc38c8f16dfc938553ed64af482edb5e150bf4caedbfcb2304"
+dependencies = [
+ "libc",
+ "num_cpus",
+ "winapi",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -544,7 +571,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
+ "libz-sys",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "pin-project",
+ "spin",
 ]
 
 [[package]]
@@ -609,8 +650,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -624,6 +667,23 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "gzp"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c65d1899521a11810501b50b898464d133e1afc96703cff57726964cfa7baf"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "core_affinity",
+ "flate2",
+ "flume",
+ "libdeflater",
+ "libz-sys",
+ "num_cpus",
+ "thiserror",
+]
 
 [[package]]
 name = "h2"
@@ -868,6 +928,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libdeflate-sys"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1f7b0817f85e2ba608892f30fbf4c9d03f3ebf9db0c952d1b7c8f7387b54785"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "libdeflater"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671e63282f642c7bcc7d292b212d5a4739fef02a77fe98429a75d308f96e7931"
+dependencies = [
+ "libdeflate-sys",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,6 +978,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
 dependencies = [
  "cc",
+ "cmake",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -909,6 +989,16 @@ name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+
+[[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -981,6 +1071,15 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "neon"
@@ -1356,6 +1455,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,6 +1592,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,6 +1671,26 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/apps/hubble/src/addon/Cargo.toml
+++ b/apps/hubble/src/addon/Cargo.toml
@@ -34,6 +34,7 @@ tempfile = "3.10.1"
 rand = "0.8.5"
 hex = "0.4.3"
 flate2 = "1.0.28"
+gzp = "0.11.3"
 
 [build-dependencies]
 tonic-build = "0.11"

--- a/apps/hubble/src/rustfunctions.ts
+++ b/apps/hubble/src/rustfunctions.ts
@@ -154,8 +154,8 @@ export const rsDbCommit = async (db: RustDb, keyValues: DbKeyValue[]): Promise<v
   return await lib.dbCommit.call(db, keyValues);
 };
 
-export const rsDbSnapshotBackup = async (mainDb: RustDb, trieDb: RustDb): Promise<string> => {
-  return await lib.dbSnapshotBackup(mainDb, trieDb);
+export const rsDbSnapshotBackup = async (mainDb: RustDb, trieDb: RustDb, timestamp: number): Promise<string> => {
+  return await lib.dbSnapshotBackup(mainDb, trieDb, timestamp);
 };
 
 /**

--- a/apps/hubble/src/storage/jobs/dbSnapshotBackupJob.ts
+++ b/apps/hubble/src/storage/jobs/dbSnapshotBackupJob.ts
@@ -66,11 +66,11 @@ export class DbSnapshotBackupJobScheduler {
     this._running = true;
 
     log.info({}, "starting Db Snapshot Backup job");
-    const start = Date.now();
+    const startTimestampMs = Date.now();
 
     // Back up the DB before opening it
     const tarGzResult = await ResultAsync.fromPromise(
-      rsDbSnapshotBackup(this._mainDb.rustDb, this._trieDb.rustDb),
+      rsDbSnapshotBackup(this._mainDb.rustDb, this._trieDb.rustDb, startTimestampMs),
       (e) => e as Error,
     );
 
@@ -89,6 +89,7 @@ export class DbSnapshotBackupJobScheduler {
         tarGzResult.value,
         this._options.s3SnapshotBucket,
         messageCount,
+        startTimestampMs,
       );
       if (s3Result.isOk()) {
         // Delete the tar file chunks directory, ignore errors
@@ -99,7 +100,7 @@ export class DbSnapshotBackupJobScheduler {
         if (deleteResult.isErr()) {
           log.warn(
             { error: deleteResult.error, errMessaeg: deleteResult.error.message },
-            "failed to delete tar backup chunks",
+            "failed to delete tar.gz snapshot backup chunks",
           );
         }
 
@@ -109,10 +110,10 @@ export class DbSnapshotBackupJobScheduler {
         log.error({ error: s3Result.error, errMsg: s3Result.error.message }, "failed to upload snapshot to S3");
       }
     } else {
-      log.error({ error: tarGzResult.error }, "failed to create tar backup for S3");
+      log.error({ error: tarGzResult.error }, "failed to create tar.gz snapshot backup for S3");
     }
 
-    log.info({ timeTakenMs: Date.now() - start }, "finished Db Snapshot Backup job");
+    log.info({ timeTakenMs: Date.now() - startTimestampMs }, "finished Db Snapshot Backup job");
     this._running = false;
 
     return ok(undefined);

--- a/apps/hubble/src/utils/snapshot.ts
+++ b/apps/hubble/src/utils/snapshot.ts
@@ -53,6 +53,7 @@ export const snapshotDirectory = (fcNetwork: FarcasterNetwork, prevVersionCounte
   const network = FarcasterNetwork[fcNetwork].toString();
   return `snapshots/${network}/DB_SCHEMA_${LATEST_DB_SCHEMA_VERSION - (prevVersionCounter ?? 0)}`;
 };
+
 export const snapshotURLAndMetadata = async (
   fcNetwork: FarcasterNetwork,
   prevVersionCounter?: number,
@@ -66,6 +67,7 @@ export const snapshotURLAndMetadata = async (
   const data: SnapshotMetadata = response.value;
   return ok([`https://${s3Bucket}/${data.keyBase}`, data]);
 };
+
 export const snapshotURL = (
   fcNetwork: FarcasterNetwork,
   prevVersionCounter?: number,
@@ -79,8 +81,10 @@ export const uploadToS3 = async (
   chunkedDirPath: string,
   s3Bucket: string = SNAPSHOT_S3_DEFAULT_BUCKET,
   messageCount?: number,
+  timestamp?: number,
 ): HubAsyncResult<string> => {
-  const startTimestamp = Date.now();
+  const startTimestamp = timestamp ?? Date.now();
+
   const s3 = new S3Client({
     region: S3_REGION,
   });


### PR DESCRIPTION
## Motivation

When we're creating a snapshot, we open a fresh DB and write keys to it. For this DB, we don't need the WAL, since it is not a live DB, so we can disable WAL to write keys faster.

## Change Summary

- Disable WAL
- Use batched writes
- Compress .tar.gz with 4 threads

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)
