### PR TITLE
fix: remove unnecessary database reads when merging casts

### DIFF
--- a/.changeset/thirty-flies-sleep.md
+++ b/.changeset/thirty-flies-sleep.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+Remove unnecessary database reads when merging casts

--- a/apps/hubble/src/addon/src/store/cast_store.rs
+++ b/apps/hubble/src/addon/src/store/cast_store.rs
@@ -93,29 +93,9 @@ impl StoreDef for CastStoreDef {
 
     fn find_merge_add_conflicts(
         &self,
-        db: &RocksDB,
-        message: &protos::Message,
+        _db: &RocksDB,
+        _message: &protos::Message,
     ) -> Result<(), super::store::HubError> {
-        // Look up the remove tsHash for this cast
-        let remove_key = self.make_remove_key(message)?;
-        // If remove tsHash exists, fail because this cast has already been removed
-        if let Ok(Some(_)) = db.get(&remove_key) {
-            return Err(HubError {
-                code: "bad_request.conflict".to_string(),
-                message: "message conflicts with a CastRemove".to_string(),
-            });
-        }
-
-        // Look up the add tsHash for this cast
-        let add_key = self.make_add_key(message)?;
-        // If add tsHash exists, no-op because this cast has already been added
-        if let Ok(Some(_)) = db.get(&add_key) {
-            return Err(HubError {
-                code: "bad_request.duplicate".to_string(),
-                message: "message has already been merged".to_string(),
-            });
-        }
-
         // No conflicts
         Ok(())
     }

--- a/apps/hubble/src/rpc/test/messageService.test.ts
+++ b/apps/hubble/src/rpc/test/messageService.test.ts
@@ -91,7 +91,7 @@ describe("submitMessage", () => {
     test("fails with conflict", async () => {
       await engine.mergeMessage(castRemove);
       const result = await client.submitMessage(castAdd);
-      expect(result).toEqual(err(new HubError("bad_request.conflict", "message conflicts with a CastRemove")));
+      expect(result).toEqual(err(new HubError("bad_request.conflict", "message conflicts with a more recent remove")));
     });
 
     test("fails for frame action", async () => {

--- a/apps/hubble/src/storage/stores/castStore.test.ts
+++ b/apps/hubble/src/storage/stores/castStore.test.ts
@@ -347,7 +347,7 @@ describe("merge", () => {
 
         await store.merge(castRemoveEarlier);
         await expect(store.merge(castAdd)).rejects.toEqual(
-          new HubError("bad_request.conflict", "message conflicts with a CastRemove"),
+          new HubError("bad_request.conflict", "message conflicts with a more recent remove"),
         );
 
         await assertCastRemoveWins(castRemoveEarlier);
@@ -357,7 +357,7 @@ describe("merge", () => {
       test("fails with an earlier timestamp", async () => {
         await store.merge(castRemove);
         await expect(store.merge(castAdd)).rejects.toEqual(
-          new HubError("bad_request.conflict", "message conflicts with a CastRemove"),
+          new HubError("bad_request.conflict", "message conflicts with a more recent remove"),
         );
 
         await assertCastRemoveWins(castRemove);
@@ -374,7 +374,7 @@ describe("merge", () => {
 
         await store.merge(castRemoveEarlier);
         await expect(store.merge(castAdd)).rejects.toEqual(
-          new HubError("bad_request.conflict", "message conflicts with a CastRemove"),
+          new HubError("bad_request.conflict", "message conflicts with a more recent remove"),
         );
 
         await assertCastRemoveWins(castRemoveEarlier);
@@ -389,7 +389,7 @@ describe("merge", () => {
 
         await store.merge(castRemoveLater);
         await expect(store.merge(castAdd)).rejects.toEqual(
-          new HubError("bad_request.conflict", "message conflicts with a CastRemove"),
+          new HubError("bad_request.conflict", "message conflicts with a more recent remove"),
         );
 
         await assertCastRemoveWins(castRemoveLater);


### PR DESCRIPTION
## Motivation

Since the base store implementation already handles conflicts for casts correctly: https://github.com/farcasterxyz/hub-monorepo/blob/main/apps/hubble/src/addon/src/store/store.rs#L195-L274 it feels wasteful to potentially use two additional DB lookups checking for an identical edge-case.

This PR removes these two additional lookups and lets the base store logic handle casts in the same way that all other stores are handled.

## Change Summary

- Remove two unnecessary database reads when merging casts

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing unnecessary database reads when merging casts to improve efficiency and accuracy.

### Detailed summary
- Removed unnecessary database reads when merging casts
- Updated error message for conflicts with a more recent remove
- Refactored the `find_merge_add_conflicts` function to remove unnecessary checks
- Updated test cases to reflect the new error message for conflicts

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->