### PR TITLE
fix: Add `ps` to Hubble image

### DIFF
--- a/Dockerfile.hubble
+++ b/Dockerfile.hubble
@@ -61,6 +61,8 @@ RUN rm -rf node_modules && yarn install --production --ignore-scripts --prefer-o
 
 FROM node:21.6-slim as app
 
+RUN apt-get update && apt-get install -y procps
+
 # Set non-root user and expose ports
 USER node
 


### PR DESCRIPTION
## Motivation

This quiets down some warnings emitted by PM2.

## Change Summary

Install `ps` in the Docker image.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding the `procps` package to the Dockerfile for the `hubble` image.

### Detailed summary
- Added installation of `procps` package to the Dockerfile for `hubble` image.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->