### PR TITLE
fix(replicator): respect fnames_username_unique constraint

### DIFF
--- a/.changeset/grumpy-spoons-pay.md
+++ b/.changeset/grumpy-spoons-pay.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/replicator": patch
+---
+
+respect fnames_username_unique constraint

--- a/apps/replicator/src/processors/usernameProof.ts
+++ b/apps/replicator/src/processors/usernameProof.ts
@@ -41,6 +41,8 @@ export const processUserNameProofAdd = async (proof: UserNameProof, trx: DBTrans
     )
     .execute();
 
+  await trx.deleteFrom("fnames").where("username", "=", username).execute();
+
   await trx
     .insertInto("fnames")
     .values({
@@ -62,7 +64,8 @@ export const processUserNameProofRemove = async (proof: UserNameProof, trx: DBTr
     .deleteFrom("usernameProofs")
     .where("username", "=", username)
     .where("timestamp", "=", farcasterTimeToDate(proof.timestamp))
+    .where("fid", "=", proof.fid)
     .execute();
 
-  await trx.deleteFrom("fnames").where("username", "=", username).execute();
+  await trx.deleteFrom("fnames").where("username", "=", username).where("fid", "=", proof.fid).execute();
 };

--- a/apps/replicator/src/processors/usernameProof.ts
+++ b/apps/replicator/src/processors/usernameProof.ts
@@ -59,11 +59,10 @@ export const processUserNameProofRemove = async (proof: UserNameProof, trx: DBTr
   const now = new Date();
 
   await trx
-    .updateTable("usernameProofs")
+    .deleteFrom("usernameProofs")
     .where("username", "=", username)
     .where("timestamp", "=", farcasterTimeToDate(proof.timestamp))
-    .set({ deletedAt: now, updatedAt: now })
     .execute();
 
-  await trx.updateTable("fnames").where("username", "=", username).set({ deletedAt: now, updatedAt: now }).execute();
+  await trx.deleteFrom("fnames").where("username", "=", username).execute();
 };


### PR DESCRIPTION
## Motivation

When a fname is transfered, the fnames_username_unique prevents using delete_at but requires a deletion of the data.

## Change Summary

Since hubble forgets about the old fname attachement, I choosed to delete it instead of changing the constraint.
* fname <=> old fid is now deleted
* userproof <=> old fid is now deleted
 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

closes farcasterxyz/hub-monorepo#1970

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on respecting the `fnames_username_unique` constraint in `usernameProof.ts`.

### Detailed summary
- Added patch to respect `fnames_username_unique` constraint
- Updated `processUserNameProofRemove` to delete from and insert into `fnames` table based on conditions
- Changed `updateTable` to `deleteFrom` in `processUserNameProofRemove` for `usernameProofs` table
- Updated conditions in `processUserNameProofRemove` to include `fid` when deleting from `fnames` table

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->