### PR TITLE
fix: Validate merge messages only when storing messages

### DIFF
--- a/.changeset/gorgeous-lions-refuse.md
+++ b/.changeset/gorgeous-lions-refuse.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+Validate merge messages only when storing messages

--- a/packages/shuttle/src/shuttle/messageProcessor.ts
+++ b/packages/shuttle/src/shuttle/messageProcessor.ts
@@ -11,17 +11,13 @@ export class MessageProcessor {
     operation: StoreMessageOperation = "merge",
     log: pino.Logger | undefined = undefined,
   ): Promise<boolean> {
-    // const log = createLogger(messageLogData(message));
-    // if (ENVIRONMENT === "prod" && message.data?.network !== FC_NETWORK_ID) {
-    //   throw new BadRequestError(
-    //     `Message ${bytesToHex(message.hash)} has unexpected network ID: ${message.data?.network}`,
-    //   );
-    // }
-
-    const validation = await validations.validateMessage(message);
-    if (validation.isErr()) {
-      log?.warn(`Invalid message ${bytesToHex(message.hash)}: ${validation.error.message}`);
-      throw new Error(`Invalid message: ${validation.error.message}`);
+    // Only validate merge messages since we may be deleting an invalid message
+    if (operation === "merge") {
+      const validation = await validations.validateMessage(message);
+      if (validation.isErr()) {
+        log?.warn(`Invalid message ${bytesToHex(message.hash)}: ${validation.error.message}`);
+        throw new Error(`Invalid message: ${validation.error.message}`);
+      }
     }
 
     if (!message.data) throw new Error("Message data is missing");


### PR DESCRIPTION
## Motivation

This avoids a Catch-22 where when we discover an invalid message and want to remove it we are unable to because of the validation.

## Change Summary

Change validation to only occur for merge messages.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on validating merge messages only when storing them in the `shuttle` package.

### Detailed summary
- Added conditional validation for merge messages only
- Removed unnecessary commented-out code
- Updated error handling for invalid merge messages

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->