### PR TITLE
fix: Fname index from LittleEndian -> BigEndian

### DIFF
--- a/.changeset/tidy-suns-flow.md
+++ b/.changeset/tidy-suns-flow.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Fix fname index from Little endian -> big endian

--- a/apps/hubble/src/addon/src/store/name_registry_events.rs
+++ b/apps/hubble/src/addon/src/store/name_registry_events.rs
@@ -5,20 +5,20 @@ use crate::{
     protos::UserNameProof,
 };
 
-use super::{HubError, RootPrefix};
+use super::{make_fid_key, HubError, RootPrefix};
 
 pub fn make_fname_username_proof_key(name: &[u8]) -> Vec<u8> {
-    let mut key = Vec::with_capacity(1 + 32 + 1 + 32);
+    let mut key = Vec::with_capacity(1 + 32);
     key.push(RootPrefix::FNameUserNameProof as u8);
     key.extend_from_slice(name);
     key
 }
 
 pub fn make_fname_username_proof_by_fid_key(fid: u32) -> Vec<u8> {
-    let mut key = Vec::with_capacity(1 + 4 + 1 + 32);
+    let mut key = Vec::with_capacity(1 + 4);
 
     key.push(RootPrefix::FNameUserNameProofByFid as u8);
-    key.extend_from_slice(&fid.to_le_bytes());
+    key.extend_from_slice(&make_fid_key(fid));
     key
 }
 

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -262,6 +262,7 @@ describe("Multi peer sync engine", () => {
 
       // Do the sync again, this time enabling audit
       await syncEngine2.performSync("engine1", clientForServer1, true);
+      await sleepWhile(() => syncEngine2.syncTrieQSize > 0, SLEEPWHILE_TIMEOUT);
 
       // Make sure root hash matches
       expect(await syncEngine1.trie.rootHash()).toEqual(await syncEngine2.trie.rootHash());

--- a/apps/hubble/src/storage/db/message.ts
+++ b/apps/hubble/src/storage/db/message.ts
@@ -10,7 +10,7 @@ import {
   UserMessagePostfixMax,
   UserPostfix,
 } from "./types.js";
-import { MessagesPage, PAGE_SIZE_MAX, PageOptions } from "../stores/types.js";
+import { PAGE_SIZE_MAX, PageOptions } from "../stores/types.js";
 
 export const makeFidKey = (fid: number): Buffer => {
   const buffer = Buffer.alloc(FID_BYTES);

--- a/apps/hubble/src/storage/db/migrations/11.fnameIndex.test.ts
+++ b/apps/hubble/src/storage/db/migrations/11.fnameIndex.test.ts
@@ -1,0 +1,67 @@
+import { performDbMigrations } from "./migrations.js";
+import { jestRocksDB } from "../jestUtils.js";
+import { Factories, UserNameProof, UserNameType } from "@farcaster/hub-nodejs";
+import { FID_BYTES, RootPrefix } from "../types.js";
+import { makeFidKey } from "../message.js";
+import { ResultAsync } from "neverthrow";
+
+const db = jestRocksDB("fnameUserNameProofByFid.migration.test");
+
+const fid1 = Factories.Fid.build();
+const fid2 = fid1 + 1;
+
+describe("fnameUserNameProofByFid migration", () => {
+  beforeAll(async () => {});
+
+  test("should migrate the fname index properly", async () => {
+    // To trigger the migration, we need the FnameUserNameProofs to exist
+    const fname1 = Buffer.from("fname1");
+    const fnameProofFid1 = Buffer.concat([Buffer.from([RootPrefix.FNameUserNameProof]), fname1]);
+    const fid1UsernameProof = Factories.UserNameProof.build({
+      name: fname1,
+      fid: fid1,
+      timestamp: 0,
+      type: UserNameType.USERNAME_TYPE_FNAME,
+    });
+    await db.put(fnameProofFid1, Buffer.from(UserNameProof.encode(fid1UsernameProof).finish()));
+
+    const fname2 = Buffer.from("fname2");
+    const fnameProofFid2 = Buffer.concat([Buffer.from([RootPrefix.FNameUserNameProof]), fname2]);
+    const fid2UsernameProof = Factories.UserNameProof.build({
+      name: fname2,
+      fid: fid2,
+      timestamp: 0,
+      type: UserNameType.USERNAME_TYPE_FNAME,
+    });
+    await db.put(fnameProofFid2, Buffer.from(UserNameProof.encode(fid2UsernameProof).finish()));
+
+    // First, write an incorrect index
+    const littleEndianFid = Buffer.alloc(FID_BYTES);
+    littleEndianFid.writeUint32LE(fid1);
+
+    const incorrectIndexKey = Buffer.concat([Buffer.from([RootPrefix.FNameUserNameProofByFid]), littleEndianFid]);
+    const correctIndexKey = Buffer.concat([Buffer.from([RootPrefix.FNameUserNameProofByFid]), makeFidKey(fid1)]);
+    const fixedIndexValue = fnameProofFid1;
+    await db.put(incorrectIndexKey, fixedIndexValue);
+
+    // Then also create a correct index
+    const unchangedIndexKey = Buffer.concat([Buffer.from([RootPrefix.FNameUserNameProofByFid]), makeFidKey(fid2)]);
+    const unchangedIndexValue = fnameProofFid2;
+    await db.put(unchangedIndexKey, unchangedIndexValue);
+
+    // Now run the migration
+    await performDbMigrations(db, 10, 11);
+
+    // Check that the incorrect index was deleted
+    const incorrectIndexValueResult = await ResultAsync.fromPromise(db.get(incorrectIndexKey), (e) => e as Error);
+    expect(incorrectIndexValueResult.isErr()).toBe(true);
+
+    // Check that the correct index was written correctly
+    const correctIndexValue = await db.get(correctIndexKey);
+    expect(correctIndexValue).toEqual(fixedIndexValue);
+
+    // Check that the correct index was unchanged
+    const correctIndexValueResult = await db.get(unchangedIndexKey);
+    expect(correctIndexValueResult).toEqual(unchangedIndexValue);
+  });
+});

--- a/apps/hubble/src/storage/db/migrations/11.fnameIndex.ts
+++ b/apps/hubble/src/storage/db/migrations/11.fnameIndex.ts
@@ -1,0 +1,73 @@
+import { UserNameProof, bytesCompare } from "@farcaster/hub-nodejs";
+import { logger } from "../../../utils/logger.js";
+import RocksDB from "../rocksdb.js";
+import { FID_BYTES, RootPrefix } from "../types.js";
+import { makeFidKey } from "../message.js";
+import { ResultAsync } from "neverthrow";
+
+const log = logger.child({ component: "fnameIndex" });
+
+/**
+ * Up untill now, we were accidentally writing the fid index for the fname messages as Little Endian
+ * instead of Big Endian in name_registry_events.rs:make_fname_username_proof_by_fid_key.
+ * This migration will fix that to be big endian, and also remove the little endian index keys
+ */
+export const fixFnameIndexLittleEndianToBigEndian = async (db: RocksDB): Promise<boolean> => {
+  // Go over the DB to see if there are any old indexes that didn't get migrated
+  log.info({}, "Starting fnameIndex migration");
+
+  const start = Date.now();
+  // Now count the number of fname messages that and ones that don't have a corresponding index
+  let missingIndexes = 0;
+  let totalFnames = 0;
+  let rightKey = 0;
+  let fixedIndexes = 0;
+
+  await db.forEachIteratorByPrefix(Buffer.from([RootPrefix.FNameUserNameProof]), async (key, value) => {
+    if (!key || !value) {
+      return;
+    }
+
+    totalFnames += 1;
+    const userNameProof = UserNameProof.decode(value);
+    const fid = userNameProof.fid;
+
+    if (totalFnames % 10_000 === 0) {
+      log.info({ totalFnames, missingIndexes, rightKey, fixedIndexes }, "Migrating fname index progress...");
+    }
+
+    // Check if the index exists
+    const indexKey = Buffer.concat([Buffer.from([RootPrefix.FNameUserNameProofByFid]), makeFidKey(fid)]);
+    const indexValue = await ResultAsync.fromPromise(db.get(indexKey), (e) => e as Error);
+
+    if (indexValue.isErr() || !indexValue.value || bytesCompare(indexValue.value, key) !== 0) {
+      missingIndexes += 1;
+      // Write the index correctly
+      await db.put(indexKey, key);
+
+      // If the Little endian index exists, delete that one
+      const littleEndianFid = Buffer.alloc(FID_BYTES);
+      littleEndianFid.writeUint32LE(fid);
+      const littleEndianIndexKey = Buffer.concat([Buffer.from([RootPrefix.FNameUserNameProofByFid]), littleEndianFid]);
+
+      // Ignore the error if it doesn't exist
+      await ResultAsync.fromPromise(db.del(littleEndianIndexKey), (e) => e as Error);
+      fixedIndexes += 1;
+
+      // const name = Buffer.from(userNameProof.name).toString("utf-8");
+      // log.info(
+      //   { name, fid, key, value, indexValue, indexKey, littleEndianIndexKey },
+      //   "Index doesn't exist for fname, fixed",
+      // );
+    } else {
+      rightKey += 1;
+    }
+  });
+
+  log.info(
+    { totalFnames, missingIndexes, fixedIndexes, rightKey, durationMs: Date.now() - start },
+    "Checked all fnames",
+  );
+
+  return true;
+};

--- a/apps/hubble/src/storage/db/migrations/migrations.ts
+++ b/apps/hubble/src/storage/db/migrations/migrations.ts
@@ -12,6 +12,7 @@ import { fnameSyncIds } from "./5.fnameSyncIds.js";
 import { oldContractEvents } from "./6.oldContractEvents.js";
 import { clearAdminResets } from "./7.clearAdminResets.js";
 import { fnameUserNameProofByFidPrefix } from "./9.fnameUserNameProofByFidPrefix.js";
+import { fixFnameIndexLittleEndianToBigEndian } from "./11.fnameIndex.js";
 
 type MigrationFunctionType = (db: RocksDB) => Promise<boolean>;
 const migrations = new Map<number, MigrationFunctionType>();
@@ -66,6 +67,10 @@ migrations.set(10, async (_db: RocksDB) => {
    * by compatible versions of the hub)
    */
   return true;
+});
+
+migrations.set(11, async (db: RocksDB) => {
+  return await fixFnameIndexLittleEndianToBigEndian(db);
 });
 
 // To Add a new migration


### PR DESCRIPTION
## Motivation

We were accidentally encoding fid as little endian in the fname index. Do a migration to fix to use big endian.


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes an issue where the `fname` index was incorrectly stored in Little Endian instead of Big Endian.

### Detailed summary
- Fixed `fname` index from Little Endian to Big Endian
- Added migration to correct existing index values
- Updated key generation functions to handle Big Endian
- Added tests for migration process

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->