### PR TITLE
chore: Switch to custom hot-shots package

### DIFF
--- a/.changeset/gold-snails-bow.md
+++ b/.changeset/gold-snails-bow.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+Switch from @figma/hot-shots to @farcaster/hot-shots

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -16,8 +16,8 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@farcaster/hot-shots": "^10.0.0",
     "@farcaster/hub-nodejs": "^0.11.10",
-    "@figma/hot-shots": "^9.0.0-figma.1",
     "commander": "^11.0.0",
     "ioredis": "^5.3.2",
     "neverthrow": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1830,6 +1830,11 @@
   dependencies:
     lodash.mergewith "^4.6.2"
 
+"@farcaster/hot-shots@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.npmjs.org/@farcaster/hot-shots/-/hot-shots-10.0.0.tgz#6a2f4374c19bb69c0cd271be36f90cfc3bd10d74"
+  integrity sha512-wVbdYvZL41SuCOFOUPsso16Ld/CZtjhVE0dJr8xgR2AygniI7YR9a9lmtIZS94/LUxL84JLCAkUJzTIpPKCagQ==
+
 "@fastify/accept-negotiator@^1.0.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@fastify/accept-negotiator/-/accept-negotiator-1.1.0.tgz#c1c66b3b771c09742a54dd5bc87c582f6b0630ff"


### PR DESCRIPTION

## Motivation

We want to include the ability to configure UDP socket options. We've created a fork of the upstream `hot-shots` package and removed the optional dependency on `unix-dgram`, since we aren't using that ourselves.

## Change Summary

Switches to our own fork of the `hot-shots` package.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `@farcaster/shuttle` package to switch from `@figma/hot-shots` to `@farcaster/hot-shots`.

### Detailed summary
- Switched from `@figma/hot-shots` to `@farcaster/hot-shots` in `@farcaster/shuttle`
- Updated `@farcaster/hot-shots` dependency to version `10.0.0`
- Updated `lodash.mergewith` to version `^4.6.2`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->