### PR TITLE
chore: Segment bundle delay stats by message status

### DIFF
--- a/.changeset/eight-bags-fetch.md
+++ b/.changeset/eight-bags-fetch.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+chore: Segment bundle delay stats by message status


### PR DESCRIPTION
## Motivation

Segment bundle delay stats by message status

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on segmenting bundle delay stats by message status in the `handleGossipMessage` function of `Hubble`.

### Detailed summary
- Added tracking of bundle delay stats for invalid, success, and failure cases
- Segmented bundle delay stats based on message status
- Improved reporting logic for gossip messages in `handleGossipMessage`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->