### PR TITLE
feat: expose LinkCompactState messages via rpc

### DIFF
--- a/.changeset/lazy-flies-rule.md
+++ b/.changeset/lazy-flies-rule.md
@@ -1,0 +1,9 @@
+---
+"@farcaster/hub-nodejs": patch
+"@farcaster/hub-web": patch
+"@farcaster/shuttle": patch
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+Add rpc to expose LinkCompactStateMessage + explicit handling of type

--- a/apps/hubble/src/addon/src/db/rocksdb.rs
+++ b/apps/hubble/src/addon/src/db/rocksdb.rs
@@ -942,7 +942,7 @@ impl RocksDB {
     pub fn js_for_each_iterator_by_js_opts(mut cx: FunctionContext) -> JsResult<JsPromise> {
         let db = get_db(&mut cx)?;
 
-        // JS Iterator options 
+        // JS Iterator options
         let js_opts = get_iterator_options(&mut cx, 0)?;
 
         // The argument is a callback function

--- a/apps/hubble/src/addon/src/lib.rs
+++ b/apps/hubble/src/addon/src/lib.rs
@@ -153,6 +153,10 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
         "getAllLinkMessagesByFid",
         LinkStore::js_get_all_link_messages_by_fid,
     )?;
+    cx.export_function(
+        "getLinkCompactStateMessageByFid",
+        LinkStore::js_get_link_compact_state_message_by_fid,
+    )?;
 
     // ReactionStore methods
     cx.export_function("createReactionStore", ReactionStore::create_reaction_store)?;

--- a/apps/hubble/src/addon/src/store/cast_store.rs
+++ b/apps/hubble/src/addon/src/store/cast_store.rs
@@ -227,6 +227,13 @@ impl StoreDef for CastStoreDef {
         })
     }
 
+    fn make_compact_state_prefix(&self, _fid: u32) -> Result<Vec<u8>, HubError> {
+        Err(HubError {
+            code: "bad_request.invalid_param".to_string(),
+            message: "Cast Store doesn't support compact state".to_string(),
+        })
+    }
+
     fn get_prune_size_limit(&self) -> u32 {
         self.prune_size_limit
     }

--- a/apps/hubble/src/addon/src/store/link_store.rs
+++ b/apps/hubble/src/addon/src/store/link_store.rs
@@ -168,6 +168,14 @@ impl LinkStore {
         store.get_all_messages_by_fid(fid, page_options)
     }
 
+    pub fn get_link_compact_state_message_by_fid(
+        store: &Store,
+        fid: u32,
+        page_options: &PageOptions,
+    ) -> Result<MessagesPage, HubError> {
+        store.get_all_messages_by_fid(fid, page_options)
+    }
+
     pub fn get_links_by_target(
         store: &Store,
         target: &Target,
@@ -680,6 +688,31 @@ impl LinkStore {
 
         THREAD_POOL.lock().unwrap().execute(move || {
             let messages = Self::get_all_link_messages_by_fid(&store, fid, &page_options);
+
+            deferred_settle_messages(deferred, &channel, messages);
+        });
+
+        Ok(promise)
+    }
+
+    pub fn js_get_link_compact_state_message_by_fid(
+        mut cx: FunctionContext,
+    ) -> JsResult<JsPromise> {
+        let store = get_store(&mut cx)?;
+
+        let fid = cx.argument::<JsNumber>(0).unwrap().value(&mut cx) as u32;
+        let page_options = get_page_options(&mut cx, 1)?;
+
+        // fid must be specified
+        if fid == 0 {
+            return cx.throw_error("fid is required");
+        }
+
+        let channel = cx.channel();
+        let (deferred, promise) = cx.promise();
+
+        THREAD_POOL.lock().unwrap().execute(move || {
+            let messages = Self::get_link_compact_state_message_by_fid(&store, fid, &page_options);
 
             deferred_settle_messages(deferred, &channel, messages);
         });

--- a/apps/hubble/src/addon/src/store/link_store.rs
+++ b/apps/hubble/src/addon/src/store/link_store.rs
@@ -173,7 +173,7 @@ impl LinkStore {
         fid: u32,
         page_options: &PageOptions,
     ) -> Result<MessagesPage, HubError> {
-        store.get_all_messages_by_fid(fid, page_options)
+        store.get_compact_state_messages_by_fid(fid, page_options)
     }
 
     pub fn get_links_by_target(
@@ -947,6 +947,16 @@ impl StoreDef for LinkStore {
                         )),
                     })
             })
