### PR TITLE
perf: Use all workers for validateOrRevokeMessages job

### DIFF
--- a/.changeset/lazy-emus-sit.md
+++ b/.changeset/lazy-emus-sit.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+perf: Use multiple workers for validateOrRevokeMessages job

--- a/apps/hubble/src/addon/src/db/rocksdb.rs
+++ b/apps/hubble/src/addon/src/db/rocksdb.rs
@@ -3,7 +3,7 @@ use crate::logger::LOGGER;
 use crate::statsd::statsd;
 use crate::store::{
     self, get_db, get_iterator_options, hub_error_to_js_throw, increment_vec_u8, HubError,
-    PageOptions,
+    PageOptions, PAGE_SIZE_MAX,
 };
 use crate::trie::merkle_trie::TRIE_DBPATH_PREFIX;
 use crate::THREAD_POOL;
@@ -60,6 +60,7 @@ impl RocksDbTransactionBatch {
     }
 }
 
+#[derive(Debug)]
 pub struct IteratorOptions {
     pub opts: rocksdb::ReadOptions,
     pub reverse: bool,
@@ -248,10 +249,8 @@ impl RocksDB {
         let txn = db.as_ref().unwrap().transaction();
         for (key, value) in batch.batch {
             if value.is_none() {
-                // println!("rust txn is delete, key: {:?}", key);
                 txn.delete(key)?;
             } else {
-                // println!("rust txn is put, key: {:?}", key);
                 txn.put(key, value.unwrap())?;
             }
         }
@@ -322,9 +321,6 @@ impl RocksDB {
             upper_prefix = prefix_end.to_vec();
         }
 
-        // println!("lower_prefix: {:?}", lower_prefix);
-        // println!("upper_prefix: {:?}", upper_prefix);
-
         let mut opts = rocksdb::ReadOptions::default();
         opts.set_iterate_lower_bound(lower_prefix);
         opts.set_iterate_upper_bound(upper_prefix);
@@ -359,7 +355,7 @@ impl RocksDB {
      * Iterate over all keys with a given prefix.
      * The callback function should return true to stop the iteration, or false to continue.
      */
-    pub fn for_each_iterator_by_prefix<F>(
+    pub fn for_each_iterator_by_prefix_paged<F>(
         &self,
         prefix: &[u8],
         page_options: &PageOptions,
@@ -381,6 +377,7 @@ impl RocksDB {
 
         let mut all_done = true;
         let mut count = 0;
+
         while iter.valid() {
             if let Some((key, value)) = iter.item() {
                 if f(&key, &value)? {
@@ -390,7 +387,7 @@ impl RocksDB {
                 if page_options.page_size.is_some() {
                     count += 1;
                     if count >= page_options.page_size.unwrap() {
-                        all_done = false;
+                        all_done = true;
                         break;
                     }
                 }
@@ -408,7 +405,7 @@ impl RocksDB {
 
     // Same as for_each_iterator_by_prefix above, but does not limit by page size. To be used in
     // cases where higher level callers are doing custom filtering
-    pub fn for_each_iterator_by_prefix_unbounded<F>(
+    pub fn for_each_iterator_by_prefix<F>(
         &self,
         prefix: &[u8],
         page_options: &PageOptions,
@@ -422,7 +419,10 @@ impl RocksDB {
             page_token: page_options.page_token.clone(),
             reverse: page_options.reverse,
         };
-        self.for_each_iterator_by_prefix(prefix, &unbounded_page_options, f)
+
+        let all_done =
+            self.for_each_iterator_by_prefix_paged(prefix, &unbounded_page_options, f)?;
+        Ok(all_done)
     }
 
     /**
@@ -847,6 +847,71 @@ impl RocksDB {
         Ok(promise)
     }
 
+    /**
+     * Bulk fetch a page of keys with a given prefix with the given page options.
+     */
+    pub fn js_fetch_iterator_page_by_prefix(mut cx: FunctionContext) -> JsResult<JsPromise> {
+        let db = get_db(&mut cx)?;
+
+        // Prefix
+        let prefix = cx.argument::<JsBuffer>(0)?.as_slice(&cx).to_vec();
+
+        // Page options
+        let page_options = store::get_page_options(&mut cx, 1)?;
+
+        let channel = cx.channel();
+        let (deferred, promise) = cx.promise();
+        THREAD_POOL.lock().unwrap().execute(move || {
+            let mut results = Vec::new();
+            let mut next_page_token = Vec::new();
+
+            let iter_result =
+                db.for_each_iterator_by_prefix_paged(&prefix, &page_options, |key, value| {
+                    results.push((key.to_vec(), value.to_vec()));
+                    if results.len() > PAGE_SIZE_MAX {
+                        next_page_token = key[prefix.len()..].to_vec();
+                        return Ok(true);
+                    }
+                    Ok(false)
+                });
+
+            deferred.settle_with(&channel, move |mut cx| match iter_result {
+                Err(e) => hub_error_to_js_throw(&mut cx, e),
+                Ok(all_done) => {
+                    let js_array = JsArray::new(&mut cx, results.len());
+                    for (i, (key, value)) in results.iter().enumerate() {
+                        let js_object = JsObject::new(&mut cx);
+                        let mut key_buffer = cx.buffer(key.len())?;
+                        key_buffer.as_mut_slice(&mut cx).copy_from_slice(key);
+                        js_object.set(&mut cx, "key", key_buffer)?;
+
+                        let mut value_buffer = cx.buffer(value.len())?;
+                        value_buffer.as_mut_slice(&mut cx).copy_from_slice(value);
+                        js_object.set(&mut cx, "value", value_buffer)?;
+
+                        js_array.set(&mut cx, i as u32, js_object)?;
+                    }
+
+                    let js_object = JsObject::new(&mut cx);
+                    let js_all_done = cx.boolean(all_done);
+
+                    let mut js_next_page_token = cx.buffer(next_page_token.len())?;
+                    js_next_page_token
+                        .as_mut_slice(&mut cx)
+                        .copy_from_slice(&next_page_token);
+
+                    js_object.set(&mut cx, "allFinished", js_all_done)?;
+                    js_object.set(&mut cx, "nextPageToken", js_next_page_token)?;
+                    js_object.set(&mut cx, "dbKeyValues", js_array)?;
+
+                    Ok(js_object)
+                }
+            });
+        });
+
+        Ok(promise)
+    }
+
     pub fn js_for_each_iterator_by_prefix(mut cx: FunctionContext) -> JsResult<JsPromise> {
         let db = get_db(&mut cx)?;
 
@@ -859,7 +924,7 @@ impl RocksDB {
         // The argument is a callback function
         let callback = cx.argument::<JsFunction>(2)?;
 
-        let result = db.for_each_iterator_by_prefix(&prefix, &page_options, |key, value| {
+        let result = db.for_each_iterator_by_prefix_paged(&prefix, &page_options, |key, value| {
             // Use the extracted function here
             Self::call_js_callback(&mut cx, &callback, key, value)
         });

--- a/apps/hubble/src/addon/src/db/rocksdb.rs
+++ b/apps/hubble/src/addon/src/db/rocksdb.rs
@@ -60,7 +60,6 @@ impl RocksDbTransactionBatch {
     }
 }
 
-#[derive(Debug)]
 pub struct IteratorOptions {
     pub opts: rocksdb::ReadOptions,
     pub reverse: bool,

--- a/apps/hubble/src/addon/src/lib.rs
+++ b/apps/hubble/src/addon/src/lib.rs
@@ -120,6 +120,10 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
         RocksDB::js_delete_all_keys_in_range,
     )?;
     cx.export_function(
+        "dbFetchIteratorPageByPrefix",
+        RocksDB::js_fetch_iterator_page_by_prefix,
+    )?;
+    cx.export_function(
         "dbForEachIteratorByPrefix",
         RocksDB::js_for_each_iterator_by_prefix,
     )?;

--- a/apps/hubble/src/addon/src/store/cast_store.rs
+++ b/apps/hubble/src/addon/src/store/cast_store.rs
@@ -571,7 +571,7 @@ impl CastStore {
 
         store
             .db()
-            .for_each_iterator_by_prefix_unbounded(&prefix, page_options, |key, _| {
+            .for_each_iterator_by_prefix(&prefix, page_options, |key, _| {
                 let ts_hash_offset = prefix.len();
                 let fid_offset = ts_hash_offset + TS_HASH_LENGTH;
 
@@ -662,7 +662,7 @@ impl CastStore {
 
         store
             .db()
-            .for_each_iterator_by_prefix_unbounded(&prefix, page_options, |key, _| {
+            .for_each_iterator_by_prefix(&prefix, page_options, |key, _| {
                 let ts_hash_offset = prefix.len();
                 let fid_offset = ts_hash_offset + TS_HASH_LENGTH;
 

--- a/apps/hubble/src/addon/src/store/link_store.rs
+++ b/apps/hubble/src/addon/src/store/link_store.rs
@@ -164,7 +164,7 @@ impl LinkStore {
 
         store
             .db()
-            .for_each_iterator_by_prefix_unbounded(&prefix, page_options, |key, value| {
+            .for_each_iterator_by_prefix(&prefix, page_options, |key, value| {
                 if r#type.is_empty() || value.eq(r#type.as_bytes()) {
                     let ts_hash_offset = prefix.len();
                     let fid_offset: usize = ts_hash_offset + TS_HASH_LENGTH;

--- a/apps/hubble/src/addon/src/store/message.rs
+++ b/apps/hubble/src/addon/src/store/message.rs
@@ -340,7 +340,7 @@ where
     let mut messages = Vec::new();
     let mut last_key = vec![];
 
-    db.for_each_iterator_by_prefix_unbounded(prefix, page_options, |key, value| {
+    db.for_each_iterator_by_prefix(prefix, page_options, |key, value| {
         match message_decode(value) {
             Ok(message) => {
                 if filter(&message) {

--- a/apps/hubble/src/addon/src/store/reaction_store.rs
+++ b/apps/hubble/src/addon/src/store/reaction_store.rs
@@ -543,7 +543,7 @@ impl ReactionStore {
 
         store
             .db()
-            .for_each_iterator_by_prefix_unbounded(&prefix, page_options, |key, value| {
+            .for_each_iterator_by_prefix(&prefix, page_options, |key, value| {
                 if reaction_type == ReactionType::None as i32
                     || (value.len() == 1 && value[0] == reaction_type as u8)
                 {

--- a/apps/hubble/src/addon/src/store/store.rs
+++ b/apps/hubble/src/addon/src/store/store.rs
@@ -746,10 +746,8 @@ impl Store {
         // 1. Delete all remove messages
         // 2. Delete all add messages that are not in the target_fids list
         let prefix = &make_message_primary_key(fid, self.store_def.postfix(), None);
-        self.db.for_each_iterator_by_prefix_unbounded(
-            prefix,
-            &PageOptions::default(),
-            |_key, value| {
+        self.db
+            .for_each_iterator_by_prefix(prefix, &PageOptions::default(), |_key, value| {
                 let message = message_decode(value)?;
 
                 // Only if message is older than the compact state message
@@ -774,8 +772,7 @@ impl Store {
                 }
 
                 Ok(false) // Continue the iteration
-            },
-        )?;
+            })?;
 
         let mut txn = self.db.txn();
         // Delete all the merge conflicts
@@ -938,10 +935,8 @@ impl Store {
         let mut txn = self.db.txn();
 
         let prefix = &make_message_primary_key(fid, self.store_def.postfix(), None);
-        self.db.for_each_iterator_by_prefix_unbounded(
-            prefix,
-            &PageOptions::default(),
-            |_key, value| {
+        self.db
+            .for_each_iterator_by_prefix(prefix, &PageOptions::default(), |_key, value| {
                 if count <= (prune_size_limit as u64) * units {
                     return Ok(true); // Stop the iteration, nothing left to prune
                 }
@@ -976,8 +971,7 @@ impl Store {
                 pruned_events.push(hub_event);
 
                 Ok(false) // Continue the iteration
-            },
-        )?;
+            })?;
 
         self.db.commit(txn)?;
         Ok(pruned_events)

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -20,6 +20,7 @@ import {
   UserNameProof,
   validations,
 } from "@farcaster/hub-nodejs";
+import { ClientOptions as StatsDClientOptions } from "@figma/hot-shots";
 import { PeerId } from "@libp2p/interface-peer-id";
 import { peerIdFromBytes, peerIdFromString } from "@libp2p/peer-id";
 import { publicAddressesFirst } from "@libp2p/utils/address-sort";
@@ -74,7 +75,7 @@ import { CheckIncomingPortsJobScheduler } from "./storage/jobs/checkIncomingPort
 import { applyNetworkConfig, fetchNetworkConfig, NetworkConfig } from "./network/utils/networkConfig.js";
 import { UpdateNetworkConfigJobScheduler } from "./storage/jobs/updateNetworkConfigJob.js";
 import { DbSnapshotBackupJobScheduler } from "./storage/jobs/dbSnapshotBackupJob.js";
-import { statsd, StatsDInitParams } from "./utils/statsd.js";
+import { statsd } from "./utils/statsd.js";
 import {
   getDbSchemaVersion,
   LATEST_DB_SCHEMA_VERSION,
@@ -193,7 +194,7 @@ export interface HubOptions {
   rankRpcs?: boolean;
 
   /** StatsD parameters */
-  statsdParams?: StatsDInitParams | undefined;
+  statsdParams?: StatsDClientOptions | undefined;
 
   /** ETH mainnet RPC URL(s) */
   ethMainnetRpcUrl?: string;

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -23,7 +23,8 @@ import { PeriodicPeerCheckScheduler } from "./periodicPeerCheck.js";
 import { GOSSIP_PROTOCOL_VERSION } from "./protocol.js";
 import { AddrInfo } from "@chainsafe/libp2p-gossipsub/types";
 import { PeerScoreThresholds } from "@chainsafe/libp2p-gossipsub/score";
-import { statsd, StatsDInitParams } from "../../utils/statsd.js";
+import { statsd } from "../../utils/statsd.js";
+import { ClientOptions } from "@figma/hot-shots";
 import { createFromProtobuf, exportToProtobuf } from "@libp2p/peer-id-factory";
 import EventEmitter from "events";
 import RocksDB from "../../storage/db/rocksdb.js";
@@ -80,7 +81,7 @@ export interface NodeOptions {
   /** The maximum amount of time to dial a peer in libp2p network in milliseconds */
   p2pConnectTimeoutMs?: number | undefined;
   /** StatsD parameters */
-  statsdParams?: StatsDInitParams | undefined;
+  statsdParams?: ClientOptions | undefined;
 }
 
 export type GossipMessageResult = {

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -95,7 +95,7 @@ export class LibP2PNode {
   async makeNode(options: NodeOptions): HubAsyncResult<boolean> {
     // since we are running in a worker thread, we need to initialize statsd
     if (options.statsdParams) {
-      initializeStatsd(options.statsdParams.host, options.statsdParams.port);
+      initializeStatsd(options.statsdParams.host ?? "", options.statsdParams.port ?? 0);
     }
 
     const listenIPMultiAddr = options.ipMultiAddr ?? MultiaddrLocalHost;

--- a/apps/hubble/src/network/sync/merkleTrie.test.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.test.ts
@@ -7,7 +7,6 @@ import RocksDB from "../../storage/db/rocksdb.js";
 import { RootPrefix } from "../../storage/db/types.js";
 import { SyncId, TIMESTAMP_LENGTH } from "./syncId.js";
 import { jest } from "@jest/globals";
-import { sleep } from "../../utils/crypto.js";
 
 const TEST_TIMEOUT_SHORT = 10 * 1000;
 const TEST_TIMEOUT_LONG = 60 * 1000;

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -1555,19 +1555,11 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
   }
 
   private async readDbStatsFromDb(): Promise<DbStats> {
-    let numFids = 0;
-    let numFnames = 0;
-
-    await this._db.forEachIteratorByPrefix(
+    const numFids = await this._db.countKeysAtPrefix(
       Buffer.from([RootPrefix.OnChainEvent, OnChainEventPostfix.IdRegisterByFid]),
-      () => {
-        numFids += 1;
-      },
     );
 
-    await this._db.forEachIteratorByPrefix(Buffer.from([RootPrefix.FNameUserNameProof]), () => {
-      numFnames += 1;
-    });
+    const numFnames = await this._db.countKeysAtPrefix(Buffer.from([RootPrefix.FNameUserNameProof]));
 
     return {
       numItems: await this._trie.items(),

--- a/apps/hubble/src/storage/db/rocksdb.test.ts
+++ b/apps/hubble/src/storage/db/rocksdb.test.ts
@@ -318,8 +318,8 @@ describe("with db", () => {
       );
       expect(bytesCompare(values[0] as Buffer, keys[0] as Buffer)).toEqual(0);
       expect(bytesCompare(values[99] as Buffer, keys[99] as Buffer)).toEqual(0);
-      expect(allFinished).toEqual(false);
       expect(values.length).toEqual(100);
+      expect(allFinished).toEqual(true);
 
       // 6. Iterate through all messages with no prefix + page size
       values = [];
@@ -332,7 +332,7 @@ describe("with db", () => {
       );
       expect(bytesCompare(values[0] as Buffer, keys[0] as Buffer)).toEqual(0);
       expect(bytesCompare(values[99] as Buffer, keys[99] as Buffer)).toEqual(0);
-      expect(allFinished).toEqual(false);
+      expect(allFinished).toEqual(true);
       expect(values.length).toEqual(100);
 
       // 6.1 Iterate through all messages with no prefix + page size + page token
@@ -345,7 +345,7 @@ describe("with db", () => {
         { pageSize: 100, pageToken: keys[100] as Buffer },
       );
       expect(bytesCompare(values[0] as Buffer, keys[101] as Buffer)).toEqual(0);
-      expect(allFinished).toEqual(false);
+      expect(allFinished).toEqual(true);
       expect(values.length).toEqual(100);
 
       // 6.2 Iterate through all messages with no prefix + page size + page token + reverse
@@ -358,7 +358,7 @@ describe("with db", () => {
         { pageSize: 100, pageToken: keys[100] as Buffer, reverse: true },
       );
       expect(bytesCompare(values[0] as Buffer, keys[99] as Buffer)).toEqual(0);
-      expect(allFinished).toEqual(false);
+      expect(allFinished).toEqual(true);
       expect(values.length).toEqual(100);
 
       // 6.3 Iterate through all messages with no prefix + page token
@@ -565,7 +565,7 @@ describe("with db", () => {
       allFinished = await rsDbForEachIteratorByPrefix(db.rustDb, Buffer.from([100]), { pageSize: 3 }, (_key, value) => {
         values.push(value as Buffer);
       });
-      expect(allFinished).toEqual(false);
+      expect(allFinished).toEqual(true);
       expect(values).toEqual(allValues.slice(0, 3));
 
       // With a continuation token and page size, the next 3 values are returned
@@ -578,7 +578,7 @@ describe("with db", () => {
           values.push(value as Buffer);
         },
       );
-      expect(allFinished).toEqual(false);
+      expect(allFinished).toEqual(true);
       expect(values).toEqual(allValues.slice(3, 6));
 
       // With a continuation token and no page size, all remaining values are returned
@@ -618,6 +618,15 @@ describe("with db", () => {
       // allFinished returns false if the callback returns true
       values = [];
       allFinished = await rsDbForEachIteratorByPrefix(db.rustDb, Buffer.from([100]), {}, (_key, value) => {
+        values.push(value as Buffer);
+        return true;
+      });
+      expect(allFinished).toEqual(false);
+      expect(values).toEqual(allValues.slice(0, 1));
+
+      // allFinished returns false if the callback returns true with pageSize
+      values = [];
+      allFinished = await rsDbForEachIteratorByPrefix(db.rustDb, Buffer.from([100]), { pageSize: 5 }, (_key, value) => {
         values.push(value as Buffer);
         return true;
       });


### PR DESCRIPTION
## Motivation

We were awaiting each message in validateOrRevokeMessagesJob even though we have multiple workers available. Fix

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving performance by using multiple workers for the `validateOrRevokeMessages` job in the Hubble app.

### Detailed summary
- Implemented the usage of multiple workers for the `validateOrRevokeMessages` job in the Hubble app for improved performance.
- Updated function calls in various files to use the new `dbFetchIteratorPageByPrefix` method.
- Replaced specific `statsd` initialization parameters with `ClientOptions` for better configuration handling.

> The following files were skipped due to too many changes: `apps/hubble/src/storage/engine/index.ts`, `apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts`, `apps/hubble/src/storage/db/rocksdb.test.ts`, `apps/hubble/src/addon/src/db/rocksdb.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->