### PR TITLE
cli tool for computing sync health and exploring causes for message diffs

### DIFF
--- a/.changeset/honest-flies-jog.md
+++ b/.changeset/honest-flies-jog.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": minor
+---
+
+CLI tool for measuring sync health

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -30,6 +30,7 @@ import { profileGossipServer } from "./profile/gossipProfile.js";
 import { getStatsdInitialization, initializeStatsd } from "./utils/statsd.js";
 import os from "os";
 import { startupCheck, StartupCheckStatus } from "./utils/startupCheck.js";
+import { printSyncHealth } from "./utils/syncHealth.js";
 import { mainnet, optimism } from "viem/chains";
 import { finishAllProgressBars } from "./utils/progressBars.js";
 import { MAINNET_BOOTSTRAP_PEERS } from "./bootstrapPeers.mainnet.js";
@@ -940,6 +941,21 @@ const readPeerId = async (filePath: string) => {
   const proto = await readFile(filePath);
   return createFromProtobuf(proto);
 };
+
+/*//////////////////////////////////////////////////////////////
+                          SYNC HEALTH COMMAND
+//////////////////////////////////////////////////////////////*/
+
+app
+  .command("sync-health")
+  .description("Measure sync health")
+  .option("-s, --start-seconds-ago <number>", "How many seconds ago to start the sync health query", "600")
+  .option("--span <seconds>", "How many seconds to count over", "30")
+  .option("--max-num-peers <count>", "Maximum number of peers to measure for", "20")
+  .option("--primary-node <host:port>", "Node to measure all peers against (required)", "hoyt.farcaster.xyz:2283")
+  .action(async (cliOptions) => {
+    await printSyncHealth(cliOptions.startSecondsAgo, cliOptions.span, cliOptions.maxNumPeers, cliOptions.primaryNode);
+  });
 
 app.parse(process.argv);
 

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -949,12 +949,19 @@ const readPeerId = async (filePath: string) => {
 app
   .command("sync-health")
   .description("Measure sync health")
-  .option("-s, --start-seconds-ago <number>", "How many seconds ago to start the sync health query", "600")
-  .option("--span <seconds>", "How many seconds to count over", "30")
+  .requiredOption("--start-time-ofday <time>", "How many seconds ago to start the sync health query")
+  .requiredOption("--stop-time-ofday <time>", "How many seconds to count over")
   .option("--max-num-peers <count>", "Maximum number of peers to measure for", "20")
   .option("--primary-node <host:port>", "Node to measure all peers against (required)", "hoyt.farcaster.xyz:2283")
+  .option("--outfile <filename>", "File to output measurements to", "health.out")
   .action(async (cliOptions) => {
-    await printSyncHealth(cliOptions.startSecondsAgo, cliOptions.span, cliOptions.maxNumPeers, cliOptions.primaryNode);
+    await printSyncHealth(
+      cliOptions.startTimeOfday,
+      cliOptions.stopTimeOfday,
+      cliOptions.maxNumPeers,
+      cliOptions.primaryNode,
+      cliOptions.outfile,
+    );
   });
 
 app.parse(process.argv);

--- a/apps/hubble/src/utils/syncHealth.ts
+++ b/apps/hubble/src/utils/syncHealth.ts
@@ -1,0 +1,309 @@
+import {
+  Metadata,
+  getInsecureHubRpcClient,
+  getSSLHubRpcClient,
+  toFarcasterTime,
+  TrieNodePrefix,
+  HubResult,
+  HubRpcClient,
+  TrieNodeMetadataResponse,
+} from "@farcaster/hub-nodejs";
+
+import { addressInfoFromGossip, addressInfoToString } from "./p2p.js";
+
+import { timestampToPaddedTimestampPrefix } from "../network/sync/syncId.js";
+import { err, ok } from "neverthrow";
+
+class SyncHealthStats {
+  primaryNumMessages: number;
+  peerNumMessages: number;
+
+  constructor(primaryNumMessages: number, peerNumMessages: number) {
+    this.primaryNumMessages = primaryNumMessages;
+    this.peerNumMessages = peerNumMessages;
+  }
+
+  computeDiff = () => {
+    return this.primaryNumMessages - this.peerNumMessages;
+  };
+
+  computeDiffPercentage = () => {
+    return this.computeDiff() / this.primaryNumMessages;
+  };
+}
+
+const RPC_TIMEOUT_SECONDS = 2;
+
+const getTimePrefix = (time: number) => {
+  return toFarcasterTime(time).map((farcasterTime) => {
+    return Buffer.from(timestampToPaddedTimestampPrefix(farcasterTime));
+  });
+};
+
+const getMetadata = (timePrefix: Buffer, rpcClient: HubRpcClient): Promise<HubResult<TrieNodeMetadataResponse>> => {
+  return rpcClient.getSyncMetadataByPrefix(TrieNodePrefix.create({ prefix: timePrefix }), new Metadata(), {
+    deadline: Date.now() + RPC_TIMEOUT_SECONDS * 1000,
+  });
+};
+
+const getCommonPrefix = (prefix1: Buffer, prefix2: Buffer): Buffer => {
+  const commonPrefix = [];
+  for (let i = 0; i < Math.min(prefix1.length, prefix2.length); i++) {
+    const startValue = prefix1[i];
+    const stopValue = prefix2[i];
+    if (startValue !== undefined && startValue === stopValue) {
+      commonPrefix.push(startValue);
+    } else {
+      break;
+    }
+  }
+  return Buffer.from(commonPrefix);
+};
+
+const isPrefix = (prefix1: Buffer, prefix2: Buffer): boolean => {
+  return prefix1.toString().startsWith(prefix2.toString());
+};
+
+// Currently unused but will be useful for understanding where diffs are coming from. It's also an alternate way to get message counts and can replace traverseRange
+const traverseSubtree = async (
+  node: TrieNodeMetadataResponse,
+  startTimePrefix: Buffer,
+  stopTimePrefix: Buffer,
+  rpcClient: HubRpcClient,
+  f: (node: TrieNodeMetadataResponse) => undefined,
+) => {
+  const metadata = await getMetadata(Buffer.from(node.prefix), rpcClient);
+
+  if (metadata.isErr()) {
+    return err(metadata.error);
+  }
+
+  f(metadata.value);
+
+  for (const child of metadata.value.children) {
+    const childValue = Buffer.from(child.prefix);
+    const notBeforeStart = Buffer.compare(childValue, startTimePrefix) !== -1;
+    const notAfterStop = Buffer.compare(childValue, stopTimePrefix) !== 1;
+    const onStartPath = isPrefix(startTimePrefix, childValue);
+    if ((onStartPath || notBeforeStart) && notAfterStop) {
+      await traverseSubtree(child, startTimePrefix, stopTimePrefix, rpcClient, f);
+    }
+  }
+
+  return ok(undefined);
+};
+
+const traverseRange = async (
+  node: TrieNodeMetadataResponse,
+  startTimePrefix: Buffer,
+  stopTimePrefix: Buffer,
+  rpcClient: HubRpcClient,
+  f: (node: TrieNodeMetadataResponse) => undefined,
+) => {
+  const metadata = await getMetadata(Buffer.from(node.prefix), rpcClient);
+
+  if (metadata.isErr()) {
+    return err(metadata.error);
+  }
+
+  for (const child of metadata.value.children) {
+    const childValue = Buffer.from(child.prefix);
+    if (Buffer.compare(childValue, startTimePrefix) === 0) {
+      f(child);
+    } else if (isPrefix(startTimePrefix, childValue) || isPrefix(stopTimePrefix, childValue)) {
+      await traverseRange(child, startTimePrefix, stopTimePrefix, rpcClient, f);
+    } else if (Buffer.compare(childValue, startTimePrefix) === 1 && Buffer.compare(childValue, stopTimePrefix) === -1) {
+      f(child);
+    }
+  }
+
+  return ok(undefined);
+};
+
+// Queries for the number of messages between the start time and stop time and is efficient with respect to the number of rpcs to the peer. It only queries down along the start prefix and stop prefix starting at the common prefix.
+
+const getNumMessagesInSpanOptimized = async (rpcClient: HubRpcClient, startTime: number, stopTime: number) => {
+  const startTimePrefix = getTimePrefix(startTime);
+  if (startTimePrefix.isErr()) {
+    return err(startTimePrefix.error);
+  }
+
+  const stopTimePrefix = getTimePrefix(stopTime);
+
+  if (stopTimePrefix.isErr()) {
+    return err(stopTimePrefix.error);
+  }
+
+  const commonPrefix = getCommonPrefix(startTimePrefix.value, stopTimePrefix.value);
+
+  const commonPrefixMetadata = await getMetadata(Buffer.from(commonPrefix), rpcClient);
+
+  if (commonPrefixMetadata.isErr()) {
+    return err(commonPrefixMetadata.error);
+  }
+
+  let numMessages = 0;
+  const result = await traverseRange(
+    commonPrefixMetadata.value,
+    startTimePrefix.value,
+    stopTimePrefix.value,
+    rpcClient,
+    (node: TrieNodeMetadataResponse) => {
+      numMessages += node.numMessages;
+    },
+  );
+
+  if (result.isErr()) {
+    return err(result.error);
+  }
+
+  return ok(numMessages);
+};
+
+// Queries for the number of messages between the start time and stop time and is very simple. It queries once per second and works if the time span is short.
+const getNumMessagesInSpan = async (rpcClient: HubRpcClient, startTime: number, stopTime: number) => {
+  let numMessages = 0;
+
+  for (let i = startTime; i < stopTime; i += 1000) {
+    const timePrefix = getTimePrefix(i);
+
+    if (timePrefix.isErr()) {
+      return err(timePrefix.error);
+    }
+
+    const metadata = await getMetadata(timePrefix.value, rpcClient);
+
+    if (metadata.isErr()) {
+      return err(metadata.error);
+    }
+
+    numMessages += metadata.value.numMessages;
+  }
+
+  return ok(numMessages);
+};
+
+const computeSyncHealthStats = async (
+  startTime: number,
+  stopTime: number,
+  primaryRpcClient: HubRpcClient,
+  peer2RpcClient: HubRpcClient,
+  getNumMessagesInSpan: (rpcClient: HubRpcClient, startTime: number, stopTime: number) => Promise<HubResult<number>>,
+) => {
+  const numMessagesPrimary = await getNumMessagesInSpan(primaryRpcClient, startTime, stopTime);
+  const numMessagesPeer = await getNumMessagesInSpan(peer2RpcClient, startTime, stopTime);
+
+  if (numMessagesPrimary.isErr()) {
+    return err(numMessagesPrimary.error);
+  }
+
+  if (numMessagesPeer.isErr()) {
+    return err(numMessagesPeer.error);
+  }
+
+  console.log("Primary node num messages", numMessagesPrimary.value);
+  console.log("Peer num messages", numMessagesPeer.value);
+
+  return ok(new SyncHealthStats(numMessagesPrimary.value, numMessagesPeer.value));
+};
+
+const pickPeers = async (rpcClient: HubRpcClient, count: number): Promise<HubResult<(string | undefined)[]>> => {
+  const peers = await rpcClient.getCurrentPeers({});
+  return peers.map((peers) => {
+    // Shuffle peers then pick [count]
+    return peers.contacts
+      .map((value) => ({ value, sort: Math.random() }))
+      .sort((a, b) => a.sort - b.sort)
+      .map(({ value }) => value)
+      .slice(0, count)
+      .map((peer) => {
+        if (peer.rpcAddress) {
+          const addrInfo = addressInfoFromGossip(peer.rpcAddress);
+          if (addrInfo.isOk()) {
+            return addressInfoToString(addrInfo.value);
+          }
+        }
+        return;
+      });
+  });
+};
+
+export const printSyncHealth = async (
+  rangeStartSecondsAgo: number,
+  rangeSpanSeconds: number,
+  maxNumPeers: number,
+  primaryNode: string,
+) => {
+  const startTime = Math.floor((Date.now() - rangeStartSecondsAgo * 1000) / 1000) * 1000;
+  const stopTime = startTime + rangeSpanSeconds * 1000;
+  console.log("Start time: %d, Stop time: %d", startTime, stopTime);
+  const node1RpcClient = getSSLHubRpcClient(primaryNode);
+
+  let numErrors = 0;
+  let numSuccess = 0;
+  let sumScores = 0;
+
+  node1RpcClient.$.waitForReady(Date.now() + RPC_TIMEOUT_SECONDS * 1000, async (err) => {
+    if (err) {
+      console.log("Primary rpc client not ready", err);
+      throw Error();
+    } else {
+      const peers = await pickPeers(node1RpcClient, maxNumPeers);
+      if (peers.isErr()) {
+        console.log("Error querying peers");
+        return;
+      }
+
+      for (const peer of peers.value) {
+        if (peer === undefined) {
+          continue;
+        }
+        let peerRpcClient;
+
+        try {
+          // Most hubs seem to work with the insecure one
+          peerRpcClient = getInsecureHubRpcClient(peer);
+
+          peerRpcClient.$.waitForReady(Date.now() + RPC_TIMEOUT_SECONDS * 1000, (err) => {
+            if (err) {
+              peerRpcClient = getSSLHubRpcClient(peer);
+            }
+          });
+        } catch (e) {
+          peerRpcClient = getSSLHubRpcClient(peer);
+        }
+
+        try {
+          const syncHealthStats = await computeSyncHealthStats(
+            startTime,
+            stopTime,
+            node1RpcClient,
+            peerRpcClient,
+            // getNumMessagesInSpan, keeping this in here so it's easy to flip which computation we use. This one is simpler.
+            getNumMessagesInSpanOptimized,
+          );
+          if (syncHealthStats.isOk()) {
+            // Sync health is us relative to peer. If the sync health is high, means we have more messages. If it's low, we have less.
+            const score = syncHealthStats.value.computeDiff();
+            console.log("Peer:", peer);
+            console.log("Message count diff: %d", score);
+            console.log("Message count diff percentage: %d", syncHealthStats.value.computeDiffPercentage());
+            console.log();
+            numSuccess++;
+            sumScores += score;
+          } else {
+            numErrors++;
+          }
+          peerRpcClient.close();
+        } catch (err) {
+          numErrors += 1;
+        }
+      }
+    }
+
+    console.log("Error count: %d", numErrors);
+    console.log("Average health: %d", sumScores / numSuccess);
+
+    node1RpcClient.close();
+  });
+};


### PR DESCRIPTION
## Motivation

We want a better metric than current number of messages (i.e. "sync percent") for measuring sync health. It doesn't account for the fact that there are valid reasons for temporary displacements in message counts (i.e. compaction, small network delays). Instead, we want to take some chunk of time in the past and count up messages in that chunk and compare the counts as a somewhat more evolved sync metric. 

## Change Summary

CLI command that computes sync health between one node and peers, explores nonzero diffs, and prints out summarized, structured output. 

```
❯ node build/cli.js sync-health --max-num-peers 50 --primary-node lamia.farcaster.xyz:2283 --start-time-ofday 11:30:00 --stop-time-ofday 11:35:00
❯ cat health.out  |  jq
{
  "startTime": "2024-06-21T15:15:00.000Z",
  "stopTime": "2024-06-21T15:17:00.000Z",
  "primary": "hoyt.farcaster.xyz:2283",
  "peer": "84.247.160.59:2283",
  "primaryMessageCount": 5311,
  "peerMessageCount": 4930,
  "diff": 381,
  "diffPercentage": 0.0717379024665788,
  "numSuccessToPeer": 378,
  "numErrorToPeer": 6,
  "successTypesToPeer": [
    null,
    3,
    2,
    6
  ],
  "errorMessagesToPeer": [
    "no storage",
    "invalid signer: signer 0x02c2f67b36cec88270462f95d7c553d13bc339be61c02db591c9144fcf2592dd not found for fid 681926"
  ],
  "numSuccessToPrimary": 0,
  "numErrorToPrimary": 0,
  "successTypesToPrimary": [],
  "errorMessagesToPrimary": []
}
```

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a CLI tool `hubble` for measuring sync health. It includes commands to measure sync health and calculates message statistics between nodes.

### Detailed summary
- Added `sync-health` command to measure sync health
- Introduced classes for message stats and sync health stats
- Implemented functions to query message counts and compute stats
- Added functions to pick peers and compute sync IDs

> The following files were skipped due to too many changes: `apps/hubble/src/utils/syncHealth.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->