### PR TITLE
fix: timer type issue for clearInterval compatibility

### DIFF
--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1176,7 +1176,7 @@ export class Hub implements HubInterface {
   /** Stop the GossipNode and RPC Server */
   async stop(reason: HubShutdownReason, terminateGossipWorker = true) {
     log.info("Stopping Hubble...");
-    clearInterval(this.contactTimer);
+    clearInterval(this.contactTimer as NodeJS.Timeout);
 
     // First, stop the RPC/Gossip server so we don't get any more messages
     if (!this.options.httpServerDisabled) {


### PR DESCRIPTION
refs: #2099


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `clearInterval` method in the `stop` function of `hubble.ts` to explicitly define the type as `NodeJS.Timeout`.

### Detailed summary
- Updated `clearInterval` method to define type as `NodeJS.Timeout` for `contactTimer` in `stop` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->