### PR TITLE
fix: Fetch prev version snapshot if current one is missing

### DIFF
--- a/.changeset/lovely-lizards-build.md
+++ b/.changeset/lovely-lizards-build.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Fetch previous snapshot if current db one is not present

--- a/apps/hubble/src/storage/db/migrations/11.fnameIndex.test.ts
+++ b/apps/hubble/src/storage/db/migrations/11.fnameIndex.test.ts
@@ -5,12 +5,12 @@ import { FID_BYTES, RootPrefix } from "../types.js";
 import { makeFidKey } from "../message.js";
 import { ResultAsync } from "neverthrow";
 
-const db = jestRocksDB("fnameUserNameProofByFid.migration.test");
+const db = jestRocksDB("fnameFidIndex.migration.test");
 
 const fid1 = Factories.Fid.build();
 const fid2 = fid1 + 1;
 
-describe("fnameUserNameProofByFid migration", () => {
+describe("fnameFidIndex migration", () => {
   beforeAll(async () => {});
 
   test("should migrate the fname index properly", async () => {

--- a/apps/hubble/src/utils/snapshot.ts
+++ b/apps/hubble/src/utils/snapshot.ts
@@ -157,8 +157,8 @@ export const uploadToS3 = async (
   }
 };
 
-const maxRetries = 3;
-const retryDelayMs = 10 * 1000;
+const maxRetries = 5;
+const retryDelayMs = 1 * 60 * 1000;
 
 async function uploadChunk(
   s3: S3Client,
@@ -177,7 +177,7 @@ async function uploadChunk(
       retries++;
       if (retries < maxRetries) {
         logger.warn({ key, retries, errMsg: (e as Error)?.message }, "Snapshot chunk upload failed. Retrying...");
-        await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+        await new Promise((resolve) => setTimeout(resolve, retryDelayMs * retries));
       } else {
         logger.error(
           { key, errMsg: (e as Error)?.message },


### PR DESCRIPTION
## Motivation

If the present DB version snapshot is missing, fetch the previous one. 
## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a bug in the `@farcaster/hubble` package related to fetching previous snapshots. 

### Detailed summary
- Renamed migration test file and index for better clarity
- Increased max retries and retry delay for snapshot uploads
- Refactored snapshot retrieval logic to handle errors better

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->