### PR TITLE
chore: Cleanup sync trie bulk inserts

### DIFF
--- a/.changeset/real-pets-walk.md
+++ b/.changeset/real-pets-walk.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+chore: Cleanup trie batch inserts to use batches

--- a/apps/hubble/src/addon/src/trie/merkle_trie_tests.rs
+++ b/apps/hubble/src/addon/src/trie/merkle_trie_tests.rs
@@ -16,14 +16,14 @@ mod tests {
 
         let key1: Vec<_> = "0000482712".bytes().collect();
         println!("{:?}", key1);
-        trie.insert(&key1).unwrap();
+        trie.insert(vec![key1.clone()]).unwrap();
 
         let node = trie.get_node(&key1).unwrap();
         assert_eq!(node.value().unwrap(), key1);
 
         // Add another key
         let key2: Vec<_> = "0000482713".bytes().collect();
-        trie.insert(&key2).unwrap();
+        trie.insert(vec![key2.clone()]).unwrap();
 
         // The get node should still work for both keys
         let node = trie.get_node(&key1).unwrap();

--- a/apps/hubble/src/addon/src/trie/trie_node.rs
+++ b/apps/hubble/src/addon/src/trie/trie_node.rs
@@ -157,130 +157,246 @@ impl TrieNode {
         &mut self,
         db: &Arc<RocksDB>,
         txn: &mut RocksDbTransactionBatch,
-        key: &Vec<u8>,
+        mut keys: Vec<Vec<u8>>,
         current_index: usize,
-    ) -> Result<bool, HubError> {
-        // Do not compact the timestamp portion of the trie, since it is used to compare snapshots
-        if current_index >= TIMESTAMP_LENGTH && self.is_leaf() && self.key.is_none() {
-            // Reached a leaf node with no value, insert it
-
-            self.key = Some(key.clone());
-            self.items += 1;
-
-            self.update_hash(db, &key[..current_index])?;
-            self.put_to_txn(txn, &key[..current_index]);
-
-            return Ok(true);
+    ) -> Result<Vec<bool>, HubError> {
+        if keys.len() == 0 {
+            return Err(HubError {
+                code: "bad_request.invalid_param".to_string(),
+                message: "No keys to insert".to_string(),
+            });
         }
 
+        // Note that all the keys will have the same prefix, so we can get the [0]th one
+        let prefix = keys[0][..current_index].to_vec();
+
+        let mut results = keys.iter().map(|_| false).collect::<Vec<bool>>();
+
+        // Vec to store the keys that were not inserted and their index
+        let remaining_keys;
+
+        // Do not compact the timestamp portion of the trie, since it is used to compare snapshots
         if current_index >= TIMESTAMP_LENGTH && self.is_leaf() {
-            // See if the key already exists
-            if bytes_compare(self.key.as_ref().unwrap_or(&vec![]), key.as_slice()) == 0 {
-                // Key already exists, do nothing
-                return Ok(false);
+            let mut inserted = false;
+            if self.key.is_none() {
+                let key = keys.pop().unwrap();
+                // Reached a leaf node with no value, insert it
+                self.key = Some(key);
+                self.items += 1;
+
+                self.update_hash(db, &prefix)?;
+                self.put_to_txn(txn, &prefix);
+
+                inserted = true;
+
+                results[0] = true; // the first key was inserted successfully
+            }
+
+            if keys.is_empty() {
+                return Ok(results);
+            }
+
+            // See if the any of the keys already exists
+            remaining_keys = keys
+                .into_iter()
+                .enumerate()
+                .filter_map(|(i, key)| {
+                    if bytes_compare(self.key.as_ref().unwrap_or(&vec![]), key.as_slice()) == 0 {
+                        // Key already exists, do nothing
+                        results[i] = false;
+                        None
+                    } else {
+                        Some((i + if inserted { 1 } else { 0 }, key)) // If we already pop()ed the first key, the index is i + 1
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            if remaining_keys.is_empty() {
+                // Nothing new was inserted, return
+                return Ok(results);
             }
 
             //  If the key is different, and a value exists, then split the node
             self.split_leaf_node(db, txn, current_index)?;
-        }
+        } else {
+            // If not a leaf, then we need to add all the keys
+            remaining_keys = keys.into_iter().enumerate().collect::<Vec<_>>()
+        };
 
-        if current_index >= key.len() {
+        // Check if any of the remaining keys are invalid
+        if remaining_keys
+            .iter()
+            .any(|(_, key)| current_index >= key.len())
+        {
             return Err(HubError {
                 code: "bad_request.invalid_param".to_string(),
                 message: "Key length exceeded".to_string(),
             });
         }
-        let char = key[current_index];
-        if !self.children.contains_key(&char) {
-            self.children
-                .insert(char, TrieNodeType::Node(TrieNode::default()));
+
+        // For the remaining keys, group them by the key[current_index] and insert them in bulk
+        // at the next level
+        let mut grouped_keys = HashMap::new();
+        for (i, key) in remaining_keys.into_iter() {
+            let char = key[current_index];
+            grouped_keys
+                .entry(char)
+                .or_insert_with(|| vec![])
+                .push((i, key));
         }
 
-        // Recurse into a non-leaf node and instruct it to insert the value
-        let child = self.get_or_load_child(db, &key[..current_index], char)?;
-        let result = child.insert(db, txn, key, current_index + 1)?;
+        let mut successes = 0;
+        for (char, child_keys) in grouped_keys.into_iter() {
+            if !self.children.contains_key(&char) {
+                self.children
+                    .insert(char, TrieNodeType::Node(TrieNode::default()));
+            }
 
-        if result {
-            self.items += 1;
+            // Recurse into a non-leaf node and instruct it to insert the value.
+            let child = self.get_or_load_child(db, &prefix, char)?;
 
-            self.update_hash(db, &key[..current_index])?;
-            self.put_to_txn(txn, &key[..current_index]);
+            // Split the child_keys into the "i"s and the keys
+            let mut is = vec![];
+            let mut keys = vec![];
+            for (i, key) in child_keys.into_iter() {
+                is.push(i);
+                keys.push(key);
+            }
+
+            let child_results = child.insert(db, txn, keys, current_index + 1)?;
+
+            for (i, result) in is.into_iter().zip(child_results) {
+                results[i] = result;
+                if result {
+                    successes += 1;
+                }
+            }
         }
 
-        Ok(result)
+        if successes > 0 {
+            self.items += successes;
+
+            self.update_hash(db, &prefix)?;
+            self.put_to_txn(txn, &prefix);
+        }
+
+        Ok(results)
     }
 
     pub fn delete(
         &mut self,
         db: &Arc<RocksDB>,
         txn: &mut RocksDbTransactionBatch,
-        key: &[u8],
+        keys: Vec<Vec<u8>>,
         current_index: usize,
-    ) -> Result<bool, HubError> {
+    ) -> Result<Vec<bool>, HubError> {
+        let prefix = keys[0][..current_index].to_vec();
+        let mut results = keys.iter().map(|_| false).collect::<Vec<bool>>();
+
         if self.is_leaf() {
-            if bytes_compare(self.key.as_ref().unwrap_or(&vec![]), key) == 0 {
-                self.key = None;
-                self.items -= 1;
+            // If any of the keys match, then we delete the key
+            for (i, key) in keys.iter().enumerate() {
+                if bytes_compare(self.key.as_ref().unwrap_or(&vec![]), key) == 0 {
+                    self.key = None;
+                    self.items -= 1;
 
-                self.delete_to_txn(txn, &key[..current_index]);
+                    self.delete_to_txn(txn, &prefix);
+                    self.update_hash(db, &prefix)?;
 
-                return Ok(true);
+                    results[i] = true;
+                    break;
+                }
             }
 
-            return Ok(false);
+            return Ok(results);
         }
 
-        if current_index >= key.len() {
+        // Check if any of the remaining keys are invalid
+        if keys.iter().any(|key| current_index >= key.len()) {
             return Err(HubError {
                 code: "bad_request.invalid_param".to_string(),
                 message: "Key length exceeded".to_string(),
             });
         }
-        let char = key[current_index];
-        if !self.children.contains_key(&char) {
-            return Ok(false);
+
+        // For the remaining keys, we group them by the key[current_index] and delete them in bulk
+        // at the next level
+        let mut grouped_keys = HashMap::new();
+        for (i, key) in keys.into_iter().enumerate() {
+            let char = key[current_index];
+            grouped_keys
+                .entry(char)
+                .or_insert_with(|| vec![])
+                .push((i, key));
         }
 
-        let child = self.get_or_load_child(db, &key[..current_index], char)?;
-        let result = child.delete(db, txn, key, current_index + 1)?;
-        let child_items = child.items;
+        let mut successes = 0;
+        for (char, child_keys) in grouped_keys.into_iter() {
+            if !self.children.contains_key(&char) {
+                // There are no more nodes under this, so we can return false for all the keys
+                for (i, _) in child_keys.into_iter() {
+                    results[i] = false;
+                }
+                continue;
+            }
 
-        if result {
-            self.items -= 1;
+            let child = self.get_or_load_child(db, &prefix, char)?;
+
+            // Split the child_keys into the "i"s and the keys
+            let mut is = vec![];
+            let mut keys = vec![];
+            for (i, key) in child_keys.into_iter() {
+                is.push(i);
+                keys.push(key);
+            }
+
+            let child_results = child.delete(db, txn, keys, current_index + 1)?;
+            let child_items = child.items;
 
             // Delete the child if it's empty. This is required to make sure the hash will be the same
             // as another trie that doesn't have this node in the first place.
             if child_items == 0 {
                 self.children.remove(&char);
+            }
 
-                if self.items == 0 {
-                    // Delete this node
-                    self.delete_to_txn(txn, &key[..current_index]);
-                    self.update_hash(db, &key[..current_index])?;
-                    return Ok(true);
+            for (i, result) in is.into_iter().zip(child_results) {
+                results[i] = result;
+                if result {
+                    successes += 1;
                 }
+            }
+        }
+
+        if successes > 0 {
+            self.items -= successes;
+
+            if self.items == 0 {
+                // Delete this node
+                self.delete_to_txn(txn, &prefix);
+                self.update_hash(db, &prefix)?;
+                return Ok(results);
             }
 
             if self.items == 1 && self.children.len() == 1 && current_index >= TIMESTAMP_LENGTH {
                 // Compact the trie by removing the child and moving the key up
                 let char = *self.children.keys().next().unwrap();
-                let child = self.get_or_load_child(db, &key[..current_index], char)?;
+                let child = self.get_or_load_child(db, &prefix, char)?;
 
                 if child.key.is_some() {
                     self.key = child.key.take();
                     self.children.remove(&char);
 
                     // Delete child
-                    let child_prefix = Self::make_primary_key(&key[..current_index], Some(char));
+                    let child_prefix = Self::make_primary_key(&prefix, Some(char));
                     self.delete_to_txn(txn, &child_prefix);
                 }
             }
 
-            self.update_hash(db, &key[..current_index])?;
-            self.put_to_txn(txn, &key[..current_index]);
+            self.update_hash(db, &prefix)?;
+            self.put_to_txn(txn, &prefix);
         }
 
-        Ok(result)
+        Ok(results)
     }
 
     pub fn exists(
@@ -317,18 +433,19 @@ impl TrieNode {
         current_index: usize,
     ) -> Result<(), HubError> {
         let key = self.key.take().unwrap();
+        let prefix = key[..current_index].to_vec();
+
         let new_child_char = key[current_index];
 
         self.children
             .insert(new_child_char, TrieNodeType::Node(TrieNode::default()));
 
         if let Some(TrieNodeType::Node(new_child)) = self.children.get_mut(&new_child_char) {
-            new_child.insert(db, txn, &key, current_index + 1)?;
+            new_child.insert(db, txn, vec![key], current_index + 1)?;
         }
 
-        let prefix = &key[..current_index];
-        self.update_hash(db, prefix)?;
-        self.put_to_txn(txn, prefix);
+        self.update_hash(db, &prefix)?;
+        self.put_to_txn(txn, &prefix);
 
         Ok(())
     }

--- a/apps/hubble/src/addon/src/trie/trie_node_tests.rs
+++ b/apps/hubble/src/addon/src/trie/trie_node_tests.rs
@@ -42,15 +42,15 @@ mod tests {
 
         // Can't insert keylengths < 10
         let key = (0..9).collect::<Vec<_>>();
-        let r = node.insert(&db, &mut txn, &key, 0);
+        let r = node.insert(&db, &mut txn, vec![key], 0);
         assert_eq!(r.is_err(), true);
         assert_eq!(r.unwrap_err().code, "bad_request.invalid_param".to_string());
         assert_eq!(node.items(), 0);
 
         // Add a new key. [0, 1, 2, .... 20]
         let key = (0..=20).collect::<Vec<_>>();
-        let r = node.insert(&db, &mut txn, &key, 0);
-        assert_eq!(r, Ok(true));
+        let r = node.insert(&db, &mut txn, vec![key.clone()], 0);
+        assert_eq!(r.unwrap()[0], true);
         assert_eq!(node.items(), 1);
         assert_eq!(node.value(), None);
 
@@ -83,8 +83,8 @@ mod tests {
 
         // Inserting the same item again it idempotent
         let prev_hash = node.hash();
-        let r = node.insert(&db, &mut txn, &key, 0);
-        assert_eq!(r, Ok(false));
+        let r = node.insert(&db, &mut txn, vec![key.clone()], 0);
+        assert_eq!(r.unwrap()[0], false);
         assert_eq!(node.items(), 1);
         assert_eq!(node.hash(), prev_hash);
         assert_eq!(txn.batch.len(), 0);
@@ -107,8 +107,8 @@ mod tests {
         let split_pos = 12;
         key2[split_pos] = 42; // Differs from the original key at the 12th position
         let prev_hash = node.hash();
-        let r = node.insert(&db, &mut txn, &key2, 0);
-        assert_eq!(r, Ok(true));
+        let r = node.insert(&db, &mut txn, vec![key2.clone()], 0);
+        assert_eq!(r.unwrap()[0], true);
         assert_eq!(node.items(), 2);
         assert_ne!(node.hash(), prev_hash);
 
@@ -136,8 +136,8 @@ mod tests {
         let split_pos = 4;
         key3[split_pos] = 84; // Differs from the original key at the 4th position
         let prev_hash = node.hash();
-        let r = node.insert(&db, &mut txn, &key3, 0);
-        assert_eq!(r, Ok(true));
+        let r = node.insert(&db, &mut txn, vec![key3.clone()], 0);
+        assert_eq!(r.unwrap()[0], true);
         assert_eq!(node.items(), 3);
         assert_ne!(node.hash(), prev_hash);
 
@@ -192,11 +192,11 @@ mod tests {
         let mut key2 = key1.clone();
         key2[20] = 42;
 
-        let r = node.insert(&db, &mut txn, &key1, 0);
-        assert_eq!(r, Ok(true));
+        let r = node.insert(&db, &mut txn, vec![key1.clone()], 0);
+        assert_eq!(r.unwrap()[0], true);
 
-        let r = node.insert(&db, &mut txn, &key2, 0);
-        assert_eq!(r, Ok(true));
+        let r = node.insert(&db, &mut txn, vec![key2.clone()], 0);
+        assert_eq!(r.unwrap()[0], true);
 
         // Check that both exists return true
         let r = node.exists(&db, &key1, 0);
@@ -206,12 +206,12 @@ mod tests {
         assert_eq!(r, Ok(true));
 
         // Make sure both delete Ok
-        let r = node.delete(&db, &mut txn, &key1, 0);
-        assert_eq!(r, Ok(true));
+        let r = node.delete(&db, &mut txn, vec![key1.clone()], 0);
+        assert_eq!(r.unwrap()[0], true);
         assert_eq!(node.items(), 1);
 
-        let r = node.delete(&db, &mut txn, &key2, 0);
-        assert_eq!(r, Ok(true));
+        let r = node.delete(&db, &mut txn, vec![key2.clone()], 0);
+        assert_eq!(r.unwrap()[0], true);
         assert_eq!(node.items(), 0);
         assert_eq!(node.hash(), empty_hash());
 
@@ -238,12 +238,12 @@ mod tests {
 
         // Add a new key. [0, 1, 2, .... 20]
         let key = (0..=20).collect::<Vec<_>>();
-        let r = node.insert(&db, &mut txn, &key, 0);
-        assert_eq!(r, Ok(true));
+        let r = node.insert(&db, &mut txn, vec![key.clone()], 0);
+        assert_eq!(r.unwrap()[0], true);
 
         // delete the key
-        let r = node.delete(&db, &mut txn, &key, 0);
-        assert_eq!(r, Ok(true));
+        let r = node.delete(&db, &mut txn, vec![key.clone()], 0);
+        assert_eq!(r.unwrap()[0], true);
         assert_eq!(node.items(), 0);
         assert_eq!(node.hash(), empty_hash());
 
@@ -257,17 +257,17 @@ mod tests {
         let mut key2 = key1.clone();
         key2[split_pos] = 42;
 
-        let r = node.insert(&db, &mut txn, &key1, 0);
-        assert_eq!(r, Ok(true));
+        let r = node.insert(&db, &mut txn, vec![key1.clone()], 0);
+        assert_eq!(r.unwrap()[0], true);
         let hash1 = node.hash();
 
-        let r = node.insert(&db, &mut txn, &key2, 0);
-        assert_eq!(r, Ok(true));
+        let r = node.insert(&db, &mut txn, vec![key2.clone()], 0);
+        assert_eq!(r.unwrap()[0], true);
         assert_ne!(node.hash(), hash1);
 
         // Delete the second key
-        let r = node.delete(&db, &mut txn, &key2, 0);
-        assert_eq!(r, Ok(true));
+        let r = node.delete(&db, &mut txn, vec![key2.clone()], 0);
+        assert_eq!(r.unwrap()[0], true);
 
         // The first key should still exist
         let r = node.exists(&db, &key1, 0);
@@ -281,8 +281,8 @@ mod tests {
         assert_eq!(node.hash(), hash1);
 
         // Delete the first key
-        let r = node.delete(&db, &mut txn, &key1, 0);
-        assert_eq!(r, Ok(true));
+        let r = node.delete(&db, &mut txn, vec![key1.clone()], 0);
+        assert_eq!(r.unwrap()[0], true);
         assert_eq!(node.items(), 0);
 
         // Deleting one of 3 keys only compacts that branch of the trie
@@ -298,13 +298,13 @@ mod tests {
 
         let mut txn = RocksDbTransactionBatch::new();
         for id in ids.iter() {
-            let r = node.insert(&db, &mut txn, id, 0).unwrap();
-            assert_eq!(r, true);
+            let r = node.insert(&db, &mut txn, vec![id.clone()], 0).unwrap();
+            assert_eq!(r[0], true);
         }
 
         // Remove the first id
-        let r = node.delete(&db, &mut txn, &ids[0], 0).unwrap();
-        assert_eq!(r, true);
+        let r = node.delete(&db, &mut txn, vec![ids[0].clone()], 0).unwrap();
+        assert_eq!(r[0], true);
 
         // Expect the other 2 ids to still exist
         for id in ids.iter().skip(1) {
@@ -319,10 +319,11 @@ mod tests {
         assert_eq!(split_node.children().len(), 2);
 
         // Delete both ids
-        for id in ids.iter().skip(1) {
-            let r = node.delete(&db, &mut txn, id, 0).unwrap();
-            assert_eq!(r, true);
-        }
+
+        let r = node
+            .delete(&db, &mut txn, vec![ids[1].clone(), ids[2].clone()], 0)
+            .unwrap();
+        assert_eq!(r, [true, true]);
 
         // Deleting from a deeper node should compact the trie at the split node
         let ids: Vec<Vec<u8>> = vec![
@@ -336,13 +337,13 @@ mod tests {
 
         let mut txn = RocksDbTransactionBatch::new();
         for id in ids.iter() {
-            let r = node.insert(&db, &mut txn, id, 0).unwrap();
-            assert_eq!(r, true);
+            let r = node.insert(&db, &mut txn, vec![id.clone()], 0).unwrap();
+            assert_eq!(r[0], true);
         }
 
         // Remove just the first ID
-        let r = node.delete(&db, &mut txn, &ids[0], 0).unwrap();
-        assert_eq!(r, true);
+        let r = node.delete(&db, &mut txn, vec![ids[0].clone()], 0);
+        assert_eq!(r.unwrap()[0], true);
 
         // The other 2 ids should still exist
         assert_eq!(node.items(), 2);
@@ -362,8 +363,8 @@ mod tests {
 
         // delete the other 2 ids
         for id in ids.iter().skip(1) {
-            let r = node.delete(&db, &mut txn, id, 0).unwrap();
-            assert_eq!(r, true);
+            let r = node.delete(&db, &mut txn, vec![id.clone()], 0).unwrap();
+            assert_eq!(r, [true]);
         }
 
         // Cleanup
@@ -399,8 +400,8 @@ mod tests {
         // Add the ids in forward order
         let mut txn = RocksDbTransactionBatch::new();
         for id in ids.iter() {
-            let r = node.insert(&db, &mut txn, id, 0).unwrap();
-            assert_eq!(r, true);
+            let r = node.insert(&db, &mut txn, vec![id.clone()], 0).unwrap();
+            assert_eq!(r[0], true);
         }
         db.commit(txn).unwrap();
         let forward_hash = node.hash();
@@ -408,16 +409,16 @@ mod tests {
         // Delete the ids in forward order
         let mut txn = RocksDbTransactionBatch::new();
         for id in ids.iter() {
-            let r = node.delete(&db, &mut txn, id, 0).unwrap();
-            assert_eq!(r, true);
+            let r = node.delete(&db, &mut txn, vec![id.clone()], 0).unwrap();
+            assert_eq!(r, [true]);
         }
         db.commit(txn).unwrap();
 
         // Ad the ids in reverse order
         let mut txn = RocksDbTransactionBatch::new();
         for id in ids.iter().rev() {
-            let r = node.insert(&db, &mut txn, id, 0).unwrap();
-            assert_eq!(r, true);
+            let r = node.insert(&db, &mut txn, vec![id.clone()], 0).unwrap();
+            assert_eq!(r[0], true);
         }
         db.commit(txn).unwrap();
         assert_eq!(node.hash(), forward_hash);
@@ -444,6 +445,314 @@ mod tests {
         for id in ids.iter() {
             assert_eq!(all_values.contains(id), true);
         }
+
+        // Cleanup
+        db.destroy().unwrap();
+    }
+
+    #[test]
+    fn test_batch_insert_delete() {
+        // Create a new DB with a random temporary path
+        let tmp_path = tempfile::tempdir()
+            .unwrap()
+            .path()
+            .as_os_str()
+            .to_string_lossy()
+            .to_string();
+        let db = Arc::new(RocksDB::new(&tmp_path).unwrap());
+        db.open().unwrap();
+
+        // Create a new TrieNode
+        let mut node = TrieNode::new();
+        assert_eq!(node.items(), 0);
+        assert_eq!(node.hash(), Vec::<u8>::new());
+
+        let ids: Vec<Vec<u8>> = vec![
+            format!("{:0>width$}010680", "0", width = TIMESTAMP_LENGTH * 2),
+            format!("{:0>width$}010a10", "0", width = TIMESTAMP_LENGTH * 2),
+            format!("{:0>width$}05d220", "0", width = TIMESTAMP_LENGTH * 2),
+        ]
+        .into_iter()
+        .map(|id| Vec::from_hex(id).unwrap())
+        .collect();
+
+        let mut txn = RocksDbTransactionBatch::new();
+        let r = node.insert(&db, &mut txn, ids.clone(), 0).unwrap();
+        assert_eq!(r, vec![true, true, true]);
+        db.commit(txn).unwrap();
+
+        assert_eq!(node.items(), ids.len());
+
+        // Make sure that all the values are there
+        let all_values = node.get_all_values(&db, &[]).unwrap();
+        for id in ids.iter() {
+            assert_eq!(all_values.contains(id), true);
+        }
+
+        // Inserting them again returns false
+        let mut txn = RocksDbTransactionBatch::new();
+        let r = node.insert(&db, &mut txn, ids.clone(), 0).unwrap();
+        assert_eq!(r, vec![false, false, false]);
+
+        // Inserting a subset of the ids returns true for the new ones
+        let mut new_ids = ids.clone();
+        new_ids.push(Vec::from_hex("0030662167aabbccddeeff").unwrap());
+
+        let mut txn = RocksDbTransactionBatch::new();
+        let r = node.insert(&db, &mut txn, new_ids.clone(), 0).unwrap();
+        assert_eq!(r, vec![false, false, false, true]);
+
+        assert_eq!(node.items(), new_ids.len());
+
+        // Make sure that all the values are there
+        let all_values = node.get_all_values(&db, &[]).unwrap();
+        for id in new_ids.iter() {
+            assert_eq!(all_values.contains(id), true);
+        }
+
+        // Deleting a single value works
+        let mut txn = RocksDbTransactionBatch::new();
+        let r = node
+            .delete(&db, &mut txn, vec![new_ids[0].clone()], 0)
+            .unwrap();
+        assert_eq!(r, [true]);
+
+        // Make sure that the value is no longer there
+        assert_eq!(node.exists(&db, &ids[0], 0).unwrap(), false);
+
+        // Deleting it again returns false
+        let mut txn = RocksDbTransactionBatch::new();
+        let r = node
+            .delete(&db, &mut txn, vec![new_ids[0].clone()], 0)
+            .unwrap();
+        assert_eq!(r, [false]);
+
+        // Deleting all the values works, even if one of the values is already deleted
+        let mut txn = RocksDbTransactionBatch::new();
+        let r = node.delete(&db, &mut txn, ids.clone(), 0).unwrap();
+        assert_eq!(r, [false, true, true]);
+
+        // Make sure that all the values are no longer there
+        for id in ids.iter() {
+            assert_eq!(node.exists(&db, id, 0).unwrap(), false);
+        }
+
+        // There's only 1 value left, which is the last value of new_ids
+        assert_eq!(node.items(), 1);
+
+        // Deleting all new_ids returns true only for the last one
+        let mut txn = RocksDbTransactionBatch::new();
+        let r = node.delete(&db, &mut txn, new_ids.clone(), 0).unwrap();
+        assert_eq!(r, [false, false, false, true]);
+
+        // Make sure that the last value is no longer there
+        assert_eq!(node.exists(&db, &new_ids[3], 0).unwrap(), false);
+
+        // There are no values left
+        assert_eq!(node.items(), 0);
+
+        // Cleanup
+        db.destroy().unwrap();
+    }
+
+    #[test]
+    fn test_random_batch_insert() {
+        // Create 1000 random keys, each between 11 and 20 bytes long
+        let mut keys = vec![];
+        for _ in 0..1000 {
+            let len = rand::random::<u8>() % 10 + 11;
+            let key: Vec<u8> = (0..len).map(|_| rand::random::<u8>()).collect();
+            keys.push(key);
+        }
+
+        // Create a new DB with a random temporary path
+        let tmp_path = tempfile::tempdir()
+            .unwrap()
+            .path()
+            .as_os_str()
+            .to_string_lossy()
+            .to_string();
+        let db = Arc::new(RocksDB::new(&tmp_path).unwrap());
+        db.open().unwrap();
+
+        // Create a new TrieNode
+        let mut node = TrieNode::new();
+        assert_eq!(node.items(), 0);
+
+        let mut txn = RocksDbTransactionBatch::new();
+        let r = node.insert(&db, &mut txn, keys.clone(), 0).unwrap();
+        assert_eq!(r.len(), keys.len());
+        assert_eq!(r.iter().all(|x| *x), true);
+
+        db.commit(txn).unwrap();
+
+        assert_eq!(node.items(), keys.len());
+
+        // Make sure that all the values are there
+        assert_eq!(
+            keys.iter().all(|key| node.exists(&db, key, 0).unwrap()),
+            true
+        );
+
+        let hash_before = node.hash();
+
+        // Delete all the items and create a new trie node
+        db.clear().unwrap();
+        let mut node = TrieNode::new();
+        assert_eq!(node.items(), 0);
+
+        // Add the keys again in batches of 100
+        for chunk in keys.chunks(100) {
+            let mut txn = RocksDbTransactionBatch::new();
+            let r = node.insert(&db, &mut txn, chunk.to_vec(), 0).unwrap();
+            assert_eq!(r.len(), chunk.len());
+            assert_eq!(r.iter().all(|x| *x), true);
+            db.commit(txn).unwrap();
+        }
+
+        assert_eq!(node.items(), keys.len());
+        assert_eq!(node.hash(), hash_before); // Hashes should match
+
+        // Delete all the items and create a new trie node
+        db.clear().unwrap();
+        let mut node = TrieNode::new();
+        assert_eq!(node.items(), 0);
+
+        // Add the keys again one by one
+        for key in keys.iter() {
+            let mut txn = RocksDbTransactionBatch::new();
+            let r = node.insert(&db, &mut txn, vec![key.clone()], 0).unwrap();
+            assert_eq!(r.len(), 1);
+            assert_eq!(r[0], true);
+            db.commit(txn).unwrap();
+        }
+
+        assert_eq!(node.items(), keys.len());
+        assert_eq!(node.hash(), hash_before); // Hashes should match
+
+        // Cleanup
+        db.destroy().unwrap();
+    }
+
+    #[test]
+    fn test_random_batch_delete() {
+        // Create 1000 random keys, each between 11 and 20 bytes long
+        let mut keys = vec![];
+        for _ in 0..1000 {
+            let len = rand::random::<u8>() % 10 + 11;
+            let key: Vec<u8> = (0..len).map(|_| rand::random::<u8>()).collect();
+            keys.push(key);
+        }
+
+        // Create a new DB with a random temporary path
+        let tmp_path = tempfile::tempdir()
+            .unwrap()
+            .path()
+            .as_os_str()
+            .to_string_lossy()
+            .to_string();
+        let db = Arc::new(RocksDB::new(&tmp_path).unwrap());
+        db.open().unwrap();
+
+        // Create a new TrieNode
+        let mut node = TrieNode::new();
+        assert_eq!(node.items(), 0);
+
+        let mut txn = RocksDbTransactionBatch::new();
+        let r = node.insert(&db, &mut txn, keys.clone(), 0).unwrap();
+        assert_eq!(r.len(), keys.len());
+        assert_eq!(r.iter().all(|x| *x), true);
+
+        db.commit(txn).unwrap();
+
+        assert_eq!(node.items(), keys.len());
+
+        // Deleting them all at once should work
+        let mut txn = RocksDbTransactionBatch::new();
+        let r = node.delete(&db, &mut txn, keys.clone(), 0).unwrap();
+        assert_eq!(r.len(), keys.len());
+        assert_eq!(r.iter().all(|x| *x), true);
+        db.commit(txn).unwrap();
+        assert_eq!(node.items(), 0);
+
+        // Create a new TrieNode and insert them again
+        let mut node = TrieNode::new();
+        let mut txn = RocksDbTransactionBatch::new();
+        node.insert(&db, &mut txn, keys.clone(), 0).unwrap();
+        db.commit(txn).unwrap();
+        assert_eq!(node.items(), keys.len());
+
+        // Deleting them in batches of 100 should work
+        let mut hashes = vec![];
+        for (i, chunk) in keys.chunks(100).enumerate() {
+            let mut txn = RocksDbTransactionBatch::new();
+            let r = node.delete(&db, &mut txn, chunk.to_vec(), 0).unwrap();
+            assert_eq!(r.len(), chunk.len());
+            assert_eq!(r.iter().all(|x| *x), true);
+            db.commit(txn).unwrap();
+
+            assert_eq!(node.items(), keys.len() - (100 * (i + 1)));
+            hashes.push(node.hash());
+        }
+        assert_eq!(node.items(), 0);
+
+        // Create a new TrieNode and insert them again
+        let mut node = TrieNode::new();
+        let mut txn = RocksDbTransactionBatch::new();
+        node.insert(&db, &mut txn, keys.clone(), 0).unwrap();
+        db.commit(txn).unwrap();
+        assert_eq!(node.items(), keys.len());
+
+        // Deleting them one-by-one should work, and the hashes should match every 100 keys deleted
+        for (i, key) in keys.iter().enumerate() {
+            let mut txn = RocksDbTransactionBatch::new();
+            let r = node.delete(&db, &mut txn, vec![key.clone()], 0).unwrap();
+            assert_eq!(r, [true]);
+            db.commit(txn).unwrap();
+
+            assert_eq!(node.items(), keys.len() - (i + 1));
+
+            if (i + 1) % 100 == 0 {
+                assert_eq!(node.hash(), hashes[(i + 1) / 100 - 1]);
+            }
+        }
+
+        // Create a new TrieNode and insert them again
+        let mut node = TrieNode::new();
+        let mut txn = RocksDbTransactionBatch::new();
+        node.insert(&db, &mut txn, keys.clone(), 0).unwrap();
+        db.commit(txn).unwrap();
+        assert_eq!(node.items(), keys.len());
+
+        // Deleting the first half of the keys should work
+        let mut txn = RocksDbTransactionBatch::new();
+        let r = node
+            .delete(&db, &mut txn, keys[0..500].to_vec(), 0)
+            .unwrap();
+        assert_eq!(r.len(), 500);
+        assert_eq!(r.iter().all(|x| *x), true);
+        db.commit(txn).unwrap();
+        assert_eq!(node.items(), 500);
+        let hash_before = node.hash();
+
+        // Create a new TrieNode and insert them again
+        db.clear().unwrap();
+        let mut node = TrieNode::new();
+        let mut txn = RocksDbTransactionBatch::new();
+        node.insert(&db, &mut txn, keys.clone(), 0).unwrap();
+        db.commit(txn).unwrap();
+        assert_eq!(node.items(), keys.len());
+
+        // Deleting the first half, but in reverse order, should work and the hashes should match
+        let mut txn = RocksDbTransactionBatch::new();
+        let keys_reversed = keys[0..500].iter().rev().cloned().collect();
+        let r = node.delete(&db, &mut txn, keys_reversed, 0).unwrap();
+        assert_eq!(r.len(), 500);
+        assert_eq!(r.iter().all(|x| *x), true);
+        db.commit(txn).unwrap();
+        assert_eq!(node.items(), 500);
+
+        assert_eq!(node.hash(), hash_before);
 
         // Cleanup
         db.destroy().unwrap();

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -27,7 +27,7 @@ import { publicAddressesFirst } from "@libp2p/utils/address-sort";
 import { unmarshalPrivateKey, unmarshalPublicKey } from "@libp2p/crypto/keys";
 import { Multiaddr, multiaddr } from "@multiformats/multiaddr";
 import { err, ok, Result, ResultAsync } from "neverthrow";
-import { GOSSIP_SEEN_TTL, GossipNode, MAX_MESSAGE_QUEUE_SIZE } from "./network/p2p/gossipNode.js";
+import { GOSSIP_SEEN_TTL, GossipNode, MAX_SYNCTRIE_QUEUE_SIZE } from "./network/p2p/gossipNode.js";
 import { PeriodicSyncJobScheduler } from "./network/sync/periodicSyncJob.js";
 import SyncEngine, { FIRST_SYNC_DELAY } from "./network/sync/syncEngine.js";
 import AdminServer from "./rpc/adminServer.js";
@@ -1263,7 +1263,7 @@ export class Hub implements HubInterface {
     }
 
     if (gossipMessage.message || gossipMessage.messageBundle) {
-      if (this.syncEngine.syncMergeQSize + this.syncEngine.syncTrieQSize > MAX_MESSAGE_QUEUE_SIZE) {
+      if (this.syncEngine.syncMergeQSize + this.syncEngine.syncTrieQSize > MAX_SYNCTRIE_QUEUE_SIZE) {
         // If there are too many messages in the queue, drop this message. This is a gossip message, so the sync
         // will eventually re-fetch and merge this message in anyway.
         const msg = "Sync queue is full, dropping gossip message";
@@ -1644,7 +1644,7 @@ export class Hub implements HubInterface {
   /* -------------------------------------------------------------------------- */
 
   async submitMessageBundle(messageBundle: MessageBundle, source?: HubSubmitSource): Promise<HubResult<number>[]> {
-    if (this.syncEngine.syncTrieQSize > MAX_MESSAGE_QUEUE_SIZE) {
+    if (this.syncEngine.syncTrieQSize > MAX_SYNCTRIE_QUEUE_SIZE) {
       log.warn({ syncTrieQSize: this.syncEngine.syncTrieQSize }, "SubmitMessage rejected: Sync trie queue is full");
       // Since we're rejecting the full bundle, return an error for each message
       return messageBundle.messages.map(() =>
@@ -1760,7 +1760,7 @@ export class Hub implements HubInterface {
   }
 
   async submitMessage(submittedMessage: Message, source?: HubSubmitSource): HubAsyncResult<number> {
-    if (this.syncEngine.syncTrieQSize > MAX_MESSAGE_QUEUE_SIZE) {
+    if (this.syncEngine.syncTrieQSize > MAX_SYNCTRIE_QUEUE_SIZE) {
       log.warn({ syncTrieQSize: this.syncEngine.syncTrieQSize }, "SubmitMessage rejected: Sync trie queue is full");
       return err(new HubError("unavailable.storage_failure", "Sync trie queue is full"));
     }

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -32,7 +32,7 @@ import { RootPrefix } from "../../storage/db/types.js";
 import { sleep } from "../../utils/crypto.js";
 
 /** The maximum number of pending merge messages before we drop new incoming gossip or sync messages. */
-export const MAX_MESSAGE_QUEUE_SIZE = 5000;
+export const MAX_SYNCTRIE_QUEUE_SIZE = 100_000;
 /** The TTL for messages in the seen cache */
 export const GOSSIP_SEEN_TTL = 1000 * 60 * 5;
 

--- a/apps/hubble/src/network/sync/merkleTrie.test.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.test.ts
@@ -151,12 +151,12 @@ describe("MerkleTrie", () => {
       expect(await trie.exists(syncId1)).toBeTruthy();
       expect(await trie.exists(syncId2)).toBeTruthy();
 
-      await trie.deleteBySyncId(syncId1);
+      await trie.delete(syncId1);
 
       expect(await trie.exists(syncId1)).toBeFalsy();
       expect(await trie.exists(syncId2)).toBeTruthy();
 
-      await trie.deleteBySyncId(syncId2);
+      await trie.delete(syncId2);
 
       expect(await trie.exists(syncId1)).toBeFalsy();
       expect(await trie.exists(syncId2)).toBeFalsy();
@@ -251,7 +251,7 @@ describe("MerkleTrie", () => {
         await trie2.stop();
 
         // Delete half the items from the first trie
-        await Promise.all(syncIds.slice(0, syncIds.length / 2).map(async (syncId) => trie.deleteBySyncId(syncId)));
+        await Promise.all(syncIds.slice(0, syncIds.length / 2).map(async (syncId) => trie.delete(syncId)));
         await trie.commitToDb();
 
         // Initialize a new trie from the same DB
@@ -287,7 +287,7 @@ describe("MerkleTrie", () => {
 
       expect(await trie.exists(syncId)).toBeTruthy();
 
-      await trie.deleteBySyncId(syncId);
+      await trie.delete(syncId);
       expect(await trie.items()).toEqual(0);
       expect(await trie.rootHash()).toEqual(EMPTY_HASH);
 
@@ -300,7 +300,7 @@ describe("MerkleTrie", () => {
 
       const rootHashBeforeDelete = await trie.rootHash();
       const syncId2 = await NetworkFactories.SyncId.create();
-      expect(await trie.deleteBySyncId(syncId2)).toBeFalsy();
+      expect(await trie.delete(syncId2)).toBeFalsy();
 
       const rootHashAfterDelete = await trie.rootHash();
       expect(rootHashAfterDelete).toEqual(rootHashBeforeDelete);
@@ -315,7 +315,7 @@ describe("MerkleTrie", () => {
       const rootHashBeforeDelete = await trie.rootHash();
       await trie.insert(syncId2);
 
-      await trie.deleteBySyncId(syncId2);
+      await trie.delete(syncId2);
       expect(await trie.rootHash()).toEqual(rootHashBeforeDelete);
     });
 
@@ -326,7 +326,7 @@ describe("MerkleTrie", () => {
       await trie.insert(syncId1);
       await trie.insert(syncId2);
 
-      await trie.deleteBySyncId(syncId1);
+      await trie.delete(syncId1);
 
       const secondTrie = new MerkleTrie(db2);
       await secondTrie.initialize();
@@ -352,7 +352,7 @@ describe("MerkleTrie", () => {
       expect(count).toEqual(1 + TIMESTAMP_LENGTH);
 
       // Delete
-      await trie.deleteBySyncId(id);
+      await trie.delete(id);
       await trie.commitToDb();
 
       count = await forEachDbItem(trie.getDb());
@@ -371,7 +371,7 @@ describe("MerkleTrie", () => {
       expect(count).toBeGreaterThan(1 + TIMESTAMP_LENGTH);
 
       // Delete
-      await trie.deleteBySyncId(syncId1);
+      await trie.delete(syncId1);
       await trie.commitToDb();
 
       count = await forEachDbItem(trie.getDb());
@@ -398,7 +398,7 @@ describe("MerkleTrie", () => {
       await Promise.all(syncIds.map(async (syncId) => trie.insert(syncId)));
 
       // Delete half of the items
-      await Promise.all(syncIds.slice(0, syncIds.length / 2).map(async (syncId) => trie.deleteBySyncId(syncId)));
+      await Promise.all(syncIds.slice(0, syncIds.length / 2).map(async (syncId) => trie.delete(syncId)));
 
       // Check that the items are still there
       await Promise.all(
@@ -421,7 +421,7 @@ describe("MerkleTrie", () => {
 
         // Delete half of the items
         const deletePromise = Promise.all(
-          syncIds1.slice(0, syncIds1.length / 2).map(async (syncId) => trie.deleteBySyncId(syncId)),
+          syncIds1.slice(0, syncIds1.length / 2).map(async (syncId) => trie.delete(syncId)),
         );
         const insert2Promise = Promise.all(syncIds2.map(async (syncId) => trie.insert(syncId)));
         const existPromise = await Promise.all(
@@ -466,7 +466,7 @@ describe("MerkleTrie", () => {
 
       expect(await trie2.rootHash()).toEqual(rootHash);
 
-      expect(await trie2.deleteBySyncId(syncId1)).toBeTruthy();
+      expect(await trie2.delete(syncId1)).toBeTruthy();
 
       expect(await trie2.rootHash()).not.toEqual(rootHash);
       expect(await trie2.exists(syncId1)).toBeFalsy();
@@ -488,7 +488,7 @@ describe("MerkleTrie", () => {
       await trie.unloadChidrenAtRoot();
 
       // Now try deleting syncId1
-      expect(await trie.deleteBySyncId(syncId1)).toBeTruthy();
+      expect(await trie.delete(syncId1)).toBeTruthy();
       await trie.commitToDb();
 
       expect(await trie.rootHash()).not.toEqual(rootHash);

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -385,9 +385,7 @@ describe("Multi peer sync engine", () => {
     // Now, delete the messages from engine 1
     engine1.getDb().clear();
     const allValues = await syncEngine1.trie.getAllValues(new Uint8Array());
-    for (const value of allValues) {
-      await syncEngine1.trie.deleteByBytes(value);
-    }
+    await syncEngine1.trie.deleteByBytes(allValues);
 
     // Now, engine 1 should have no messages. Getting the metadata for the root should return
     // undefined since the root node doesn't exist any more
@@ -623,9 +621,9 @@ describe("Multi peer sync engine", () => {
     await engine2.mergeMessage(castAdd);
 
     // ...but we'll corrupt the sync trie by pretending that the castAdd message, an onchain event and an fname are missing
-    await syncEngine2.trie.deleteBySyncId(SyncId.fromMessage(castAdd));
-    await syncEngine2.trie.deleteBySyncId(SyncId.fromOnChainEvent(storageEvent));
-    await syncEngine2.trie.deleteBySyncId(SyncId.fromFName(fname));
+    await syncEngine2.trie.delete(SyncId.fromMessage(castAdd));
+    await syncEngine2.trie.delete(SyncId.fromOnChainEvent(storageEvent));
+    await syncEngine2.trie.delete(SyncId.fromFName(fname));
 
     // syncengine2 should only have 2 onchain events
     expect(await syncEngine2.trie.items()).toEqual(2);

--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -530,8 +530,8 @@ describe("SyncEngine", () => {
         await engine.mergeOnChainEvent(custodyEvent);
         await engine.mergeUserNameProof(userNameProof);
 
-        await syncEngine.trie.deleteBySyncId(SyncId.fromOnChainEvent(custodyEvent));
-        await syncEngine.trie.deleteBySyncId(SyncId.fromFName(userNameProof));
+        await syncEngine.trie.delete(SyncId.fromOnChainEvent(custodyEvent));
+        await syncEngine.trie.delete(SyncId.fromFName(userNameProof));
 
         expect(await syncEngine.trie.exists(SyncId.fromFName(userNameProof))).toBeFalsy();
         expect(await syncEngine.trie.exists(SyncId.fromOnChainEvent(custodyEvent))).toBeFalsy();
@@ -559,11 +559,11 @@ describe("SyncEngine", () => {
       await engine.mergeMessage(castAdd);
 
       // Manually remove cast add to have an emtpy trie
-      await syncEngine.trie.deleteBySyncId(SyncId.fromMessage(castAdd));
-      await syncEngine.trie.deleteBySyncId(SyncId.fromOnChainEvent(custodyEvent));
-      await syncEngine.trie.deleteBySyncId(SyncId.fromOnChainEvent(signerEvent));
-      await syncEngine.trie.deleteBySyncId(SyncId.fromOnChainEvent(storageEvent));
-      await syncEngine.trie.deleteBySyncId(SyncId.fromFName(fnameProof));
+      await syncEngine.trie.delete(SyncId.fromMessage(castAdd));
+      await syncEngine.trie.delete(SyncId.fromOnChainEvent(custodyEvent));
+      await syncEngine.trie.delete(SyncId.fromOnChainEvent(signerEvent));
+      await syncEngine.trie.delete(SyncId.fromOnChainEvent(storageEvent));
+      await syncEngine.trie.delete(SyncId.fromFName(fnameProof));
       expect(await syncEngine.trie.exists(SyncId.fromMessage(castAdd))).toBeFalsy();
       expect(await syncEngine.trie.items()).toEqual(0);
 

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -487,9 +487,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
 
   /** Revoke the individual syncIDs in the Sync Trie */
   public async revokeSyncIds(syncIds: SyncId[]) {
-    for (const syncId of syncIds) {
-      await this._trie.deleteByBytes(syncId.syncId());
-    }
+    await this._trie.deleteByBytes(syncIds.map((syncId) => syncId.syncId()));
   }
 
   public async stop() {
@@ -1523,11 +1521,11 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
   }
 
   public async removeFname(usernameProof: UserNameProof): Promise<void> {
-    await this._trie.deleteBySyncId(SyncId.fromFName(usernameProof));
+    await this._trie.delete(SyncId.fromFName(usernameProof));
   }
 
   public async removeMessage(message: Message): Promise<void> {
-    await this._trie.deleteBySyncId(SyncId.fromMessage(message));
+    await this._trie.delete(SyncId.fromMessage(message));
   }
 
   public async getTrieNodeMetadata(prefix: Uint8Array): Promise<NodeMetadata | undefined> {

--- a/apps/hubble/src/rustfunctions.ts
+++ b/apps/hubble/src/rustfunctions.ts
@@ -673,9 +673,9 @@ export const rsMerkleTrieStop = async (trie: RustMerkleTrie): Promise<void> => {
 export const rsMerkleTrieBatchUpdate = async (
   trie: RustMerkleTrie,
   inserts: Uint8Array[],
-  operations: boolean[],
+  deletes: Uint8Array[],
 ): Promise<boolean[]> => {
-  return await lib.merkleTrieBatchUpdate.call(trie, inserts, operations);
+  return await lib.merkleTrieBatchUpdate.call(trie, inserts, deletes);
 };
 
 export const rsMerkleTrieInsert = async (trie: RustMerkleTrie, key: Uint8Array): Promise<boolean> => {

--- a/apps/hubble/src/storage/db/migrations/5.fnameSyncIds.test.ts
+++ b/apps/hubble/src/storage/db/migrations/5.fnameSyncIds.test.ts
@@ -41,8 +41,8 @@ describe("fnameSyncIds migration", () => {
       );
 
       await syncTrie.insert(paddedFnameSyncId);
-      await syncTrie.insertBytes(unpaddedFnameSyncId1Bytes);
-      await syncTrie.insertBytes(unpaddedFnameSyncId2Bytes);
+      await syncTrie.insertBytes([unpaddedFnameSyncId1Bytes]);
+      await syncTrie.insertBytes([unpaddedFnameSyncId2Bytes]);
 
       expect(await syncTrie.existsByBytes(paddedFnameSyncId.syncId())).toBe(true);
       expect(await syncTrie.existsByBytes(unpaddedFnameSyncId1Bytes)).toBe(true);

--- a/apps/hubble/src/storage/db/migrations/5.fnameSyncIds.ts
+++ b/apps/hubble/src/storage/db/migrations/5.fnameSyncIds.ts
@@ -37,7 +37,7 @@ export const fnameSyncIds = async (db: RocksDB): Promise<boolean> => {
 
         if (await syncTrie.existsByBytes(unpaddedBytes)) {
           count += 1;
-          await syncTrie.deleteByBytes(unpaddedBytes);
+          await syncTrie.deleteByBytes([unpaddedBytes]);
         }
       } catch (e) {
         log.error({ err: e }, `Failed to delete fname sync id for fname: ${proof.value.name}`);

--- a/apps/hubble/src/storage/db/migrations/6.oldContractEvents.ts
+++ b/apps/hubble/src/storage/db/migrations/6.oldContractEvents.ts
@@ -42,7 +42,7 @@ export const oldContractEvents = async (db: RocksDB): Promise<boolean> => {
           count += 1;
           try {
             await db.del(key);
-            await syncTrie.deleteBySyncId(SyncId.fromOnChainEvent(event));
+            await syncTrie.delete(SyncId.fromOnChainEvent(event));
           } catch (e) {
             log.error({ err: e }, `Failed to delete event ${event.type} ${event.fid} from block ${event.blockNumber}`);
           }

--- a/apps/hubble/src/storage/db/migrations/7.clearAdminResets.ts
+++ b/apps/hubble/src/storage/db/migrations/7.clearAdminResets.ts
@@ -37,7 +37,7 @@ export const clearAdminResets = async (db: RocksDB): Promise<boolean> => {
           count += 1;
           try {
             await db.del(key);
-            await syncTrie.deleteBySyncId(SyncId.fromOnChainEvent(event));
+            await syncTrie.delete(SyncId.fromOnChainEvent(event));
           } catch (e) {
             log.error({ err: e }, `Failed to delete event ${event.type} ${event.fid} from block ${event.blockNumber}`);
           }

--- a/apps/hubble/src/test/bench/merkleTrie.ts
+++ b/apps/hubble/src/test/bench/merkleTrie.ts
@@ -73,10 +73,8 @@ export const benchMerkleTrie = async ({
 
   while (i < syncIds.length) {
     let start = performance.now();
-    for (let j = 0; j < cycle; j++) {
-      // biome-ignore lint/style/noNonNullAssertion: legacy code, avoid using ignore for new code
-      await trie.insert(syncIds[(i + j) % syncIds.length]!);
-    }
+    await trie.insertBatch(syncIds.slice(i, i + cycle));
+
     await trie.commitToDb();
     const insertDuration = performance.now() - start;
 


### PR DESCRIPTION
## Motivation

Cleanup the sync trie bulk inserts to insert multiple items at a time


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on optimizing trie batch inserts and improving sync ID handling. 

### Detailed summary
- Refactored trie batch insert operations for efficiency
- Updated sync ID deletion methods for better performance
- Adjusted queue sizes for gossip messages and sync trie operations
- Enhanced error handling and message submission logic

> The following files were skipped due to too many changes: `apps/hubble/src/network/sync/merkleTrie.test.ts`, `apps/hubble/src/network/sync/merkleTrie.ts`, `apps/hubble/src/addon/src/trie/merkle_trie.rs`, `apps/hubble/src/addon/src/trie/trie_node.rs`, `apps/hubble/src/addon/src/trie/trie_node_tests.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->