### PR TITLE
fix: Always log when updating contact info

### DIFF
--- a/.changeset/big-bulldogs-hunt.md
+++ b/.changeset/big-bulldogs-hunt.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Always log when updating contact info

--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -604,7 +604,7 @@ describe("SyncEngine", () => {
       expect(syncEngine.getContactInfoForPeerId(peerId.toString())?.contactInfo).toEqual(contactInfo);
 
       // Adding a newer contact info should replace the existing one
-      expect(syncEngine.addContactInfoForPeerId(peerId, newerContactInfo)).toBeInstanceOf(Err);
+      expect(syncEngine.addContactInfoForPeerId(peerId, newerContactInfo)).toBeInstanceOf(Ok);
       expect(syncEngine.getContactInfoForPeerId(peerId.toString())?.contactInfo).toEqual(newerContactInfo);
     });
   });

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -541,30 +541,24 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
 
   public addContactInfoForPeerId(peerId: PeerId, contactInfo: ContactInfoContentBody) {
     const existingPeerInfo = this.getContactInfoForPeerId(peerId.toString());
-    if (existingPeerInfo) {
-      if (contactInfo.timestamp > existingPeerInfo.contactInfo.timestamp) {
-        this.currentHubPeerContacts.set(peerId.toString(), { peerId, contactInfo });
-      }
+    if (existingPeerInfo && contactInfo.timestamp <= existingPeerInfo.contactInfo.timestamp) {
       return err(new HubError("bad_request.duplicate", "peer already exists"));
-    } else {
-      log.info(
-        {
-          peerInfo: contactInfo,
-          theirMessages: contactInfo.count,
-          peerNetwork: contactInfo.network,
-          peerVersion: contactInfo.hubVersion,
-          peerAppVersion: contactInfo.appVersion,
-          connectedPeers: this.getPeerCount(),
-          peerId: peerId.toString(),
-          isNew: !!existingPeerInfo,
-          gossipDelay: (Date.now() - contactInfo.timestamp) / 1000,
-        },
-        "Updated Peer ContactInfo",
-      );
-
-      this.currentHubPeerContacts.set(peerId.toString(), { peerId, contactInfo });
     }
-
+    log.info(
+      {
+        peerInfo: contactInfo,
+        theirMessages: contactInfo.count,
+        peerNetwork: contactInfo.network,
+        peerVersion: contactInfo.hubVersion,
+        peerAppVersion: contactInfo.appVersion,
+        connectedPeers: this.getPeerCount(),
+        peerId: peerId.toString(),
+        isNew: !!existingPeerInfo,
+        gossipDelay: (Date.now() - contactInfo.timestamp) / 1000,
+      },
+      "Updated Peer ContactInfo",
+    );
+    this.currentHubPeerContacts.set(peerId.toString(), { peerId, contactInfo });
     return ok(undefined);
   }
 


### PR DESCRIPTION
## Motivation

We were only logging when we received a brand new contactInfo, we should be logging everytime we see a new or updated contactInfo

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `syncEngine` in the Hubble app to always log when updating contact info.

### Detailed summary
- Updated `addContactInfoForPeerId` method to always log when updating contact info
- Replaced `Err` with `Ok` in test for adding newer contact info
- Improved error handling for duplicate peer entries

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->