### PR TITLE
feat(shuttle): Store cast type in message body

### DIFF
--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.3.2
+
+### Patch Changes
+
+- feat(shuttle): store cast type in message body
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/shuttle/src/shuttle/db.ts
+++ b/packages/shuttle/src/shuttle/db.ts
@@ -16,6 +16,7 @@ import {
   UpdateQueryBuilder,
 } from "kysely";
 import {
+  CastType,
   HashScheme,
   MessageType,
   ReactionType,
@@ -53,6 +54,7 @@ export type CastAddBodyJson = {
   mentions?: number[];
   mentionsPositions?: number[];
   parent?: CastIdJson | string;
+  type: CastType;
 };
 
 export type CastRemoveBodyJson = {

--- a/packages/shuttle/src/utils.ts
+++ b/packages/shuttle/src/utils.ts
@@ -111,6 +111,7 @@ export function convertProtobufMessageBodyToJson(message: Message): MessageBodyJ
         text,
         parentCastId,
         parentUrl,
+        type,
       } = message.data.castAddBody;
 
       const embeds: string[] = [];
@@ -135,6 +136,7 @@ export function convertProtobufMessageBodyToJson(message: Message): MessageBodyJ
         mentions,
         mentionsPositions,
         text,
+        type,
         parent: parentCastId ? { fid: parentCastId.fid, hash: bytesToHex(parentCastId.hash) } : parentUrl,
       };
       break;


### PR DESCRIPTION
## Motivation

Store cast type in message body for shuttle

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates `@farcaster/shuttle` to version 0.3.2. The main change is storing the cast type in the message body.

### Detailed summary
- Updated package version to 0.3.2
- Added `CastType` to message body in `db.ts`
- Added `type` field to message body in `utils.ts`
- Updated `convertProtobufMessageBodyToJson` function in `utils.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->