### PR TITLE
fix: prevent unnecessary encode/decode in grpc APIs

### DIFF
--- a/.changeset/lemon-olives-change.md
+++ b/.changeset/lemon-olives-change.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Prevent unnecessary decode/encode in rpc APIs

--- a/apps/hubble/src/addon/src/store/cast_store.rs
+++ b/apps/hubble/src/addon/src/store/cast_store.rs
@@ -594,7 +594,7 @@ impl CastStore {
                 Ok(false) // Continue iterating
             })?;
 
-        let messages = message::get_many_messages(store.db().borrow(), message_keys)?;
+        let messages = message::get_many_messages_as_bytes(store.db().borrow(), message_keys)?;
         let next_page_token = if last_key.len() > 0 {
             Some(last_key[prefix.len()..].to_vec())
         } else {
@@ -685,7 +685,7 @@ impl CastStore {
                 Ok(false) // Continue iterating
             })?;
 
-        let messages = message::get_many_messages(store.db().borrow(), message_keys)?;
+        let messages = message::get_many_messages_as_bytes(store.db().borrow(), message_keys)?;
         let next_page_token = if last_key.len() > 0 {
             Some(last_key[prefix.len()..].to_vec())
         } else {

--- a/apps/hubble/src/addon/src/store/cast_store.rs
+++ b/apps/hubble/src/addon/src/store/cast_store.rs
@@ -594,7 +594,8 @@ impl CastStore {
                 Ok(false) // Continue iterating
             })?;
 
-        let messages = message::get_many_messages_as_bytes(store.db().borrow(), message_keys)?;
+        let messages_bytes =
+            message::get_many_messages_as_bytes(store.db().borrow(), message_keys)?;
         let next_page_token = if last_key.len() > 0 {
             Some(last_key[prefix.len()..].to_vec())
         } else {
@@ -602,7 +603,7 @@ impl CastStore {
         };
 
         Ok(MessagesPage {
-            messages,
+            messages_bytes,
             next_page_token,
         })
     }
@@ -685,7 +686,8 @@ impl CastStore {
                 Ok(false) // Continue iterating
             })?;
 
-        let messages = message::get_many_messages_as_bytes(store.db().borrow(), message_keys)?;
+        let messages_bytes =
+            message::get_many_messages_as_bytes(store.db().borrow(), message_keys)?;
         let next_page_token = if last_key.len() > 0 {
             Some(last_key[prefix.len()..].to_vec())
         } else {
@@ -693,7 +695,7 @@ impl CastStore {
         };
 
         Ok(MessagesPage {
-            messages,
+            messages_bytes,
             next_page_token,
         })
     }

--- a/apps/hubble/src/addon/src/store/cast_store.rs
+++ b/apps/hubble/src/addon/src/store/cast_store.rs
@@ -493,7 +493,7 @@ impl CastStore {
         fid: u32,
         page_options: &PageOptions,
     ) -> Result<MessagesPage, HubError> {
-        store.get_adds_by_fid(fid, page_options, Some(|_: &Message| true))
+        store.get_adds_by_fid::<fn(&protos::Message) -> bool>(fid, page_options, None)
     }
 
     pub fn js_create_cast_store(mut cx: FunctionContext) -> JsResult<JsBox<Arc<Store>>> {
@@ -539,7 +539,7 @@ impl CastStore {
         fid: u32,
         page_options: &PageOptions,
     ) -> Result<MessagesPage, HubError> {
-        store.get_removes_by_fid(fid, page_options, Some(|_: &Message| true))
+        store.get_removes_by_fid::<fn(&protos::Message) -> bool>(fid, page_options, None)
     }
 
     pub fn js_get_cast_removes_by_fid(mut cx: FunctionContext) -> JsResult<JsPromise> {

--- a/apps/hubble/src/addon/src/store/link_store.rs
+++ b/apps/hubble/src/addon/src/store/link_store.rs
@@ -190,7 +190,8 @@ impl LinkStore {
                 Ok(false)
             })?;
 
-        let messages = message::get_many_messages_as_bytes(store.db().borrow(), message_keys)?;
+        let messages_bytes =
+            message::get_many_messages_as_bytes(store.db().borrow(), message_keys)?;
         let next_page_token = if last_key.len() > 0 {
             Some(last_key[prefix.len()..].to_vec())
         } else {
@@ -198,7 +199,7 @@ impl LinkStore {
         };
 
         Ok(MessagesPage {
-            messages,
+            messages_bytes,
             next_page_token,
         })
     }

--- a/apps/hubble/src/addon/src/store/link_store.rs
+++ b/apps/hubble/src/addon/src/store/link_store.rs
@@ -190,7 +190,7 @@ impl LinkStore {
                 Ok(false)
             })?;
 
