### PR TITLE
feat(shuttle): add support for reverse reconciliation

### DIFF
--- a/.changeset/beige-suns-poke.md
+++ b/.changeset/beige-suns-poke.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": minor
+---
+
+feat: Add support for reverse reconciliation


### PR DESCRIPTION
## Motivation

Fixes https://github.com/farcasterxyz/hub-monorepo/issues/2018

## Change Summary

Add support for reverse reconciliation where messages are present in the db but missing in the hub. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for reverse reconciliation in the `@farcaster/shuttle` package.

### Detailed summary
- Added a new `onDbMessage` callback function to `MessageReconciliation` class
- Implemented reconciliation of messages in the database but not in the hub
- Added `DBMessage` type for database messages with relevant fields

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->