### PR TITLE
Prune messages after merge

### DIFF
--- a/.changeset/shy-schools-end.md
+++ b/.changeset/shy-schools-end.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+Prune messages directly after merge

--- a/apps/hubble/src/addon/src/store/store.rs
+++ b/apps/hubble/src/addon/src/store/store.rs
@@ -807,7 +807,7 @@ impl Store {
         ts_hash: &[u8; TS_HASH_LENGTH],
         message: &Message,
     ) -> Result<Vec<u8>, HubError> {
-        // If the store supports compact state messages, we don't merge messages that exist in the compact state
+        // If the store supports compact state messages, don't merge messages older than the compact state message
         if self.store_def.compact_state_type_supported() {
             // Get the compact state message
             let compact_state_key = self.store_def.make_compact_state_add_key(message)?;

--- a/apps/hubble/src/storage/stores/linkStore.test.ts
+++ b/apps/hubble/src/storage/stores/linkStore.test.ts
@@ -753,7 +753,7 @@ describe("revoke", () => {
   });
 });
 
-describe("pruneMessages", () => {
+describe("mergePrunesMessages", () => {
   let prunedMessages: Message[];
 
   const pruneMessageListener = (event: PruneMessageHubEvent) => {
@@ -828,16 +828,21 @@ describe("pruneMessages", () => {
       expect(prunedMessages).toEqual([]);
     });
 
-    test("prunes earliest add messages", async () => {
-      const messages = [add1, add2, add3, add4, add5];
-      for (const message of messages) {
-        await sizePrunedStore.merge(message);
-      }
+    test("earlier add messages gets pruned", async () => {
+      await sizePrunedStore.merge(add1);
+      await sizePrunedStore.merge(add2);
+      await sizePrunedStore.merge(add3);
+      expect(prunedMessages).toEqual([]);
+
+      await sizePrunedStore.merge(add4);
+      expect(prunedMessages).toEqual([add1]);
+
+      await sizePrunedStore.merge(add5);
+      expect(prunedMessages).toEqual([add1, add2]);
 
       const result = await sizePrunedStore.pruneMessages(fid);
       expect(result.isOk()).toBeTruthy();
-      expect(result._unsafeUnwrap().length).toEqual(2);
-
+      expect(result._unsafeUnwrap().length).toEqual(0);
       expect(prunedMessages).toEqual([add1, add2]);
 
       for (const message of prunedMessages as LinkAddMessage[]) {
@@ -851,16 +856,21 @@ describe("pruneMessages", () => {
       }
     });
 
-    test("prunes earliest remove messages", async () => {
-      const messages = [remove1, remove2, remove3, remove4, remove5];
-      for (const message of messages) {
-        await sizePrunedStore.merge(message);
-      }
+    test("earlier remove messages gets pruned", async () => {
+      await sizePrunedStore.merge(remove1);
+      await sizePrunedStore.merge(remove2);
+      await sizePrunedStore.merge(remove3);
+      expect(prunedMessages).toEqual([]);
+
+      await sizePrunedStore.merge(remove4);
+      expect(prunedMessages).toEqual([remove1]);
+
+      await sizePrunedStore.merge(remove5);
+      expect(prunedMessages).toEqual([remove1, remove2]);
 
       const result = await sizePrunedStore.pruneMessages(fid);
       expect(result.isOk()).toBeTruthy();
-      expect(result._unsafeUnwrap().length).toEqual(2);
-
+      expect(result._unsafeUnwrap().length).toEqual(0);
       expect(prunedMessages).toEqual([remove1, remove2]);
 
       for (const message of prunedMessages as LinkRemoveMessage[]) {
@@ -874,16 +884,21 @@ describe("pruneMessages", () => {
       }
     });
 
-    test("prunes earliest messages", async () => {
-      const messages = [add1, remove2, add3, remove4, add5];
-      for (const message of messages) {
-        await sizePrunedStore.merge(message);
-      }
+    test("earlier message gets pruned", async () => {
+      await sizePrunedStore.merge(add1);
+      await sizePrunedStore.merge(remove2);
+      await sizePrunedStore.merge(add3);
+      expect(prunedMessages).toEqual([]);
+
+      await sizePrunedStore.merge(remove4);
+      expect(prunedMessages).toEqual([add1]);
+
+      await sizePrunedStore.merge(add5);
+      expect(prunedMessages).toEqual([add1, remove2]);
 
       const result = await sizePrunedStore.pruneMessages(fid);
       expect(result.isOk()).toBeTruthy();
-      expect(result._unsafeUnwrap().length).toEqual(2);
-
+      expect(result._unsafeUnwrap().length).toEqual(0);
       expect(prunedMessages).toEqual([add1, remove2]);
     });
 
@@ -891,6 +906,7 @@ describe("pruneMessages", () => {
       const messages = [add1, remove1, add2, remove2, add3];
       for (const message of messages) {
         await sizePrunedStore.merge(message);
+        expect(prunedMessages).toEqual([]);
       }
 
       const result = await sizePrunedStore.pruneMessages(fid);
@@ -912,12 +928,12 @@ describe("pruneMessages", () => {
 
       // newer messages can still be added
       await expect(sizePrunedStore.merge(add4)).resolves.toBeGreaterThan(0);
+      expect(prunedMessages).toEqual([add1]);
 
       // Prune removes earliest
       const result = await sizePrunedStore.pruneMessages(fid);
       expect(result.isOk()).toBeTruthy();
-      expect(result._unsafeUnwrap().length).toEqual(1);
-
+      expect(result._unsafeUnwrap().length).toEqual(0);
       expect(prunedMessages).toEqual([add1]);
     });
   });

--- a/apps/hubble/src/storage/stores/linkStore.test.ts
+++ b/apps/hubble/src/storage/stores/linkStore.test.ts
@@ -753,7 +753,7 @@ describe("revoke", () => {
   });
 });
 
-describe("mergePrunesMessages", () => {
+describe("merge should prunes messages", () => {
   let prunedMessages: Message[];
 
   const pruneMessageListener = (event: PruneMessageHubEvent) => {

--- a/apps/hubble/src/storage/stores/reactionStore.test.ts
+++ b/apps/hubble/src/storage/stores/reactionStore.test.ts
@@ -829,7 +829,7 @@ describe("revoke", () => {
   });
 });
 
-describe("pruneMessages", () => {
+describe("mergePrunesMessages", () => {
   let prunedMessages: Message[];
 
   const pruneMessageListener = (event: PruneMessageHubEvent) => {
@@ -906,16 +906,21 @@ describe("pruneMessages", () => {
       expect(prunedMessages).toEqual([]);
     });
 
-    test("prunes earliest add messages", async () => {
-      const messages = [add1, add2, add3, add4, add5];
-      for (const message of messages) {
-        await sizePrunedStore.merge(message);
-      }
+    test("earlier add messages gets pruned", async () => {
+      await sizePrunedStore.merge(add1);
+      await sizePrunedStore.merge(add2);
+      await sizePrunedStore.merge(add3);
+      expect(prunedMessages).toEqual([]);
+
+      await sizePrunedStore.merge(add4);
+      expect(prunedMessages).toEqual([add1]);
+
+      await sizePrunedStore.merge(add5);
+      expect(prunedMessages).toEqual([add1, add2]);
 
       const result = await sizePrunedStore.pruneMessages(fid);
       expect(result.isOk()).toBeTruthy();
-      expect(result._unsafeUnwrap().length).toEqual(2);
-
+      expect(result._unsafeUnwrap().length).toEqual(0);
       expect(prunedMessages).toEqual([add1, add2]);
 
       for (const message of prunedMessages as ReactionAddMessage[]) {
@@ -929,16 +934,21 @@ describe("pruneMessages", () => {
       }
     });
 
-    test("prunes earliest remove messages", async () => {
-      const messages = [remove1, remove2, remove3, remove4, remove5];
-      for (const message of messages) {
-        await sizePrunedStore.merge(message);
-      }
+    test("earlier remove messages gets pruned", async () => {
+      await sizePrunedStore.merge(remove1);
+      await sizePrunedStore.merge(remove2);
+      await sizePrunedStore.merge(remove3);
+      expect(prunedMessages).toEqual([]);
+
+      await sizePrunedStore.merge(remove4);
+      expect(prunedMessages).toEqual([remove1]);
+
+      await sizePrunedStore.merge(remove5);
+      expect(prunedMessages).toEqual([remove1, remove2]);
 
       const result = await sizePrunedStore.pruneMessages(fid);
       expect(result.isOk()).toBeTruthy();
-      expect(result._unsafeUnwrap().length).toEqual(2);
-
+      expect(result._unsafeUnwrap().length).toEqual(0);
       expect(prunedMessages).toEqual([remove1, remove2]);
 
       for (const message of prunedMessages as ReactionRemoveMessage[]) {
@@ -952,16 +962,21 @@ describe("pruneMessages", () => {
       }
     });
 
-    test("prunes earliest messages", async () => {
-      const messages = [add1, remove2, add3, remove4, add5];
-      for (const message of messages) {
-        await sizePrunedStore.merge(message);
-      }
+    test("earlier message gets pruned", async () => {
+      await sizePrunedStore.merge(add1);
+      await sizePrunedStore.merge(remove2);
+      await sizePrunedStore.merge(add3);
+      expect(prunedMessages).toEqual([]);
+
+      await sizePrunedStore.merge(remove4);
+      expect(prunedMessages).toEqual([add1]);
+
+      await sizePrunedStore.merge(add5);
+      expect(prunedMessages).toEqual([add1, remove2]);
 
       const result = await sizePrunedStore.pruneMessages(fid);
       expect(result.isOk()).toBeTruthy();
-      expect(result._unsafeUnwrap().length).toEqual(2);
-
+      expect(result._unsafeUnwrap().length).toEqual(0);
       expect(prunedMessages).toEqual([add1, remove2]);
     });
 
@@ -969,6 +984,7 @@ describe("pruneMessages", () => {
       const messages = [add1, remove1, add2, remove2, add3];
       for (const message of messages) {
         await sizePrunedStore.merge(message);
+        expect(prunedMessages).toEqual([]);
       }
 
       const result = await sizePrunedStore.pruneMessages(fid);
@@ -990,11 +1006,12 @@ describe("pruneMessages", () => {
 
       // newer messages can still be added
       await expect(sizePrunedStore.merge(add4)).resolves.toBeGreaterThan(0);
+      expect(prunedMessages).toEqual([add1]);
 
       // Prune removes earliest
       const result = await sizePrunedStore.pruneMessages(fid);
       expect(result.isOk()).toBeTruthy();
-      expect(result._unsafeUnwrap().length).toEqual(1);
+      expect(result._unsafeUnwrap().length).toEqual(0);
 
       expect(prunedMessages).toEqual([add1]);
     });

--- a/apps/hubble/src/storage/stores/reactionStore.test.ts
+++ b/apps/hubble/src/storage/stores/reactionStore.test.ts
@@ -829,7 +829,7 @@ describe("revoke", () => {
   });
 });
 
-describe("mergePrunesMessages", () => {
+describe("merge should prunes messages", () => {
   let prunedMessages: Message[];
 
   const pruneMessageListener = (event: PruneMessageHubEvent) => {


### PR DESCRIPTION
Updates isPrunable to be getPruneAction which lets caller know if
message should be pruned (original function) or would cause a prune
action (added functionality). When applicable we prune for the given
FID after the message is merged.

Prune job is still running in the background but can be removed
in the future once it's confirmed there's no stragglers.

Benchmarking with production data, this change seems to add a 5%
overhead on average. The FID lock added to Store::prune_messages
is required for performance reasons. Without the lock, the overhead
is run dependent and takes 100%-500% longer.

----

## Motivation

Currently hubs are seeing regular latency spikes due the periodic pruning job. This update causes the hub to immediately prune messages for a given `FID` after the message is merged.

## Change Summary

Updates `isPrunable` to be `getPruneAction` which lets caller know if message should be pruned (original function) or would cause a prune action (added functionality). When applicable we prune for the given `FID` after the message is merged.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

Adds a FID based lock to `Store::prune_messages`. This might be an issue for the prune job which are left running. If a prune job is taking a long time it may block merges. I suspect this won't be too different from what's happening today during prunes as the threadpool is limited to 4 threads, so a slow prune would already be blocking things.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing message merge operations in the `store.rs` file and adding a `PruneAction` enum in `storeEventHandler.ts`.

### Detailed summary
- Improved atomic merge operations with locks for performance
- Added `PruneAction` enum to determine pruning actions
- Updated functions for better message pruning and handling

> The following files were skipped due to too many changes: `apps/hubble/src/storage/stores/reactionStore.test.ts`, `apps/hubble/src/storage/stores/rustStoreBase.ts`, `apps/hubble/src/storage/stores/castStore.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->