### PR TITLE
chore: release 1.13.5

### DIFF
--- a/.changeset/cold-kids-compete.md
+++ b/.changeset/cold-kids-compete.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: gossip contact info every 30 minutes instead of every minute, avoid gossiping contact info on peer connect, skip contact info updates that happen too frequently

--- a/.changeset/sweet-students-rule.md
+++ b/.changeset/sweet-students-rule.md
@@ -1,7 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
-"@farcaster/hub-web": patch
-"@farcaster/hubble": patch
----
-
-feat: Add endpoints to control sync

--- a/.changeset/tiny-kangaroos-refuse.md
+++ b/.changeset/tiny-kangaroos-refuse.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: add experimental HTTP APIs to control sync

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @farcaster/hubble
 
+## 1.13.5
+
+### Patch Changes
+
+- 224e75fa: fix: gossip contact info every 30 minutes instead of every minute, avoid gossiping contact info on peer connect, skip contact info updates that happen too frequently
+- c723f655: feat: Add endpoints to control sync
+- 667a5b30: feat: add experimental HTTP APIs to control sync
+- Updated dependencies [c723f655]
+  - @farcaster/hub-nodejs@0.11.19
+
 ## 1.13.4
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.13.4",
+  "version": "1.13.5",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -75,7 +75,7 @@
     "@chainsafe/libp2p-noise": "^11.0.0 ",
     "@datastructures-js/priority-queue": "^6.3.1",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.11.18",
+    "@farcaster/hub-nodejs": "^0.11.19",
     "@fastify/cors": "^8.4.0",
     "@figma/hot-shots": "^9.0.0-figma.1",
     "@grpc/grpc-js": "~1.8.22",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-nodejs
 
+## 0.11.19
+
+### Patch Changes
+
+- c723f655: feat: Add endpoints to control sync
+
 ## 0.11.18
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.11.18",
+  "version": "0.11.19",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-web/CHANGELOG.md
+++ b/packages/hub-web/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-web
 
+## 0.8.12
+
+### Patch Changes
+
+- c723f655: feat: Add endpoints to control sync
+
 ## 0.8.11
 
 ### Patch Changes

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-web",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Motivation

- Reduce network bandwidth with gossip improvements
- Support experimental sync APIs (note: may be removed or significantly altered in the future) 

## Change Summary

- Update p2p gossip to reduce unnecessary contact updates
- Add experimental sync control APIs

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates versions and adds endpoints for sync control in `hub-web` and `hub-nodejs`, and includes various improvements and fixes in the `hubble` app.

### Detailed summary
- Updated `hub-web` version to 0.8.12
- Updated `hub-nodejs` version to 0.11.19
- Added endpoints for sync control
- Improved gossip contact info frequency in `hubble` app
- Added experimental HTTP APIs for sync control in `hubble` app

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->