### PR TITLE
feat: add endpoints to control sync

### DIFF
--- a/.changeset/sweet-students-rule.md
+++ b/.changeset/sweet-students-rule.md
@@ -1,0 +1,7 @@
+---
+"@farcaster/hub-nodejs": patch
+"@farcaster/hub-web": patch
+"@farcaster/hubble": patch
+---
+
+feat: Add endpoints to control sync

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -349,7 +349,6 @@ export class Hub implements HubInterface {
   private adminServer: AdminServer;
   private httpApiServer: HttpAPIServer;
 
-  private contactTimer?: NodeJS.Timer;
   private rocksDB: RocksDB;
   private syncEngine: SyncEngine;
   private allowedPeerIds: string[] | undefined;
@@ -1176,7 +1175,6 @@ export class Hub implements HubInterface {
   /** Stop the GossipNode and RPC Server */
   async stop(reason: HubShutdownReason, terminateGossipWorker = true) {
     log.info("Stopping Hubble...");
-    clearInterval(this.contactTimer);
 
     // First, stop the RPC/Gossip server so we don't get any more messages
     if (!this.options.httpServerDisabled) {

--- a/apps/hubble/src/rpc/httpServer.ts
+++ b/apps/hubble/src/rpc/httpServer.ts
@@ -23,6 +23,7 @@ import {
   ValidationResponse,
   base58ToBytes,
   bytesToBase58,
+  SyncStatusResponse,
 } from "@farcaster/hub-nodejs";
 import { Metadata, ServerUnaryCall } from "@grpc/grpc-js";
 import fastify from "fastify";
@@ -265,6 +266,29 @@ export class HttpAPIServer {
       const call = getCallObject("getCurrentPeers", {}, request);
       this.grpcImpl.getCurrentPeers(call, handleResponse(reply, ContactInfoResponse));
     });
+
+    // //================stopSync================
+    // // @doc-tag: /stopSync
+    // this.app.get("/v1/stopSync", (request, reply) => {
+    //   const call = getCallObject("stopSync", {}, request);
+    //   this.grpcImpl.stopSync(call, handleResponse(reply, SyncStatusResponse));
+    // });
+    //
+    // //================syncStatus================
+    // // @doc-tag: /syncStatus
+    // this.app.get<{ Querystring: { peer_id: string } }>("/v1/syncStatus", (request, reply) => {
+    //   const { peer_id } = request.query;
+    //   const call = getCallObject("syncStatus", { peerId: peer_id }, request);
+    //   this.grpcImpl.getSyncStatus(call, handleResponse(reply, SyncStatusResponse));
+    // });
+    //
+    // //================forceSync================
+    // // @doc-tag: /forceSync
+    // this.app.get<{ Querystring: { peer_id: string } }>("/v1/forceSync", (request, reply) => {
+    //   const { peer_id } = request.query;
+    //   const call = getCallObject("forceSync", { peerId: peer_id }, request);
+    //   this.grpcImpl.forceSync(call, handleResponse(reply, SyncStatusResponse));
+    // });
 
     //================Casts================
     // @doc-tag: /castById?fid=...&hash=...

--- a/apps/hubble/src/rpc/httpServer.ts
+++ b/apps/hubble/src/rpc/httpServer.ts
@@ -267,29 +267,6 @@ export class HttpAPIServer {
       this.grpcImpl.getCurrentPeers(call, handleResponse(reply, ContactInfoResponse));
     });
 
-    // //================stopSync================
-    // // @doc-tag: /stopSync
-    // this.app.get("/v1/stopSync", (request, reply) => {
-    //   const call = getCallObject("stopSync", {}, request);
-    //   this.grpcImpl.stopSync(call, handleResponse(reply, SyncStatusResponse));
-    // });
-    //
-    // //================syncStatus================
-    // // @doc-tag: /syncStatus
-    // this.app.get<{ Querystring: { peer_id: string } }>("/v1/syncStatus", (request, reply) => {
-    //   const { peer_id } = request.query;
-    //   const call = getCallObject("syncStatus", { peerId: peer_id }, request);
-    //   this.grpcImpl.getSyncStatus(call, handleResponse(reply, SyncStatusResponse));
-    // });
-    //
-    // //================forceSync================
-    // // @doc-tag: /forceSync
-    // this.app.get<{ Querystring: { peer_id: string } }>("/v1/forceSync", (request, reply) => {
-    //   const { peer_id } = request.query;
-    //   const call = getCallObject("forceSync", { peerId: peer_id }, request);
-    //   this.grpcImpl.forceSync(call, handleResponse(reply, SyncStatusResponse));
-    // });
-
     //================Casts================
     // @doc-tag: /castById?fid=...&hash=...
     this.app.get<{ Querystring: { fid: string; hash: string } }>("/v1/castById", (request, reply) => {

--- a/apps/hubble/src/rpc/test/httpServer.test.ts
+++ b/apps/hubble/src/rpc/test/httpServer.test.ts
@@ -14,6 +14,7 @@ import {
   ReactionAddMessage,
   ReactionType,
   reactionTypeToJSON,
+  SyncStatusResponse,
   toFarcasterTime,
   UserDataAddMessage,
   UserDataType,
@@ -836,6 +837,25 @@ describe("httpServer", () => {
       expect(response5.data).toEqual(protoToJSON(idRegistryEvent, OnChainEvent));
     });
   });
+
+  //   describe("sync APIs", () => {
+  //     test("stopSync", async () => {
+  //       const url = getFullUrl("/v1/stopSync");
+  //       const response = await axiosGet(url);
+  //
+  //       expect(response.status).toBe(200);
+  //       expect(response.data).toEqual(
+  //         protoToJSON(
+  //           SyncStatusResponse.create({
+  //             isSyncing: false,
+  //             engineStarted: true,
+  //             syncStatus: [],
+  //           }),
+  //           SyncStatusResponse,
+  //         ),
+  //       );
+  //     });
+  //   });
 });
 
 async function axiosGet(url: string) {

--- a/apps/hubble/src/rpc/test/httpServer.test.ts
+++ b/apps/hubble/src/rpc/test/httpServer.test.ts
@@ -837,25 +837,6 @@ describe("httpServer", () => {
       expect(response5.data).toEqual(protoToJSON(idRegistryEvent, OnChainEvent));
     });
   });
