### PR TITLE
chore: Release Shuttle 0.2.5

### DIFF
--- a/.changeset/gorgeous-lions-refuse.md
+++ b/.changeset/gorgeous-lions-refuse.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-Validate merge messages only when storing messages

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.2.5
+
+### Patch Changes
+
+- 20c4ef64: Validate merge messages only when storing messages
+
 ## 0.2.4
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Motivation

Release 0.2.5 of Shuttle.

## Change Summary

Bump version.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `@farcaster/shuttle` package to `0.2.5` and includes a patch change related to merge message validation.

### Detailed summary
- Updated version to `0.2.5`
- Patch change: Validate merge messages only when storing messages

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->