### PR TITLE
chore: Skip DNS lookups for IP addresses in statsd module

### DIFF
--- a/.changeset/long-onions-lick.md
+++ b/.changeset/long-onions-lick.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+Stop DNS lookups for loopback address in statsd calls

--- a/packages/shuttle/src/statsd.ts
+++ b/packages/shuttle/src/statsd.ts
@@ -1,3 +1,27 @@
-import StatsD from "@figma/hot-shots";
+import dns, { LookupOptions } from "node:dns";
+import { isIP } from "node:net";
 
-export const statsd = new StatsD({ cacheDns: true, maxBufferSize: 4096 /* 4KiB */ });
+import StatsD from "@farcaster/hot-shots";
+
+export const statsd = new StatsD({
+  host: "127.0.0.1", // Avoid Node.js deprecation warning by specifying explicitly
+  cacheDns: true,
+  maxBufferSize: 4096 /* 4KiB */,
+  udpSocketOptions: {
+    type: "udp4",
+    lookup: (
+      hostname: string,
+      options: LookupOptions,
+      callback: (err: unknown, address: unknown, family: number) => void,
+    ) => {
+      // Bypass dns.lookup if hostname is IP address
+      if (isIP(hostname)) {
+        callback(null, hostname, 4);
+        return;
+      }
+
+      // Resolve if a real hostname
+      dns.lookup(hostname, options, callback);
+    },
+  },
+});


### PR DESCRIPTION
## Motivation

Node's default behavior results in a lot of unnecessary DNS lookups being made for the loopback IP address. Skip it.

## Change Summary

Don't do a DNS lookup when the host is an IP.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on optimizing statsd calls by stopping DNS lookups for loopback addresses in the shuttle package.

### Detailed summary
- Updated `statsd.ts` in `shuttle` package
- Added explicit host configuration to avoid deprecation warning
- Implemented custom DNS lookup function to bypass lookup for IP addresses

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->