### PR TITLE
fix: hub p2p failures

### DIFF
--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1397,7 +1397,7 @@ export class Hub implements HubInterface {
   }
 
   private async handleContactInfo(peerId: PeerId, content: ContactInfoContent): Promise<boolean> {
-    // statsd().gauge("peer_store.count", await this.gossipNode.peerStoreCount());
+    statsd().gauge("peer_store.count", await this.gossipNode.peerStoreCount());
 
     let message: ContactInfoContentBody = content.body
       ? content.body

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1388,8 +1388,8 @@ export class Hub implements HubInterface {
         return err(new HubError("bad_request.invalid_param", "Unknown message type while handlgGossipMessage"));
       }
     } else if (gossipMessage.contactInfoContent) {
-      const _ = await this.handleContactInfo(peerIdResult.value, gossipMessage.contactInfoContent);
-      await this.gossipNode.reportValid(msgId, peerIdFromString(source.toString()).toBytes(), false);
+      const result = await this.handleContactInfo(peerIdResult.value, gossipMessage.contactInfoContent);
+      await this.gossipNode.reportValid(msgId, peerIdFromString(source.toString()).toBytes(), result);
       return ok(undefined);
     } else {
       return err(new HubError("bad_request.invalid_param", "invalid message type"));

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -823,7 +823,6 @@ parentPort?.on("message", async (msg: LibP2PNodeMethodGenericMessage) => {
       const sourceId = peerIdFromBytes(source);
       await libp2pNode.reportValid(msgId, sourceId, isValid);
 
-      const postMessageStart = Date.now();
       parentPort?.postMessage({
         methodCallId,
         result: makeResult<"reportValid">(undefined),

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -203,6 +203,14 @@ export class LibP2PNode {
         // Only set optional fields if defined to avoid errors
         ...(peerId && { peerId }),
         connectionGater: this._connectionGater,
+        connectionManager: {
+          maxConnections: 256,
+          dialTimeout: 2000,
+          inboundUpgradeTimeout: 2000,
+          maxEventLoopDelay: 5000,
+          maxAddrsToDial: 3,
+          inboundConnectionThreshold: 2,
+        },
         addresses: {
           listen: [listenMultiAddrStr],
           announce: announceMultiAddrStrList,

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -616,13 +616,9 @@ parentPort?.on("message", async (msg: LibP2PNodeMethodGenericMessage) => {
     case "allPeerIds": {
       const peerIds = libp2pNode.allPeerIds();
 
-      const postMessageStart = Date.now();
       parentPort?.postMessage({
         methodCallId,
         result: makeResult<"allPeerIds">(peerIds),
-      });
-      statsd().timing("gossip.worker.parent_port_post_message", Date.now() - postMessageStart, 1, {
-        method: "allPeerIds",
       });
       break;
     }
@@ -631,26 +627,18 @@ parentPort?.on("message", async (msg: LibP2PNodeMethodGenericMessage) => {
       const [peerId, multiaddr] = specificMsg.args;
 
       await libp2pNode.addPeerToAddressBook(await createFromProtobuf(peerId), MultiAddr.multiaddr(multiaddr));
-      const postMessageStart = Date.now();
       parentPort?.postMessage({
         methodCallId,
         result: makeResult<"addToAddressBook">(undefined),
-      });
-      statsd().timing("gossip.worker.parent_port_post_message", Date.now() - postMessageStart, 1, {
-        method: "addToAddressBook",
       });
       break;
     }
     case "peerStoreCount": {
       const count = await libp2pNode.peerStoreCount();
 
-      const postMessageStart = Date.now();
       parentPort?.postMessage({
         methodCallId,
         result: makeResult<"peerStoreCount">(count),
-      });
-      statsd().timing("gossip.worker.parent_port_post_message", Date.now() - postMessageStart, 1, {
-        method: "peerStoreCount",
       });
       break;
     }
@@ -673,7 +661,6 @@ parentPort?.on("message", async (msg: LibP2PNodeMethodGenericMessage) => {
       const [multiaddr] = specificMsg.args;
 
       const result = await libp2pNode.connectAddress(MultiAddr.multiaddr(multiaddr));
-      const postMessageStart = Date.now();
       parentPort?.postMessage({
         methodCallId,
         result: makeResult<"connectAddress">({
@@ -681,9 +668,6 @@ parentPort?.on("message", async (msg: LibP2PNodeMethodGenericMessage) => {
           errorType: result?.isErr() ? result.error.errCode : undefined,
           errorMessage: result?.isErr() ? result.error.message : undefined,
         }),
-      });
-      statsd().timing("gossip.worker.parent_port_post_message", Date.now() - postMessageStart, 1, {
-        method: "connectAddress",
       });
       break;
     }
@@ -756,7 +740,6 @@ parentPort?.on("message", async (msg: LibP2PNodeMethodGenericMessage) => {
       const publishResult = await libp2pNode.broadcastMessage(Message.decode(message));
       const combinedResult = Result.combine(publishResult ?? []);
 
-      const postMessageStart = Date.now();
       parentPort?.postMessage({
         methodCallId,
         result: makeResult<"broadcastMessage">({
@@ -767,9 +750,6 @@ parentPort?.on("message", async (msg: LibP2PNodeMethodGenericMessage) => {
             ? combinedResult.value.flatMap((r) => r.recipients).map((p) => exportToProtobuf(p))
             : [],
         }),
-      });
-      statsd().timing("gossip.worker.parent_port_post_message", Date.now() - postMessageStart, 1, {
-        method: "broadcastMessage",
       });
       break;
     }
@@ -847,9 +827,6 @@ parentPort?.on("message", async (msg: LibP2PNodeMethodGenericMessage) => {
       parentPort?.postMessage({
         methodCallId,
         result: makeResult<"reportValid">(undefined),
-      });
-      statsd().timing("gossip.worker.parent_port_post_message", Date.now() - postMessageStart, 1, {
-        method: "reportValid",
       });
       break;
     }

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -198,13 +198,20 @@ export class LibP2PNode {
     }
     this._connectionGater = new ConnectionFilter(options.allowedPeerIdStrs, options.deniedPeerIdStrs);
 
+    // libp2p default max connections is infinity, which is too high
+    const maxConnections = process.env["LIBP2P_MAX_CONNECTIONS"]
+      ? parseInt(process.env["LIBP2P_MAX_CONNECTIONS"])
+      : 256;
+
     const result = await ResultAsync.fromPromise(
       createLibp2p({
         // Only set optional fields if defined to avoid errors
         ...(peerId && { peerId }),
         connectionGater: this._connectionGater,
         connectionManager: {
-          maxConnections: 256,
+          // Hub CRDTs stream messages, and setting min to 1 guards against max being set to 0 erroneously
+          minConnections: 1,
+          maxConnections: maxConnections,
           dialTimeout: 2000,
           inboundUpgradeTimeout: 2000,
           maxEventLoopDelay: 5000,

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -607,9 +607,14 @@ parentPort?.on("message", async (msg: LibP2PNodeMethodGenericMessage) => {
     }
     case "allPeerIds": {
       const peerIds = libp2pNode.allPeerIds();
+
+      const postMessageStart = Date.now();
       parentPort?.postMessage({
         methodCallId,
         result: makeResult<"allPeerIds">(peerIds),
+      });
+      statsd().timing("gossip.worker.parent_port_post_message", Date.now() - postMessageStart, 1, {
+        method: "allPeerIds",
       });
       break;
     }
@@ -618,18 +623,26 @@ parentPort?.on("message", async (msg: LibP2PNodeMethodGenericMessage) => {
       const [peerId, multiaddr] = specificMsg.args;
 
       await libp2pNode.addPeerToAddressBook(await createFromProtobuf(peerId), MultiAddr.multiaddr(multiaddr));
+      const postMessageStart = Date.now();
       parentPort?.postMessage({
         methodCallId,
         result: makeResult<"addToAddressBook">(undefined),
+      });
+      statsd().timing("gossip.worker.parent_port_post_message", Date.now() - postMessageStart, 1, {
+        method: "addToAddressBook",
       });
       break;
     }
     case "peerStoreCount": {
       const count = await libp2pNode.peerStoreCount();
 
+      const postMessageStart = Date.now();
       parentPort?.postMessage({
         methodCallId,
         result: makeResult<"peerStoreCount">(count),
+      });
+      statsd().timing("gossip.worker.parent_port_post_message", Date.now() - postMessageStart, 1, {
+        method: "peerStoreCount",
       });
       break;
     }
@@ -652,6 +665,7 @@ parentPort?.on("message", async (msg: LibP2PNodeMethodGenericMessage) => {
       const [multiaddr] = specificMsg.args;
 
       const result = await libp2pNode.connectAddress(MultiAddr.multiaddr(multiaddr));
+      const postMessageStart = Date.now();
       parentPort?.postMessage({
         methodCallId,
         result: makeResult<"connectAddress">({
@@ -659,6 +673,9 @@ parentPort?.on("message", async (msg: LibP2PNodeMethodGenericMessage) => {
           errorType: result?.isErr() ? result.error.errCode : undefined,
           errorMessage: result?.isErr() ? result.error.message : undefined,
         }),
+      });
+      statsd().timing("gossip.worker.parent_port_post_message", Date.now() - postMessageStart, 1, {
+        method: "connectAddress",
       });
       break;
     }
@@ -731,6 +748,7 @@ parentPort?.on("message", async (msg: LibP2PNodeMethodGenericMessage) => {
       const publishResult = await libp2pNode.broadcastMessage(Message.decode(message));
       const combinedResult = Result.combine(publishResult ?? []);
 
+      const postMessageStart = Date.now();
       parentPort?.postMessage({
         methodCallId,
         result: makeResult<"broadcastMessage">({
@@ -741,6 +759,9 @@ parentPort?.on("message", async (msg: LibP2PNodeMethodGenericMessage) => {
             ? combinedResult.value.flatMap((r) => r.recipients).map((p) => exportToProtobuf(p))
             : [],
         }),
+      });
+      statsd().timing("gossip.worker.parent_port_post_message", Date.now() - postMessageStart, 1, {
+        method: "broadcastMessage",
       });
       break;
     }
@@ -813,9 +834,14 @@ parentPort?.on("message", async (msg: LibP2PNodeMethodGenericMessage) => {
       const [msgId, source, isValid] = specificMsg.args;
       const sourceId = peerIdFromBytes(source);
       await libp2pNode.reportValid(msgId, sourceId, isValid);
+
+      const postMessageStart = Date.now();
       parentPort?.postMessage({
         methodCallId,
         result: makeResult<"reportValid">(undefined),
+      });
+      statsd().timing("gossip.worker.parent_port_post_message", Date.now() - postMessageStart, 1, {
+        method: "reportValid",
       });
       break;
     }

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -208,8 +208,8 @@ export class LibP2PNode {
           dialTimeout: 2000,
           inboundUpgradeTimeout: 2000,
           maxEventLoopDelay: 5000,
-          maxAddrsToDial: 3,
-          inboundConnectionThreshold: 2,
+          maxAddrsToDial: 5,
+          inboundConnectionThreshold: 5,
         },
         addresses: {
           listen: [listenMultiAddrStr],


### PR DESCRIPTION
## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to optimize connection management in the libp2p network and improve logging for updated peer contact info.

### Detailed summary
- Set a max connection limit in libp2p to 256
- Log updated peer contact info only if updated more than an hour ago
- Adjust the max contact info age to 2 minutes
- Optimize peer store count calculation for gossiping
- Increment stats for too old contact info messages
- Comment out a redundant setTimeout call for gossiping

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->