### PR TITLE
chore: Lower level of shuttle logs to debug

### DIFF
--- a/.changeset/hungry-pillows-shout.md
+++ b/.changeset/hungry-pillows-shout.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+Lower level of shuttle logs to debug

--- a/packages/shuttle/src/shuttle/messageReconciliation.ts
+++ b/packages/shuttle/src/shuttle/messageReconciliation.ts
@@ -38,7 +38,7 @@ export class MessageReconciliation {
       MessageType.VERIFICATION_ADD_ETH_ADDRESS,
       MessageType.USER_DATA_ADD,
     ]) {
-      this.log.info(`Reconciling messages for FID ${fid} of type ${type}`);
+      this.log.debug(`Reconciling messages for FID ${fid} of type ${type}`);
       await this.reconcileMessagesOfTypeForFid(fid, type, onHubMessage, onDbMessage);
     }
   }
@@ -57,7 +57,7 @@ export class MessageReconciliation {
       const messageHashes = messages.map((msg) => msg.hash);
 
       if (messageHashes.length === 0) {
-        this.log.info(`No messages of type ${type} for FID ${fid}`);
+        this.log.debug(`No messages of type ${type} for FID ${fid}`);
         continue;
       }
 


### PR DESCRIPTION
## Motivation

These logs aren't strictly useful in a normal sense.

## Change Summary

Lower them to debug log level to make the logs less noisy.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to lower the level of shuttle logs to debug in the `MessageReconciliation` class in the `shuttle` package.

### Detailed summary
- Lowered the logging level to debug in `messageReconciliation.ts` for better debugging.
- Replaced `this.log.info` with `this.log.debug` for certain log messages.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->