### PR TITLE
fix: Fix gossip worker spending too much time iterating peer store

### DIFF
--- a/.changeset/twelve-eggs-bathe.md
+++ b/.changeset/twelve-eggs-bathe.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Fix gossip worker spending too much time iterating peer store

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1251,6 +1251,7 @@ export class Hub implements HubInterface {
       );
 
       await this.gossipNode.gossipContactInfo(contactInfo);
+      statsd().gauge("peer_store.count", await this.gossipNode.peerStoreCount());
       return Promise.resolve(ok(undefined));
     }
   }
@@ -1397,8 +1398,6 @@ export class Hub implements HubInterface {
   }
 
   private async handleContactInfo(peerId: PeerId, content: ContactInfoContent): Promise<boolean> {
-    statsd().gauge("peer_store.count", await this.gossipNode.peerStoreCount());
-
     let message: ContactInfoContentBody = content.body
       ? content.body
       : ContactInfoContentBody.create({

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -363,6 +363,7 @@ export class LibP2PNode {
   }
 
   async peerStoreCount() {
+    // Note this is performance intensive and blocks the event loop if there are many peers
     const peers = await this._node?.peerStore.all();
     return peers?.length ?? 0;
   }


### PR DESCRIPTION
## Motivation

```
 [Bottom up (heavy) profile]:
  Note: percentage shows a share of a particular caller in the total
  amount of its parent calls.
  Callers occupying less than 1.0% are not shown.

   ticks parent  name
  1460430   43.7%  /home/sanjay/.nvm/versions/node/v18.15.0/bin/node
  795879   54.5%    /home/sanjay/.nvm/versions/node/v18.15.0/bin/node
  224383   28.2%      LazyCompile: *peerIdFromBytes file:///home/sanjay/hubble_dev/node_modules/@libp2p/peer-id/dist/src/index.js:153:32
  224365  100.0%        LazyCompile: *all file:///home/sanjay/hubble_dev/node_modules/@libp2p/peer-store/dist/src/store.js:170:15
  224365  100.0%          /home/sanjay/.nvm/versions/node/v18.15.0/bin/node
  174182   21.9%      LazyCompile: *load file:///home/sanjay/hubble_dev/node_modules/@libp2p/peer-store/dist/src/store.js:35:15
  174145  100.0%        /home/sanjay/.nvm/versions/node/v18.15.0/bin/node
  90942   11.4%      LazyCompile: *decode file:///home/sanjay/hubble_dev/node_modules/multiformats/src/bases/base.js:343:12
  90931  100.0%        LazyCompile: *all file:///home/sanjay/hubble_dev/node_modules/@libp2p/peer-store/dist/src/store.js:170:15
  90931  100.0%          /home/sanjay/.nvm/versions/node/v18.15.0/bin/node
  79173    9.9%      /home/sanjay/.nvm/versions/node/v18.15.0/bin/node
  27262   34.4%        LazyCompile: *cleanPath file:///home/sanjay/hubble_dev/node_modules/@libp2p/peer-store/node_modules/@multiformats/multiaddr/dist/src/codec.js:165:26
  27252  100.0%          LazyCompile: *bytesToMultiaddrParts file:///home/sanjay/hubble_dev/node_modules/@libp2p/peer-store/node_modules/@multiformats/multiaddr/dist/src/codec.js:56:38
  27235   99.9%            LazyCompile: *load file:///home/sanjay/hubble_dev/node_modules/@libp2p/peer-store/dist/src/store.js:35:15
  15786   19.9%        LazyCompile: *all file:///home/sanjay/hubble_dev/node_modules/@libp2p/peer-store/dist/src/store.js:170:15
  15786  100.0%          /home/sanjay/.nvm/versions/node/v18.15.0/bin/node
    879    5.6%            LazyCompile: *forEach file:///home/sanjay/hubble_dev/node_modules/@libp2p/peer-store/dist/src/index.js:24:18
  12903   16.3%        LazyCompile: *format file:///home/sanjay/hubble_dev/node_modules/multiformats/src/cid.js:20:23
  12886   99.9%          LazyCompile: *all file:///home/sanjay/hubble_dev/node_modules/@libp2p/peer-store/dist/src/store.js:170:15
  12886  100.0%            /home/sanjay/.nvm/versions/node/v18.15.0/bin/node
  10342   13.1%        LazyCompile: *peerIdFromBytes file:///home/sanjay/hubble_dev/node_modules/@libp2p/peer-id/dist/src/index.js:153:32
  10341  100.0%          LazyCompile: *all file:///home/sanjay/hubble_dev/node_modules/@libp2p/peer-store/dist/src/store.js:170:15
  10341  100.0%            /home/sanjay/.nvm/versions/node/v18.15.0/bin/node
   7094    9.0%        LazyCompile: *bytesToMultiaddrParts file:///home/sanjay/hubble_dev/node_modules/@libp2p/peer-store/node_modules/@multiformats/multiaddr/dist/src/codec.js:56:38
   7092  100.0%          LazyCompile: *load file:///home/sanjay/hubble_dev/node_modules/@libp2p/peer-store/dist/src/store.js:35:15
   7092  100.0%            /home/sanjay/.nvm/versions/node/v18.15.0/bin/node
   3885    4.9%        LazyCompile: *_peerIdToDatastoreKey file:///home/sanjay/hubble_dev/node_modules/@libp2p/peer-store/dist/src/store.js:21:26
   3883   99.9%          LazyCompile: *all file:///home/sanjay/hubble_dev/node_modules/@libp2p/peer-store/dist/src/store.js:170:15
   3883  100.0%            /home/sanjay/.nvm/versions/node/v18.15.0/bin/node
  38786    4.9%      LazyCompile: *fromString file:///home/sanjay/hubble_dev/node_modules/uint8arrays/dist/src/from-string.js:10:27
  24315   62.7%        LazyCompile: *Key file:///home/sanjay/hubble_dev/node_modules/interface-datastore/dist/src/key.js:29:16
  24275   99.8%          LazyCompile: *all file:///home/sanjay/hubble_dev/node_modules/@libp2p/peer-store/dist/src/store.js:170:15
  24275  100.0%            /home/sanjay/.nvm/versions/node/v18.15.0/bin/node
   7340   18.9%        LazyCompile: *_peerIdToDatastoreKey file:///home/sanjay/hubble_dev/node_modules/@libp2p/peer-store/dist/src/store.js:21:26
   7338  100.0%          LazyCompile: *all file:///home/sanjay/hubble_dev/node_modules/@libp2p/peer-store/dist/src/store.js:170:15
   7338  100.0%            /home/sanjay/.nvm/versions/node/v18.15.0/bin/node
   7110   18.3%        LazyCompile: *_allKeys file:///home/sanjay/hubble_dev/node_modules/datastore-core/dist/src/memory.js:32:14
   7110  100.0%          /home/sanjay/.nvm/versions/node/v18.15.0/bin/node
   7010   98.6%            LazyCompile: *next file:///home/sanjay/hubble_dev/node_modules/it-peekable/dist/src/index.js:17:15
     98    1.4%            Function: ^next file:///home/sanjay/hubble_dev/node_modules/it-peekable/dist/src/index.js:17:15
  25814    3.2%      LazyCompile: *toString file:///home/sanjay/hubble_dev/node_modules/uint8arrays/dist/src/to-string.js:9:25
  24662   95.5%        LazyCompile: *bytes2mh file:///home/sanjay/hubble_dev/node_modules/@libp2p/peer-store/node_modules/@multiformats/multiaddr/dist/src/convert.js:188:18
  24661  100.0%          LazyCompile: *bytesToMultiaddrParts file:///home/sanjay/hubble_dev/node_modules/@libp2p/peer-store/node_modules/@multiformats/multiaddr/dist/src/codec.js:56:38

```

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on optimizing the performance of the `peerStoreCount` function in the `gossipNodeWorker.ts` file by addressing the issue of blocking the event loop. 

### Detailed summary
- Added a comment highlighting the performance-intensive nature of `peerStoreCount` function
- Removed redundant `statsd().gauge` call in `handleContactInfo` method

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->