### PR TITLE
fix: pad type bytes in link_store keys

### DIFF
--- a/.changeset/famous-otters-confess.md
+++ b/.changeset/famous-otters-confess.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: pad type bytes in link_store keys

--- a/apps/hubble/src/addon/src/store/link_store.rs
+++ b/apps/hubble/src/addon/src/store/link_store.rs
@@ -283,7 +283,10 @@ impl LinkStore {
         // TODO: does the fid and rtype need to be padded? Is it okay not the check their lengths?
         key.extend_from_slice(&make_user_key(fid));
         key.push(UserPostfix::LinkAdds.as_u8());
-        key.extend_from_slice(&link_body.r#type.as_bytes());
+        let type_bytes = &mut link_body.r#type.as_bytes().to_vec();
+        // Pad with zero bytes
+        type_bytes.resize(Self::LINK_TYPE_BYTE_SIZE, 0);
+        key.extend_from_slice(&type_bytes);
         match link_body.target {
             None => {}
             Some(Target::TargetFid(fid)) => {
@@ -328,7 +331,10 @@ impl LinkStore {
         // TODO: does the fid and rtype need to be padded? Is it okay not the check their lengths?
         key.extend_from_slice(&make_user_key(fid));
         key.push(UserPostfix::LinkRemoves.as_u8());
-        key.extend_from_slice(&link_body.r#type.as_bytes());
+        let type_bytes = &mut link_body.r#type.as_bytes().to_vec();
+        // Pad with zero bytes
+        type_bytes.resize(Self::LINK_TYPE_BYTE_SIZE, 0);
+        key.extend_from_slice(&type_bytes);
         match link_body.target {
             None => {}
             Some(Target::TargetFid(fid)) => {


### PR DESCRIPTION
## Motivation

One guess for why https://warpcast.com/v/0x6276d3ae is happening is that the RocksDB keys generated before `link_store` was ported to Rust differ from the JS implementation. Specifically the length of the `type` bytes is padded to 8 bytes in the previous implementation: https://github.com/farcasterxyz/hub-monorepo/blob/b53a76f0f141096e3d195c132d8d7ba72f4215ef/apps/hubble/src/storage/stores/linkStore.ts#L48-L53

This PR does the same in the Rust implementation.

## Change Summary

Pads `type` bytes used for generating RocksDB keys to at least 8 bytes mirroring the JS implementation.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a bug related to padding type bytes in `link_store` keys in the `hubble` app.

### Detailed summary
- Pad type bytes in `link_store` keys with zero bytes to fix a bug
- Use a mutable vector to resize and extend the type bytes uniformly

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->