### PR TITLE
feat: extend verification signature length

### DIFF
--- a/.changeset/neat-bikes-live.md
+++ b/.changeset/neat-bikes-live.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/core": patch
+---
+
+feat: extend verification signature max length

--- a/packages/core/src/validations.test.ts
+++ b/packages/core/src/validations.test.ts
@@ -841,15 +841,15 @@ describe("validateVerificationAddEthAddressSignature", () => {
     expect(result).toEqual(err(new HubError("bad_request.invalid_param", "RPC client not provided for chainId 1")));
   });
 
-  test("fails if ethSignature is > 256 bytes", async () => {
+  test("fails if ethSignature is > 512 bytes", async () => {
     const body = await Factories.VerificationAddAddressBody.create(
       {
-        claimSignature: Factories.Bytes.build({}, { transient: { length: 257 } }),
+        claimSignature: Factories.Bytes.build({}, { transient: { length: 513 } }),
       },
       { transient: { protocol: Protocol.ETHEREUM } },
     );
     const result = await validations.validateVerificationAddEthAddressSignature(body, fid, network, {});
-    expect(result).toEqual(err(new HubError("bad_request.validation_failure", "claimSignature > 256 bytes")));
+    expect(result).toEqual(err(new HubError("bad_request.validation_failure", "claimSignature > 512 bytes")));
   });
 
   test("succeeds for contract signatures", async () => {
@@ -1315,7 +1315,11 @@ describe("validateSingleBody", () => {
             hash: new Uint8Array(),
           },
         },
-        linkBody: { type: "follow", displayTimestamp: 1768551184, targetFid: 4 },
+        linkBody: {
+          type: "follow",
+          displayTimestamp: 1768551184,
+          targetFid: 4,
+        },
       },
     });
 

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -403,8 +403,8 @@ export const validateVerificationAddEthAddressSignature = async (
   network: protobufs.FarcasterNetwork,
   publicClients: PublicClients = defaultPublicClients,
 ): HubAsyncResult<Uint8Array> => {
-  if (body.claimSignature.length > 256) {
-    return err(new HubError("bad_request.validation_failure", "claimSignature > 256 bytes"));
+  if (body.claimSignature.length > 512) {
+    return err(new HubError("bad_request.validation_failure", "claimSignature > 512 bytes"));
   }
 
   const reconstructedClaim = makeVerificationAddressClaim(


### PR DESCRIPTION
## Motivation

A few power users with EVM smart contract wallets have bumped into the verification signature limit. (Currently 256 bytes). The longest one I've observed was 324 bytes. 

## Change Summary

Increase max length of EVM verification signatures to 512 bytes. (This should be long enough for a Safe with a threshold of 7 signers).

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR extends the maximum length of verification signature from 256 to 512 bytes.

### Detailed summary
- Extended verification signature max length from 256 to 512 bytes in validations.ts
- Updated test cases in validations.test.ts to reflect the new max length
- Improved formatting in validations.test.ts for better readability

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->