### PR TITLE
chore: Update curve25519-dalek from 4.1.1 to 4.1.3 in Rust extension

### DIFF
--- a/.changeset/silver-wombats-rule.md
+++ b/.changeset/silver-wombats-rule.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+chore: Update curve25519-dalek from 4.1.1 to 4.1.3 in Rust extension

--- a/apps/hubble/src/addon/Cargo.lock
+++ b/apps/hubble/src/addon/Cargo.lock
@@ -433,16 +433,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.1"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
- "platforms",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -1220,12 +1219,6 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
-name = "platforms"
-version = "3.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4503fa043bf02cee09a9582e9554b4c6403b2ef55e4612e96561d294419429f8"
 
 [[package]]
 name = "powerfmt"


### PR DESCRIPTION
## Motivation

Addresses a vulnerability.

## Change Summary

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `curve25519-dalek` package in the Rust extension of the `@farcaster/hubble` addon from version 4.1.1 to 4.1.3.

### Detailed summary
- Updated `curve25519-dalek` package version from 4.1.1 to 4.1.3
- Removed `platforms` package
- Updated checksum for `curve25519-dalek` package

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
- [x] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)