-
-  //   describe("sync APIs", () => {
-  //     test("stopSync", async () => {
-  //       const url = getFullUrl("/v1/stopSync");
-  //       const response = await axiosGet(url);
-  //
-  //       expect(response.status).toBe(200);
-  //       expect(response.data).toEqual(
-  //         protoToJSON(
-  //           SyncStatusResponse.create({
-  //             isSyncing: false,
-  //             engineStarted: true,
-  //             syncStatus: [],
-  //           }),
-  //           SyncStatusResponse,
-  //         ),
-  //       );
-  //     });
-  //   });
 });
 
 async function axiosGet(url: string) {

--- a/apps/hubble/src/rpc/test/syncService.test.ts
+++ b/apps/hubble/src/rpc/test/syncService.test.ts
@@ -4,6 +4,7 @@ import {
   Factories,
   FarcasterNetwork,
   getInsecureHubRpcClient,
+  HubError,
   HubInfoRequest,
   HubRpcClient,
   OnChainEvent,
@@ -98,5 +99,21 @@ describe("getSyncStatus", () => {
     expect(result.isOk()).toBeTruthy();
     expect(result._unsafeUnwrap().isSyncing).toEqual(false);
     expect(result._unsafeUnwrap().syncStatus).toHaveLength(0);
+  });
+});
+
+describe("stopSync", () => {
+  test("succeeds", async () => {
+    const result = await client.stopSync({});
+    expect(result.isOk()).toBeTruthy();
+    expect(result._unsafeUnwrap().isSyncing).toEqual(false);
+    expect(result._unsafeUnwrap().syncStatus).toHaveLength(0);
+  });
+});
+
+describe("forceSync", () => {
+  test("fails when peer is not found", async () => {
+    const result = await client.forceSync(SyncStatusRequest.create({ peerId: "test" }));
+    expect(result._unsafeUnwrapErr()).toEqual(new HubError("bad_request", "Peer not found"));
   });
 });

