### PR TITLE
fix(hub-web import): undo change that breaks build in certain environments

### DIFF
--- a/.changeset/five-kings-love.md
+++ b/.changeset/five-kings-love.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hub-web": minor
+---
+
+fix import error that breaks some builds

--- a/packages/hub-web/src/generated/rpc.ts
+++ b/packages/hub-web/src/generated/rpc.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { grpc } from "@improbable-eng/grpc-web";
+import grpcWeb from "@improbable-eng/grpc-web";
 import { BrowserHeaders } from "browser-headers";
 import { Observable } from "rxjs";
 import { share } from "rxjs/operators";
@@ -42,6 +42,8 @@ import {
   VerificationRequest,
 } from "./request_response";
 import { UserNameProof } from "./username_proof";
+
+const grpc = grpcWeb.grpc;
 
 export interface HubService {
   /** Submit Methods */


### PR DESCRIPTION
## Motivation

The most recent change to this file reintroduced the issue identified in https://github.com/farcasterxyz/hub-monorepo/issues/863

This undoes that breaking change

## Change Summary

Remove curly braces to make import into default instead of named to fix an import error in certain builds

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the import statement in `packages/hub-web/src/generated/rpc.ts` to fix an import error that was causing build failures.

### Detailed summary
- Updated import statement for `grpc` from "@improbable-eng/grpc-web" to `grpcWeb`
- Renamed `grpc` variable to `grpcWeb.grpc` to maintain functionality

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->