### PR TITLE
chore: Release Shuttle 0.2.6

### DIFF
--- a/.changeset/gold-snails-bow.md
+++ b/.changeset/gold-snails-bow.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-Switch from @figma/hot-shots to @farcaster/hot-shots

--- a/.changeset/long-onions-lick.md
+++ b/.changeset/long-onions-lick.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-Stop DNS lookups for loopback address in statsd calls

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/hub-shuttle
 
+## 0.2.6
+
+### Patch Changes
+
+- 7490ff5d: Switch from @figma/hot-shots to @farcaster/hot-shots
+- afa31270: Stop DNS lookups for loopback address in statsd calls
+
 ## 0.2.5
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Motivation

Cut a release with a significant reduction in DNS lookups.

## Change Summary

`yarn changeset version`

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `@farcaster/shuttle` package to `0.2.6`, making important patch changes related to dependency and DNS lookup optimizations.

### Detailed summary
- Updated package version to `0.2.6`
- Switched from `@figma/hot-shots` to `@farcaster/hot-shots`
- Stopped DNS lookups for loopback address in statsd calls

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->