### PR TITLE
chore: Release v1.12.1

### DIFF
--- a/.changeset/neat-goats-dance.md
+++ b/.changeset/neat-goats-dance.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Retry uploads of snapshot chunks to R2

--- a/.changeset/ten-cycles-beg.md
+++ b/.changeset/ten-cycles-beg.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Check if we need to prune before actually pruning

--- a/.changeset/tidy-suns-flow.md
+++ b/.changeset/tidy-suns-flow.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Fix fname index from Little endian -> big endian

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hubble
 
+## 1.12.1
+
+### Patch Changes
+
+- 26ced763: fix: Retry uploads of snapshot chunks to R2
+- 4286432d: fix: Check if we need to prune before actually pruning
+- 7b850fb9: fix: Fname index from Little endian -> big endian migration
+
 ## 1.12.0
 
 ### Minor Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",


### PR DESCRIPTION
## Motivation

v 1.12.1
 


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `@farcaster/hubble` to `1.12.1` and includes patch changes related to fixing upload retries, pruning checks, and index migration.

### Detailed summary
- Updated version to `1.12.1`
- Retry uploads of snapshot chunks to R2
- Check before pruning
- Fname index migration from Little endian to big endian

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->