### PR TITLE
fix(shuttle): Handle missing group key 

### DIFF
--- a/.changeset/calm-rings-lie.md
+++ b/.changeset/calm-rings-lie.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+Gracefully handle "no such key" when querying group on first start


### PR DESCRIPTION
## Motivation

We didn't handle the case where the group key wasn't already created.

## Change Summary

Handle it.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on gracefully handling "no such key" errors when querying a group on the first start in the `shuttle` package.

### Detailed summary
- Added error handling for "no such key" scenario
- Skips group creation if key doesn't exist
- Improved robustness in handling ReplyError

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->