### PR TITLE
fix(shuttle): Preserve redis subscriber backwards compatibility

### DIFF
--- a/.changeset/thin-poems-unite.md
+++ b/.changeset/thin-poems-unite.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+fix: Preserve redis stream backwards compatibility

--- a/packages/shuttle/src/shuttle/redis.ts
+++ b/packages/shuttle/src/shuttle/redis.ts
@@ -20,7 +20,12 @@ export class RedisClient {
   }
 
   async setLastProcessedEvent(hubId: string, eventId: number) {
-    await this.client.set(`hub:${hubId}:last-hub-event-id`, eventId.toString());
+    const key = `hub:${hubId}:last-hub-event-id`;
+    if (eventId === 0) {
+      await this.client.del(key);
+    } else {
+      await this.client.set(key, eventId.toString());
+    }
   }
 
   async getLastProcessedEvent(hubId: string) {


### PR DESCRIPTION
## Motivation

Preserve redis backwards compatibility by migrating the keys if present

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [xx] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on preserving Redis stream compatibility and migrating old label-based keys in the `shuttle` package.

### Detailed summary
- Fixed handling of Redis stream keys in `shuttle/redis.ts`
- Added `redisKey` property and migration logic in `hubSubscriber.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->