### PR TITLE
chore: Release 1.12.2

### DIFF
--- a/.changeset/fast-emus-own.md
+++ b/.changeset/fast-emus-own.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Fix incorrect link message padding

--- a/.changeset/few-impalas-call.md
+++ b/.changeset/few-impalas-call.md
@@ -1,8 +1,0 @@
----
-"@farcaster/hub-nodejs": minor
-"@farcaster/hub-web": minor
-"@farcaster/core": minor
-"@farcaster/hubble": minor
----
-
-added approxSize to getInfo()

--- a/.changeset/lovely-lizards-build.md
+++ b/.changeset/lovely-lizards-build.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Fetch previous snapshot if current db one is not present

--- a/.changeset/tame-flowers-fry.md
+++ b/.changeset/tame-flowers-fry.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hub-web": patch
----
-
-fix: grpcWeb import

--- a/.changeset/tiny-trains-shout.md
+++ b/.changeset/tiny-trains-shout.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Throttle pruning so hub is not overloaded

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   build-image:
     timeout-minutes: 10
-    runs-on: 'warp-ubuntu-latest-arm64-32x'
+    runs-on: 'warp-ubuntu-latest-arm64-16x'
 
     steps:
       - uses: actions/checkout@v4
@@ -59,9 +59,9 @@ jobs:
       matrix:
         include:
           - node_version: 20
-            runs_on: 'warp-ubuntu-latest-x64-32x'
+            runs_on: 'warp-ubuntu-latest-x64-16x'
           - node_version: 21
-            runs_on: 'warp-ubuntu-latest-arm64-32x'
+            runs_on: 'warp-ubuntu-latest-arm64-16x'
 
     runs-on: ${{ matrix.runs_on }}
     name: test (${{ matrix.node_version }})

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @farcaster/hubble
 
+## 1.12.2
+
+### Patch Changes
+
+- 8e7dec10: fix: Fix incorrect link message padding
+- c261fba6: added approxSize to getInfo()
+- 0e342af3: fix: Fetch previous snapshot if current db one is not present
+- 8c759d66: fix: Throttle pruning so hub is not overloaded
+- Updated dependencies [c261fba6]
+  - @farcaster/hub-nodejs@0.11.12
+
 ## 1.12.1
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -75,7 +75,7 @@
     "@chainsafe/libp2p-noise": "^11.0.0 ",
     "@datastructures-js/priority-queue": "^6.3.1",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.11.11",
+    "@farcaster/hub-nodejs": "^0.11.12",
     "@fastify/cors": "^8.4.0",
     "@figma/hot-shots": "^9.0.0-figma.1",
     "@grpc/grpc-js": "~1.8.21",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/core
 
+## 0.14.12
+
+### Patch Changes
+
+- c261fba6: added approxSize to getInfo()
+
 ## 0.14.11
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.14.11",
+  "version": "0.14.12",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hub-nodejs
 
+## 0.11.12
+
+### Patch Changes
+
+- c261fba6: added approxSize to getInfo()
+- Updated dependencies [c261fba6]
+  - @farcaster/core@0.14.12
+
 ## 0.11.11
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.11.11",
+  "version": "0.11.12",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -20,7 +20,7 @@
     "url": "https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/hub-nodejs"
   },
   "dependencies": {
-    "@farcaster/core": "0.14.11",
+    "@farcaster/core": "0.14.12",
     "@grpc/grpc-js": "~1.8.21",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"

--- a/packages/hub-web/CHANGELOG.md
+++ b/packages/hub-web/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @farcaster/hub-web
 
+## 0.8.9
+
+### Patch Changes
+
+- c261fba6: added approxSize to getInfo()
+- 920f6c02: fix: grpcWeb import
+- Updated dependencies [c261fba6]
+  - @farcaster/core@0.14.12
+
 ## 0.8.8
 
 ### Patch Changes

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-web",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -32,7 +32,7 @@
     "ts-proto": "^1.146.0"
   },
   "dependencies": {
-    "@farcaster/core": "^0.14.11",
+    "@farcaster/core": "^0.14.12",
     "@improbable-eng/grpc-web": "^0.15.0",
     "rxjs": "^7.8.0"
   }


### PR DESCRIPTION
## Motivation

Release 1.12.2

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates version numbers across multiple packages and adds a new method `approxSize` to `getInfo()` in the core package.

### Detailed summary
- Updated versions to 0.14.12 in core package
- Updated versions to 0.11.12 in hub-nodejs package
- Updated versions to 0.8.9 in hub-web package
- Added `approxSize` method to `getInfo()` in core package
- Various dependency updates and fixes in different packages

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->