+    }
+
+    fn make_compact_state_prefix(&self, fid: u32) -> Result<Vec<u8>, HubError> {
+        let mut prefix =
+            Vec::with_capacity(Self::ROOT_PREFIXED_FID_BYTE_SIZE + Self::POSTFIX_BYTE_SIZE);
+
+        prefix.extend_from_slice(&make_user_key(fid));
+        prefix.push(UserPostfix::LinkCompactStateMessage.as_u8());
+
+        Ok(prefix)
     }
 
     fn make_add_key(&self, message: &Message) -> Result<Vec<u8>, HubError> {

--- a/apps/hubble/src/addon/src/store/reaction_store.rs
+++ b/apps/hubble/src/addon/src/store/reaction_store.rs
@@ -153,6 +153,13 @@ impl StoreDef for ReactionStoreDef {
         })
     }
 
+    fn make_compact_state_prefix(&self, _fid: u32) -> Result<Vec<u8>, HubError> {
+        Err(HubError {
+            code: "bad_request.invalid_param".to_string(),
+            message: "Reaction Store doesn't support compact state".to_string(),
+        })
+    }
+
     fn get_prune_size_limit(&self) -> u32 {
         self.prune_size_limit
     }

--- a/apps/hubble/src/addon/src/store/store.rs
+++ b/apps/hubble/src/addon/src/store/store.rs
@@ -1003,6 +1003,21 @@ impl Store {
 
         Ok(messages)
     }
+
+    pub fn get_compact_state_messages_by_fid(
+        &self,
+        fid: u32,
+        page_options: &PageOptions,
+    ) -> Result<MessagesPage, HubError> {
+        let prefix = make_message_primary_key(fid, self.store_def.postfix(), None);
+        let messages =
+            message::get_messages_page_by_prefix(&self.db, &prefix, &page_options, |message| {
+                self.store_def.compact_state_type_supported()
+                    && self.store_def.is_compact_state_type(&message)
+            })?;
+
+        Ok(messages)
+    }
 }
 
 // Neon bindings

--- a/apps/hubble/src/addon/src/store/store.rs
+++ b/apps/hubble/src/addon/src/store/store.rs
@@ -159,6 +159,7 @@ pub trait StoreDef: Send + Sync {
     fn make_add_key(&self, message: &Message) -> Result<Vec<u8>, HubError>;
     fn make_remove_key(&self, message: &Message) -> Result<Vec<u8>, HubError>;
     fn make_compact_state_add_key(&self, message: &Message) -> Result<Vec<u8>, HubError>;
+    fn make_compact_state_prefix(&self, fid: u32) -> Result<Vec<u8>, HubError>;
 
     fn get_prune_size_limit(&self) -> u32;
 
@@ -1009,14 +1010,26 @@ impl Store {
         fid: u32,
         page_options: &PageOptions,
     ) -> Result<MessagesPage, HubError> {
-        let prefix = make_message_primary_key(fid, self.store_def.postfix(), None);
-        let messages =
-            message::get_messages_page_by_prefix(&self.db, &prefix, &page_options, |message| {
-                self.store_def.compact_state_type_supported()
-                    && self.store_def.is_compact_state_type(&message)
-            })?;
+        if !self.store_def.compact_state_type_supported() {
+            return Err(HubError::invalid_parameter("compact state not supported"));
+        }
 
-        Ok(messages)
+        match self.store_def.make_compact_state_prefix(fid) {
+            Ok(prefix) => {
+                let messages = message::get_messages_page_by_prefix(
+                    &self.db,
+                    &prefix,
+                    &page_options,
+                    |message| {
+                        self.store_def.compact_state_type_supported()
+                            && self.store_def.is_compact_state_type(&message)
+                    },
+                )?;
+
+                Ok(messages)
+            }
+            Err(e) => Err(e),
+        }
     }
 }
 

