### PR TITLE
fix: Use batch to check for de-dups when merging

### DIFF
--- a/.changeset/poor-wolves-invite.md
+++ b/.changeset/poor-wolves-invite.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Batch the de-dup check for merging messages

--- a/apps/hubble/src/addon/src/lib.rs
+++ b/apps/hubble/src/addon/src/lib.rs
@@ -107,6 +107,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("dbClose", RocksDB::js_close)?;
     cx.export_function("dbDestroy", RocksDB::js_destroy)?;
     cx.export_function("dbLocation", RocksDB::js_location)?;
+    cx.export_function("dbKeysExist", RocksDB::js_keys_exist)?;
     cx.export_function("dbGet", RocksDB::js_get)?;
     cx.export_function("dbGetMany", RocksDB::js_get_many)?;
     cx.export_function("dbPut", RocksDB::js_put)?;

--- a/apps/hubble/src/rustfunctions.ts
+++ b/apps/hubble/src/rustfunctions.ts
@@ -132,6 +132,10 @@ export const rsDbLocation = (db: RustDb): string => {
   return lib.dbLocation.call(db);
 };
 
+export const rsDbKeysExist = async (db: RustDb, keys: Uint8Array[]): Promise<boolean[]> => {
+  return await lib.dbKeysExist.call(db, keys);
+};
+
 export const rsDbGet = async (db: RustDb, key: Uint8Array): Promise<Buffer> => {
   return await lib.dbGet.call(db, key);
 };

--- a/apps/hubble/src/storage/db/message.ts
+++ b/apps/hubble/src/storage/db/message.ts
@@ -127,6 +127,15 @@ export const getMessage = async <T extends Message>(
   return messageDecode(new Uint8Array(buffer)) as T;
 };
 
+export const areMessagesInDb = async (db: RocksDB, messages: Message[]): Promise<boolean[]> => {
+  const exists = await db.keysExist(messages.map((message) => makeMessagePrimaryKeyFromMessage(message)));
+  if (exists.isErr()) {
+    // Return a false for each message that we couldn't check
+    return messages.map(() => false);
+  }
+  return exists.value;
+};
+
 export const isMessageInDB = async (db: RocksDB, message: Message): Promise<boolean> => {
   const exists = await ResultAsync.fromPromise(
     (async () => {

--- a/apps/hubble/src/storage/db/rocksdb.test.ts
+++ b/apps/hubble/src/storage/db/rocksdb.test.ts
@@ -130,6 +130,30 @@ describe("with db", () => {
     });
   });
 
+  describe("keysExist", () => {
+    test("exists for single key", async () => {
+      await db.put(Buffer.from("foo"), Buffer.from("bar"));
+      const exists = await db.keysExist([Buffer.from("foo")]);
+      expect(exists._unsafeUnwrap()).toEqual([true]);
+    });
+
+    test("exists works for keys that exist mixed with don't exist", async () => {
+      await db.put(Buffer.from("foo"), Buffer.from("bar"));
+      const exists = await db.keysExist([Buffer.from("foo"), Buffer.from("alice")]);
+      expect(exists._unsafeUnwrap()).toEqual([true, false]);
+    });
+
+    test("exists works when no keys exist", async () => {
+      const exists = await db.keysExist([Buffer.from("foo"), Buffer.from("alice")]);
+      expect(exists._unsafeUnwrap()).toEqual([false, false]);
+    });
+
+    test("exists works for no keys", async () => {
+      const exists = await db.keysExist([]);
+      expect(exists._unsafeUnwrap()).toEqual([]);
+    });
+  });
+
   describe("put", () => {
     test("puts a value by key", async () => {
       await expect(db.put(Buffer.from("foo"), Buffer.from("bar"))).resolves.toEqual(undefined);

--- a/apps/hubble/src/storage/db/rocksdb.ts
+++ b/apps/hubble/src/storage/db/rocksdb.ts
@@ -19,8 +19,10 @@ import {
   rustErrorToHubError,
   rsDbCountKeysAtPrefix,
   rsDbDeleteAllKeysInRange,
+  rsDbKeysExist,
 } from "../../rustfunctions.js";
 import { PageOptions } from "storage/stores/types.js";
+import { HubAsyncResult } from "@farcaster/hub-nodejs";
 
 export type DbStatus = "new" | "opening" | "open" | "closing" | "closed";
 
@@ -112,6 +114,10 @@ class RocksDB {
     }
 
     return v.value;
+  }
+
+  async keysExist(keys: Buffer[]): HubAsyncResult<boolean[]> {
+    return await ResultAsync.fromPromise(rsDbKeysExist(this._db, keys), (e) => rustErrorToHubError(e));
   }
 
   async get(key: Buffer): Promise<Buffer> {


### PR DESCRIPTION
## Motivation

Use a batch to check for de-dups when merging messages so as to not block the main nodejs thread


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on optimizing message merging in the `hubble` app by batching de-duplication checks. 

### Detailed summary
- Added `rsDbKeysExist` function to batch de-duplication checks for merging messages
- Updated `areMessagesInDb` and `isMessageInDB` functions to utilize the new batching check
- Added `keysExist` method in `RocksDB` class to handle batch keys existence check
- Added tests for the `keysExist` functionality in the `RocksDB` class

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->