### PR TITLE
chore: Switch to WarpBuild for CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   build-image:
     timeout-minutes: 10
-    runs-on: 'buildjet-16vcpu-ubuntu-2204-arm'
+    runs-on: 'warp-ubuntu-latest-arm64-32x'
 
     steps:
       - uses: actions/checkout@v4
@@ -59,9 +59,9 @@ jobs:
       matrix:
         include:
           - node_version: 20
-            runs_on: 'buildjet-8vcpu-ubuntu-2204'
+            runs_on: 'warp-ubuntu-latest-x64-32x'
           - node_version: 21
-            runs_on: 'buildjet-16vcpu-ubuntu-2204-arm'
+            runs_on: 'warp-ubuntu-latest-arm64-32x'
 
     runs-on: ${{ matrix.runs_on }}
     name: test (${{ matrix.node_version }})
@@ -83,6 +83,10 @@ jobs:
         options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
+      # Needed for WarpBuild ARM runners
+      - if: ${{ startsWith(runner.arch, 'ARM') }}
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Motivation

Switch to WarpBuild.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the GitHub Actions workflow to use new ARM-based runners provided by WarpBuild.

### Detailed summary
- Changed the runner type to 'warp-ubuntu-latest-arm64-32x' for ARM architecture
- Updated node versions and corresponding runner types
- Added setup for ARM architecture in the workflow steps

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->