### PR TITLE
feat(shuttle): Allow RedisClient's client to be a cluster instance

### DIFF
--- a/.changeset/smart-garlics-sniff.md
+++ b/.changeset/smart-garlics-sniff.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+feat(shuttle) Allow Redis client to be a cluster instance

--- a/packages/shuttle/src/shuttle/redis.ts
+++ b/packages/shuttle/src/shuttle/redis.ts
@@ -1,4 +1,4 @@
-import { Redis, RedisOptions } from "ioredis";
+import { Redis, Cluster, RedisOptions } from "ioredis";
 
 export const getRedisClient = (redisUrl: string, redisOpts?: RedisOptions) => {
   const client = new Redis(redisUrl, {
@@ -10,8 +10,8 @@ export const getRedisClient = (redisUrl: string, redisOpts?: RedisOptions) => {
 };
 
 export class RedisClient {
-  public client: Redis;
-  constructor(client: Redis) {
+  public client: Redis | Cluster;
+  constructor(client: Redis | Cluster) {
     this.client = client;
   }
   static create(redisUrl: string, redisOpts?: RedisOptions) {


### PR DESCRIPTION
## Why is this change needed?

We were artificially limiting the accepted type to a `Redis` instance, when a `Cluster` instance would also work fine.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for Redis cluster instances in the `shuttle` package.

### Detailed summary
- Added support for Redis cluster instances in `shuttle/redis.ts`
- Updated `RedisClient` constructor to accept either `Redis` or `Cluster` client
- Updated `create` method to handle Redis cluster instances

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->