### PR TITLE
feat: Add HUB_OPTIONS env var to docker compose

### DIFF
--- a/.changeset/blue-snails-vanish.md
+++ b/.changeset/blue-snails-vanish.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: All HUB_OPTIONS env var to docker compose

--- a/apps/hubble/docker-compose.yml
+++ b/apps/hubble/docker-compose.yml
@@ -33,6 +33,7 @@ services:
         --statsd-metrics-server $STATSD_METRICS_SERVER
         --hub-operator-fid ${HUB_OPERATOR_FID:-0}
         --opt-out-diagnostics ${HUB_OPT_OUT_DIAGNOSTICS:-false}
+        ${HUB_OPTIONS:-}
     ports:
       - '${HTTPAPI_PORT:-2281}:${HTTPAPI_PORT:-2281}' # HTTP API. You can set HTTP_PORT in .env
       - '${GOSSIP_PORT:-2282}:${GOSSIP_PORT:-2282}' # Gossip. You can set GOSSIP_PORT in .env


### PR DESCRIPTION
## Motivation

Allow customizing docker compose startup commands via a HUB_OPTIONS env var

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `docker-compose.yml` file for the `@farcaster/hubble` app to allow customizing HUB_OPTIONS environment variable.

### Detailed summary
- Added `HUB_OPTIONS` environment variable to docker compose for `@farcaster/hubble` app
- Removed specific values for `HUB_OPERATOR_FID` and `HUB_OPT_OUT_DIAGNOSTICS` in favor of `HUB_OPTIONS` customization

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->