### PR TITLE
fix: Retry uploads of snapshot chunks to R2

### DIFF
--- a/.changeset/neat-goats-dance.md
+++ b/.changeset/neat-goats-dance.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Retry uploads of snapshot chunks to R2

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -523,6 +523,8 @@ describe("Multi peer sync engine", () => {
   test("local peer removes bad syncId entries from the sync trie", async () => {
     await engine1.mergeOnChainEvent(custodyEvent);
     await engine2.mergeOnChainEvent(custodyEvent);
+    await sleepWhile(() => syncEngine2.syncTrieQSize > 0, SLEEPWHILE_TIMEOUT);
+    await sleepWhile(() => syncEngine1.syncTrieQSize > 0, SLEEPWHILE_TIMEOUT);
 
     const engine1Hash = await syncEngine1.trie.rootHash();
     expect(engine1Hash).toEqual(await syncEngine2.trie.rootHash());


### PR DESCRIPTION
## Motivation

R2 uploads sometimes fail, so add retries

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving snapshot chunk uploads in the `@farcaster/hubble` package. 

### Detailed summary
- Added retry mechanism for snapshot chunk uploads to R2
- Updated snapshot upload function to handle retries and logging
- Introduced `uploadChunk` function for uploading snapshot chunks with retries

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->