### PR TITLE
fix(replicator): heap out of memory

### DIFF
--- a/.changeset/tricky-sheep-sneeze.md
+++ b/.changeset/tricky-sheep-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/replicator": patch
+---
+
+Fix replicator heap out of memory

--- a/apps/replicator/.env.sample
+++ b/apps/replicator/.env.sample
@@ -2,6 +2,7 @@ LOG_LEVEL=info
 COLORIZE=true
 # Set this higher the further the hub is from the replicator
 CONCURRENCY=32
+MAX_OLD_SPACE_SIZE=2048 # ram of system
 WORKER_TYPE=thread
 WEB_UI_PORT=9000
 REDIS_URL=redis:6379

--- a/apps/replicator/docker-compose.yml
+++ b/apps/replicator/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         dockerfile: Dockerfile.replicator
     restart: unless-stopped
     init: true
-    command: ['node', 'build/app.js', 'start']
+    command: ['node', '--max-old-space-size=${MAX_OLD_SPACE_SIZE:-2048}', 'build/app.js', 'start']
     environment:
       - LOG_LEVEL
       - HUB_HOST


### PR DESCRIPTION
## Motivation

there's this ongoing issue of running out of memory with the apps.

e.g.  
https://github.com/farcasterxyz/hub-monorepo/issues/1015  
or  
https://github.com/farcasterxyz/hub-monorepo/issues/1407  

## Change Summary

Adding the node `--max-old-space-size` flag with the ram size fixes the issue.

[The requirements speak of 2GB ram requirement](https://github.com/farcasterxyz/hub-monorepo/blob/main/apps/replicator/README.md#requirements), so setting this as default value.

https://github.com/farcasterxyz/hub-monorepo/blob/a6367658e5c518956a612f793bec06eef5eb1a35/apps/replicator/docker-compose.yml#L11

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [X] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

-

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the replicator heap out of memory error by setting a maximum old space size for the Node.js process.

### Detailed summary
- Updated `MAX_OLD_SPACE_SIZE` to 2048 in `.env.sample`
- Modified `command` in `docker-compose.yml` to include `--max-old-space-size=${MAX_OLD_SPACE_SIZE:-2048}`
- Resolved replicator heap out of memory issue

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->