### PR TITLE
fix: full state events should not include deletes

### DIFF
--- a/.changeset/sixty-shoes-occur.md
+++ b/.changeset/sixty-shoes-occur.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": minor
+---
+
+fix: full state events should not include deleted messages

--- a/apps/hubble/src/addon/src/store/store.rs
+++ b/apps/hubble/src/addon/src/store/store.rs
@@ -325,7 +325,18 @@ pub trait StoreDef: Send + Sync {
             r#type: HubEventType::MergeMessage as i32,
             body: Some(hub_event::Body::MergeMessageBody(MergeMessageBody {
                 message: Some(message.clone()),
-                deleted_messages: merge_conflicts,
+                deleted_messages: match &message.data {
+                    Some(data) => {
+                        if data.r#type == self.compact_state_message_type() as i32 {
+                            // In the case of merging compact state, we omit the deleted messages as this would
+                            // result in an unbounded message size:
+                            Vec::<Message>::new()
+                        } else {
+                            merge_conflicts
+                        }
+                    }
+                    None => Vec::<Message>::new(),
+                },
             })),
             id: 0,
         }

--- a/apps/hubble/src/storage/stores/linkStoreCompactState.test.ts
+++ b/apps/hubble/src/storage/stores/linkStoreCompactState.test.ts
@@ -112,7 +112,7 @@ describe("Merge LinkCompactState messages", () => {
 
     // Make sure that the hub event was proper.
     expect(hubEvent?.mergeMessageBody?.message?.data?.fid).toEqual(fid);
-    expect(hubEvent?.mergeMessageBody?.deletedMessages).toEqual([linkAdd2]);
+    expect(hubEvent?.mergeMessageBody?.deletedMessages).toEqual([]);
 
     // Now that there's a compact state message, linkAdd2 still won't merge because it is not in the target_fids
     const expectError2 = await ResultAsync.fromPromise(set.merge(linkAdd2), (e) => e as HubError);
@@ -185,7 +185,7 @@ describe("Merge LinkCompactState messages", () => {
 
     // Make sure that the hub event was proper.
     expect(hubEvent?.mergeMessageBody?.message?.data?.fid).toEqual(fid);
-    expect(hubEvent?.mergeMessageBody?.deletedMessages?.length).toEqual(2);
+    expect(hubEvent?.mergeMessageBody?.deletedMessages?.length).toEqual(0);
   });
 
   test("merge link compaction messages removes LinkRemove messages", async () => {
@@ -236,7 +236,7 @@ describe("Merge LinkCompactState messages", () => {
 
     // Expect the hub event to be proper
     expect(hubEvent?.mergeMessageBody?.message?.data?.fid).toEqual(fid);
-    expect(hubEvent?.mergeMessageBody?.deletedMessages).toEqual([linkRemove1]);
+    expect(hubEvent?.mergeMessageBody?.deletedMessages).toEqual([]);
 
     // linkAdd1 and linkRemove1 are both not in the set
     // Trying to merge them will fail
@@ -298,7 +298,7 @@ describe("Merge LinkCompactState messages", () => {
 
     // Expect the hub event to be proper
     expect(hubEvent?.mergeMessageBody?.message?.data?.fid).toEqual(fid);
-    expect(hubEvent?.mergeMessageBody?.deletedMessages).toEqual([linkAdd1]);
+    expect(hubEvent?.mergeMessageBody?.deletedMessages).toEqual([]);
 
     // Merge a new compact state after linkAdd2
     const linkCompactState2 = await Factories.LinkCompactStateMessage.create({
@@ -318,7 +318,7 @@ describe("Merge LinkCompactState messages", () => {
 
     // Expect the hub event to be proper. The deleted messages should also have the previous compact state
     expect(hubEvent?.mergeMessageBody?.message?.data?.fid).toEqual(fid);
-    expect(hubEvent?.mergeMessageBody?.deletedMessages).toEqual([linkCompactState, linkAdd2]);
+    expect(hubEvent?.mergeMessageBody?.deletedMessages).toEqual([]);
   });
 
   test("link compact can be inserted in the middle of a set", async () => {
@@ -559,7 +559,8 @@ describe("Merge LinkCompactState messages", () => {
 
       // Make sure the hub event is proper
       expect(hubEvent?.mergeMessageBody?.message?.data?.fid).toEqual(fid);
-      expect(hubEvent?.mergeMessageBody?.deletedMessages).toEqual([linkAdd3]);
+      // merging compact state messages do not yield deleted deltas, they are implicit:
+      expect(hubEvent?.mergeMessageBody?.deletedMessages).toEqual([]);
 
       // linkAdd3 is now removed
       allMessages = (await set.getAllLinkMessagesByFid(fid)).messages;


### PR DESCRIPTION
## Why is this change needed?

The current processing of full state events results in an unbounded number of deleted messages, making event consumption downstream unpredictable and prone to getting stuck on singular large events. Because merge events historically applied to deltas, and deltas were generally small in effect size, this was a reasonable consideration, but for full state (compact) messages, it is implicit on what is added (everything in it) and what is not (everything not in it), making the deleted messages something implicitly handled by downstream consumers.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the behavior of full state events in the `store.rs` file and test cases related to compact state messages in the `linkStoreCompactState.test.ts`.

### Detailed summary
- Fixed full state events to exclude deleted messages in `store.rs`
- Updated test cases to reflect changes in handling deleted messages for compact state messages in `linkStoreCompactState.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->