### PR TITLE
fix::the input device is not a TTY

### DIFF
--- a/scripts/hubble-bootstrap.sh
+++ b/scripts/hubble-bootstrap.sh
@@ -67,6 +67,20 @@ fetch_file_from_repo() {
     curl -sS -o "$local_filename" "$download_url" || { echo "Failed to fetch $download_url."; exit 1; }
 }
 
+setup_hubble_command() {
+    if command -v hubbly >/dev/null 2>&1; then
+        echo "✅ Hubbly command is installed."
+        return 0
+    fi
+    
+cat > /usr/local/bin/hubble <<EOF
+#!/bin/bash
+cd ~/hubble
+exec ./hubble.sh \$1 < /dev/tty
+EOF
+    chmod +x /usr/local/bin/hubble
+}
+
 do_bootstrap() {
     # Make the ~/hubble directory if it doesn't exist
     mkdir -p ~/hubble
@@ -77,6 +91,9 @@ do_bootstrap() {
 
     mv "$tmp_file" ~/hubble/hubble.sh
     chmod +x ~/hubble/hubble.sh
+
+    #Setting hubble system commands
+    setup_hubble_command
 
     # Run the hubble.sh script
     cd ~/hubble

--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -342,7 +342,7 @@ setup_identity() {
     chmod 777 .hub .rocks
 
    if [[ ! -f "./.hub/default_id.protobuf" ]]; then
-        $COMPOSE_CMD run -T hubble yarn identity create
+        $COMPOSE_CMD run --rm -T hubble yarn identity create
         echo "✅ Created Peer Identity"
     else
         echo "✅ Peer Identity exists"

--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -342,7 +342,7 @@ setup_identity() {
     chmod 777 .hub .rocks
 
    if [[ ! -f "./.hub/default_id.protobuf" ]]; then
-        $COMPOSE_CMD run hubble yarn identity create
+        $COMPOSE_CMD run -T hubble yarn identity create
         echo "✅ Created Peer Identity"
     else
         echo "✅ Peer Identity exists"


### PR DESCRIPTION
#2115 fix::the input device is not a TTY

## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the hubble script by adding a setup function for hubble commands and improves command execution. 

### Detailed summary
- Added `setup_hubble_command` function to install hubble command
- Improved execution of hubble commands in `hubble.sh` script

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->