### PR TITLE
fix: Ensure patch files are included in Docker environment during build

### DIFF
--- a/Dockerfile.hubble
+++ b/Dockerfile.hubble
@@ -41,6 +41,7 @@ ENV RUSTFLAGS="-C target-feature=-crt-static"
 COPY --chown=node:node --from=prune /home/node/app/out/json/ .
 COPY --chown=node:node --from=prune /home/node/app/out/yarn.lock ./yarn.lock
 
+COPY --chown=node:node patches patches
 RUN yarn install --frozen-lockfile --network-timeout 1800000
 RUN yarn postinstall
 


### PR DESCRIPTION
## Motivation

We weren't including these files, so `yarn postinstall` didn't work as expected.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new directory `patches` to the Docker image, running `yarn install` with specific options, and executing `yarn postinstall`.

### Detailed summary
- Added `patches` directory to Docker image
- Ran `yarn install` with `--frozen-lockfile --network-timeout 1800000`
- Executed `yarn postinstall`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->