### PR TITLE
Add script to migrate RocksDB database

### DIFF
--- a/apps/hubble/src/addon/Cargo.toml
+++ b/apps/hubble/src/addon/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["index.node"]
 build = "build.rs"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "lib"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -44,3 +44,7 @@ glob = "0.3.1"
 version = "1.0.0"
 default-features = false
 features = [ "futures", "napi-6"]
+
+[[bin]]
+name = "migrate-db"
+path = "bin/migrate_db.rs"

--- a/apps/hubble/src/addon/bin/migrate_db.rs
+++ b/apps/hubble/src/addon/bin/migrate_db.rs
@@ -1,0 +1,110 @@
+use std::{
+    sync::{mpsc::sync_channel, Arc},
+    time::Instant,
+};
+
+use addon::{db::RocksDB, store::PageOptions};
+use rocksdb::{DBCompressionType, Options};
+
+const THREADS: usize = 8;
+const COUNT_PER_PRINT: usize = 500_000;
+const SOURCE_DIR: &'static str = "<replace me>";
+const DEST_DIR: &'static str = "<replace me>";
+
+fn main() {
+    let mut opts = Options::default();
+    opts.set_compression_type(DBCompressionType::Lz4);
+    opts.create_if_missing(true);
+    opts.set_allow_concurrent_memtable_write(true);
+    opts.increase_parallelism(4);
+
+    migrate_db(SOURCE_DIR, DEST_DIR, opts.clone());
+
+    migrate_db(
+        &format!("{}/trieDb", SOURCE_DIR),
+        &format!("/{}/trieDb", DEST_DIR),
+        opts,
+    );
+}
+
+fn migrate_db(source: &str, dest: &str, opts: Options) -> usize {
+    let source_db = RocksDB::new(source).unwrap();
+    let dest_db = Arc::new(RocksDB::new(dest).unwrap());
+
+    source_db.open().unwrap();
+    dest_db.open_with_opts(opts).unwrap();
+
+    let mut threads = vec![];
+    let mut senders = vec![];
+
+    for i in 0..THREADS {
+        let (item_tx, item_rx) = sync_channel::<(Vec<u8>, Vec<u8>)>(2048);
+
+        senders.push(item_tx);
+
+        let dest_db = dest_db.clone();
+
+        let handle = std::thread::spawn(move || {
+            println!("Thread {} started", i);
+            while let Ok((key, value)) = item_rx.recv() {
+                dest_db.put(&key, &value).unwrap();
+            }
+            println!("Thread {} closed", i);
+        });
+
+        threads.push(handle);
+    }
+
+    let mut count = 0;
+    let mut last_count_ts = Instant::now();
+
+    let mut first_key = None;
+    dest_db
+        .for_each_iterator_by_prefix(
+            &[],
+            &PageOptions {
+                reverse: true,
+                ..Default::default()
+            },
+            |key, _| {
+                first_key = Some(key.to_vec());
+                Ok(true)
+            },
+        )
+        .unwrap();
+
+    source_db
+        .for_each_iterator_by_prefix(&[], &PageOptions::default(), |key, value| {
+            count += 1;
+
+            senders[count % senders.len()]
+                .send((key.to_vec(), value.to_vec()))
+                .unwrap();
+
+            if count % COUNT_PER_PRINT == 0 {
+                let now = Instant::now();
+                let elapsed = now.duration_since(last_count_ts).as_secs_f64();
+                let per_second = COUNT_PER_PRINT as f64 / elapsed;
+                last_count_ts = now;
+                println!("queued {}, {per_second}mps", count);
+            }
+
+            Ok(false)
+        })
+        .unwrap();
+
+    drop(senders);
+
+    println!("DONE reading from database {}", count);
+
+    for handle in threads {
+        handle.join().unwrap();
+    }
+
+    println!("DONE writing to database {}", count);
+
+    source_db.close().unwrap();
+    dest_db.close().unwrap();
+
+    count
+}

--- a/apps/hubble/src/addon/src/db/rocksdb.rs
+++ b/apps/hubble/src/addon/src/db/rocksdb.rs
@@ -102,11 +102,15 @@ impl RocksDB {
     }
 
     pub fn open(&self) -> Result<(), HubError> {
-        let mut db_lock = self.db.write().unwrap();
-
         // Create RocksDB options
         let mut opts = Options::default();
         opts.create_if_missing(true); // Creates a database if it does not exist
+
+        self.open_with_opts(opts)
+    }
+
+    pub fn open_with_opts(&self, opts: Options) -> Result<(), HubError> {
+        let mut db_lock = self.db.write().unwrap();
 
         let mut tx_db_opts = rocksdb::TransactionDBOptions::default();
         tx_db_opts.set_default_lock_timeout(5000); // 5 seconds

--- a/apps/hubble/src/addon/src/lib.rs
+++ b/apps/hubble/src/addon/src/lib.rs
@@ -9,11 +9,11 @@ use std::{convert::TryInto, sync::Mutex};
 use store::{LinkStore, ReactionStore, Store, UserDataStore};
 use threadpool::ThreadPool;
 
-mod db;
-mod logger;
-mod statsd;
-mod store;
-mod trie;
+pub mod db;
+pub mod logger;
+pub mod statsd;
+pub mod store;
+pub mod trie;
 
 mod protos {
     include!(concat!("./", "/proto/protobufs.rs"));


### PR DESCRIPTION
## Motivation

Allows you to tweak storage settings for testing / benchmarking.

## Change Summary

Makes addon modules public. Doesn't affect runtime application, only adds helpful script to migrate the database state for testing.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the `lib.rs` file, add a new binary `migrate-db`, and improve the database migration process.

### Detailed summary
- Moved modules to `pub mod` in `lib.rs`
- Added a new binary `migrate-db` in `Cargo.toml`
- Refactored database open method in `rocksdb.rs`
- Implemented a database migration script in `migrate_db.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->