### PR TITLE
fix: Protoc Versioning Issue

### DIFF
--- a/apps/hubble/src/addon/build.rs
+++ b/apps/hubble/src/addon/build.rs
@@ -11,6 +11,7 @@ fn main() {
     tonic_build::configure()
         .build_server(true)
         .build_client(false)
+        .protoc_arg("--experimental_allow_proto3_optional")
         .compile(&proto_files, &proto_include_dirs)
         .unwrap_or_else(|e| panic!("Failed to compile protos: {}", e));
 }


### PR DESCRIPTION
## Motivation

When trying to run Hubble from source on an Ubuntu machine, there is a versioning mismatch with the protobuf deps. This was the suggested change rather than pinning a version directly

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a `protoc_arg` `--experimental_allow_proto3_optional` to the build configuration.

### Detailed summary
- Added `protoc_arg("--experimental_allow_proto3_optional")` to the build configuration for protos.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->