--- a/apps/hubble/src/addon/src/store/user_data_store.rs
+++ b/apps/hubble/src/addon/src/store/user_data_store.rs
@@ -106,6 +106,13 @@ impl StoreDef for UserDataStoreDef {
         })
     }
 
+    fn make_compact_state_prefix(&self, _fid: u32) -> Result<Vec<u8>, HubError> {
+        Err(HubError {
+            code: "bad_request.invalid_param".to_string(),
+            message: "UserDataStore doesn't support compact state".to_string(),
+        })
+    }
+
     fn get_prune_size_limit(&self) -> u32 {
         self.prune_size_limit
     }

--- a/apps/hubble/src/addon/src/store/username_proof_store.rs
+++ b/apps/hubble/src/addon/src/store/username_proof_store.rs
@@ -91,6 +91,13 @@ impl StoreDef for UsernameProofStoreDef {
         })
     }
 
+    fn make_compact_state_prefix(&self, _fid: u32) -> Result<Vec<u8>, HubError> {
+        Err(HubError {
+            code: "bad_request.invalid_param".to_string(),
+            message: "Username Proof Store doesn't support compact state".to_string(),
+        })
+    }
+
     fn is_add_type(&self, message: &Message) -> bool {
         message.signature_scheme == protos::SignatureScheme::Ed25519 as i32
             && message.data.is_some()

--- a/apps/hubble/src/addon/src/store/verification_store.rs
+++ b/apps/hubble/src/addon/src/store/verification_store.rs
@@ -210,6 +210,13 @@ impl StoreDef for VerificationStoreDef {
         })
     }
 
