### PR TITLE
feat: add unique peer map to sync engine to represent current active peers

### DIFF
--- a/.changeset/popular-shoes-bathe.md
+++ b/.changeset/popular-shoes-bathe.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: add unique peer map to sync engine to represent current active peers

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -1,5 +1,6 @@
 import { PublishResult } from "@libp2p/interface-pubsub";
 import { Worker } from "worker_threads";
+import { PeerInfo } from "@libp2p/interface-peer-info";
 import {
   ContactInfoContent,
   FarcasterNetwork,
@@ -50,6 +51,8 @@ interface NodeEvents {
   peerConnect: (connection: Connection) => void;
   /** Triggers when a peer disconnects and includes the libp2p Connection object */
   peerDisconnect: (connection: Connection) => void;
+  /** Triggers when a peer is discovered and includes the libp2p PeerInfo object */
+  peerDiscovery: (peerInfo: PeerInfo) => void;
 }
 
 /** Optional arguments provided when creating a Farcaster Gossip Node */

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -495,7 +495,7 @@ export default class Server {
             return;
           }
 
-          const contactInfoArray = Array.from(currentHubPeerContacts).map((peerContact) => peerContact.contactInfo);
+          const contactInfoArray = Array.from(currentHubPeerContacts).map((peerContact) => peerContact[1]);
           callback(null, ContactInfoResponse.create({ contacts: contactInfoArray }));
         })();
       },

--- a/apps/hubble/src/utils/ttl_map.test.ts
+++ b/apps/hubble/src/utils/ttl_map.test.ts
@@ -1,0 +1,142 @@
+import { TTLMap } from "./ttl_map.js";
+import { jest } from "@jest/globals";
+
+describe("TTLMap", () => {
+  jest.useFakeTimers();
+
+  test("size should accurately reflect non-expired entries", () => {
+    const map = new TTLMap<string, number>(1000);
+
+    expect(map.size()).toBe(0);
+
+    map.set("a", 1);
+    expect(map.size()).toBe(1);
+
+    map.set("b", 2);
+    expect(map.size()).toBe(2);
+
+    jest.advanceTimersByTime(500);
+    map.set("c", 3);
+    expect(map.size()).toBe(3);
+
+    jest.advanceTimersByTime(501);
+    expect(map.size()).toBe(1);
+
+    map.get("a"); // This should trigger cleanup of expired entry
+    expect(map.size()).toBe(1);
+  });
+
+  test("set should not double count when updating existing entries", () => {
+    const map = new TTLMap<string, number>(1000);
+
+    map.set("a", 1);
+    expect(map.size()).toBe(1);
+
+    map.set("a", 2); // Updating existing non-expired entry
+    expect(map.size()).toBe(1);
+
+    jest.advanceTimersByTime(1001);
+    map.set("a", 3); // Updating expired entry
+    expect(map.size()).toBe(1);
+  });
+
+  test("delete should correctly update size for expired and non-expired entries", () => {
+    const map = new TTLMap<string, number>(1000);
+
+    map.set("a", 1);
+    map.set("b", 2);
+    expect(map.size()).toBe(2);
+
+    map.delete("a");
+    expect(map.size()).toBe(1);
+
+    jest.advanceTimersByTime(1001);
+    expect(map.delete("b")).toBe(true); // Deleting expired entry
+    expect(map.size()).toBe(0);
+  });
+
+  test("get should update size when retrieving expired entries", () => {
+    const map = new TTLMap<string, number>(1000);
+
+    map.set("a", 1);
+    expect(map.size()).toBe(1);
+
+    jest.advanceTimersByTime(1001);
+    expect(map.get("a")).toBeUndefined();
+    expect(map.size()).toBe(0);
+  });
+
+  test("resetTTL should correctly handle expired and non-expired entries", () => {
+    const map = new TTLMap<string, number>(1000);
+
+    map.set("a", 1);
+    expect(map.size()).toBe(1);
+
+    jest.advanceTimersByTime(500);
+    map.resetTTL("a");
+    expect(map.size()).toBe(1);
+
+    jest.advanceTimersByTime(750);
+    expect(map.get("a")).toBe(1);
+    expect(map.size()).toBe(1);
+
+    jest.advanceTimersByTime(251);
+    map.resetTTL("a");
+    expect(map.size()).toBe(1);
+    expect(map.get("a")).toBe(1);
+  });
+
+  test("getAll should return only non-expired entries", () => {
+    const map = new TTLMap<string, number>(1000);
+
+    map.set("a", 1);
+    map.set("b", 2);
+    map.set("c", 3);
+
+    jest.advanceTimersByTime(500);
+    map.set("d", 4);
+
+    jest.advanceTimersByTime(501);
+
+    const allEntries = map.getAll();
+    expect(allEntries).toHaveLength(1);
+    expect(allEntries[0]).toEqual(["d", 4]);
+    expect(map.size()).toBe(1);
+  });
+
+  test("clear should reset size to zero", () => {
+    const map = new TTLMap<string, number>(1000);
+
+    map.set("a", 1);
+    map.set("b", 2);
+    expect(map.size()).toBe(2);
+
+    map.clear();
+    expect(map.size()).toBe(0);
+
+    map.set("c", 3);
+    expect(map.size()).toBe(1);
+  });
+
+  test("size should be accurate after multiple operations", () => {
+    const map = new TTLMap<string, number>(1000);
+
+    map.set("a", 1);
+    map.set("b", 2);
+    map.set("c", 3);
+    expect(map.size()).toBe(3);
+
+    jest.advanceTimersByTime(500);
+    map.delete("b");
+    map.set("d", 4);
+    expect(map.size()).toBe(3);
+
+    jest.advanceTimersByTime(501);
+    map.get("a"); // This should trigger cleanup
+    expect(map.size()).toBe(1);
+
+    map.set("e", 5);
+    map.resetTTL("d");
+    expect(map.size()).toBe(2);
+  });
+});

