### PR TITLE
perf: remove by signer index

### DIFF
--- a/apps/hubble/src/addon/src/store/message.rs
+++ b/apps/hubble/src/addon/src/store/message.rs
@@ -92,6 +92,8 @@ pub enum UserPostfix {
     // NOTE: If you add a new message type, make sure that it is only used to store Message protobufs.
     // If you need to store an index, use one of the UserPostfix values below (>86).
     /** Index records (must be 86-255) */
+    // Deprecated
+    // BySigner = 86, // Index message by its signer
 
     /** CastStore add and remove sets */
     CastAdds = 87,

--- a/apps/hubble/src/addon/src/store/message.rs
+++ b/apps/hubble/src/addon/src/store/message.rs
@@ -92,7 +92,6 @@ pub enum UserPostfix {
     // NOTE: If you add a new message type, make sure that it is only used to store Message protobufs.
     // If you need to store an index, use one of the UserPostfix values below (>86).
     /** Index records (must be 86-255) */
-    BySigner = 86, // Index message by its signer
 
     /** CastStore add and remove sets */
     CastAdds = 87,
@@ -251,19 +250,6 @@ pub fn make_message_primary_key(
     key
 }
 
-fn make_message_by_signer_key(fid: u32, signer: Vec<u8>, r#type: u8, ts_hash: [u8; 24]) -> Vec<u8> {
-    let mut key = Vec::with_capacity(1 + 4 + 1 + 32 + 1 + 24);
-    key.extend_from_slice(&make_user_key(fid));
-    key.push(UserPostfix::BySigner as u8);
-    key.extend_from_slice(&signer);
-    if r#type > 0 {
-        key.push(r#type as u8);
-    }
-    key.extend_from_slice(&ts_hash);
-
-    key
-}
-
 pub fn make_cast_id_key(cast_id: &CastId) -> Vec<u8> {
     let mut key = Vec::with_capacity(4 + HASH_LENGTH);
     key.extend_from_slice(&make_fid_key(cast_id.fid as u32));
@@ -408,15 +394,6 @@ pub fn put_message_transaction(
     );
     txn.put(primary_key, message_encode(&message));
 
-    let by_signer_key = make_message_by_signer_key(
-        message.data.as_ref().unwrap().fid as u32,
-        message.signer.clone(),
-        message.data.as_ref().unwrap().r#type as u8,
-        ts_hash,
-    );
-
-    txn.put(by_signer_key, [TRUE_VALUE].to_vec());
-
     Ok(())
 }
 
@@ -433,14 +410,6 @@ pub fn delete_message_transaction(
         Some(&ts_hash),
     );
     txn.delete(primary_key);
-
-    let by_signer_key = make_message_by_signer_key(
-        message.data.as_ref().unwrap().fid as u32,
-        message.signer.clone(),
-        message.data.as_ref().unwrap().r#type as u8,
-        ts_hash,
-    );
-    txn.delete(by_signer_key);
 
     Ok(())
 }

--- a/apps/hubble/src/storage/db/message.ts
+++ b/apps/hubble/src/storage/db/message.ts
@@ -213,20 +213,19 @@ export const getAllMessagesBySigner = async (
   signer: Uint8Array,
   messageType?: MessageType,
 ): Promise<Message[]> => {
-  const prefix = makeUserKey(fid);
+  const userPrefix = makeUserKey(fid);
+  const maxPrefix = Buffer.concat([userPrefix, Buffer.from([UserMessagePostfixMax + 1])]);
+  const iteratorOptions = {
+    gte: userPrefix,
+    lt: maxPrefix,
+  };
+
   const messages: Message[] = [];
 
   // Loop through all keys that start with the given prefix
-  await db.forEachIteratorByPrefix(prefix, (key, value) => {
+  await db.forEachIteratorByOpts(iteratorOptions, (key, value) => {
     if (!value) {
       return false;
-    }
-
-    const type = key.readUint8(prefix.length);
-
-    // We assume the iterator runs sequentially and thus we can stop when we pass 85, as that is the max non-index type
-    if (type > 85) {
-      return true;
     }
 
     const decoded = messageDecode(new Uint8Array(value));

--- a/apps/hubble/src/storage/db/message.ts
+++ b/apps/hubble/src/storage/db/message.ts
@@ -1,10 +1,17 @@
-import { bytesIncrement, HubError, HubResult, Message, MessageData, MessageType } from "@farcaster/hub-nodejs";
+import {
+  bytesIncrement,
+  HubError,
+  HubResult,
+  Message,
+  MessageData,
+  MessageType,
+  bytesCompare,
+} from "@farcaster/hub-nodejs";
 import { err, ok, Result, ResultAsync } from "neverthrow";
 import RocksDB, { RocksDbIteratorOptions, RocksDbTransaction } from "./rocksdb.js";
 import {
   FID_BYTES,
   RootPrefix,
-  TRUE_VALUE,
   TSHASH_LENGTH,
   UserMessagePostfix,
   UserMessagePostfixMax,
@@ -43,22 +50,6 @@ export const makeMessagePrimaryKeyFromMessage = (message: Message): Buffer => {
     throw tsHash.error;
   }
   return makeMessagePrimaryKey(message.data.fid, typeToSetPostfix(message.data.type), tsHash.value);
-};
-
-/** <user prefix byte, fid, signer index byte, signer, type, tsHash> */
-export const makeMessageBySignerKey = (
-  fid: number,
-  signer: Uint8Array,
-  type?: MessageType,
-  tsHash?: Uint8Array,
-): Buffer => {
-  return Buffer.concat([
-    makeUserKey(fid),
-    Buffer.from([UserPostfix.BySigner]),
-    Buffer.from(signer),
-    Buffer.from(type ? [type] : ""),
-    Buffer.from(tsHash ?? ""),
-  ]);
 };
 
 /** Generate tsHash from timestamp and hash */
@@ -215,44 +206,41 @@ export const getPageIteratorOptsByPrefix = (prefix: Buffer, pageOptions: PageOpt
       };
 };
 
-export const getMessagesBySignerPrefix = (db: RocksDB, fid: number, signer: Uint8Array, type?: MessageType): Buffer => {
-  return makeMessageBySignerKey(fid, signer, type);
-};
-
 /** Get an array of messages for a given fid and signer */
-export const getAllMessagesBySigner = async <T extends Message>(
+export const getAllMessagesBySigner = async (
   db: RocksDB,
   fid: number,
   signer: Uint8Array,
-  type?: MessageType,
-): Promise<T[]> => {
-  // Generate prefix by excluding tsHash from the bySignerKey
-  // Format of bySignerKey: <user prefix byte, fid, by signer index byte, signer, type, tsHash>
-  const prefix = makeMessageBySignerKey(fid, signer, type);
-
-  // Initialize array of message primary keys
-  const primaryKeys: Buffer[] = [];
+  messageType?: MessageType,
+): Promise<Message[]> => {
+  const prefix = makeUserKey(fid);
+  const messages: Message[] = [];
 
   // Loop through all keys that start with the given prefix
-  await db.forEachIteratorByPrefix(prefix, (key, _) => {
-    // Get the tsHash for the message using its position in the key relative to the prefix
-    // If the prefix did not include type, add an extra byte to the tsHash offset
-    const tsHashOffset = prefix.length + (type ? 0 : 1);
-    const tsHash = new Uint8Array(key as Buffer).slice(tsHashOffset);
+  await db.forEachIteratorByPrefix(prefix, (key, value) => {
+    if (!value) {
+      return false;
+    }
 
-    // Get the type for the message, either from the predefined type variable or by looking at the byte
-    // prior to the tsHash in the key
-    const messageType = type ?? (new Uint8Array(key as Buffer).slice(tsHashOffset - 1, tsHashOffset)[0] as MessageType);
+    const type = key.readUint8(prefix.length);
 
-    // Convert the message type to a set postfix
-    const setPostfix = typeToSetPostfix(messageType);
+    // We assume the iterator runs sequentially and thus we can stop when we pass 85, as that is the max non-index type
+    if (type > 85) {
+      return true;
+    }
 
-    // Use the fid, setPostfix, and tsHash to generate the primaryKey for the message and store it
-    primaryKeys.push(makeMessagePrimaryKey(fid, setPostfix, tsHash));
+    const decoded = messageDecode(new Uint8Array(value));
+
+    const isCorrectType = messageType === undefined || messageType === decoded.data?.type;
+
+    if (isCorrectType && bytesCompare(decoded.signer, signer) === 0) {
+      messages.push(decoded);
+    }
+
+    return false;
   });
 
-  // Look up many messages using the array of primaryKeys
-  return getManyMessages(db, primaryKeys);
+  return messages;
 };
 
 export const putMessageTransaction = (txn: RocksDbTransaction, message: Message): RocksDbTransaction => {
@@ -264,10 +252,9 @@ export const putMessageTransaction = (txn: RocksDbTransaction, message: Message)
     throw tsHash.error; // TODO: use result pattern
   }
   const primaryKey = makeMessagePrimaryKey(message.data.fid, typeToSetPostfix(message.data.type), tsHash.value);
-  const bySignerKey = makeMessageBySignerKey(message.data.fid, message.signer, message.data.type, tsHash.value);
 
   const messageBuffer = messageEncode(message);
-  return txn.put(primaryKey, Buffer.from(messageBuffer)).put(bySignerKey, TRUE_VALUE);
+  return txn.put(primaryKey, Buffer.from(messageBuffer));
 };
 
 export const deleteMessageTransaction = (txn: RocksDbTransaction, message: Message): RocksDbTransaction => {
@@ -279,8 +266,7 @@ export const deleteMessageTransaction = (txn: RocksDbTransaction, message: Messa
     throw tsHash.error; // TODO: use result pattern
   }
   const primaryKey = makeMessagePrimaryKey(message.data.fid, typeToSetPostfix(message.data.type), tsHash.value);
-  const bySignerKey = makeMessageBySignerKey(message.data.fid, message.signer, message.data.type, tsHash.value);
-  return txn.del(bySignerKey).del(primaryKey);
+  return txn.del(primaryKey);
 };
 
 // If the message's data_bytes is set, then we'll not store the data field in the DB.

--- a/apps/hubble/src/storage/db/types.ts
+++ b/apps/hubble/src/storage/db/types.ts
@@ -106,8 +106,6 @@ export enum UserPostfix {
 
   /** Index records (must be 86-255) */
 
-  BySigner = 86, // Index message by its signer
-
   /** CastStore add and remove sets */
   CastAdds = 87,
   CastRemoves = 88,

--- a/apps/hubble/src/storage/engine/index.test.ts
+++ b/apps/hubble/src/storage/engine/index.test.ts
@@ -31,6 +31,7 @@ import {
   base58ToBytes,
   VerificationAddAddressMessage,
   recreateSolanaClaimMessage,
+  bytesCompare,
 } from "@farcaster/hub-nodejs";
 import { err, Ok, ok } from "neverthrow";
 import { jestRocksDB } from "../db/jestUtils.js";
@@ -1135,7 +1136,9 @@ describe("revokeMessagesBySigner", () => {
     for (const message of signerMessages) {
       await expect(checkMessage(message)).rejects.toThrow();
     }
-    expect(revokedMessages).toEqual(signerMessages);
+    expect(revokedMessages.sort((a, b) => bytesCompare(a.hash, b.hash))).toEqual(
+      signerMessages.sort((a, b) => bytesCompare(a.hash, b.hash)),
+    );
   });
 });
 
@@ -1186,7 +1189,9 @@ describe("with listeners and workers", () => {
 
       expect(revokedMessages).toEqual([]);
       await sleep(200); // Wait for engine to revoke messages
-      expect(revokedMessages).toEqual([castAdd, reactionAdd, linkAdd]);
+      expect(revokedMessages.sort((a, b) => bytesCompare(a.hash, b.hash))).toEqual(
+        [castAdd, reactionAdd, linkAdd].sort((a, b) => bytesCompare(a.hash, b.hash)),
+      );
     });
 
     test("does not revoke UserDataAdd when fname is transferred to different address but same fid", async () => {

--- a/apps/hubble/src/storage/stores/linkStore.test.ts
+++ b/apps/hubble/src/storage/stores/linkStore.test.ts
@@ -18,7 +18,6 @@ import { jestRocksDB } from "../db/jestUtils.js";
 import {
   getMessage,
   makeFidKey,
-  makeMessageBySignerKey,
   makeMessagePrimaryKeyFromMessage,
   makeTsHash,
   makeUserKey,
@@ -705,9 +704,7 @@ describe("merge", () => {
     const assertIncorrectPaddingExists = async (message: LinkAddMessage | LinkRemoveMessage, exists: boolean) => {
       const badAddKey = makeIncorrectKey(message);
       const primaryKey = makeMessagePrimaryKeyFromMessage(message);
-      const tsHash = makeTsHash(message.data.timestamp, message.hash)._unsafeUnwrap();
-      const bySignerKey = makeMessageBySignerKey(message.data.fid, message.signer, message.data.type, tsHash);
-      await expect(db.keysExist([badAddKey, primaryKey, bySignerKey])).resolves.toEqual(ok([exists, exists, exists]));
+      await expect(db.keysExist([badAddKey, primaryKey])).resolves.toEqual(ok([exists, exists]));
     };
 
     test("duplicate link add with incorrect padding", async () => {


### PR DESCRIPTION
## Motivation

The BySigner index is taking up a lot of space and is only used for quickly removing messages after a signer is revoked. As a trade-off, this index can be removed in favor of iterating over more messages when revoking.

## Change Summary

Remove code that populates the "BySigner" index and replace functions that used the index with new implementations that iterate over all messages from a given FID instead.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates message handling in the `hubble` app by refactoring key generation and message processing logic.

### Detailed summary
- Refactored key generation functions in `message.ts`
- Updated message handling in `engine/index.ts`
- Removed unused functions and imports

> The following files were skipped due to too many changes: `apps/hubble/src/storage/db/message.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->