### PR TITLE
feat: increase verification signature max length

### DIFF
--- a/.changeset/olive-readers-suffer.md
+++ b/.changeset/olive-readers-suffer.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/core": patch
+---
+
+feat: extend verifications signature max length

--- a/packages/core/src/validations.test.ts
+++ b/packages/core/src/validations.test.ts
@@ -841,15 +841,15 @@ describe("validateVerificationAddEthAddressSignature", () => {
     expect(result).toEqual(err(new HubError("bad_request.invalid_param", "RPC client not provided for chainId 1")));
   });
 
-  test("fails if ethSignature is > 512 bytes", async () => {
+  test("fails if ethSignature is > 2048 bytes", async () => {
     const body = await Factories.VerificationAddAddressBody.create(
       {
-        claimSignature: Factories.Bytes.build({}, { transient: { length: 513 } }),
+        claimSignature: Factories.Bytes.build({}, { transient: { length: 2049 } }),
       },
       { transient: { protocol: Protocol.ETHEREUM } },
     );
     const result = await validations.validateVerificationAddEthAddressSignature(body, fid, network, {});
-    expect(result).toEqual(err(new HubError("bad_request.validation_failure", "claimSignature > 512 bytes")));
+    expect(result).toEqual(err(new HubError("bad_request.validation_failure", "claimSignature > 2048 bytes")));
   });
 
   test("succeeds for contract signatures", async () => {

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -403,8 +403,8 @@ export const validateVerificationAddEthAddressSignature = async (
   network: protobufs.FarcasterNetwork,
   publicClients: PublicClients = defaultPublicClients,
 ): HubAsyncResult<Uint8Array> => {
-  if (body.claimSignature.length > 512) {
-    return err(new HubError("bad_request.validation_failure", "claimSignature > 512 bytes"));
+  if (body.claimSignature.length > 2048) {
+    return err(new HubError("bad_request.validation_failure", "claimSignature > 2048 bytes"));
   }
 
   const reconstructedClaim = makeVerificationAddressClaim(


### PR DESCRIPTION
## Motivation

Coinbase Smart Wallet signatures are 1088 bytes long. We've bumped this several times, so add some headroom on top.

## Change Summary

Increase verification signature max length to 2048 bytes.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR extends the maximum length of the `claimSignature` field in verifications to 2048 bytes for better validation accuracy.

### Detailed summary
- Increased `claimSignature` max length from 512 to 2048 bytes in validations
- Updated test cases to reflect the new max length of `claimSignature`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->