### PR TITLE
feat: Allow skipping validation when processing event stream

### DIFF
--- a/.changeset/flat-eels-repeat.md
+++ b/.changeset/flat-eels-repeat.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+Allow skipping validation when storing message

--- a/packages/shuttle/src/shuttle/messageProcessor.ts
+++ b/packages/shuttle/src/shuttle/messageProcessor.ts
@@ -10,9 +10,10 @@ export class MessageProcessor {
     trx: DB,
     operation: StoreMessageOperation = "merge",
     log: pino.Logger | undefined = undefined,
+    validate = true,
   ): Promise<boolean> {
     // Only validate merge messages since we may be deleting an invalid message
-    if (operation === "merge") {
+    if (validate && operation === "merge") {
       const validation = await validations.validateMessage(message);
       if (validation.isErr()) {
         log?.warn(`Invalid message ${bytesToHex(message.hash)}: ${validation.error.message}`);


### PR DESCRIPTION
## Motivation

If you trust your hubs, there's no need to perform validation of the signature again. Based on our performance profiling, this could take up to 20% of wall clock time.

## Change Summary

Allow disabling validation when storing a message.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on allowing skipping validation when storing a message in the `@farcaster/shuttle` package. 

### Detailed summary
- Added a new parameter `validate` with default value `true` in `StoreMessageOperation`
- Updated the condition to validate merge messages only if `validate` is true

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->