### PR TITLE
[chore] Update TypeScript 5.0.2 to 5.4.5

### DIFF
--- a/.changeset/two-ghosts-develop.md
+++ b/.changeset/two-ghosts-develop.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+Export multiple signatures for farcasterTimeToDate

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ts-node": "^10.9.1",
     "tsup": "^6.5.0",
     "turbo": "1.10.3",
-    "typescript": "^5.0.2"
+    "typescript": "^5.4.5"
   },
   "lint-staged": {
     "*.ts": ["biome check"],

--- a/packages/shuttle/src/utils.ts
+++ b/packages/shuttle/src/utils.ts
@@ -66,6 +66,9 @@ export function bytesToHex(value: Uint8Array): `0x${string}` {
   return `0x${Buffer.from(value).toString("hex")}`;
 }
 
+export function farcasterTimeToDate(time: number): Date;
+export function farcasterTimeToDate(time: null): null;
+export function farcasterTimeToDate(time: undefined): undefined;
 export function farcasterTimeToDate(time: number | null | undefined): Date | null | undefined {
   if (time === undefined) return undefined;
   if (time === null) return null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11626,15 +11626,15 @@ typed-array-length@^1.0.4:
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
 
-typescript@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
-  integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
-
 typescript@^5.2.2:
   version "5.2.2"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
+
+typescript@^5.4.5:
+  version "5.4.5"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
+  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
 
 uint8-varint@^1.0.1, uint8-varint@^1.0.2:
   version "1.0.4"


### PR DESCRIPTION
## Motivation

Stay up to date.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the TypeScript version, exports multiple signatures for `farcasterTimeToDate`, and includes a new dependency for `uint8-varint`.

### Detailed summary
- Updated TypeScript to version 5.4.5
- Exported multiple signatures for `farcasterTimeToDate`
- Added `uint8-varint` dependency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->