### PR TITLE
fix(docs): corrected errors in installation instructions

### DIFF
--- a/apps/hubble/www/docs/intro/install.md
+++ b/apps/hubble/www/docs/intro/install.md
@@ -8,7 +8,7 @@ Hubble can be installed in 30 minutes, and a full sync can take 1-2 hours to com
 
 - 16 GB of RAM
 - 4 CPU cores or vCPUs
-- 140 GB of free storage
+- 160 GB of free storage
 - A public IP address with ports 2282 - 2285 exposed
 
 See [tutorials](./tutorials.html) for instructions on how to set up cloud providers to run Hubble.

--- a/apps/hubble/www/docs/tutorials/gcp.md
+++ b/apps/hubble/www/docs/tutorials/gcp.md
@@ -44,7 +44,7 @@ resource "google_compute_instance" "farcaster-hub-vm" {
   boot_disk {
     initialize_params {
       image = "ubuntu-2004-focal-v20231213"  # Ubuntu 20.04 LTS image URL
-      size = 60  # 60 GB disk size
+      size = 160  # 160 GB disk size
     }
   }
 


### PR DESCRIPTION
Fixes issue #2086 

## Motivation

Due to errors or outdated information in the Farcaster Hub installation guides, the Hub cannot be synchronized due to lack of memory which will prevent it from starting and working correctly. This error is very important because it creates difficulties for new users at the very initial stage of work and familiarization with Farcaster Hub

## Change Summary

Changes have been made regarding the minimum amount of memory required for Farcaster Hub to work correctly. The old value is 60 GB in the GCP installation guide and 140 GB is the old value in the main installation guide. Farcaster Hub currently takes up about 150 GB. The old memory values have been changed to 160 GB, which allows you to run the Hub and have a reserve of correct operation for a period of time

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

According to the GCP guide we create a virtual server and set the server parameters via Google Cloud Console by copying the data from the guide into the created file "main.tf"
![1 screenshot](https://github.com/farcasterxyz/hub-monorepo/assets/80642652/ae6bbd6e-a3ee-4129-978d-896d932d8c35)

The virtual server has been configured with these memory settings
![2 screenshot](https://github.com/farcasterxyz/hub-monorepo/assets/80642652/ae81634a-d66f-436f-a107-5417f26cf4b4)

Then after running the script specified in the main installation guide on the created server Hub starts synchronization, but after a while it stops with the error "code 2".
![3 screenshot](https://github.com/farcasterxyz/hub-monorepo/assets/80642652/3696c741-1234-4834-8218-ed71c179e1af)

This error means that Hub cannot continue synchronization due to lack of memory 
![4 screenshot](https://github.com/farcasterxyz/hub-monorepo/assets/80642652/57aa5e65-b419-4385-ba5c-ca678c4bb60a)

Warpcast: @vsu 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR increases the disk size for the Ubuntu 20.04 LTS image in the GCP tutorial and adjusts the storage requirement to 160 GB in the installation guide.

### Detailed summary
- Increased disk size for Ubuntu 20.04 LTS image to 160 GB in GCP tutorial
- Adjusted storage requirement to 160 GB in the installation guide

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->