### PR TITLE
fix(hubble): hub operator fid is not set docker compose

### DIFF
--- a/.changeset/new-kids-provide.md
+++ b/.changeset/new-kids-provide.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fixed issue with cli arguments order in docker-compose.yml causing hub operator fid to be unset

--- a/apps/hubble/docker-compose.yml
+++ b/apps/hubble/docker-compose.yml
@@ -34,10 +34,10 @@ services:
         --eth-mainnet-rpc-url $ETH_MAINNET_RPC_URL
         --l2-rpc-url $OPTIMISM_L2_RPC_URL
         --network ${FC_NETWORK_ID:-1}
+        --hub-operator-fid ${HUB_OPERATOR_FID:-0}
         --rpc-subscribe-per-ip-limit ${RPC_SUBSCRIBE_PER_IP_LIMIT:-4}
         -b ${BOOTSTRAP_NODE:-/dns/nemes.farcaster.xyz/tcp/2282}
         --statsd-metrics-server $STATSD_METRICS_SERVER
-        --hub-operator-fid ${HUB_OPERATOR_FID:-0}
         --opt-out-diagnostics ${HUB_OPT_OUT_DIAGNOSTICS:-false}
         ${HUB_OPTIONS:-}
     ports:


### PR DESCRIPTION
## Motivation

Fixes #2088 #2117 

There is likely an underlying issue with the commander configuration but this is a quick change that gets this working for those having trouble getting the container up and running.

## Change Summary

Reordered CLI arguments in docker-compose.yml.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `docker-compose.yml` file for the `@farcaster/hubble` app to fix an issue with CLI arguments order affecting the hub operator FID.

### Detailed summary
- Added `--hub-operator-fid ${HUB_OPERATOR_FID:-0}` to fix unset hub operator FID in docker-compose.yml.
- Rearranged CLI arguments to ensure correct order and parameter assignment.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->