### PR TITLE
perf: Improve getSyncMetadataByPrefix performance

### DIFF
--- a/.changeset/proud-plums-design.md
+++ b/.changeset/proud-plums-design.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+perf: Improve getSyncMetadataByPrefix performance

--- a/apps/hubble/src/addon/src/trie/merkle_trie_tests.rs
+++ b/apps/hubble/src/addon/src/trie/merkle_trie_tests.rs
@@ -1,0 +1,72 @@
+#[cfg(test)]
+mod tests {
+    use crate::trie::merkle_trie::MerkleTrie;
+
+    #[test]
+    fn test_merkle_trie_get_node() {
+        let tmp_path = tempfile::tempdir()
+            .unwrap()
+            .path()
+            .as_os_str()
+            .to_string_lossy()
+            .to_string();
+
+        let trie = MerkleTrie::new(&tmp_path).unwrap();
+        trie.initialize().unwrap();
+
+        let key1: Vec<_> = "0000482712".bytes().collect();
+        println!("{:?}", key1);
+        trie.insert(&key1).unwrap();
+
+        let node = trie.get_node(&key1).unwrap();
+        assert_eq!(node.value().unwrap(), key1);
+
+        // Add another key
+        let key2: Vec<_> = "0000482713".bytes().collect();
+        trie.insert(&key2).unwrap();
+
+        // The get node should still work for both keys
+        let node = trie.get_node(&key1).unwrap();
+        assert_eq!(node.value().unwrap(), key1);
+        let node = trie.get_node(&key2).unwrap();
+        assert_eq!(node.value().unwrap(), key2);
+
+        // Getting the node with first 9 bytes should return the node with key1
+        let common_node = trie.get_node(&key1[0..9].to_vec()).unwrap();
+        assert_eq!(common_node.is_leaf(), false);
+        assert_eq!(common_node.children().len(), 2);
+        let mut children_keys: Vec<_> = common_node.children().keys().collect();
+        children_keys.sort();
+
+        assert_eq!(*children_keys[0], key1[9]);
+        assert_eq!(*children_keys[1], key2[9]);
+
+        // Get the metadata for the root node
+        let root_metadata = trie.get_trie_node_metadata(&key1[0..1]).unwrap();
+        assert_eq!(root_metadata.prefix, "0".bytes().collect::<Vec<_>>());
+        assert_eq!(root_metadata.num_messages, 2);
+        assert_eq!(root_metadata.children.len(), 1);
+
+        let metadata = trie.get_trie_node_metadata(&key1[0..9]).unwrap();
+
+        // Get the children
+        let mut children = metadata
+            .children
+            .into_iter()
+            .map(|(k, v)| (k, v))
+            .collect::<Vec<_>>();
+        children.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(children[0].0, key1[9]);
+        assert_eq!(children[0].1.prefix, key1);
+        assert_eq!(children[0].1.num_messages, 1);
+
+        assert_eq!(children[1].0, key2[9]);
+        assert_eq!(children[1].1.prefix, key2);
+        assert_eq!(children[1].1.num_messages, 1);
+
+        trie.stop().unwrap();
+
+        // Clean up
+        std::fs::remove_dir_all(&tmp_path).unwrap();
+    }
+}

--- a/apps/hubble/src/addon/src/trie/mod.rs
+++ b/apps/hubble/src/addon/src/trie/mod.rs
@@ -3,3 +3,6 @@ mod trie_node;
 
 #[cfg(test)]
 mod trie_node_tests;
+
+#[cfg(test)]
+mod merkle_trie_tests;

