### PR TITLE
fix: remove nemes from mainnet bootstrap peers

### DIFF
--- a/.changeset/long-drinks-collect.md
+++ b/.changeset/long-drinks-collect.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: remove nemes from mainnet bootstrap peers (deprecated)

--- a/apps/hubble/src/bootstrapPeers.mainnet.ts
+++ b/apps/hubble/src/bootstrapPeers.mainnet.ts
@@ -2,6 +2,5 @@
 export const MAINNET_BOOTSTRAP_PEERS = [
   "/dns/hoyt.farcaster.xyz/tcp/2282",
   "/dns/lamia.farcaster.xyz/tcp/2282",
-  "/dns/nemes.farcaster.xyz/tcp/2282",
   "/dns/bootstrap.neynar.com/tcp/2282",
 ];


### PR DESCRIPTION
## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the deprecated node `nemes.farcaster.xyz` from the mainnet bootstrap peers list in the `@farcaster/hubble` package.

### Detailed summary
- Removed deprecated node `nemes.farcaster.xyz` from mainnet bootstrap peers in `apps/hubble/src/bootstrapPeers.mainnet.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->