### PR TITLE
chore: Check if message count is less than prune size before pruning

### DIFF
--- a/.changeset/ten-cycles-beg.md
+++ b/.changeset/ten-cycles-beg.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Check if we need to prune before actually pruning

--- a/apps/hubble/src/addon/src/trie/merkle_trie.rs
+++ b/apps/hubble/src/addon/src/trie/merkle_trie.rs
@@ -322,7 +322,7 @@ impl MerkleTrie {
 
                 let child_node = self.get_node(&child_prefix).ok_or(HubError {
                     code: "bad_request.internal_error".to_string(),
-                    message: "Child node not found".to_string(),
+                    message: "Child Node not found".to_string(),
                 })?;
 
                 children.insert(

--- a/apps/hubble/src/addon/src/trie/trie_node.rs
+++ b/apps/hubble/src/addon/src/trie/trie_node.rs
@@ -124,7 +124,7 @@ impl TrieNode {
 
     pub fn get_node_from_trie(
         &mut self,
-        db: &Arc<RocksDB>,
+        db: &RocksDB,
         prefix: &[u8],
         current_index: usize,
     ) -> Option<&mut TrieNode> {
@@ -155,7 +155,7 @@ impl TrieNode {
      */
     pub fn insert(
         &mut self,
-        db: &Arc<RocksDB>,
+        db: &RocksDB,
         txn: &mut RocksDbTransactionBatch,
         mut keys: Vec<Vec<u8>>,
         current_index: usize,
@@ -239,14 +239,14 @@ impl TrieNode {
         let mut grouped_keys = HashMap::new();
         for (i, key) in remaining_keys.into_iter() {
             let char = key[current_index];
-            grouped_keys
-                .entry(char)
-                .or_insert_with(|| vec![])
-                .push((i, key));
+            let entry = grouped_keys.entry(char).or_insert_with(|| (vec![], vec![]));
+
+            entry.0.push(i);
+            entry.1.push(key);
         }
 
         let mut successes = 0;
-        for (char, child_keys) in grouped_keys.into_iter() {
+        for (char, (is, keys)) in grouped_keys.into_iter() {
             if !self.children.contains_key(&char) {
                 self.children
                     .insert(char, TrieNodeType::Node(TrieNode::default()));
@@ -254,15 +254,6 @@ impl TrieNode {
 
             // Recurse into a non-leaf node and instruct it to insert the value.
             let child = self.get_or_load_child(db, &prefix, char)?;
-
-            // Split the child_keys into the "i"s and the keys
-            let mut is = vec![];
-            let mut keys = vec![];
-            for (i, key) in child_keys.into_iter() {
-                is.push(i);
-                keys.push(key);
-            }
-
             let child_results = child.insert(db, txn, keys, current_index + 1)?;
 
             for (i, result) in is.into_iter().zip(child_results) {
@@ -428,7 +419,7 @@ impl TrieNode {
      */
     pub fn split_leaf_node(
         &mut self,
-        db: &Arc<RocksDB>,
+        db: &RocksDB,
         txn: &mut RocksDbTransactionBatch,
         current_index: usize,
     ) -> Result<(), HubError> {
@@ -452,7 +443,7 @@ impl TrieNode {
 
     fn get_or_load_child(
         &mut self,
-        db: &Arc<RocksDB>,
+        db: &RocksDB,
         prefix: &[u8],
         char: u8,
     ) -> Result<&mut TrieNode, HubError> {
@@ -485,7 +476,7 @@ impl TrieNode {
         }
     }
 
-    fn update_hash(&mut self, db: &Arc<RocksDB>, prefix: &[u8]) -> Result<(), HubError> {
+    fn update_hash(&mut self, db: &RocksDB, prefix: &[u8]) -> Result<(), HubError> {
         if self.is_leaf() {
             self.hash = blake3_20(&self.key.as_ref().unwrap_or(&vec![]));
         } else {

--- a/apps/hubble/src/addon/src/trie/trie_node.rs
+++ b/apps/hubble/src/addon/src/trie/trie_node.rs
@@ -4,7 +4,7 @@ use crate::{
     store::{blake3_20, bytes_compare, HubError, RootPrefix},
 };
 use prost::Message as _;
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use super::merkle_trie::TrieSnapshot;
 
@@ -276,7 +276,7 @@ impl TrieNode {
 
     pub fn delete(
         &mut self,
-        db: &Arc<RocksDB>,
+        db: &RocksDB,
         txn: &mut RocksDbTransactionBatch,
         keys: Vec<Vec<u8>>,
         current_index: usize,
@@ -392,7 +392,7 @@ impl TrieNode {
 
     pub fn exists(
         &mut self,
-        db: &Arc<RocksDB>,
+        db: &RocksDB,
         key: &[u8],
         current_index: usize,
     ) -> Result<bool, HubError> {
@@ -519,7 +519,7 @@ impl TrieNode {
 
     fn excluded_hash(
         &mut self,
-        db: &Arc<RocksDB>,
+        db: &RocksDB,
         prefix: &[u8],
         prefix_char: u8,
     ) -> Result<(usize, String), HubError> {
@@ -568,7 +568,7 @@ impl TrieNode {
 
     pub fn get_all_values(
         &mut self,
-        db: &Arc<RocksDB>,
+        db: &RocksDB,
         prefix: &[u8],
     ) -> Result<Vec<Vec<u8>>, HubError> {
         if self.is_leaf() {
@@ -596,7 +596,7 @@ impl TrieNode {
 
     pub fn get_snapshot(
         &mut self,
-        db: &Arc<RocksDB>,
+        db: &RocksDB,
         prefix: &[u8],
         current_index: usize,
     ) -> Result<TrieSnapshot, HubError> {

--- a/apps/hubble/src/storage/stores/rustStoreBase.ts
+++ b/apps/hubble/src/storage/stores/rustStoreBase.ts
@@ -176,7 +176,7 @@ export abstract class RustStoreBase<TAdd extends Message, TRemove extends Messag
     }
 
     // Return immediately if there are no messages to prune
-    if (cachedCount.value === 0) {
+    if (cachedCount.value <= this._pruneSizeLimit * units.value) {
       return ok([]);
     }
 


### PR DESCRIPTION
## Motivation

Minor cleanups + check to see if we need to prune at all

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `@farcaster/hubble` package and refactors the `rustStoreBase.ts` and various files in the `trie` module for improved functionality.

### Detailed summary
- Added a fix to check the need for pruning before pruning in `rustStoreBase.ts`
- Fixed a typo in a message in `merkle_trie.rs`
- Removed unnecessary `Arc` import in `trie_node.rs`
- Refactored `TrieNode` methods to remove `Arc<RocksDB>` parameters
- Improved key grouping logic in `TrieNode`
- Updated method signatures and logic in `TrieNode` for better functionality

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->