### PR TITLE
chore: Remove Node 18 from CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - node_version: 18
-            runs_on: 'buildjet-8vcpu-ubuntu-2204'
           - node_version: 20
             runs_on: 'buildjet-8vcpu-ubuntu-2204'
           - node_version: 21
@@ -140,4 +138,4 @@ jobs:
         uses: codecov/codecov-action@v4
         continue-on-error: true # Don't fail the build if codecov fails
         timeout-minutes: 1
-        
+


### PR DESCRIPTION
## Motivation

This has stopped receiving active support (only security updates), and we no longer ship a Node 18 Docker image.

## Change Summary

Remove Node 18.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Node.js versions in the CI workflow to 20 and 21.

### Detailed summary
- Updated Node.js versions in CI workflow to 20 and 21
- Removed Node.js version 18 from the matrix configuration

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->