-        let messages = message::get_many_messages(store.db().borrow(), message_keys)?;
+        let messages = message::get_many_messages_as_bytes(store.db().borrow(), message_keys)?;
         let next_page_token = if last_key.len() > 0 {
             Some(last_key[prefix.len()..].to_vec())
         } else {

--- a/apps/hubble/src/addon/src/store/message.rs
+++ b/apps/hubble/src/addon/src/store/message.rs
@@ -132,7 +132,7 @@ impl UserPostfix {
 
 /** A page of messages returned from various APIs */
 pub struct MessagesPage {
-    pub messages: Vec<Vec<u8>>,
+    pub messages_bytes: Vec<Vec<u8>>,
     pub next_page_token: Option<Vec<u8>>,
 }
 
@@ -326,16 +326,16 @@ pub fn get_messages_page_by_prefix<F>(
 where
     F: Fn(&MessageProto) -> bool,
 {
-    let mut messages = Vec::new();
+    let mut messages_bytes = Vec::new();
     let mut last_key = vec![];
 
     db.for_each_iterator_by_prefix(prefix, page_options, |key, value| {
         match message_decode(value) {
             Ok(message) => {
                 if filter(&message) {
-                    messages.push(value.to_vec());
+                    messages_bytes.push(value.to_vec());
 
-                    if messages.len() >= page_options.page_size.unwrap_or(PAGE_SIZE_MAX) {
+                    if messages_bytes.len() >= page_options.page_size.unwrap_or(PAGE_SIZE_MAX) {
                         last_key = key.to_vec();
                         return Ok(true); // Stop iterating
                     }
@@ -357,7 +357,7 @@ where
     };
 
     Ok(MessagesPage {
-        messages,
+        messages_bytes,
         next_page_token,
     })
 }

--- a/apps/hubble/src/addon/src/store/reaction_store.rs
+++ b/apps/hubble/src/addon/src/store/reaction_store.rs
@@ -571,7 +571,8 @@ impl ReactionStore {
                 Ok(false) // Continue iterating
             })?;
 
-        let messages = message::get_many_messages_as_bytes(store.db().borrow(), message_keys)?;
+        let messages_bytes =
+            message::get_many_messages_as_bytes(store.db().borrow(), message_keys)?;
         let next_page_token = if last_key.len() > 0 {
             Some(last_key[prefix.len()..].to_vec())
         } else {
@@ -579,7 +580,7 @@ impl ReactionStore {
         };
 
         Ok(MessagesPage {
-            messages,
+            messages_bytes,
             next_page_token,
         })
     }

--- a/apps/hubble/src/addon/src/store/reaction_store.rs
+++ b/apps/hubble/src/addon/src/store/reaction_store.rs
@@ -571,7 +571,7 @@ impl ReactionStore {
                 Ok(false) // Continue iterating
             })?;
 
-        let messages = message::get_many_messages(store.db().borrow(), message_keys)?;
+        let messages = message::get_many_messages_as_bytes(store.db().borrow(), message_keys)?;
         let next_page_token = if last_key.len() > 0 {
             Some(last_key[prefix.len()..].to_vec())
         } else {

--- a/apps/hubble/src/addon/src/store/user_data_store.rs
+++ b/apps/hubble/src/addon/src/store/user_data_store.rs
@@ -220,7 +220,7 @@ impl UserDataStore {
         fid: u32,
         page_options: &PageOptions,
     ) -> Result<MessagesPage, HubError> {
-        store.get_adds_by_fid(fid, page_options, Some(|_message: &Message| true))
+        store.get_adds_by_fid::<fn(&protos::Message) -> bool>(fid, page_options, None)
     }
 
     pub fn js_get_user_data_adds_by_fid(mut cx: FunctionContext) -> JsResult<JsPromise> {

--- a/apps/hubble/src/addon/src/store/username_proof_store.rs
+++ b/apps/hubble/src/addon/src/store/username_proof_store.rs
@@ -446,7 +446,7 @@ impl UsernameProofStore {
         fid: u32,
         page_options: &PageOptions,
     ) -> Result<MessagesPage, HubError> {
-        store.get_adds_by_fid(fid, page_options, Some(|_message: &Message| true))
+        store.get_adds_by_fid::<fn(&protos::Message) -> bool>(fid, page_options, None)
     }
 
     pub fn js_get_username_proofs_by_fid(mut cx: FunctionContext) -> JsResult<JsPromise> {

--- a/apps/hubble/src/addon/src/store/utils.rs
+++ b/apps/hubble/src/addon/src/store/utils.rs
@@ -12,7 +12,6 @@ use neon::{
         buffer::TypedArray, Deferred, JsArray, JsBoolean, JsBox, JsBuffer, JsNumber, JsObject,
     },
 };
-use prost::Message as _;
 use std::{borrow::Borrow, sync::Arc};
 
 /**
@@ -102,9 +101,7 @@ pub fn encode_messages_to_js_object<'a>(
     messages_page: MessagesPage,
 ) -> JsResult<'a, JsObject> {
     let js_messages = JsArray::new(cx, messages_page.messages.len());
-    for (i, message) in messages_page.messages.iter().enumerate() {
-        let message_bytes = message.encode_to_vec();
-
+    for (i, message_bytes) in messages_page.messages.iter().enumerate() {
         let mut js_buffer = cx.buffer(message_bytes.len())?;
         js_buffer.as_mut_slice(cx).copy_from_slice(&message_bytes);
         js_messages.set(cx, i as u32, js_buffer)?;

--- a/apps/hubble/src/addon/src/store/utils.rs
+++ b/apps/hubble/src/addon/src/store/utils.rs
@@ -100,8 +100,8 @@ pub fn encode_messages_to_js_object<'a>(
     cx: &mut TaskContext<'a>,
     messages_page: MessagesPage,
 ) -> JsResult<'a, JsObject> {
-    let js_messages = JsArray::new(cx, messages_page.messages.len());
-    for (i, message_bytes) in messages_page.messages.iter().enumerate() {
+    let js_messages = JsArray::new(cx, messages_page.messages_bytes.len());
+    for (i, message_bytes) in messages_page.messages_bytes.iter().enumerate() {
         let mut js_buffer = cx.buffer(message_bytes.len())?;
         js_buffer.as_mut_slice(cx).copy_from_slice(&message_bytes);
         js_messages.set(cx, i as u32, js_buffer)?;

--- a/apps/hubble/src/addon/src/store/verification_store.rs
+++ b/apps/hubble/src/addon/src/store/verification_store.rs
@@ -432,7 +432,7 @@ impl VerificationStore {
         fid: u32,
         page_options: &PageOptions,
     ) -> Result<MessagesPage, HubError> {
-        store.get_adds_by_fid(fid, page_options, Some(|_message: &Message| true))
+        store.get_adds_by_fid::<fn(&protos::Message) -> bool>(fid, page_options, None)
     }
 
     pub fn js_get_verification_adds_by_fid(mut cx: FunctionContext) -> JsResult<JsPromise> {
@@ -460,7 +460,7 @@ impl VerificationStore {
         fid: u32,
         page_options: &PageOptions,
     ) -> Result<MessagesPage, HubError> {
-        store.get_removes_by_fid(fid, page_options, Some(|_message: &Message| true))
+        store.get_removes_by_fid::<fn(&protos::Message) -> bool>(fid, page_options, None)
     }
 
     pub fn js_get_verification_removes_by_fid(mut cx: FunctionContext) -> JsResult<JsPromise> {

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -701,6 +701,9 @@ describe("Multi peer sync engine", () => {
     await engine2.mergeOnChainEvent(signerEvent);
     await engine2.mergeOnChainEvent(storageEvent);
 
+    await sleepWhile(() => syncEngine1.syncTrieQSize > 0, SLEEPWHILE_TIMEOUT);
+    await sleepWhile(() => syncEngine2.syncTrieQSize > 0, SLEEPWHILE_TIMEOUT);
+
     expect(await syncEngine1.trie.items()).toEqual(await syncEngine2.trie.items());
     expect(await syncEngine1.trie.rootHash()).toEqual(await syncEngine2.trie.rootHash());
 

--- a/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
@@ -134,7 +134,7 @@ export class ValidateOrRevokeMessagesJobScheduler {
         // Throttle the job.
         // We run at the rate of 50 fids per second. If we are running ahead of schedule, we sleep to catch up
         if (fid % 100 === 0) {
-          const allotedTimeMs = fid * TIME_SCHEDULED_PER_FID_MS;
+          const allotedTimeMs = (fid - lastFid) * TIME_SCHEDULED_PER_FID_MS;
           const elapsedTimeMs = Date.now() - start;
           if (allotedTimeMs > elapsedTimeMs) {
             const sleepTimeMs = allotedTimeMs - elapsedTimeMs;

--- a/apps/hubble/src/storage/stores/castStore.ts
+++ b/apps/hubble/src/storage/stores/castStore.ts
@@ -1,11 +1,4 @@
-import {
-  CastAddMessage,
-  CastId,
-  CastRemoveMessage,
-  getDefaultStoreLimit,
-  StoreType,
-  Message,
-} from "@farcaster/hub-nodejs";
+import { CastAddMessage, CastId, CastRemoveMessage, getDefaultStoreLimit, StoreType } from "@farcaster/hub-nodejs";
 import { ResultAsync } from "neverthrow";
 import RocksDB from "../db/rocksdb.js";
 import { UserPostfix } from "../db/types.js";
@@ -22,6 +15,7 @@ import {
   rsGetCastsByParent,
   rustErrorToHubError,
 } from "../../rustfunctions.js";
+import { messageDecode } from "../../storage/db/message.js";
 
 class CastStore extends RustStoreBase<CastAddMessage, CastRemoveMessage> {
   constructor(db: RocksDB, eventHandler: StoreEventHandler, options: StorePruneOptions = {}) {
@@ -38,7 +32,7 @@ class CastStore extends RustStoreBase<CastAddMessage, CastRemoveMessage> {
     if (result.isErr()) {
       throw result.error;
     }
-    return Message.decode(new Uint8Array(result.value)) as CastAddMessage;
+    return messageDecode(new Uint8Array(result.value)) as CastAddMessage;
   }
 
   /** Looks up CastRemove message by cast tsHash */
@@ -48,7 +42,7 @@ class CastStore extends RustStoreBase<CastAddMessage, CastRemoveMessage> {
     if (result.isErr()) {
       throw result.error;
     }
-    return Message.decode(new Uint8Array(result.value)) as CastRemoveMessage;
+    return messageDecode(new Uint8Array(result.value)) as CastRemoveMessage;
   }
 
   /** Gets all CastAdd messages for an fid */
@@ -57,7 +51,7 @@ class CastStore extends RustStoreBase<CastAddMessage, CastRemoveMessage> {
 
     const messages =
       messages_page.messageBytes?.map((message_bytes) => {
-        return Message.decode(new Uint8Array(message_bytes)) as CastAddMessage;
+        return messageDecode(new Uint8Array(message_bytes)) as CastAddMessage;
       }) ?? [];
 
     return { messages, nextPageToken: messages_page.nextPageToken };
@@ -69,7 +63,7 @@ class CastStore extends RustStoreBase<CastAddMessage, CastRemoveMessage> {
 
     const messages =
       message_page.messageBytes?.map((message_bytes) => {
-        return Message.decode(new Uint8Array(message_bytes)) as CastRemoveMessage;
+        return messageDecode(new Uint8Array(message_bytes)) as CastRemoveMessage;
       }) ?? [];
 
     return { messages, nextPageToken: message_page.nextPageToken };
@@ -100,7 +94,7 @@ class CastStore extends RustStoreBase<CastAddMessage, CastRemoveMessage> {
 
     const messages =
       message_page.messageBytes?.map((message_bytes) => {
-        return Message.decode(new Uint8Array(message_bytes)) as CastAddMessage;
+        return messageDecode(new Uint8Array(message_bytes)) as CastAddMessage;
       }) ?? [];
 
     return { messages, nextPageToken: message_page.nextPageToken };
@@ -112,7 +106,7 @@ class CastStore extends RustStoreBase<CastAddMessage, CastRemoveMessage> {
 
     const messages =
       message_page.messageBytes?.map((message_bytes) => {
-        return Message.decode(new Uint8Array(message_bytes)) as CastAddMessage;
+        return messageDecode(new Uint8Array(message_bytes)) as CastAddMessage;
       }) ?? [];
 
     return { messages, nextPageToken: message_page.nextPageToken };

--- a/apps/hubble/src/storage/stores/linkStore.ts
+++ b/apps/hubble/src/storage/stores/linkStore.ts
@@ -1,5 +1,5 @@
-import { getDefaultStoreLimit, LinkAddMessage, LinkRemoveMessage, Message, StoreType } from "@farcaster/hub-nodejs";
-import { makeFidKey } from "../../storage/db/message.js";
+import { getDefaultStoreLimit, LinkAddMessage, LinkRemoveMessage, StoreType } from "@farcaster/hub-nodejs";
+import { makeFidKey, messageDecode } from "../../storage/db/message.js";
 import { UserPostfix } from "../db/types.js";
 import { MessagesPage, PageOptions, StorePruneOptions } from "./types.js";
 import { ResultAsync } from "neverthrow";
@@ -7,10 +7,6 @@ import RocksDB from "../db/rocksdb.js";
 import { rsLinkStore, rustErrorToHubError } from "../../rustfunctions.js";
 import { RustStoreBase } from "./rustStoreBase.js";
 import storeEventHandler from "./storeEventHandler.js";
-
-const makeTargetKey = (target: number): Buffer => {
-  return makeFidKey(target);
-};
 
 /**
  * LinkStore persists Link Messages in RocksDB using a two-phase CRDT set to guarantee
@@ -56,7 +52,7 @@ class LinkStore extends RustStoreBase<LinkAddMessage, LinkRemoveMessage> {
       throw result.error;
     }
 
-    return Message.decode(new Uint8Array(result.value)) as LinkAddMessage;
+    return messageDecode(new Uint8Array(result.value)) as LinkAddMessage;
   }
 
   async getLinkRemove(fid: number, type: string, target: number): Promise<LinkRemoveMessage> {
@@ -69,7 +65,7 @@ class LinkStore extends RustStoreBase<LinkAddMessage, LinkRemoveMessage> {
       throw result.error;
     }
 
-    return Message.decode(new Uint8Array(result.value)) as LinkRemoveMessage;
+    return messageDecode(new Uint8Array(result.value)) as LinkRemoveMessage;
   }
 
   /** Finds all LinkAdd Messages by iterating through the prefixes */
@@ -82,7 +78,7 @@ class LinkStore extends RustStoreBase<LinkAddMessage, LinkRemoveMessage> {
 
     const messages =
       messages_page.messageBytes?.map((message_bytes) => {
-        return Message.decode(new Uint8Array(message_bytes)) as LinkAddMessage;
+        return messageDecode(new Uint8Array(message_bytes)) as LinkAddMessage;
       }) ?? [];
 
     return { messages, nextPageToken: messages_page.nextPageToken };
@@ -98,7 +94,7 @@ class LinkStore extends RustStoreBase<LinkAddMessage, LinkRemoveMessage> {
 
     const messages =
       messages_page.messageBytes?.map((message_bytes) => {
-        return Message.decode(new Uint8Array(message_bytes)) as LinkRemoveMessage;
+        return messageDecode(new Uint8Array(message_bytes)) as LinkRemoveMessage;
       }) ?? [];
 
     return { messages, nextPageToken: messages_page.nextPageToken };
@@ -114,7 +110,7 @@ class LinkStore extends RustStoreBase<LinkAddMessage, LinkRemoveMessage> {
 
     const messages =
       messages_page.messageBytes?.map((message_bytes) => {
-        return Message.decode(new Uint8Array(message_bytes)) as LinkAddMessage;
+        return messageDecode(new Uint8Array(message_bytes)) as LinkAddMessage;
       }) ?? [];
 
     return { messages, nextPageToken: messages_page.nextPageToken };
@@ -128,7 +124,7 @@ class LinkStore extends RustStoreBase<LinkAddMessage, LinkRemoveMessage> {
 
     const messages =
       messages_page.messageBytes?.map((message_bytes) => {
-        return Message.decode(new Uint8Array(message_bytes)) as LinkAddMessage | LinkRemoveMessage;
+        return messageDecode(new Uint8Array(message_bytes)) as LinkAddMessage | LinkRemoveMessage;
       }) ?? [];
 
     return { messages, nextPageToken: messages_page.nextPageToken };

--- a/apps/hubble/src/storage/stores/reactionStore.ts
+++ b/apps/hubble/src/storage/stores/reactionStore.ts
@@ -22,6 +22,7 @@ import { UserPostfix } from "../db/types.js";
 import { ResultAsync } from "neverthrow";
 import RocksDB from "storage/db/rocksdb.js";
 import { RustStoreBase } from "./rustStoreBase.js";
+import { messageDecode } from "../../storage/db/message.js";
 
 class ReactionStore extends RustStoreBase<ReactionAddMessage, ReactionRemoveMessage> {
   constructor(db: RocksDB, eventHandler: StoreEventHandler, options: StorePruneOptions = {}) {
@@ -48,7 +49,7 @@ class ReactionStore extends RustStoreBase<ReactionAddMessage, ReactionRemoveMess
     if (result.isErr()) {
       throw result.error;
     }
-    return Message.decode(new Uint8Array(result.value)) as ReactionAddMessage;
+    return messageDecode(new Uint8Array(result.value)) as ReactionAddMessage;
   }
 
   async getReactionRemove(fid: number, type: ReactionType, target: CastId | string): Promise<ReactionRemoveMessage> {
@@ -68,7 +69,7 @@ class ReactionStore extends RustStoreBase<ReactionAddMessage, ReactionRemoveMess
     if (result.isErr()) {
       throw result.error;
     }
-    return Message.decode(new Uint8Array(result.value)) as ReactionRemoveMessage;
+    return messageDecode(new Uint8Array(result.value)) as ReactionRemoveMessage;
   }
 
   async getReactionAddsByFid(
@@ -80,7 +81,7 @@ class ReactionStore extends RustStoreBase<ReactionAddMessage, ReactionRemoveMess
 
     const messages =
       messages_page.messageBytes?.map((message_bytes) => {
-        return Message.decode(new Uint8Array(message_bytes)) as ReactionAddMessage;
+        return messageDecode(new Uint8Array(message_bytes)) as ReactionAddMessage;
       }) ?? [];
 
     return { messages, nextPageToken: messages_page.nextPageToken };
@@ -95,7 +96,7 @@ class ReactionStore extends RustStoreBase<ReactionAddMessage, ReactionRemoveMess
 
     const messages =
       message_page.messageBytes?.map((message_bytes) => {
-        return Message.decode(new Uint8Array(message_bytes)) as ReactionRemoveMessage;
+        return messageDecode(new Uint8Array(message_bytes)) as ReactionRemoveMessage;
       }) ?? [];
 
     return { messages, nextPageToken: message_page.nextPageToken };
@@ -132,7 +133,7 @@ class ReactionStore extends RustStoreBase<ReactionAddMessage, ReactionRemoveMess
 
     const messages =
       message_page.messageBytes?.map((message_bytes) => {
-        return Message.decode(new Uint8Array(message_bytes)) as ReactionAddMessage;
+        return messageDecode(new Uint8Array(message_bytes)) as ReactionAddMessage;
       }) ?? [];
 
     return { messages, nextPageToken: message_page.nextPageToken };

--- a/apps/hubble/src/storage/stores/rustStoreBase.ts
+++ b/apps/hubble/src/storage/stores/rustStoreBase.ts
@@ -14,6 +14,7 @@ import { MessagesPage, PageOptions } from "./types.js";
 import { UserMessagePostfix } from "../db/types.js";
 import RocksDB from "../db/rocksdb.js";
 import { ResultAsync, err, ok } from "neverthrow";
+import { messageDecode } from "../../storage/db/message.js";
 
 export type DeepPartial<T> = T extends object
   ? {
@@ -207,7 +208,7 @@ export abstract class RustStoreBase<TAdd extends Message, TRemove extends Messag
       throw message_bytes.error;
     }
 
-    return Message.decode(new Uint8Array(message_bytes.value));
+    return messageDecode(new Uint8Array(message_bytes.value));
   }
 
   async getAllMessagesByFid(fid: number, pageOptions: PageOptions = {}): Promise<MessagesPage<TAdd | TRemove>> {
@@ -215,7 +216,7 @@ export abstract class RustStoreBase<TAdd extends Message, TRemove extends Messag
 
     const messages =
       messages_page.messageBytes?.map((message_bytes) => {
-        return Message.decode(new Uint8Array(message_bytes)) as TAdd | TRemove;
+        return messageDecode(new Uint8Array(message_bytes)) as TAdd | TRemove;
       }) ?? [];
 
     return { messages, nextPageToken: messages_page.nextPageToken };

--- a/apps/hubble/src/storage/stores/userDataStore.ts
+++ b/apps/hubble/src/storage/stores/userDataStore.ts
@@ -22,6 +22,7 @@ import {
   rustErrorToHubError,
 } from "../../rustfunctions.js";
 import { RustStoreBase } from "./rustStoreBase.js";
+import { messageDecode } from "../../storage/db/message.js";
 
 /**
  * UserDataStore persists UserData messages in RocksDB using a grow-only CRDT set to guarantee
@@ -63,7 +64,7 @@ class UserDataStore extends RustStoreBase<UserDataAddMessage, never> {
     if (result.isErr()) {
       throw result.error;
     }
-    return Message.decode(new Uint8Array(result.value)) as UserDataAddMessage;
+    return messageDecode(new Uint8Array(result.value)) as UserDataAddMessage;
   }
 
   /** Finds all UserDataAdd messages for an fid */
@@ -72,7 +73,7 @@ class UserDataStore extends RustStoreBase<UserDataAddMessage, never> {
 
     const messages =
       messages_page.messageBytes?.map((message_bytes) => {
-        return Message.decode(new Uint8Array(message_bytes)) as UserDataAddMessage;
+        return messageDecode(new Uint8Array(message_bytes)) as UserDataAddMessage;
       }) ?? [];
 
     return { messages, nextPageToken: messages_page.nextPageToken };

--- a/apps/hubble/src/storage/stores/usernameProofStore.ts
+++ b/apps/hubble/src/storage/stores/usernameProofStore.ts
@@ -7,7 +7,6 @@ import {
 } from "@farcaster/hub-nodejs";
 import { ResultAsync } from "neverthrow";
 import { UserPostfix } from "../db/types.js";
-import { Message } from "@farcaster/hub-nodejs";
 import {
   rsCreateUsernameProofStore,
   rsGetUsernameProof,
@@ -19,6 +18,7 @@ import StoreEventHandler from "./storeEventHandler.js";
 import { StorePruneOptions } from "./types.js";
 import RocksDB from "storage/db/rocksdb.js";
 import { RustStoreBase } from "./rustStoreBase.js";
+import { messageDecode } from "../../storage/db/message.js";
 
 class UsernameProofStore extends RustStoreBase<UsernameProofMessage, never> {
   constructor(db: RocksDB, eventHandler: StoreEventHandler, options: StorePruneOptions = {}) {
@@ -44,7 +44,7 @@ class UsernameProofStore extends RustStoreBase<UsernameProofMessage, never> {
     if (result.isErr()) {
       throw result.error;
     }
-    return Message.decode(new Uint8Array(result.value)) as UsernameProofMessage;
+    return messageDecode(new Uint8Array(result.value)) as UsernameProofMessage;
   }
 
   /** Finds all UserNameProof messages for an fid */
@@ -53,7 +53,7 @@ class UsernameProofStore extends RustStoreBase<UsernameProofMessage, never> {
 
     const messages =
       messages_page.messageBytes?.map((messageBytes) => {
-        return Message.decode(new Uint8Array(messageBytes)) as UsernameProofMessage;
+        return messageDecode(new Uint8Array(messageBytes)) as UsernameProofMessage;
       }) ?? [];
 
     return messages.map((message) => message.data.usernameProofBody);
@@ -67,7 +67,7 @@ class UsernameProofStore extends RustStoreBase<UsernameProofMessage, never> {
     if (result.isErr()) {
       throw result.error;
     }
-    return Message.decode(new Uint8Array(result.value)) as UsernameProofMessage;
+    return messageDecode(new Uint8Array(result.value)) as UsernameProofMessage;
   }
 }
 

--- a/apps/hubble/src/storage/stores/verificationStore.ts
+++ b/apps/hubble/src/storage/stores/verificationStore.ts
@@ -1,6 +1,5 @@
 import {
   HubAsyncResult,
-  Message,
   StoreType,
   VerificationAddAddressMessage,
   VerificationRemoveMessage,
@@ -21,6 +20,7 @@ import { UserPostfix } from "../db/types.js";
 import { ResultAsync } from "neverthrow";
 import RocksDB from "storage/db/rocksdb.js";
 import { RustStoreBase } from "./rustStoreBase.js";
+import { messageDecode } from "../../storage/db/message.js";
 
 class VerificationStore extends RustStoreBase<VerificationAddAddressMessage, VerificationRemoveMessage> {
   constructor(db: RocksDB, eventHandler: StoreEventHandler, options: StorePruneOptions = {}) {
@@ -42,7 +42,7 @@ class VerificationStore extends RustStoreBase<VerificationAddAddressMessage, Ver
     if (result.isErr()) {
       throw result.error;
     }
-    return Message.decode(new Uint8Array(result.value)) as VerificationAddAddressMessage;
+    return messageDecode(new Uint8Array(result.value)) as VerificationAddAddressMessage;
   }
 
   async getVerificationRemove(fid: number, address: Uint8Array): Promise<VerificationRemoveMessage> {
@@ -53,7 +53,7 @@ class VerificationStore extends RustStoreBase<VerificationAddAddressMessage, Ver
     if (result.isErr()) {
       throw result.error;
     }
-    return Message.decode(new Uint8Array(result.value)) as VerificationRemoveMessage;
+    return messageDecode(new Uint8Array(result.value)) as VerificationRemoveMessage;
   }
 
   async getVerificationAddsByFid(
@@ -64,7 +64,7 @@ class VerificationStore extends RustStoreBase<VerificationAddAddressMessage, Ver
 
     const messages =
       messages_page.messageBytes?.map((message_bytes) => {
-        return Message.decode(new Uint8Array(message_bytes)) as VerificationAddAddressMessage;
+        return messageDecode(new Uint8Array(message_bytes)) as VerificationAddAddressMessage;
       }) ?? [];
 
     return { messages, nextPageToken: messages_page.nextPageToken };
@@ -78,7 +78,7 @@ class VerificationStore extends RustStoreBase<VerificationAddAddressMessage, Ver
 
     const messages =
       message_page.messageBytes?.map((message_bytes) => {
-        return Message.decode(new Uint8Array(message_bytes)) as VerificationRemoveMessage;
+        return messageDecode(new Uint8Array(message_bytes)) as VerificationRemoveMessage;
       }) ?? [];
 
     return { messages, nextPageToken: message_page.nextPageToken };


### PR DESCRIPTION
## Motivation

Prevent unnecessarily encoding/decoding messages when sending to/from APIs

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on optimizing RPC APIs and message handling in the `hubble` app. 

### Detailed summary
- Optimized `get_many_messages` to return message bytes instead of decoded messages
- Updated message handling in various store modules to work with message bytes
- Replaced unnecessary encode/decode operations in RPC APIs

> The following files were skipped due to too many changes: `apps/hubble/src/addon/src/store/message.rs`, `apps/hubble/src/storage/stores/verificationStore.ts`, `apps/hubble/src/storage/stores/reactionStore.ts`, `apps/hubble/src/storage/stores/castStore.ts`, `apps/hubble/src/storage/stores/linkStore.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->