### PR TITLE
chore: Buffer statsd calls before sending datagram(s) over socket

### DIFF
--- a/.changeset/quick-stingrays-bathe.md
+++ b/.changeset/quick-stingrays-bathe.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+Buffer statsd calls before sending on socket

--- a/packages/shuttle/src/statsd.ts
+++ b/packages/shuttle/src/statsd.ts
@@ -1,3 +1,3 @@
 import StatsD from "@figma/hot-shots";
 
-export const statsd = new StatsD();
+export const statsd = new StatsD({ cacheDns: true, maxBufferSize: 4096 /* 4KiB */ });


### PR DESCRIPTION
## Motivation

This will improve throughput.

## Change Summary

Buffer stats updates before sending them to reduce the number of individual `send` calls.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on optimizing statsd calls in `shuttle` package by buffering them before sending. 

### Detailed summary
- Updated `statsd.ts` to buffer statsd calls before sending on socket
- Modified `statsd` export to include options for caching DNS and setting max buffer size to 4KiB

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->