### PR TITLE
[chore] Add Node 22 to test matrix

### DIFF
--- a/.changeset/chilled-starfishes-chew.md
+++ b/.changeset/chilled-starfishes-chew.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+[chore] Determine app version via manual JSON.parse instead of import

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,9 @@ jobs:
           - node_version: 20
             runs_on: 'warp-ubuntu-latest-x64-16x'
           - node_version: 21
-            runs_on: 'warp-ubuntu-latest-arm64-16x'
+            runs_on: 'warp-ubuntu-latest-arm64-16x' # Only works on ARM for now
+          - node_version: 22
+            runs_on: 'warp-ubuntu-latest-x64-16x'
 
     runs-on: ${{ matrix.runs_on }}
     name: test (${{ matrix.node_version }})

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -40,6 +40,7 @@ import { PruneEventsJobScheduler } from "./storage/jobs/pruneEventsJob.js";
 import { PruneMessagesJobScheduler } from "./storage/jobs/pruneMessagesJob.js";
 import { sleep } from "./utils/crypto.js";
 import { rsDbDestroy, rsValidationMethods } from "./rustfunctions.js";
+import { URL } from "node:url";
 import * as tar from "tar";
 import * as zlib from "zlib";
 import {
@@ -67,7 +68,6 @@ import StoreEventHandler from "./storage/stores/storeEventHandler.js";
 import { FNameRegistryClient, FNameRegistryEventsProvider } from "./eth/fnameRegistryEventsProvider.js";
 import { L2EventsProvider, OptimismConstants } from "./eth/l2EventsProvider.js";
 import { prettyPrintTable } from "./profile/profile.js";
-import packageJson from "./package.json" assert { type: "json" };
 import { createPublicClient, fallback, http } from "viem";
 import { mainnet, optimism } from "viem/chains";
 import { AddrInfo } from "@chainsafe/libp2p-gossipsub/types";
@@ -98,7 +98,9 @@ import { startupCheck, StartupCheckStatus } from "./utils/startupCheck.js";
 
 export type HubSubmitSource = "gossip" | "rpc" | "eth-provider" | "l2-provider" | "sync" | "fname-registry";
 
-export const APP_VERSION = packageJson.version;
+export const APP_VERSION = JSON.parse(
+  fs.readFileSync(path.join(new URL(".", import.meta.url).pathname, "..", "./package.json")).toString(),
+).version;
 export const APP_NICKNAME = process.env["HUBBLE_NAME"] ?? "Farcaster Hub";
 
 export const SNAPSHOT_S3_UPLOAD_BUCKET = "farcaster-snapshots";
@@ -725,9 +727,9 @@ export class Hub implements HubInterface {
       this.options.announceIp ?? undefined,
     );
     if (rpcAddressCheck.isErr()) {
-      const errorMessage = `Error validating RPC address at port ${this.options.rpcPort}. 
+      const errorMessage = `Error validating RPC address at port ${this.options.rpcPort}.
         Please make sure RPC port value is valid and reachable from public internet.
-        Reachable address is required for hub to perform diff sync via gRPC API and sync with the network. 
+        Reachable address is required for hub to perform diff sync via gRPC API and sync with the network.
         Hub operators may need to enable port-forwarding of traffic to hub's host and port if they are behind a NAT.
         `;
       log.warn(


### PR DESCRIPTION
## Motivation

We eventually want to release hubs on Node 22, since it's been out for a while.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the app version determination method, adjusts CI configurations for ARM support, and refactors the app version retrieval in `hubble.ts`.

### Detailed summary
- Updated app version determination method in `hubble.ts`
- Adjusted CI configurations for ARM support
- Refactored app version retrieval using manual JSON parsing

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->