### PR TITLE
chore: add stats for bundle message delays, stale contact info

### DIFF
--- a/.changeset/dull-dancers-float.md
+++ b/.changeset/dull-dancers-float.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+chore: add stats for bundle message delays, stale contact info

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -34,7 +34,7 @@ import { sleep } from "../../utils/crypto.js";
 /** The maximum number of pending merge messages before we drop new incoming gossip or sync messages. */
 export const MAX_SYNCTRIE_QUEUE_SIZE = 100_000;
 /** The TTL for messages in the seen cache */
-export const GOSSIP_SEEN_TTL = 1000 * 60 * 5;
+export const GOSSIP_SEEN_TTL = 1000 * 60 * 5; // 5 minutes
 
 /** The maximum amount of time to dial a peer in libp2p network in milliseconds */
 export const LIBP2P_CONNECT_TIMEOUT_MS = 2000;

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -1187,7 +1187,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     statsd().gauge("syncengine.merge_q", this._syncMergeQ);
 
     const startTime = Date.now();
-    const results = await this._hub.submitMessageBundle(MessageBundle.create({ messages }), "sync");
+    const results = await this._hub.submitMessageBundle(startTime, MessageBundle.create({ messages }), "sync");
 
     for (let i = 0; i < results.length; i++) {
       const result = results[i] as HubResult<number>;

--- a/apps/hubble/src/test/e2e/hubbleNetwork.test.ts
+++ b/apps/hubble/src/test/e2e/hubbleNetwork.test.ts
@@ -147,7 +147,7 @@ describe("hubble gossip and sync tests", () => {
           messages: castAddMessages,
         });
         // Submit it to hub1 via rpc so it gets gossiped
-        const bundleMergeResult = await hub1.submitMessageBundle(messageBundle, "rpc");
+        const bundleMergeResult = await hub1.submitMessageBundle(Date.now(), messageBundle, "rpc");
         expect(bundleMergeResult.length).toEqual(5);
         for (let i = 0; i < 5; i++) {
           expect(bundleMergeResult[i]?.isOk()).toBeTruthy();
@@ -167,7 +167,7 @@ describe("hubble gossip and sync tests", () => {
         }
 
         // Submitting the same bundle again should result in a duplicate error if we submit via gossip
-        const errResult2 = await hub1.submitMessageBundle(messageBundle, "gossip");
+        const errResult2 = await hub1.submitMessageBundle(Date.now(), messageBundle, "gossip");
         // Expect all the messages to be duplicates
         for (let i = 0; i < 5; i++) {
           expect(errResult2[i]?.isErr()).toBeTruthy();
@@ -193,7 +193,7 @@ describe("hubble gossip and sync tests", () => {
           hash: new Uint8Array([0, 1, 2, 1, 2]),
           messages: castAddMessages2,
         });
-        const errResult3 = await hub1.submitMessageBundle(messageBundle2, "gossip");
+        const errResult3 = await hub1.submitMessageBundle(Date.now(), messageBundle2, "gossip");
         expect(errResult3.length).toEqual(5);
         expect(errResult3[0]?.isOk()).toBeTruthy();
         expect(errResult3[1]?.isErr()).toBeTruthy();

--- a/apps/hubble/src/test/mocks.ts
+++ b/apps/hubble/src/test/mocks.ts
@@ -43,8 +43,10 @@ export class MockHub implements HubInterface {
   }
 
   async submitMessageBundle(
+    _creationTimeMs: number,
     messageBundle: MessageBundle,
     source?: HubSubmitSource | undefined,
+    _peerId?: PeerId,
   ): Promise<HubResult<number>[]> {
     const results: HubResult<number>[] = [];
     for (const message of messageBundle.messages) {


### PR DESCRIPTION
## Motivation

- Need better visibility into message delays and disambiguate between bundle delay and message delay
- Ensure stale contacts aren't disseminating through the network

## Change Summary

- Add statsd metrics for earliest and latest message timestamp in bundle and bundle creation timestamp. All timestamps are in farcaster time
- Add statsd metric for old contact info being gossiped

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing message bundle submission in the Hubble application by adding stats for message delays and contact info staleness.

### Detailed summary
- Added stats for bundle message delays and stale contact info
- Updated `submitMessageBundle` method parameters in multiple files
- Updated `submitMessageBundle` method in `Hub` class to include additional stats and parameters

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->