### PR TITLE
fix(shuttle): Bump max receive size to fix resource exhaustion error

### DIFF
--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.4.1
+
+### Patch Changes
+
+- fix: Bump max receive size to fix resource exhaustion error
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/shuttle/src/shuttle/hub.ts
+++ b/packages/shuttle/src/shuttle/hub.ts
@@ -16,8 +16,14 @@ export type HubClient = {
   client: HubRpcClient;
 };
 
+const MAX_RECEIVE_MESSAGE_LENGTH = 10 * 1024 * 1024; // 10mb
+
+const defaultOptions = {
+  "grpc.max_receive_message_length": MAX_RECEIVE_MESSAGE_LENGTH,
+};
+
 export function getHubClient(host: string, { ssl }: { ssl?: boolean }) {
-  const hub = ssl ? getSSLHubRpcClient(host) : getInsecureHubRpcClient(host);
+  const hub = ssl ? getSSLHubRpcClient(host, defaultOptions) : getInsecureHubRpcClient(host, defaultOptions);
   return { host, client: hub };
 }
 


### PR DESCRIPTION
## Motivation

Stream processing was halting due to:

```
Hub event stream processing halted 8 RESOURCE_EXHAUSTED: Received message larger than max (5086178 vs 4194304)
```

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Shuttle package to version 0.4.1, fixing a resource exhaustion error and increasing the maximum receive size. 

### Detailed summary
- Updated Shuttle package version to 0.4.1
- Increased maximum receive message length to 10mb
- Fixed resource exhaustion error

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->