+    fn make_compact_state_prefix(&self, _fid: u32) -> Result<Vec<u8>, HubError> {
+        Err(HubError {
+            code: "bad_request.invalid_param".to_string(),
+            message: "Verification Store doesn't support compact state".to_string(),
+        })
+    }
+
     fn get_prune_size_limit(&self) -> u32 {
         self.prune_size_limit
     }

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -13,6 +13,7 @@ import {
   HubServiceServer,
   HubServiceService,
   LinkAddMessage,
+  LinkCompactStateMessage,
   LinkRemoveMessage,
   Message,
   MessagesResponse,
@@ -1213,6 +1214,25 @@ export default class Server {
         });
         result?.match(
           (page: MessagesPage<LinkAddMessage | LinkRemoveMessage>) => {
+            callback(null, messagesPageToResponse(page));
+          },
+          (err: HubError) => {
+            callback(toServiceError(err));
+          },
+        );
+      },
+      getLinkCompactStateMessageByFid: async (call, callback) => {
+        const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
+        log.debug({ method: "getLinkCompactStateMessageByFid", req: call.request }, `RPC call from ${peer}`);
+
+        const { fid, pageSize, pageToken, reverse } = call.request;
+        const result = await this.engine?.getLinkCompactStateMessageByFid(fid, {
+          pageSize,
+          pageToken,
+          reverse,
+        });
+        result?.match(
+          (page: MessagesPage<LinkCompactStateMessage>) => {
             callback(null, messagesPageToResponse(page));
           },
           (err: HubError) => {

--- a/apps/hubble/src/rustfunctions.ts
+++ b/apps/hubble/src/rustfunctions.ts
@@ -639,6 +639,14 @@ export namespace rsLinkStore {
   ): Promise<RustMessagesPage> => {
     return await lib.getAllLinkMessagesByFid.call(store, fid, pageOptions);
   };
+
+  export const GetLinkCompactStateMessageByFid = async (
+    store: RustDynStore,
+    fid: number,
+    pageOptions: PageOptions,
+  ): Promise<RustMessagesPage> => {
+    return await lib.getLinkCompactStateMessageByFid.call(store, fid, pageOptions);
+  };
 }
 
 /**

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -20,6 +20,7 @@ import {
   isUsernameProofMessage,
   isVerificationAddAddressMessage,
   LinkAddMessage,
+  LinkCompactStateMessage,
   LinkRemoveMessage,
   MergeOnChainEventHubEvent,
   MergeUsernameProofHubEvent,
@@ -1026,6 +1027,26 @@ class Engine extends TypedEmitter<EngineEvents> {
     }
 
     return ResultAsync.fromPromise(this._linkStore.getAllLinkMessagesByFid(fid, pageOptions), (e) => e as HubError);
+  }
+
+  async getLinkCompactStateMessageByFid(
+    fid: number,
+    pageOptions: PageOptions = {},
+  ): HubAsyncResult<MessagesPage<LinkCompactStateMessage>> {
+    const versionCheck = ensureAboveTargetFarcasterVersion("2024.3.20");
+    if (versionCheck.isErr()) {
+      return err(versionCheck.error);
+    }
+
+    const validatedFid = validations.validateFid(fid);
+    if (validatedFid.isErr()) {
+      return err(validatedFid.error);
+    }
+
+    return ResultAsync.fromPromise(
+      this._linkStore.getLinkCompactStateMessageByFid(fid, pageOptions),
+      (e) => e as HubError,
+    );
   }
 
   /* -------------------------------------------------------------------------- */

--- a/apps/hubble/src/storage/stores/linkStore.ts
+++ b/apps/hubble/src/storage/stores/linkStore.ts
@@ -1,4 +1,10 @@
-import { getDefaultStoreLimit, LinkAddMessage, LinkRemoveMessage, StoreType } from "@farcaster/hub-nodejs";
+import {
+  getDefaultStoreLimit,
+  LinkAddMessage,
+  LinkCompactStateMessage,
+  LinkRemoveMessage,
+  StoreType,
+} from "@farcaster/hub-nodejs";
 import { makeFidKey, messageDecode } from "../../storage/db/message.js";
 import { UserPostfix } from "../db/types.js";
 import { MessagesPage, PageOptions, StorePruneOptions } from "./types.js";
@@ -125,6 +131,20 @@ class LinkStore extends RustStoreBase<LinkAddMessage, LinkRemoveMessage> {
     const messages =
       messages_page.messageBytes?.map((message_bytes) => {
         return messageDecode(new Uint8Array(message_bytes)) as LinkAddMessage | LinkRemoveMessage;
+      }) ?? [];
+
+    return { messages, nextPageToken: messages_page.nextPageToken };
+  }
+
+  async getLinkCompactStateMessageByFid(
+    fid: number,
+    pageOptions: PageOptions = {},
+  ): Promise<MessagesPage<LinkCompactStateMessage>> {
+    const messages_page = await rsLinkStore.GetLinkCompactStateMessageByFid(this._rustStore, fid, pageOptions);
+
+    const messages =
+      messages_page.messageBytes?.map((message_bytes) => {
+        return messageDecode(new Uint8Array(message_bytes)) as LinkCompactStateMessage;
       }) ?? [];
 
     return { messages, nextPageToken: messages_page.nextPageToken };

--- a/apps/hubble/src/storage/stores/linkStoreCompactState.test.ts
+++ b/apps/hubble/src/storage/stores/linkStoreCompactState.test.ts
@@ -131,6 +131,15 @@ describe("Merge LinkCompactState messages", () => {
     });
     const expectError4 = await ResultAsync.fromPromise(set.merge(linkRemove1), (e) => e as HubError);
     expect(expectError4.isErr()).toBe(true);
+
+    const result2 = await ResultAsync.fromPromise(set.getLinkCompactStateMessageByFid(fid), (e) => e as HubError);
+    expect(result2.isErr()).toBe(false);
+    const result2Value = result2._unsafeUnwrap();
+    expect(result2Value.messages.length).toBe(1);
+    expect(result2Value.messages[0].data.linkCompactStateBody.targetFids).toBe(1);
+    expect(result2Value.messages[0].data.linkCompactStateBody.targetFids[0]).toBe(
+      linkAdd1.data.linkBody.targetFid as number,
+    );
   });
 
   test("merge link compaction messages can remove all messages", async () => {

--- a/apps/hubble/src/storage/stores/linkStoreCompactState.test.ts
+++ b/apps/hubble/src/storage/stores/linkStoreCompactState.test.ts
@@ -136,8 +136,8 @@ describe("Merge LinkCompactState messages", () => {
     expect(result2.isErr()).toBe(false);
     const result2Value = result2._unsafeUnwrap();
     expect(result2Value.messages.length).toBe(1);
-    expect(result2Value.messages[0].data.linkCompactStateBody.targetFids).toBe(1);
-    expect(result2Value.messages[0].data.linkCompactStateBody.targetFids[0]).toBe(
+    expect(result2Value.messages[0]?.data.linkCompactStateBody?.targetFids.length).toBe(1);
+    expect(result2Value.messages[0]?.data.linkCompactStateBody?.targetFids[0]).toBe(
       linkAdd1.data.linkBody.targetFid as number,
     );
   });

--- a/apps/hubble/www/docs/docs/api.md
+++ b/apps/hubble/www/docs/docs/api.md
@@ -180,12 +180,13 @@ Users to retrieve valid or revoked reactions
 
 ## 5. Link Service
 
-| Method Name             | Request Type         | Response Type    | Description                                                  |
-| ----------------------- | -------------------- | ---------------- | ------------------------------------------------------------ |
-| GetLink                 | LinkRequest          | Message          | Returns a specific Link                                  |
-| GetLinksByFid           | LinksByFidRequest    | MessagesResponse | Returns Links made by an fid in reverse chron order      |
-| GetLinksByTarget        | LinksByTargetRequest | MessagesResponse | Returns LinkAdds for a given target in reverse chron order |
-| GetAllLinkMessagesByFid | FidRequest           | MessagesResponse | Returns Links made by an fid in reverse chron order      |
+| Method Name                     | Request Type         | Response Type    | Description                                                  |
+| ------------------------------- | -------------------- | ---------------- | ------------------------------------------------------------ |
+| GetLink                         | LinkRequest          | Message          | Returns a specific Link                                  |
+| GetLinksByFid                   | LinksByFidRequest    | MessagesResponse | Returns Links made by an fid in reverse chron order      |
+| GetLinksByTarget                | LinksByTargetRequest | MessagesResponse | Returns LinkAdds for a given target in reverse chron order |
+| GetAllLinkMessagesByFid         | FidRequest           | MessagesResponse | Returns Links made by an fid in reverse chron order      |
+| GetLinkCompactStateMessageByFid | FidRequest           | MessagesResponse | Returns the LinkCompactState message made by a fid       |
 
 #### Link Request
 

--- a/packages/core/src/protobufs/generated/message.ts
+++ b/packages/core/src/protobufs/generated/message.ts
@@ -288,7 +288,7 @@ export function userDataTypeToJSON(object: UserDataType): string {
   }
 }
 
-/** Type of Protocol to disambiguate verification addresses */
+/** Type of cast */
 export enum CastType {
   CAST = 0,
   LONG_CAST = 1,

--- a/packages/hub-nodejs/src/generated/message.ts
+++ b/packages/hub-nodejs/src/generated/message.ts
@@ -288,7 +288,7 @@ export function userDataTypeToJSON(object: UserDataType): string {
   }
 }
 
-/** Type of Protocol to disambiguate verification addresses */
+/** Type of cast */
 export enum CastType {
   CAST = 0,
   LONG_CAST = 1,

--- a/packages/hub-nodejs/src/generated/rpc.ts
+++ b/packages/hub-nodejs/src/generated/rpc.ts
@@ -404,6 +404,16 @@ export const HubServiceService = {
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
+  /** @http-api: none */
+  getLinkCompactStateMessageByFid: {
+    path: "/HubService/GetLinkCompactStateMessageByFid",
+    requestStream: false,
+    responseStream: false,
+    requestSerialize: (value: FidRequest) => Buffer.from(FidRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => FidRequest.decode(value),
+    responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
+  },
   /** Sync Methods */
   getInfo: {
     path: "/HubService/GetInfo",
@@ -562,6 +572,8 @@ export interface HubServiceServer extends UntypedServiceImplementation {
   getAllUserDataMessagesByFid: handleUnaryCall<FidRequest, MessagesResponse>;
   /** @http-api: none */
   getAllLinkMessagesByFid: handleUnaryCall<FidRequest, MessagesResponse>;
+  /** @http-api: none */
+  getLinkCompactStateMessageByFid: handleUnaryCall<FidRequest, MessagesResponse>;
   /** Sync Methods */
   getInfo: handleUnaryCall<HubInfoRequest, HubInfoResponse>;
   getCurrentPeers: handleUnaryCall<Empty, ContactInfoResponse>;
@@ -1098,6 +1110,22 @@ export interface HubServiceClient extends Client {
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   getAllLinkMessagesByFid(
+    request: FidRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: MessagesResponse) => void,
+  ): ClientUnaryCall;
+  /** @http-api: none */
+  getLinkCompactStateMessageByFid(
+    request: FidRequest,
+    callback: (error: ServiceError | null, response: MessagesResponse) => void,
+  ): ClientUnaryCall;
+  getLinkCompactStateMessageByFid(
+    request: FidRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: MessagesResponse) => void,
+  ): ClientUnaryCall;
+  getLinkCompactStateMessageByFid(
     request: FidRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,

--- a/packages/hub-web/src/generated/message.ts
+++ b/packages/hub-web/src/generated/message.ts
@@ -288,7 +288,7 @@ export function userDataTypeToJSON(object: UserDataType): string {
   }
 }
 
-/** Type of Cast */
+/** Type of cast */
 export enum CastType {
   CAST = 0,
   LONG_CAST = 1,

--- a/packages/hub-web/src/generated/rpc.ts
+++ b/packages/hub-web/src/generated/rpc.ts
@@ -143,6 +143,11 @@ export interface HubService {
   getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
   /** @http-api: none */
   getAllLinkMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  /** @http-api: none */
+  getLinkCompactStateMessageByFid(
+    request: DeepPartial<FidRequest>,
+    metadata?: grpcWeb.grpc.Metadata,
+  ): Promise<MessagesResponse>;
   /** Sync Methods */
   getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubInfoResponse>;
   getCurrentPeers(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<ContactInfoResponse>;
@@ -202,6 +207,7 @@ export class HubServiceClientImpl implements HubService {
     this.getAllVerificationMessagesByFid = this.getAllVerificationMessagesByFid.bind(this);
     this.getAllUserDataMessagesByFid = this.getAllUserDataMessagesByFid.bind(this);
     this.getAllLinkMessagesByFid = this.getAllLinkMessagesByFid.bind(this);
+    this.getLinkCompactStateMessageByFid = this.getLinkCompactStateMessageByFid.bind(this);
     this.getInfo = this.getInfo.bind(this);
     this.getCurrentPeers = this.getCurrentPeers.bind(this);
     this.getSyncStatus = this.getSyncStatus.bind(this);
@@ -360,6 +366,13 @@ export class HubServiceClientImpl implements HubService {
 
   getAllLinkMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetAllLinkMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
+  }
+
+  getLinkCompactStateMessageByFid(
+    request: DeepPartial<FidRequest>,
+    metadata?: grpcWeb.grpc.Metadata,
+  ): Promise<MessagesResponse> {
+    return this.rpc.unary(HubServiceGetLinkCompactStateMessageByFidDesc, FidRequest.fromPartial(request), metadata);
   }
 
   getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubInfoResponse> {
@@ -1137,6 +1150,29 @@ export const HubServiceGetAllUserDataMessagesByFidDesc: UnaryMethodDefinitionish
 
 export const HubServiceGetAllLinkMessagesByFidDesc: UnaryMethodDefinitionish = {
   methodName: "GetAllLinkMessagesByFid",
+  service: HubServiceDesc,
+  requestStream: false,
+  responseStream: false,
+  requestType: {
+    serializeBinary() {
+      return FidRequest.encode(this).finish();
+    },
+  } as any,
+  responseType: {
+    deserializeBinary(data: Uint8Array) {
+      const value = MessagesResponse.decode(data);
+      return {
+        ...value,
+        toObject() {
+          return value;
+        },
+      };
+    },
+  } as any,
+};
+
+export const HubServiceGetLinkCompactStateMessageByFidDesc: UnaryMethodDefinitionish = {
+  methodName: "GetLinkCompactStateMessageByFid",
   service: HubServiceDesc,
   requestStream: false,
   responseStream: false,

--- a/packages/shuttle/src/shuttle/hubEventProcessor.ts
+++ b/packages/shuttle/src/shuttle/hubEventProcessor.ts
@@ -3,6 +3,7 @@ import {
   isCastAddMessage,
   isCastRemoveMessage,
   isLinkAddMessage,
+  isLinkCompactStateMessage,
   isLinkRemoveMessage,
   isMergeMessageHubEvent,
   isPruneMessageHubEvent,
@@ -72,7 +73,7 @@ export class HubEventProcessor {
       return "deleted";
     }
     // Links
-    if (isAdd && isLinkAddMessage(message)) {
+    if ((isAdd && isLinkAddMessage(message)) || (isAdd && isLinkCompactStateMessage(message))) {
       return "created";
     } else if ((isAdd && isLinkRemoveMessage(message)) || (!isAdd && isLinkAddMessage(message))) {
       return "deleted";

--- a/protobufs/schemas/rpc.proto
+++ b/protobufs/schemas/rpc.proto
@@ -91,6 +91,8 @@ service HubService {
   rpc GetAllUserDataMessagesByFid(FidRequest) returns (MessagesResponse);
   // @http-api: none
   rpc GetAllLinkMessagesByFid(FidRequest) returns (MessagesResponse);
+  // @http-api: none
+  rpc GetLinkCompactStateMessageByFid(FidRequest) returns (MessagesResponse);
 
   // Sync Methods    
   rpc GetInfo(HubInfoRequest) returns (HubInfoResponse);


### PR DESCRIPTION
## Motivation

Currently, our retrieval of Link messages only show adds/removes, compact state messages serving as silent tombstones. This is fine for getting a quick set of adds/removes as they currently apply, but may produce confusing state when looking at two hubs, where one has the message, and the other doesn't, and trying to reconcile why some messages are missing from the one with the LinkCompactState message and not the other.

## Change Summary

This change adds a new rpc GetLinkCompactStateMessageByFid, which returns the relevant compact state message, if present.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR standardizes the naming convention for `CastType` across multiple files and adds support for `LinkCompactStateMessage` handling in various store modules and RPC methods.

### Detailed summary
- Standardized `CastType` naming convention to `cast` in multiple files
- Added support for `LinkCompactStateMessage` in store modules and RPC methods

> The following files were skipped due to too many changes: `apps/hubble/www/docs/docs/api.md`, `packages/hub-nodejs/src/generated/rpc.ts`, `packages/hub-web/src/generated/rpc.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->