### PR TITLE
Fix re-processing messages that were revoked

### DIFF
--- a/.changeset/red-grapes-train.md
+++ b/.changeset/red-grapes-train.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+Fix handling of reprocessed messages to mark them as no longer revoked

--- a/packages/shuttle/src/shuttle/messageProcessor.ts
+++ b/packages/shuttle/src/shuttle/messageProcessor.ts
@@ -33,6 +33,9 @@ export class MessageProcessor {
 
     switch (operation) {
       case "merge":
+        opData.deletedAt = null;
+        opData.prunedAt = null;
+        opData.revokedAt = null;
         break;
       case "delete":
         opData.deletedAt = new Date();


### PR DESCRIPTION
## Motivation

When re-processing the message it stayed as revoked in our DB.

## Change Summary

Mark as no longer revoked.

## Merge Checklist

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the handling of reprocessed messages in the `@farcaster/shuttle` package. It ensures that reprocessed messages are no longer marked as revoked.

### Detailed summary
- Fixed handling of reprocessed messages in `messageProcessor.ts`
- Set `deletedAt`, `prunedAt`, and `revokedAt` to `null` for merge operation

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->