### PR TITLE
[feat]: add approxSize to getInfo() endpoint

### DIFF
--- a/.changeset/few-impalas-call.md
+++ b/.changeset/few-impalas-call.md
@@ -1,0 +1,8 @@
+---
+"@farcaster/hub-nodejs": minor
+"@farcaster/hub-web": minor
+"@farcaster/core": minor
+"@farcaster/hubble": minor
+---
+
+added approxSize to getInfo()

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -121,6 +121,7 @@ export class MergeResult {
 }
 
 type DbStats = {
+  approxSize: number;
   numItems: number;
   numFids: number;
   numFnames: number;
@@ -263,6 +264,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
   private _started = false;
 
   private _dbStats: DbStats = {
+    approxSize: 0,
     numItems: 0,
     numFids: 0,
     numFnames: 0,
@@ -1549,7 +1551,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
   }
 
   public async getDbStats(): Promise<DbStats> {
-    return { ...this._dbStats, numItems: await this._trie.items() };
+    return { ...this._dbStats, numItems: await this._trie.items(), approxSize: await this._db.approximateSize() };
   }
 
   private async readDbStatsFromDb(): Promise<DbStats> {
@@ -1560,6 +1562,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     const numFnames = await this._db.countKeysAtPrefix(Buffer.from([RootPrefix.FNameUserNameProof]));
 
     return {
+      approxSize: await this._db.approximateSize(),
       numItems: await this._trie.items(),
       numFids: numFids,
       numFnames: numFnames,

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -467,6 +467,7 @@ export default class Server {
           if (call.request.dbStats && this.syncEngine) {
             const stats = await this.syncEngine.getDbStats();
             info.dbStats = DbStats.create({
+              approxSize: stats?.approxSize,
               numMessages: stats?.numItems,
               numFidEvents: stats?.numFids,
               numFnameEvents: stats?.numFnames,

--- a/apps/hubble/src/rpc/test/syncService.test.ts
+++ b/apps/hubble/src/rpc/test/syncService.test.ts
@@ -83,6 +83,7 @@ describe("getInfo", () => {
     expect(result._unsafeUnwrap().dbStats?.numMessages).toEqual(5); // Currently returns all items in the trie (3 events + 2 messages)
     expect(result._unsafeUnwrap().dbStats?.numFidEvents).toEqual(1);
     expect(result._unsafeUnwrap().dbStats?.numFnameEvents).toEqual(0);
+    expect(result._unsafeUnwrap().dbStats?.approxSize).toBeGreaterThan(0);
   });
 });
 

--- a/packages/core/src/protobufs/generated/request_response.ts
+++ b/packages/core/src/protobufs/generated/request_response.ts
@@ -108,6 +108,7 @@ export interface DbStats {
   numMessages: number;
   numFidEvents: number;
   numFnameEvents: number;
+  approxSize: number;
 }
 
 export interface SyncStatusRequest {
@@ -717,7 +718,7 @@ export const HubInfoResponse = {
 };
 
 function createBaseDbStats(): DbStats {
-  return { numMessages: 0, numFidEvents: 0, numFnameEvents: 0 };
+  return { numMessages: 0, numFidEvents: 0, numFnameEvents: 0, approxSize: 0 };
 }
 
 export const DbStats = {
@@ -730,6 +731,9 @@ export const DbStats = {
     }
     if (message.numFnameEvents !== 0) {
       writer.uint32(24).uint64(message.numFnameEvents);
+    }
+    if (message.approxSize !== 0) {
+      writer.uint32(32).uint64(message.approxSize);
     }
     return writer;
   },
@@ -762,6 +766,13 @@ export const DbStats = {
 
           message.numFnameEvents = longToNumber(reader.uint64() as Long);
           continue;
+        case 4:
+          if (tag != 32) {
+            break;
+          }
+
+          message.approxSize = longToNumber(reader.uint64() as Long);
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -776,6 +787,7 @@ export const DbStats = {
       numMessages: isSet(object.numMessages) ? Number(object.numMessages) : 0,
       numFidEvents: isSet(object.numFidEvents) ? Number(object.numFidEvents) : 0,
       numFnameEvents: isSet(object.numFnameEvents) ? Number(object.numFnameEvents) : 0,
+      approxSize: isSet(object.approxSize) ? Number(object.approxSize) : 0,
     };
   },
 
@@ -784,6 +796,7 @@ export const DbStats = {
     message.numMessages !== undefined && (obj.numMessages = Math.round(message.numMessages));
     message.numFidEvents !== undefined && (obj.numFidEvents = Math.round(message.numFidEvents));
     message.numFnameEvents !== undefined && (obj.numFnameEvents = Math.round(message.numFnameEvents));
+    message.approxSize !== undefined && (obj.approxSize = Math.round(message.approxSize));
     return obj;
   },
 
@@ -796,6 +809,7 @@ export const DbStats = {
     message.numMessages = object.numMessages ?? 0;
     message.numFidEvents = object.numFidEvents ?? 0;
     message.numFnameEvents = object.numFnameEvents ?? 0;
+    message.approxSize = object.approxSize ?? 0;
     return message;
   },
 };

--- a/packages/hub-nodejs/src/generated/request_response.ts
+++ b/packages/hub-nodejs/src/generated/request_response.ts
@@ -108,6 +108,7 @@ export interface DbStats {
   numMessages: number;
   numFidEvents: number;
   numFnameEvents: number;
+  approxSize: number;
 }
 
 export interface SyncStatusRequest {
@@ -717,7 +718,7 @@ export const HubInfoResponse = {
 };
 
 function createBaseDbStats(): DbStats {
-  return { numMessages: 0, numFidEvents: 0, numFnameEvents: 0 };
+  return { numMessages: 0, numFidEvents: 0, numFnameEvents: 0, approxSize: 0 };
 }
 
 export const DbStats = {
@@ -730,6 +731,9 @@ export const DbStats = {
     }
     if (message.numFnameEvents !== 0) {
       writer.uint32(24).uint64(message.numFnameEvents);
+    }
+    if (message.approxSize !== 0) {
+      writer.uint32(32).uint64(message.approxSize);
     }
     return writer;
   },
@@ -762,6 +766,13 @@ export const DbStats = {
 
           message.numFnameEvents = longToNumber(reader.uint64() as Long);
           continue;
+        case 4:
+          if (tag != 32) {
+            break;
+          }
+
+          message.approxSize = longToNumber(reader.uint64() as Long);
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -776,6 +787,7 @@ export const DbStats = {
       numMessages: isSet(object.numMessages) ? Number(object.numMessages) : 0,
       numFidEvents: isSet(object.numFidEvents) ? Number(object.numFidEvents) : 0,
       numFnameEvents: isSet(object.numFnameEvents) ? Number(object.numFnameEvents) : 0,
+      approxSize: isSet(object.approxSize) ? Number(object.approxSize) : 0,
     };
   },
 
@@ -784,6 +796,7 @@ export const DbStats = {
     message.numMessages !== undefined && (obj.numMessages = Math.round(message.numMessages));
     message.numFidEvents !== undefined && (obj.numFidEvents = Math.round(message.numFidEvents));
     message.numFnameEvents !== undefined && (obj.numFnameEvents = Math.round(message.numFnameEvents));
+    message.approxSize !== undefined && (obj.approxSize = Math.round(message.approxSize));
     return obj;
   },
 
@@ -796,6 +809,7 @@ export const DbStats = {
     message.numMessages = object.numMessages ?? 0;
     message.numFidEvents = object.numFidEvents ?? 0;
     message.numFnameEvents = object.numFnameEvents ?? 0;
+    message.approxSize = object.approxSize ?? 0;
     return message;
   },
 };

--- a/packages/hub-web/src/generated/request_response.ts
+++ b/packages/hub-web/src/generated/request_response.ts
@@ -108,6 +108,7 @@ export interface DbStats {
   numMessages: number;
   numFidEvents: number;
   numFnameEvents: number;
+  approxSize: number;
 }
 
 export interface SyncStatusRequest {
@@ -717,7 +718,7 @@ export const HubInfoResponse = {
 };
 
 function createBaseDbStats(): DbStats {
-  return { numMessages: 0, numFidEvents: 0, numFnameEvents: 0 };
+  return { numMessages: 0, numFidEvents: 0, numFnameEvents: 0, approxSize: 0 };
 }
 
 export const DbStats = {
@@ -730,6 +731,9 @@ export const DbStats = {
     }
     if (message.numFnameEvents !== 0) {
       writer.uint32(24).uint64(message.numFnameEvents);
+    }
+    if (message.approxSize !== 0) {
+      writer.uint32(32).uint64(message.approxSize);
     }
     return writer;
   },
@@ -762,6 +766,13 @@ export const DbStats = {
 
           message.numFnameEvents = longToNumber(reader.uint64() as Long);
           continue;
+        case 4:
+          if (tag != 32) {
+            break;
+          }
+
+          message.approxSize = longToNumber(reader.uint64() as Long);
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -776,6 +787,7 @@ export const DbStats = {
       numMessages: isSet(object.numMessages) ? Number(object.numMessages) : 0,
       numFidEvents: isSet(object.numFidEvents) ? Number(object.numFidEvents) : 0,
       numFnameEvents: isSet(object.numFnameEvents) ? Number(object.numFnameEvents) : 0,
+      approxSize: isSet(object.approxSize) ? Number(object.approxSize) : 0,
     };
   },
 
@@ -784,6 +796,7 @@ export const DbStats = {
     message.numMessages !== undefined && (obj.numMessages = Math.round(message.numMessages));
     message.numFidEvents !== undefined && (obj.numFidEvents = Math.round(message.numFidEvents));
     message.numFnameEvents !== undefined && (obj.numFnameEvents = Math.round(message.numFnameEvents));
+    message.approxSize !== undefined && (obj.approxSize = Math.round(message.approxSize));
     return obj;
   },
 
@@ -796,6 +809,7 @@ export const DbStats = {
     message.numMessages = object.numMessages ?? 0;
     message.numFidEvents = object.numFidEvents ?? 0;
     message.numFnameEvents = object.numFnameEvents ?? 0;
+    message.approxSize = object.approxSize ?? 0;
     return message;
   },
 };

--- a/protobufs/schemas/request_response.proto
+++ b/protobufs/schemas/request_response.proto
@@ -38,6 +38,7 @@ message DbStats {
   uint64 num_messages = 1;
   uint64 num_fid_events = 2;
   uint64 num_fname_events = 3;
+  uint64 approx_size = 4;
 }
 
 message SyncStatusRequest {


### PR DESCRIPTION
## Motivation

Exposing the size of the rocks db 

## Change Summary

Updated `DbStats` to store `approxSize` of DB 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `approxSize` field to track database size in various components and protobuf schemas.

### Detailed summary
- Added `approxSize` field to `DbStats` type
- Updated message structures to include `approxSize`
- Modified functions to handle `approxSize` calculations

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->