### PR TITLE
fix: Report better error message when hub address unspecified

### DIFF
--- a/.changeset/twelve-needles-beg.md
+++ b/.changeset/twelve-needles-beg.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hub-nodejs": patch
+---
+
+Include better error message when providing bad host address

--- a/packages/hub-nodejs/src/client.ts
+++ b/packages/hub-nodejs/src/client.ts
@@ -135,13 +135,16 @@ export const getServer = (): grpc.Server => {
 };
 
 export const getSSLClient = (address: string, options?: Partial<grpc.ClientOptions>): HubServiceClient => {
+  if (!address) throw new Error("Hub address not specified");
   return new HubServiceClient(address, grpc.credentials.createSsl(), { ...options });
 };
 
 export const getInsecureClient = (address: string, options?: Partial<grpc.ClientOptions>): HubServiceClient => {
+  if (!address) throw new Error("Hub address not specified");
   return new HubServiceClient(address, grpc.credentials.createInsecure(), { ...options });
 };
 
 export const getAdminClient = (address: string, options?: Partial<grpc.ClientOptions>): AdminServiceClient => {
+  if (!address) throw new Error("Hub address not specified");
   return new AdminServiceClient(address, grpc.credentials.createInsecure(), { ...options });
 };

--- a/packages/hub-nodejs/src/index.test.ts
+++ b/packages/hub-nodejs/src/index.test.ts
@@ -4,3 +4,7 @@ test("Client can be constructed", async () => {
   const client = getInsecureClient("127.0.0.1:0");
   expect(client).toBeTruthy();
 });
+
+test("Reports more helpful error if address unspecified", async () => {
+  expect(() => getInsecureClient("")).toThrow(new Error("Hub address not specified"));
+});


### PR DESCRIPTION
## Motivation

We want a better error message in this case, since the default is unhelpful. Fixes #703.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to improve error handling by providing more helpful error messages when an address is not specified in the `hub-nodejs` package.

### Detailed summary
- Added better error message for unspecified address in `getSSLClient`, `getInsecureClient`, and `getAdminClient` functions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->