### PR TITLE
chore: Release Shuttle 0.2.7

### DIFF
--- a/.changeset/flat-eels-repeat.md
+++ b/.changeset/flat-eels-repeat.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-Allow skipping validation when storing message

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.2.7
+
+### Patch Changes
+
+- 1b502fc2: Allow skipping validation when storing message
+
 ## 0.2.6
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Motivation

Release changes allowing you to skip validation of messages.

## Change Summary

Cut release.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR bumps the version of `@farcaster/shuttle` package to `0.2.7` and includes a patch change to allow skipping validation when storing a message.

### Detailed summary
- Bumped version to `0.2.7`
- Added ability to skip validation when storing a message

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->