--- a/packages/hub-nodejs/src/generated/rpc.ts
+++ b/packages/hub-nodejs/src/generated/rpc.ts
@@ -433,6 +433,24 @@ export const HubServiceService = {
     responseSerialize: (value: ContactInfoResponse) => Buffer.from(ContactInfoResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => ContactInfoResponse.decode(value),
   },
+  stopSync: {
+    path: "/HubService/StopSync",
+    requestStream: false,
+    responseStream: false,
+    requestSerialize: (value: Empty) => Buffer.from(Empty.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => Empty.decode(value),
+    responseSerialize: (value: SyncStatusResponse) => Buffer.from(SyncStatusResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer) => SyncStatusResponse.decode(value),
+  },
+  forceSync: {
+    path: "/HubService/ForceSync",
+    requestStream: false,
+    responseStream: false,
+    requestSerialize: (value: SyncStatusRequest) => Buffer.from(SyncStatusRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => SyncStatusRequest.decode(value),
+    responseSerialize: (value: SyncStatusResponse) => Buffer.from(SyncStatusResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer) => SyncStatusResponse.decode(value),
+  },
   /** @http-api: none */
   getSyncStatus: {
     path: "/HubService/GetSyncStatus",
@@ -577,6 +595,8 @@ export interface HubServiceServer extends UntypedServiceImplementation {
   /** Sync Methods */
   getInfo: handleUnaryCall<HubInfoRequest, HubInfoResponse>;
   getCurrentPeers: handleUnaryCall<Empty, ContactInfoResponse>;
+  stopSync: handleUnaryCall<Empty, SyncStatusResponse>;
+  forceSync: handleUnaryCall<SyncStatusRequest, SyncStatusResponse>;
   /** @http-api: none */
   getSyncStatus: handleUnaryCall<SyncStatusRequest, SyncStatusResponse>;
   /** @http-api: none */
@@ -1161,6 +1181,36 @@ export interface HubServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: ContactInfoResponse) => void,
+  ): ClientUnaryCall;
+  stopSync(
+    request: Empty,
+    callback: (error: ServiceError | null, response: SyncStatusResponse) => void,
+  ): ClientUnaryCall;
+  stopSync(
+    request: Empty,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: SyncStatusResponse) => void,
+  ): ClientUnaryCall;
+  stopSync(
+    request: Empty,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: SyncStatusResponse) => void,
+  ): ClientUnaryCall;
+  forceSync(
+    request: SyncStatusRequest,
+    callback: (error: ServiceError | null, response: SyncStatusResponse) => void,
+  ): ClientUnaryCall;
+  forceSync(
+    request: SyncStatusRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: SyncStatusResponse) => void,
+  ): ClientUnaryCall;
+  forceSync(
+    request: SyncStatusRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: SyncStatusResponse) => void,
   ): ClientUnaryCall;
   /** @http-api: none */
   getSyncStatus(

--- a/packages/hub-nodejs/src/generated/rpc.ts
+++ b/packages/hub-nodejs/src/generated/rpc.ts
@@ -433,6 +433,7 @@ export const HubServiceService = {
     responseSerialize: (value: ContactInfoResponse) => Buffer.from(ContactInfoResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => ContactInfoResponse.decode(value),
   },
+  /** @http-api: none */
   stopSync: {
     path: "/HubService/StopSync",
     requestStream: false,
@@ -442,6 +443,10 @@ export const HubServiceService = {
     responseSerialize: (value: SyncStatusResponse) => Buffer.from(SyncStatusResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => SyncStatusResponse.decode(value),
   },
+  /**
+   * This is experimental, do not rely on this endpoint existing in the future
+   * @http-api: none
+   */
   forceSync: {
     path: "/HubService/ForceSync",
     requestStream: false,
@@ -595,7 +600,12 @@ export interface HubServiceServer extends UntypedServiceImplementation {
   /** Sync Methods */
   getInfo: handleUnaryCall<HubInfoRequest, HubInfoResponse>;
   getCurrentPeers: handleUnaryCall<Empty, ContactInfoResponse>;
+  /** @http-api: none */
   stopSync: handleUnaryCall<Empty, SyncStatusResponse>;
+  /**
+   * This is experimental, do not rely on this endpoint existing in the future
+   * @http-api: none
+   */
   forceSync: handleUnaryCall<SyncStatusRequest, SyncStatusResponse>;
   /** @http-api: none */
   getSyncStatus: handleUnaryCall<SyncStatusRequest, SyncStatusResponse>;
@@ -1182,6 +1192,7 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: ContactInfoResponse) => void,
   ): ClientUnaryCall;
+  /** @http-api: none */
   stopSync(
     request: Empty,
     callback: (error: ServiceError | null, response: SyncStatusResponse) => void,
@@ -1197,6 +1208,10 @@ export interface HubServiceClient extends Client {
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: SyncStatusResponse) => void,
   ): ClientUnaryCall;
+  /**
+   * This is experimental, do not rely on this endpoint existing in the future
+   * @http-api: none
+   */
   forceSync(
     request: SyncStatusRequest,
     callback: (error: ServiceError | null, response: SyncStatusResponse) => void,

--- a/packages/hub-web/src/generated/rpc.ts
+++ b/packages/hub-web/src/generated/rpc.ts
@@ -151,6 +151,8 @@ export interface HubService {
   /** Sync Methods */
   getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubInfoResponse>;
   getCurrentPeers(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<ContactInfoResponse>;
+  stopSync(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncStatusResponse>;
+  forceSync(request: DeepPartial<SyncStatusRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncStatusResponse>;
   /** @http-api: none */
   getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncStatusResponse>;
   /** @http-api: none */
@@ -210,6 +212,8 @@ export class HubServiceClientImpl implements HubService {
     this.getLinkCompactStateMessageByFid = this.getLinkCompactStateMessageByFid.bind(this);
     this.getInfo = this.getInfo.bind(this);
     this.getCurrentPeers = this.getCurrentPeers.bind(this);
+    this.stopSync = this.stopSync.bind(this);
+    this.forceSync = this.forceSync.bind(this);
     this.getSyncStatus = this.getSyncStatus.bind(this);
     this.getAllSyncIdsByPrefix = this.getAllSyncIdsByPrefix.bind(this);
     this.getAllMessagesBySyncIds = this.getAllMessagesBySyncIds.bind(this);
@@ -381,6 +385,14 @@ export class HubServiceClientImpl implements HubService {
 
   getCurrentPeers(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<ContactInfoResponse> {
     return this.rpc.unary(HubServiceGetCurrentPeersDesc, Empty.fromPartial(request), metadata);
+  }
+
+  stopSync(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncStatusResponse> {
+    return this.rpc.unary(HubServiceStopSyncDesc, Empty.fromPartial(request), metadata);
+  }
+
+  forceSync(request: DeepPartial<SyncStatusRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncStatusResponse> {
+    return this.rpc.unary(HubServiceForceSyncDesc, SyncStatusRequest.fromPartial(request), metadata);
   }
 
   getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncStatusResponse> {
@@ -1230,6 +1242,52 @@ export const HubServiceGetCurrentPeersDesc: UnaryMethodDefinitionish = {
   responseType: {
     deserializeBinary(data: Uint8Array) {
       const value = ContactInfoResponse.decode(data);
+      return {
+        ...value,
+        toObject() {
+          return value;
+        },
+      };
+    },
+  } as any,
+};
+
+export const HubServiceStopSyncDesc: UnaryMethodDefinitionish = {
+  methodName: "StopSync",
+  service: HubServiceDesc,
+  requestStream: false,
+  responseStream: false,
+  requestType: {
+    serializeBinary() {
+      return Empty.encode(this).finish();
+    },
+  } as any,
+  responseType: {
+    deserializeBinary(data: Uint8Array) {
+      const value = SyncStatusResponse.decode(data);
+      return {
+        ...value,
+        toObject() {
+          return value;
+        },
+      };
+    },
+  } as any,
+};
+
+export const HubServiceForceSyncDesc: UnaryMethodDefinitionish = {
+  methodName: "ForceSync",
+  service: HubServiceDesc,
+  requestStream: false,
+  responseStream: false,
+  requestType: {
+    serializeBinary() {
+      return SyncStatusRequest.encode(this).finish();
+    },
+  } as any,
+  responseType: {
+    deserializeBinary(data: Uint8Array) {
+      const value = SyncStatusResponse.decode(data);
       return {
         ...value,
         toObject() {

--- a/packages/hub-web/src/generated/rpc.ts
+++ b/packages/hub-web/src/generated/rpc.ts
@@ -151,7 +151,12 @@ export interface HubService {
   /** Sync Methods */
   getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubInfoResponse>;
   getCurrentPeers(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<ContactInfoResponse>;
+  /** @http-api: none */
   stopSync(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncStatusResponse>;
+  /**
+   * This is experimental, do not rely on this endpoint existing in the future
+   * @http-api: none
+   */
   forceSync(request: DeepPartial<SyncStatusRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncStatusResponse>;
   /** @http-api: none */
   getSyncStatus(request: DeepPartial<SyncStatusRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<SyncStatusResponse>;

--- a/protobufs/schemas/rpc.proto
+++ b/protobufs/schemas/rpc.proto
@@ -97,6 +97,9 @@ service HubService {
   // Sync Methods    
   rpc GetInfo(HubInfoRequest) returns (HubInfoResponse);
   rpc GetCurrentPeers(Empty) returns (ContactInfoResponse);
+  rpc StopSync(Empty) returns (SyncStatusResponse);
+  // This is experimental, do not rely on this endpoint existing in the future
+  rpc ForceSync(SyncStatusRequest) returns (SyncStatusResponse);
   // @http-api: none
   rpc GetSyncStatus(SyncStatusRequest) returns (SyncStatusResponse);
   // @http-api: none

--- a/protobufs/schemas/rpc.proto
+++ b/protobufs/schemas/rpc.proto
@@ -97,8 +97,10 @@ service HubService {
   // Sync Methods    
   rpc GetInfo(HubInfoRequest) returns (HubInfoResponse);
   rpc GetCurrentPeers(Empty) returns (ContactInfoResponse);
+  // @http-api: none
   rpc StopSync(Empty) returns (SyncStatusResponse);
   // This is experimental, do not rely on this endpoint existing in the future
+  // @http-api: none
   rpc ForceSync(SyncStatusRequest) returns (SyncStatusResponse);
   // @http-api: none
   rpc GetSyncStatus(SyncStatusRequest) returns (SyncStatusResponse);


### PR DESCRIPTION
## Motivation

Add endpoints to force sync with a particular peer id and to interrupt current sync.

NOTE: This is experimental, these endpoints may be removed or significantly altered in the future.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds new endpoints `StopSync` and `ForceSync` to control sync behavior in the Hubble application.

### Detailed summary
- Added `SyncStatusResponse` and `SyncStatusRequest` objects for sync control
- Implemented `stopSync` and `forceSync` functions in `syncEngine.ts`
- Added corresponding RPC methods in `rpc/server.ts`
- Defined HTTP API paths for `stopSync` and `forceSync` in `hub-nodejs` and `hub-web`

> The following files were skipped due to too many changes: `packages/hub-web/src/generated/rpc.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->