### PR TITLE
fix: Ensure we run `yarn postinstall` script for production build

### DIFF
--- a/Dockerfile.hubble
+++ b/Dockerfile.hubble
@@ -55,7 +55,7 @@ COPY --chown=node:node protobufs protobufs
 RUN yarn build
 
 # Purge dev dependencies and only install production dependencies
-RUN rm -rf node_modules && yarn install --production --ignore-scripts --prefer-offline --force --frozen-lockfile
+RUN rm -rf node_modules && yarn install --production --ignore-scripts --prefer-offline --force --frozen-lockfile && yarn postinstall
 
 ###############################################################################
 ########## Stage 3: Copy over the built code to a leaner alpine image #########


### PR DESCRIPTION
## Motivation

We were still missing the patch in production.

## Change Summary

Ensure we run `postinstall` in production as well.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on optimizing the Docker build process by adding a `yarn postinstall` step after installing production dependencies.

### Detailed summary
- Added `yarn postinstall` step after installing production dependencies in the Dockerfile.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->