### PR TITLE
chore: Remove backup get_node fetching node in merkle_trie

### DIFF
--- a/.changeset/late-feet-roll.md
+++ b/.changeset/late-feet-roll.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Remove backup fetching for get_node

--- a/apps/hubble/src/addon/src/trie/merkle_trie.rs
+++ b/apps/hubble/src/addon/src/trie/merkle_trie.rs
@@ -17,7 +17,7 @@ use neon::{
     result::JsResult,
     types::{Finalize, JsBox, JsBuffer, JsPromise, JsString},
 };
-use slog::{info, o};
+use slog::{error, info, o};
 use std::{
     borrow::Borrow,
     collections::HashMap,
@@ -241,12 +241,9 @@ impl MerkleTrie {
                 return Some(node);
             }
         }
-        // If not found, get it the normal way from the trie root
-        self.root
-            .write()
-            .unwrap()
-            .as_mut()
-            .and_then(|root| root.get_node_from_trie(&self.db, prefix, 0).cloned())
+
+        // If not found, return None
+        None
     }
 
     pub fn root_hash(&self) -> Result<Vec<u8>, HubError> {

--- a/apps/hubble/src/addon/src/trie/trie_node.rs
+++ b/apps/hubble/src/addon/src/trie/trie_node.rs
@@ -61,7 +61,7 @@ impl TrieNode {
         key
     }
 
-    fn serialize(node: &TrieNode) -> Vec<u8> {
+    pub fn serialize(node: &TrieNode) -> Vec<u8> {
         let db_trie_node = DbTrieNode {
             key: node.key.as_ref().unwrap_or(&vec![]).clone(),
             child_chars: node.children.keys().map(|c| *c as u32).collect(),

--- a/apps/hubble/src/eth/watchContractEvent.ts
+++ b/apps/hubble/src/eth/watchContractEvent.ts
@@ -1,5 +1,5 @@
 import { Abi } from "abitype";
-import { HttpRequestError, PublicClient, WatchContractEventParameters, WatchContractEventReturnType } from "viem";
+import { PublicClient, WatchContractEventParameters, WatchContractEventReturnType } from "viem";
 import { logger, Logger } from "../utils/logger.js";
 import { HubError, HubResult } from "@farcaster/core";
 import { err, ok, Result } from "neverthrow";

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -383,14 +383,15 @@ describe("Multi peer sync engine", () => {
     expect(await syncEngine1.trie.rootHash()).toEqual(await syncEngine2.trie.rootHash());
 
     // Now, delete the messages from engine 1
-    await engine1.getDb().clear();
+    engine1.getDb().clear();
     const allValues = await syncEngine1.trie.getAllValues(new Uint8Array());
     for (const value of allValues) {
       await syncEngine1.trie.deleteByBytes(value);
     }
 
-    // Now, engine 1 should have no messages
-    expect((await syncEngine1.trie.getTrieNodeMetadata(new Uint8Array()))?.numMessages).toEqual(0);
+    // Now, engine 1 should have no messages. Getting the metadata for the root should return
+    // undefined since the root node doesn't exist any more
+    expect(await syncEngine1.trie.getTrieNodeMetadata(new Uint8Array())).toBeUndefined();
 
     const startScore = syncEngine2.getPeerScore("engine1")?.score ?? 0;
 


### PR DESCRIPTION
## Motivation

Remove the fallback for getting the node from the trie instead of DB, because a node will always be in the DB


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes backup fetching for `get_node`, refactors `serialize` to public, updates imports, and refactors node initialization in the Merkle trie.

### Detailed summary
- Removed backup fetching for `get_node`
- Refactored `serialize` to public in `trie_node.rs`
- Updated imports in `watchContractEvent.ts`
- Refactored node initialization in `merkle_trie.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->