### PR TITLE
fix: updated multinode docker compose

### DIFF
--- a/docker-compose-multinode.yml
+++ b/docker-compose-multinode.yml
@@ -29,6 +29,8 @@ services:
         "2283",
         "--eth-mainnet-rpc-url",
         "$ETH_MAINNET_RPC_URL",
+        "--l2-rpc-url",
+        "$OPTIMISM_L2_RPC_URL",
         "--network",
         "3",
         "--db-name",
@@ -37,7 +39,6 @@ services:
         "hubble1",
         "--id",
         "$TEST_HUB1_ID",
-        "--gossip-metrics-enabled"
       ]
     volumes:
       - ./apps/hubble/.hub:/home/node/app/apps/hubble/.hub
@@ -60,6 +61,8 @@ services:
         "2285",
         "--eth-mainnet-rpc-url",
         "$ETH_MAINNET_RPC_URL",
+        "--l2-rpc-url",
+        "$OPTIMISM_L2_RPC_URL",
         "--network",
         "3",
         "-b",
@@ -69,7 +72,7 @@ services:
         "--process-file-prefix",
         "hubble2",
         "--id",
-        "$TEST_HUB2_ID"
+        "$TEST_HUB2_ID",
       ]
     volumes:
       - ./apps/hubble/.hub:/home/node/app/apps/hubble/.hub


### PR DESCRIPTION
## Motivation

I tried running this multinode setup and ran into a couple issues with the config. This PR fixes them. 

## Change Summary

I just added arguments for the optimism rpc url (required) and removed --gossip-metrics-enabled which doesn't exist anymore. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

