### PR TITLE
chore: update statsd metrics for diff sync

### DIFF
--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -1567,16 +1567,25 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     const result = await this.validateAndMergeOnChainEvents(
       missingSyncIds.filter((id) => id.type() === SyncIdType.OnChainEvent),
     );
+    statsd().increment("syncengine.sync_messages.onchain.success", result.successCount);
+    statsd().increment("syncengine.sync_messages.onchain.error", result.errCount);
+    statsd().increment("syncengine.sync_messages.onchain.deferred", result.deferredCount);
 
     // Then Fnames
     const fnameResult = await this.validateAndMergeFnames(
       missingSyncIds.filter((id) => id.type() === SyncIdType.FName),
     );
     result.addResult(fnameResult);
+    statsd().increment("syncengine.sync_messages.fname.success", fnameResult.successCount);
+    statsd().increment("syncengine.sync_messages.fname.error", fnameResult.errCount);
+    statsd().increment("syncengine.sync_messages.fname.deferred", fnameResult.deferredCount);
 
     // And finally messages
     const messagesResult = await this.fetchAndMergeMessages(missingMessageIds, rpcClient);
     result.addResult(messagesResult);
+    statsd().increment("syncengine.sync_messages.message.success", messagesResult.successCount);
+    statsd().increment("syncengine.sync_messages.message.error", messagesResult.errCount);
+    statsd().increment("syncengine.sync_messages.message.deferred", messagesResult.deferredCount);
 
     this.curSync.fullResult.addResult(result);
 


### PR DESCRIPTION
## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding statistics tracking for different types of sync messages in the `syncEngine.ts` file.

### Detailed summary
- Added statistics tracking for on-chain events, FNames, and messages sync messages
- Incremented success, error, and deferred counts for each type of sync message

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->