--- a/apps/hubble/src/addon/src/trie/trie_node.rs
+++ b/apps/hubble/src/addon/src/trie/trie_node.rs
@@ -6,14 +6,14 @@ use crate::{
 use prost::Message as _;
 use std::{collections::HashMap, sync::Arc};
 
-use super::merkle_trie::{NodeMetadata, TrieSnapshot};
+use super::merkle_trie::TrieSnapshot;
 
 pub const TIMESTAMP_LENGTH: usize = 10;
 const MAX_VALUES_RETURNED_PER_CALL: usize = 1024;
 
 /// Represents a node in a MerkleTrie. Automatically updates the hashes when items are added,
 /// and keeps track of the number of items in the subtree.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct TrieNode {
     hash: Vec<u8>,
     items: usize,
@@ -22,7 +22,7 @@ pub struct TrieNode {
 }
 
 // An empty struct that represents a serialized trie node, which will need to be loaded from the db
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SerializedTrieNode {
     pub hash: Option<Vec<u8>>,
 }
@@ -34,7 +34,7 @@ impl SerializedTrieNode {
 }
 
 // An enum that represents the different types of trie nodes
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum TrieNodeType {
     Node(TrieNode),
     Serialized(SerializedTrieNode),
@@ -118,12 +118,11 @@ impl TrieNode {
         }
     }
 
-    #[cfg(test)]
     pub fn children(&self) -> &HashMap<u8, TrieNodeType> {
         &self.children
     }
 
-    pub fn get_node(
+    pub fn get_node_from_trie(
         &mut self,
         db: &Arc<RocksDB>,
         prefix: &[u8],
@@ -139,7 +138,7 @@ impl TrieNode {
         }
 
         if let Ok(child) = self.get_or_load_child(db, &prefix[..current_index], char) {
-            child.get_node(db, prefix, current_index + 1)
+            child.get_node_from_trie(db, prefix, current_index + 1)
         } else {
             None
         }
@@ -346,6 +345,7 @@ impl TrieNode {
             Entry::Occupied(mut entry) => {
                 if let TrieNodeType::Serialized(_) = entry.get_mut() {
                     let child_prefix = Self::make_primary_key(prefix, Some(char));
+
                     let child_node = db
                         .get(&child_prefix)?
                         .map(|b| TrieNode::deserialize(&b).unwrap())
@@ -484,39 +484,6 @@ impl TrieNode {
         }
 
         Ok(values)
-    }
-
-    pub fn get_node_metadata(
-        &mut self,
-        db: &Arc<RocksDB>,
-        prefix: &[u8],
-    ) -> Result<NodeMetadata, HubError> {
-        let mut children = HashMap::new();
-
-        let child_chars = self.children.keys().map(|c| *c).collect::<Vec<_>>();
-        for char in child_chars {
-            let child_node = self.get_or_load_child(db, prefix, char)?;
-
-            let mut child_prefix = prefix.to_vec();
-            child_prefix.push(char);
-
-            children.insert(
-                char,
-                NodeMetadata {
-                    prefix: child_prefix.clone(),
-                    num_messages: child_node.items,
-                    hash: hex::encode(child_node.hash.as_slice()),
-                    children: HashMap::new(),
-                },
-            );
-        }
-
-        Ok(NodeMetadata {
-            prefix: prefix.to_vec(),
-            num_messages: self.items,
-            hash: hex::encode(self.hash.as_slice()),
-            children,
-        })
     }
 
     pub fn get_snapshot(

--- a/apps/hubble/src/addon/src/trie/trie_node_tests.rs
+++ b/apps/hubble/src/addon/src/trie/trie_node_tests.rs
@@ -352,11 +352,11 @@ mod tests {
         }
 
         // Ensure the branch is compacted
-        let node1 = node.get_node(&db, &ids[1][0..10], 0).unwrap();
+        let node1 = node.get_node_from_trie(&db, &ids[1][0..10], 0).unwrap();
         assert_eq!(node1.is_leaf(), true);
         assert_eq!(node1.value(), Some(ids[1].clone()));
 
-        let node2 = node.get_node(&db, &ids[2][0..10], 0).unwrap();
+        let node2 = node.get_node_from_trie(&db, &ids[2][0..10], 0).unwrap();
         assert_eq!(node2.is_leaf(), true);
         assert_eq!(node2.value(), Some(ids[2].clone()));
 

--- a/apps/hubble/src/network/sync/merkleTrie.test.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.test.ts
@@ -629,7 +629,7 @@ describe("MerkleTrie", () => {
     });
   });
 
-  test("getAllValues returns all values for child nodes", async () => {
+  test("getAllValues returns all values for child nodes directly", async () => {
     const trie = await trieWithIds([1665182332, 1665182343, 1665182345]);
 
     let values = await trie.getAllValues(new Uint8Array(Buffer.from("16651823")));

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -1302,10 +1302,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
           return;
         }
 
-        const startNs = process.hrtime.bigint();
         const ourNode = await this._trie.getTrieNodeMetadata(workItem.prefix);
-        const endNs = process.hrtime.bigint();
-        statsd().timing("syncengine.get_trie_node_metadata_ns", Number(endNs - startNs));
 
         const start = Date.now();
         const theirNodeResult = await this.curSync.rpcClient.getSyncMetadataByPrefix(

--- a/apps/hubble/src/rpc/test/server.test.ts
+++ b/apps/hubble/src/rpc/test/server.test.ts
@@ -220,7 +220,7 @@ describe("server rpc tests", () => {
 
 describe("checkPort", () => {
   let server: http.Server;
-  const testPort = 3000; // Example port
+  const testPort = 3111; // Example port
 
   beforeAll((done) => {
     server = http.createServer((req, res) => {


### PR DESCRIPTION
## Motivation


This API walks the trie to get the sync metadata at the given prefix, traversing on avg 12 nodes, reading each node from the DB. However, since we already have the prefix, we can read the final node directly from the DB, saving 11 hits to the DB for every API call! 

## Change Summary


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving performance in `getSyncMetadataByPrefix` and enhancing testing for `MerkleTrie` operations.

### Detailed summary
- Added a new test module `merkle_trie_tests` for testing `MerkleTrie` functionality
- Updated `MerkleTrie` methods for better performance and error handling
- Refactored `TrieNode` struct and related methods for clarity and consistency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->