### PR TITLE
fix: Use stricter socket timeout for gossip

### DIFF
--- a/.changeset/wicked-masks-study.md
+++ b/.changeset/wicked-masks-study.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Use stricter socket timeout for gossip

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -142,6 +142,11 @@ export class LibP2PNode {
       ? process.env["GOSSIPSUB_FLOOD_PUBLISH"] === "true"
       : false;
 
+    // Default timeout is 5 mins, which is too long for us
+    const socketTimeout = process.env["GOSSIPSUB_SOCKET_TIMEOUT"]
+      ? parseInt(process.env["GOSSIPSUB_SOCKET_TIMEOUT"])
+      : 30000;
+
     const gossip = gossipsub({
       allowPublishToZeroPeers: true,
       asyncValidation: true, // Do not forward messages until we've merged it (prevents forwarding known bad messages)
@@ -202,7 +207,9 @@ export class LibP2PNode {
           listen: [listenMultiAddrStr],
           announce: announceMultiAddrStrList,
         },
-        transports: [tcp()],
+        transports: [
+          tcp({ inboundSocketInactivityTimeout: socketTimeout, outboundSocketInactivityTimeout: socketTimeout }),
+        ],
         streamMuxers: [mplex()],
         connectionEncryption: [noise()],
         pubsub: gossip,


### PR DESCRIPTION
## Motivation

Gossip metrics indicate the worker sometimes stalls for 5 mins before receiving messages in a burst. Likely due to one or more bad peers. The default socket timeout is 5 mins, set this to 30seconds to see if it helps. 

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `hubble` package to use a stricter socket timeout for gossip communication in the `gossipNodeWorker.ts` file.

### Detailed summary
- Updated the socket timeout for gossip communication to be stricter (30 seconds).
- Modified the `transports` configuration to include the new socket timeout settings.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->