### PR TITLE
chore(shuttle) Release 0.4.3

### DIFF
--- a/.changeset/calm-rings-lie.md
+++ b/.changeset/calm-rings-lie.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-Gracefully handle "no such key" when querying group on first start

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.4.3
+
+### Patch Changes
+
+- 45180584: Gracefully handle "no such key" when querying group on first start
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Why is this change needed?

Releases a bug fix that is affecting Shuttle users.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `@farcaster/shuttle` package to `0.4.3` and includes a patch to handle "no such key" error when querying group on first start.

### Detailed summary
- Updated package version to `0.4.3`
- Patched to handle "no such key" error when querying group on first start

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->