--- a/apps/hubble/src/utils/ttl_map.ts
+++ b/apps/hubble/src/utils/ttl_map.ts
@@ -1,0 +1,152 @@
+/**
+ * TTLMap - A high-performance Time-To-Live Map implementation
+ *
+ * This data structure provides a Map-like interface with automatic expiration of entries.
+ * It is designed for scenarios with thousands of elements and frequent bulk retrieval operations.
+ *
+ * Key features:
+ * - Constant-time complexity for get, set, and delete operations
+ * - Efficient bulk retrieval of non-expired entries
+ * - Coarse-grained TTL defined at the Map level
+ * - Ability to reset TTL for individual entries
+ *
+ * @template K The type of keys in the map
+ * @template V The type of values in the map
+ */
+export class TTLMap<K, V> {
+  private map: Map<K, { value: V; expiresAt: number }>;
+  private readonly ttl: number;
+  private lastCleanup: number;
+  private readonly cleanupInterval: number;
+  private nonExpiredCount: number;
+
+  /**
+   * @param ttl Time-to-live in milliseconds for entries
+   * @param cleanupInterval Optional interval for running the cleanup process (default: ttl / 2)
+   */
+  constructor(ttl: number, cleanupInterval?: number) {
+    this.map = new Map();
+    this.ttl = ttl;
+    this.lastCleanup = Date.now();
+    this.cleanupInterval = cleanupInterval || Math.floor(ttl / 2);
+    this.nonExpiredCount = 0;
+  }
+
+  /**
+   * Sets a key-value pair in the map with the current TTL
+   * @param key The key to set
+   * @param value The value to set
+   * @returns The TTLMap instance for method chaining
+   */
+  set(key: K, value: V): this {
+    const now = Date.now();
+    const expiresAt = now + this.ttl;
+    const existingEntry = this.map.get(key);
+
+    if (!existingEntry) {
+      this.nonExpiredCount++;
+    }
+
+    this.map.set(key, { value, expiresAt });
+    this.cleanupIfNeeded();
+    return this;
+  }
+
+  /**
+   * Retrieves a value from the map if it exists and hasn't expired
+   * @param key The key to retrieve
+   * @returns The value if found and not expired, undefined otherwise
+   */
+  get(key: K): V | undefined {
+    const entry = this.map.get(key);
+    if (entry) {
+      if (entry.expiresAt > Date.now()) {
+        return entry.value;
+      } else {
+        this.map.delete(key);
+        this.nonExpiredCount--;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Deletes a key-value pair from the map
+   * @param key The key to delete
+   * @returns true if the element was in the map and not expired, false otherwise
+   */
+  delete(key: K): boolean {
+    const entry = this.map.get(key);
+    if (entry) {
+      if (entry.expiresAt > Date.now()) {
+        this.nonExpiredCount--;
+      }
+      return this.map.delete(key);
+    }
+    return false;
+  }
+
+  /**
+   * Resets the TTL for a given key without changing its value
+   * @param key The key to reset the TTL for
+   * @returns true if the key exists and TTL was reset, false otherwise
+   */
+  resetTTL(key: K): boolean {
+    const entry = this.map.get(key);
+    if (entry) {
+      entry.expiresAt = Date.now() + this.ttl;
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Retrieves all non-expired entries from the map
+   * This method is optimized for frequent calls and large datasets
+   * @returns An array of [key, value] pairs for all non-expired entries
+   */
+  getAll(): [K, V][] {
+    this.cleanupIfNeeded();
+    const now = Date.now();
+    return Array.from(this.map.entries())
+      .filter(([, { expiresAt }]) => expiresAt > now)
+      .map(([key, { value }]) => [key, value]);
+  }
+
+  /**
+   * Clears all entries from the map
+   */
+  clear(): void {
+    this.nonExpiredCount = 0;
+    this.map.clear();
+  }
+
+  /**
+   * Returns the number of non-expired entries in the map
+   * @returns The number of non-expired entries in the map
+   */
+  size(): number {
+    this.cleanupIfNeeded();
+    return this.nonExpiredCount;
+  }
+
+  /**
+   * Performs cleanup of expired entries if the cleanup interval has elapsed
+   * This method is called internally and doesn't need to be invoked manually
+   */
+  private cleanupIfNeeded(): void {
+    const now = Date.now();
+    if (now - this.lastCleanup > this.cleanupInterval) {
+      let nonExpired = 0;
+      this.map.forEach((entry, key) => {
+        if (entry.expiresAt <= now) {
+          this.map.delete(key);
+        } else {
+          nonExpired++;
+        }
+      });
+      this.lastCleanup = now;
+      this.nonExpiredCount = nonExpired;
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

- Current peer store keeps track of all hubs that successfully connected
- However, peers may connect and never be seen again due to churn or change in Peer ID 
- We add TTL Map of peers that only adds peers, never deletes, and expires any peer that hasn't gossiped updates in 24 hours 

## Change Summary

- add unique peer map to sync engine to represent current active peers

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a unique peer map to track active peers in the sync engine of the Hubble app. It also adds a high-performance TTLMap for efficient entry expiration management.

### Detailed summary
- Added unique peer map for active peers in the sync engine
- Implemented TTLMap for automatic expiration of entries
- Updated handling of peer discovery events
- Enhanced peer contact management in the sync engine

> The following files were skipped due to too many changes: `apps/hubble/src/utils/ttl_map.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->