### PR TITLE
fix: sharding events should work when requesting historical events

### DIFF
--- a/.changeset/giant-monkeys-walk.md
+++ b/.changeset/giant-monkeys-walk.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: sharding events should work when requesting historical events

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -1329,7 +1329,10 @@ export default class Server {
 
           await this.engine.getDb().forEachIteratorByOpts(eventsIteratorOpts.value, async (_key, value) => {
             const event = HubEvent.decode(Uint8Array.from(value as Buffer));
-            if (request.eventTypes.length === 0 || request.eventTypes.includes(event.type)) {
+            const isRequestedType = request.eventTypes.length === 0 || request.eventTypes.includes(event.type);
+            const isRequestedFid = totalShards === 0 || fidFromEvent(event) % totalShards === shardIndex;
+            const shouldWriteEvent = isRequestedType && isRequestedFid;
+            if (shouldWriteEvent) {
               const writeResult = bufferedStreamWriter.writeToStream(event);
 
               if (writeResult.isErr()) {

--- a/apps/hubble/src/rpc/test/eventService.test.ts
+++ b/apps/hubble/src/rpc/test/eventService.test.ts
@@ -352,5 +352,24 @@ describe("sharded event stream", () => {
     oddEvents.map(([, event]) => {
       expect(event.fid || event.data.fid).toBe(303);
     });
+
+    // Should also work when requesting events from the past
+    // biome-ignore lint/suspicious/noExplicitAny: legacy code, avoid using ignore for new code
+    const evenHistoricalEvents: [HubEventType, any][] = [];
+    // biome-ignore lint/suspicious/noExplicitAny: legacy code, avoid using ignore for new code
+    const oddHistoricalEvents: [HubEventType, any][] = [];
+
+    await setupSubscription(evenHistoricalEvents, { totalShards: 2, shardIndex: 0, fromId: 0 });
+    await setupSubscription(oddHistoricalEvents, { totalShards: 2, shardIndex: 1, fromId: 0 });
+    await sleep(100);
+
+    expect(evenHistoricalEvents).toHaveLength(5);
+    expect(oddHistoricalEvents).toHaveLength(5);
+    evenHistoricalEvents.map(([, event]) => {
+      expect(event.fid || event.data.fid).toBe(202);
+    });
+    oddHistoricalEvents.map(([, event]) => {
+      expect(event.fid || event.data.fid).toBe(303);
+    });
   });
 });


### PR DESCRIPTION
## Motivation

Sharding params weren't taken into account when fromId was passed in

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing sharding events for historical event requests in `@farcaster/hubble`.

### Detailed summary
- Fixed sharding events for historical event requests
- Added logic to handle historical events in event service tests

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->