### PR TITLE
fix: retry fname transfer fetch on fail

### DIFF
--- a/.changeset/cold-ducks-attack.md
+++ b/.changeset/cold-ducks-attack.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+Retry fetching fname transfers on failed merge

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -438,7 +438,14 @@ export class Hub implements HubInterface {
       chain: mainnet,
       transport: fallback(transports, { rank: options.rankRpcs ?? false }),
     });
-    this.engine = new Engine(this.rocksDB, options.network, eventHandler, mainnetClient, opClient);
+    this.engine = new Engine(
+      this.rocksDB,
+      options.network,
+      eventHandler,
+      mainnetClient,
+      opClient,
+      this.fNameRegistryEventsProvider,
+    );
 
     const profileSync = options.profileSync ?? false;
     this.syncEngine = new SyncEngine(

--- a/apps/hubble/src/storage/engine/index.test.ts
+++ b/apps/hubble/src/storage/engine/index.test.ts
@@ -520,12 +520,8 @@ describe("mergeMessage", () => {
         test("retries and succeeds when username proof has not been merged yet", async () => {
           fNameClient.setTransfersToReturn([]);
 
-          // This is a bit of a hack
-          // Since all of the tests run on the same engine it takes less than 60 attempts to get rate limited
-          for (let i = 0; i < 58; i++) {
-            const result = await engine.mergeMessage(usernameAdd);
-            expect(result).toMatchObject(err({ errCode: "bad_request.validation_failure" }));
-            expect(result._unsafeUnwrapErr().message).toMatch("is not registered");
+          for (let i = 0; i < 61; i++) {
+            await engine.mergeMessage(usernameAdd);
           }
 
           const result = await engine.mergeMessage(usernameAdd);

--- a/apps/hubble/src/storage/engine/index.test.ts
+++ b/apps/hubble/src/storage/engine/index.test.ts
@@ -32,7 +32,7 @@ import {
   VerificationAddAddressMessage,
   recreateSolanaClaimMessage,
 } from "@farcaster/hub-nodejs";
-import { err, Ok, ok } from "neverthrow";
+import { err, Ok, ok, ResultAsync } from "neverthrow";
 import { jestRocksDB } from "../db/jestUtils.js";
 import Engine from "../engine/index.js";
 import { sleep } from "../../utils/crypto.js";
@@ -43,15 +43,50 @@ import { setReferenceDateForTest } from "../../utils/versions.js";
 import { getUserNameProof } from "../db/nameRegistryEvent.js";
 import { publicClient } from "../../test/utils.js";
 import { jest } from "@jest/globals";
+import { FNameRegistryEventsProvider, FNameTransfer } from "../../eth/fnameRegistryEventsProvider.js";
+import { MockFnameRegistryClient } from "../../test/mocks.js";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
 const db = jestRocksDB("protobufs.engine.test");
 const network = FarcasterNetwork.TESTNET;
-const engine = new Engine(db, network, undefined, publicClient);
+
+const account = privateKeyToAccount(generatePrivateKey());
+const fNameClient = new MockFnameRegistryClient(account);
+
+// biome-ignore lint/style/useConst: cannot use lint as we need a reference before instantiation
+let engine: Engine;
+
+const fNameProvider = new FNameRegistryEventsProvider(
+  fNameClient,
+  // Mock version of the hub interface
+  {
+    submitUserNameProof: (proof) => engine.mergeUserNameProof(proof),
+    getHubState: () => ResultAsync.fromSafePromise(Promise.resolve({ lastFnameProof: 0 })),
+    putHubState: () => undefined,
+    // biome-ignore lint/suspicious/noExplicitAny: mock doesnt specify full interface
+  } as any,
+  false,
+);
+engine = new Engine(db, network, undefined, publicClient, undefined, fNameProvider);
 
 const fid = Factories.Fid.build();
 const fname = Factories.Fname.build();
 const signer = Factories.Ed25519Signer.build();
 const custodySigner = Factories.Eip712Signer.build();
+
+const transferEvents: FNameTransfer[] = [
+  {
+    id: 1,
+    username: Buffer.from(fname).toString("utf-8"),
+    from: 0,
+    to: fid,
+    timestamp: 1686291736947,
+    owner: account.address,
+    server_signature: "",
+  },
+];
+
+fNameClient.setTransfersToReturn([[], transferEvents]);
 
 let custodySignerKey: Uint8Array;
 let signerKey: Uint8Array;
@@ -67,6 +102,10 @@ let verificationAdd: VerificationAddAddressMessage;
 let userDataAdd: UserDataAddMessage;
 
 beforeAll(async () => {
+  // This forces the provider to fetch the signer address
+  await fNameProvider.start();
+  await fNameProvider.stop();
+
   signerKey = (await signer.getSignerKey())._unsafeUnwrap();
   custodySignerKey = (await custodySigner.getSignerKey())._unsafeUnwrap();
   custodyEvent = Factories.IdRegistryOnChainEvent.build({ fid }, { transient: { to: custodySignerKey } });
@@ -463,6 +502,10 @@ describe("mergeMessage", () => {
           });
 
           await expect(engine.mergeUserNameProof(proof)).resolves.toBeInstanceOf(Ok);
+          await expect(engine.mergeMessage(usernameAdd)).resolves.toBeInstanceOf(Ok);
+        });
+
+        test("retries and succeeds when username proof has not been merged yet", async () => {
           await expect(engine.mergeMessage(usernameAdd)).resolves.toBeInstanceOf(Ok);
         });
 

--- a/apps/hubble/src/storage/engine/index.test.ts
+++ b/apps/hubble/src/storage/engine/index.test.ts
@@ -60,7 +60,7 @@ const fNameProvider = new FNameRegistryEventsProvider(
   fNameClient,
   // Mock version of the hub interface
   {
-    submitUserNameProof: (proof) => engine.mergeUserNameProof(proof),
+    submitUserNameProof: (proof: UserNameProof) => engine.mergeUserNameProof(proof),
     getHubState: () => ResultAsync.fromSafePromise(Promise.resolve({ lastFnameProof: 0 })),
     putHubState: () => undefined,
     // biome-ignore lint/suspicious/noExplicitAny: mock doesnt specify full interface

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -917,7 +917,7 @@ class Engine extends TypedEmitter<EngineEvents> {
 
       const result = await ResultAsync.fromPromise(this._userDataStore.getUserNameProof(name), (e) => e as HubError);
 
-      if (result.isErr() && retries > 0 && this._fNameRegistryEventsProvider) {
+      if (result.isErr() && result.error.errCode === "not_found" && retries > 0 && this._fNameRegistryEventsProvider) {
         await this._fNameRegistryEventsProvider.retryTransferByName(name);
         return this.getUserNameProof(name, retries - 1);
       }

--- a/apps/hubble/src/test/e2e/testFnameRegistryServer.ts
+++ b/apps/hubble/src/test/e2e/testFnameRegistryServer.ts
@@ -4,12 +4,17 @@ import fastify, { FastifyInstance } from "fastify";
 export class TestFNameRegistryServer {
   private server?: FastifyInstance;
   private port = 0;
+  private transfers;
+
+  constructor(transfers = []) {
+    this.transfers = transfers;
+  }
 
   public async start(): Promise<string> {
     this.server = fastify();
 
     this.server.get("/transfers", async (request, reply) => {
-      reply.send({ transfers: [] });
+      reply.send({ transfers: this.transfers });
     });
 
     this.server.get("/signer", async (request, reply) => {


### PR DESCRIPTION
## Motivation

Potential solution for https://github.com/farcasterxyz/hub-monorepo/issues/2001. Adds a mechanism to re-fetch fname transfers for a given name when merging a `UserDataAdd` that fails due to missing proof.

## Change Summary

Refetches fname transfers when merging a `UserDataAdd` that errors out due to a missing proof. Also moves some code around for testing purposes.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the `@farcaster/hubble` module by improving transfer retry logic and adding a new `FNameRegistryClientInterface` with related functionalities.

### Detailed summary
- Added retry logic for fetching transfers on failed merge
- Introduced `FNameRegistryClientInterface` with methods for managing transfers
- Updated `MockFnameRegistryClient` with transfer handling functionality

> The following files were skipped due to too many changes: `apps/hubble/src/storage/engine/index.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->