### PR TITLE
chore: Release 1.13.4

### DIFF
--- a/.changeset/long-drinks-collect.md
+++ b/.changeset/long-drinks-collect.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: remove nemes from mainnet bootstrap peers (deprecated)

--- a/.changeset/twelve-eggs-bathe.md
+++ b/.changeset/twelve-eggs-bathe.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Fix gossip worker spending too much time iterating peer store

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/hubble
 
+## 1.13.4
+
+### Patch Changes
+
+- 3f0fb85c: fix: remove nemes from mainnet bootstrap peers (deprecated)
+- 366ce95c: fix: Fix gossip worker spending too much time iterating peer store
+
 ## 1.13.3
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",


### PR DESCRIPTION
## Motivation

Release performance fixes for gossip

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `@farcaster/hubble` to `1.13.4` in the package.json and includes patch changes related to fixing issues with mainnet bootstrap peers and gossip worker.

### Detailed summary
- Updated version to `1.13.4`
- Removed `nemes` from mainnet bootstrap peers
- Fixed gossip worker spending too much time iterating peer store

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->