### PR TITLE
fix: Use R2 for snapshots

### DIFF
--- a/.changeset/shiny-carrots-behave.md
+++ b/.changeset/shiny-carrots-behave.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Use R2 for snapshots

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -959,11 +959,11 @@ async function verifyAWSCredentials(): Promise<boolean> {
   try {
     const params = {
       Bucket: SNAPSHOT_S3_UPLOAD_BUCKET,
-      Prefix: "/",
+      Prefix: "snapshots/",
     };
 
     const result = await s3.send(new ListObjectsV2Command(params));
-    logger.info({ result }, "Verified R2 credentials for snapshots");
+    logger.info({ keys: result.KeyCount }, "Verified R2 credentials for snapshots");
 
     return true;
   } catch (error) {

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -9,7 +9,15 @@ import { mkdir, readFile, writeFile } from "fs/promises";
 import { Result, ResultAsync } from "neverthrow";
 import { dirname, resolve } from "path";
 import { exit } from "process";
-import { APP_VERSION, FARCASTER_VERSION, Hub, HubOptions, HubShutdownReason, S3_REGION } from "./hubble.js";
+import {
+  APP_VERSION,
+  FARCASTER_VERSION,
+  Hub,
+  HubOptions,
+  HubShutdownReason,
+  S3_REGION,
+  SNAPSHOT_S3_UPLOAD_BUCKET,
+} from "./hubble.js";
 import { logger } from "./utils/logger.js";
 import { addressInfoFromParts, hostPortFromString, ipMultiAddrStrFromAddressInfo, parseAddress } from "./utils/p2p.js";
 import { DEFAULT_RPC_CONSOLE, startConsole } from "./console/console.js";
@@ -25,10 +33,10 @@ import { startupCheck, StartupCheckStatus } from "./utils/startupCheck.js";
 import { mainnet, optimism } from "viem/chains";
 import { finishAllProgressBars } from "./utils/progressBars.js";
 import { MAINNET_BOOTSTRAP_PEERS } from "./bootstrapPeers.mainnet.js";
-import { GetCallerIdentityCommand, STSClient } from "@aws-sdk/client-sts";
 import axios from "axios";
-import { snapshotURLAndMetadata } from "./utils/snapshot.js";
+import { r2Endpoint, snapshotURLAndMetadata } from "./utils/snapshot.js";
 import { DEFAULT_DIAGNOSTIC_REPORT_URL, initDiagnosticReporter } from "./utils/diagnosticReport.js";
+import { ListObjectsV2Command, S3Client } from "@aws-sdk/client-s3";
 
 /** A CLI to accept options from the user and start the Hub */
 
@@ -942,16 +950,24 @@ app.parse(process.argv);
 // Verify that we have access to the AWS credentials.
 // Either via environment variables or via the AWS credentials file
 async function verifyAWSCredentials(): Promise<boolean> {
-  const sts = new STSClient({ region: S3_REGION });
+  const s3 = new S3Client({
+    region: S3_REGION,
+    endpoint: r2Endpoint(),
+    forcePathStyle: true,
+  });
 
   try {
-    const identity = await sts.send(new GetCallerIdentityCommand({}));
+    const params = {
+      Bucket: SNAPSHOT_S3_UPLOAD_BUCKET,
+      Prefix: "/",
+    };
 
-    logger.info({ accountId: identity.Account }, "Verified AWS credentials");
+    const result = await s3.send(new ListObjectsV2Command(params));
+    logger.info({ result }, "Verified R2 credentials for snapshots");
 
     return true;
   } catch (error) {
-    logger.error({ err: error }, "Failed to verify AWS credentials. No S3 snapshot upload will be performed.");
+    logger.error({ err: error }, "Failed to verify R2 credentials. No snapshots performed.");
     return false;
   }
 }

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -100,8 +100,9 @@ export type HubSubmitSource = "gossip" | "rpc" | "eth-provider" | "l2-provider" 
 export const APP_VERSION = packageJson.version;
 export const APP_NICKNAME = process.env["HUBBLE_NAME"] ?? "Farcaster Hub";
 
-export const SNAPSHOT_S3_DEFAULT_BUCKET = "download.farcaster.xyz";
-export const S3_REGION = "us-east-1";
+export const SNAPSHOT_S3_UPLOAD_BUCKET = "farcaster-snapshots";
+export const SNAPSHOT_S3_DEFAULT_BUCKET = "download-beta.farcaster.xyz";
+export const S3_REGION = "auto";
 
 export const FARCASTER_VERSION = "2024.3.20";
 export const FARCASTER_VERSIONS_SCHEDULE: VersionSchedule[] = [

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -101,7 +101,7 @@ export const APP_VERSION = packageJson.version;
 export const APP_NICKNAME = process.env["HUBBLE_NAME"] ?? "Farcaster Hub";
 
 export const SNAPSHOT_S3_UPLOAD_BUCKET = "farcaster-snapshots";
-export const SNAPSHOT_S3_DEFAULT_BUCKET = "download-beta.farcaster.xyz";
+export const SNAPSHOT_S3_DEFAULT_BUCKET = "download.farcaster.xyz";
 export const S3_REGION = "auto";
 
 export const FARCASTER_VERSION = "2024.3.20";


### PR DESCRIPTION
## Motivation

Upload / download snapshots from R2 instead of S3


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Hubble app to use R2 for snapshots and introduces a new `SNAPSHOT_S3_UPLOAD_BUCKET`.

### Detailed summary
- Updated snapshot handling to use R2
- Added `SNAPSHOT_S3_UPLOAD_BUCKET` for uploading snapshots
- Introduced `r2Endpoint` function for R2 endpoint configuration

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->