### PR TITLE
fix: update start time to farcaster time when submitting message bundles from sync

### DIFF
--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -1220,7 +1220,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     this._syncMergeQ += messages.length;
     statsd().gauge("syncengine.merge_q", this._syncMergeQ);
 
-    const startTime = Date.now();
+    const startTime = getFarcasterTime().unwrapOr(0);
     const results = await this._hub.submitMessageBundle(startTime, MessageBundle.create({ messages }), "sync");
 
     for (let i = 0; i < results.length; i++) {


### PR DESCRIPTION

## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to replace the usage of `Date.now()` with `getFarcasterTime().unwrapOr(0)` in `syncEngine.ts` for more accurate time tracking during message bundle submission.

### Detailed summary
- Replaced `Date.now()` with `getFarcasterTime().unwrapOr(0)` for startTime in `syncEngine.ts`
- Improved accuracy in time tracking during message bundle submission.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->