### PR TITLE
chore: Update pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,6 @@
-## Motivation
+## Why is this change needed?
 
 Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.
-
-## Change Summary
-
-Describe the changes being made in 1-2 concise sentences.
 
 ## Merge Checklist
 
@@ -14,8 +10,3 @@ _Choose all relevant options below by adding an `x` now or at any time before su
 - [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
 - [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
 - [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
-- [ ] All [commits have been signed](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#22-signing-commits)
-
-## Additional Context
-
-If this is a relatively large or complex change, provide more details here that will help reviewers


### PR DESCRIPTION
## Why is this change needed?

Our template is in need of a makeover. Made the following changes:

- Change **Motivation** to **Why is this change needed?** to emphasize what we mean by Motivation.

- Remove the **Change Summary** section since this is automatically summarized by PR-Codex bot.

- Remove requirement to sign commits, since this doesn't provide any _real_ security and makes it slightly harder for contributors. Since GitHub doesn't prevent them from creating the PR in the first place if the HEAD commit isn't signed, we might as well allow it so we don't need to manually bypass.

- Removed **Additional Context** section since this seemed superfluous.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the `Change Summary` section from the pull request template and updates the checklist options. 

### Detailed summary
- Removed `Change Summary` section from PR template
- Updated checklist options in PR template

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->