### PR TITLE
apps/hubble: fix docker-compose.yml warning

### DIFF
--- a/apps/hubble/docker-compose.yml
+++ b/apps/hubble/docker-compose.yml
@@ -8,8 +8,6 @@
 #
 #   git fetch --tags --force && git checkout @latest && docker compose up
 
-version: '3.9'
-
 services:
   hubble:
     image: farcasterxyz/hubble:latest


### PR DESCRIPTION
"version is obsolelte"

Docker has made this line obsolete, no need to nention docker compose version

## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `docker-compose.yml` file for the `hubble` service to use version 3.9 and the latest image `farcasterxyz/hubble:latest`.

### Detailed summary
- Updated `docker-compose.yml` to version 3.9
- Changed `hubble` service image to `farcasterxyz/hubble:latest`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->