### PR TITLE
fix: Throttle pruning so hub is not overloaded

### DIFF
--- a/.changeset/tiny-trains-shout.md
+++ b/.changeset/tiny-trains-shout.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Throttle pruning so hub is not overloaded

--- a/apps/hubble/src/storage/jobs/pruneMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/pruneMessagesJob.ts
@@ -10,7 +10,7 @@ export const DEFAULT_PRUNE_MESSAGES_JOB_CRON = "0 */2 * * *"; // Every two hours
 
 // How much time to allocate to pruning each fid.
 // 1000 fids per second = 1 fid per ms. 500k fids will take under 10 minutes
-const TIME_SCHEDULED_PER_FID_MS = 1;
+const TIME_SCHEDULED_PER_FID_MS = 5; // Temporarily increase to 5ms per fid to reduce load on DB, while we move to pruning at merge
 
 const log = logger.child({
   component: "PruneMessagesJob",


### PR DESCRIPTION
## Motivation

We're too aggressive during pruning which is causing hubs to become unresponsive sometimes. Long term fix is to prune during merge, but that involves migrating the storage cache to rust. Short term fix in the meantime.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
