### PR TITLE
fix: Upload snapshots using PutObject

### DIFF
--- a/.changeset/clean-eagles-reflect.md
+++ b/.changeset/clean-eagles-reflect.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Use `PutObject` to upload snapshot chunks to R2

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -101,7 +101,7 @@ export const APP_VERSION = packageJson.version;
 export const APP_NICKNAME = process.env["HUBBLE_NAME"] ?? "Farcaster Hub";
 
 export const SNAPSHOT_S3_UPLOAD_BUCKET = "farcaster-snapshots";
-export const SNAPSHOT_S3_DEFAULT_BUCKET = "download.farcaster.xyz";
+export const SNAPSHOT_S3_DOWNLOAD_BUCKET = "download.farcaster.xyz";
 export const S3_REGION = "auto";
 
 export const FARCASTER_VERSION = "2024.3.20";
@@ -943,7 +943,7 @@ export class Hub implements HubInterface {
     }
   }
   async snapshotSync(overwrite?: boolean): HubAsyncResult<boolean> {
-    const s3Bucket = this.options.s3SnapshotBucket ?? SNAPSHOT_S3_DEFAULT_BUCKET;
+    const s3Bucket = this.options.s3SnapshotBucket ?? SNAPSHOT_S3_DOWNLOAD_BUCKET;
     return new Promise((resolve) => {
       (async () => {
         let progressBar: SingleBar | undefined;

--- a/apps/hubble/src/network/sync/merkleTrie.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.ts
@@ -11,7 +11,7 @@ import {
 } from "../../storage/db/types.js";
 import { logger } from "../../utils/logger.js";
 import { messageDecode } from "../../storage/db/message.js";
-import { BLAKE3TRUNCATE160_EMPTY_HASH, sleep } from "../../utils/crypto.js";
+import { BLAKE3TRUNCATE160_EMPTY_HASH } from "../../utils/crypto.js";
 import {
   rsCreateMerkleTrie,
   rsCreateMerkleTrieFromDb,

--- a/apps/hubble/src/utils/snapshot.ts
+++ b/apps/hubble/src/utils/snapshot.ts
@@ -2,7 +2,7 @@ import { DbStats, FarcasterNetwork, HubAsyncResult, HubError } from "@farcaster/
 import { LATEST_DB_SCHEMA_VERSION } from "../storage/db/migrations/migrations.js";
 import axios from "axios";
 import { err, ok, ResultAsync } from "neverthrow";
-import { S3_REGION, SNAPSHOT_S3_DEFAULT_BUCKET, SNAPSHOT_S3_UPLOAD_BUCKET } from "../hubble.js";
+import { S3_REGION, SNAPSHOT_S3_DOWNLOAD_BUCKET, SNAPSHOT_S3_UPLOAD_BUCKET } from "../hubble.js";
 import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import fs from "fs";
 import { Upload } from "@aws-sdk/lib-storage";
@@ -57,7 +57,7 @@ export const snapshotDirectory = (fcNetwork: FarcasterNetwork, prevVersionCounte
 export const snapshotURLAndMetadata = async (
   fcNetwork: FarcasterNetwork,
   prevVersionCounter?: number,
-  s3Bucket: string = SNAPSHOT_S3_DEFAULT_BUCKET,
+  s3Bucket: string = SNAPSHOT_S3_DOWNLOAD_BUCKET,
 ): HubAsyncResult<[string, SnapshotMetadata]> => {
   const dirPath = snapshotURL(fcNetwork, prevVersionCounter, s3Bucket);
   const response = await fetchSnapshotMetadata(dirPath);
@@ -71,7 +71,7 @@ export const snapshotURLAndMetadata = async (
 export const snapshotURL = (
   fcNetwork: FarcasterNetwork,
   prevVersionCounter?: number,
-  s3Bucket: string = SNAPSHOT_S3_DEFAULT_BUCKET,
+  s3Bucket: string = SNAPSHOT_S3_DOWNLOAD_BUCKET,
 ): string => {
   return `https://${s3Bucket}/${snapshotDirectory(fcNetwork, prevVersionCounter)}`;
 };
@@ -119,23 +119,16 @@ export const uploadToS3 = async (
     });
 
     // The chunks should be uploaded via multipart upload to S3
-    const chunkUploadParams = new Upload({
-      client: s3,
-      params: {
-        Bucket: s3Bucket,
-        Key: key,
-        Body: fileStream,
-      },
-      queueSize: 4, // 4 concurrent uploads
-      partSize: 1000 * 1024 * 1024, // 1 GB
-    });
+    const chunkUploadParams = {
+      Bucket: s3Bucket,
+      Key: key,
+      Body: fileStream,
+    };
 
-    chunkUploadParams.on("httpUploadProgress", (progress) => {
-      logger.info({ progress }, "Uploading snapshot to S3 - progress");
-    });
+    logger.info({ key }, "Uploading snapshot chunk to S3");
 
     try {
-      await chunkUploadParams.done();
+      await s3.send(new PutObjectCommand(chunkUploadParams));
       logger.info({ key, file, timeTakenMs: Date.now() - startTimestamp }, "Snapshot chunk uploaded to S3");
     } catch (e: unknown) {
       return err(new HubError("unavailable.network_failure", (e as Error).message));
@@ -154,6 +147,7 @@ export const uploadToS3 = async (
     Bucket: s3Bucket,
     Key: `${snapshotDirectory(fcNetwork)}/latest.json`,
     Body: JSON.stringify(metadata, null, 2),
+    ContentType: "application/json",
   };
 
   try {


### PR DESCRIPTION
## Motivation

Upload snapshot chunk files to R2 using PutObject to avoid multi part uploads that are causing problems.


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the snapshot upload process by using `PutObject` to upload snapshot chunks to S3.

### Detailed summary
- Updated snapshot upload process to use `PutObject` for chunk uploads to S3
- Renamed `SNAPSHOT_S3_DEFAULT_BUCKET` to `SNAPSHOT_S3_DOWNLOAD_BUCKET`
- Updated bucket references in functions related to snapshot URLs and metadata

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->