### PR TITLE
chore: Release shuttle 0.2.4

### DIFF
--- a/.changeset/plenty-badgers-boil.md
+++ b/.changeset/plenty-badgers-boil.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-fix: increase hub timeout limit

--- a/.changeset/quick-stingrays-bathe.md
+++ b/.changeset/quick-stingrays-bathe.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-Buffer statsd calls before sending on socket

--- a/.changeset/thin-poems-unite.md
+++ b/.changeset/thin-poems-unite.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-fix: Preserve redis stream backwards compatibility

--- a/.changeset/wild-llamas-work.md
+++ b/.changeset/wild-llamas-work.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-feat: add fid sharding

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @farcaster/hub-shuttle
 
+## 0.2.4
+
+### Patch Changes
+
+- 30b8d64f: fix: increase hub timeout limit
+- 80aadc6a: Buffer statsd calls before sending on socket
+- 589e5770: fix: Preserve redis stream backwards compatibility
+- 0c1ab37f: feat: add fid sharding
+
 ## 0.2.3
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Motivation

Create shuttle patch release

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `@farcaster/shuttle` to `0.2.4`, including bug fixes, performance improvements, and new features.

### Detailed summary
- Increased hub timeout limit
- Buffered statsd calls before sending on socket
- Preserved redis stream backwards compatibility
- Added fid sharding

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->