### PR TITLE
feat: make message processor handle removals for compact state explicitly, warn on mismatching deletes

### DIFF
--- a/.changeset/silver-weeks-eat.md
+++ b/.changeset/silver-weeks-eat.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+feat: make message processor handle removals for compact state explicitly, warn on mismatching deletes

--- a/packages/shuttle/src/shuttle/hubEventProcessor.ts
+++ b/packages/shuttle/src/shuttle/hubEventProcessor.ts
@@ -13,11 +13,13 @@ import {
   isVerificationAddAddressMessage,
   isVerificationRemoveMessage,
   Message,
+  MessageType,
 } from "@farcaster/hub-nodejs";
 import { DB } from "./db";
 import { MessageProcessor } from "./messageProcessor";
 import { MessageHandler, MessageState, StoreMessageOperation } from "./";
 import { log } from "../log";
+import { bytesToHex } from "../utils";
 
 export class HubEventProcessor {
   static async processHubEvent(db: DB, event: HubEvent, handler: MessageHandler) {
@@ -49,7 +51,7 @@ export class HubEventProcessor {
     wasMissed = false,
   ) {
     await db.transaction().execute(async (trx) => {
-      if (deletedMessages.length > 0) {
+      if (deletedMessages.length > 0 && (operation !== "merge" || !MessageProcessor.isCompactStateMessage(message))) {
         await Promise.all(
           deletedMessages.map(async (deletedMessage) => {
             const isNew = await MessageProcessor.storeMessage(deletedMessage, trx, "delete", log);
@@ -57,6 +59,24 @@ export class HubEventProcessor {
             await handler.handleMessageMerge(deletedMessage, trx, "delete", state, isNew, wasMissed);
           }),
         );
+      } else if (operation === "merge" && MessageProcessor.isCompactStateMessage(message)) {
+        const affectedMessages = await MessageProcessor.deleteDifferenceMessages(message, trx, log);
+        await Promise.all(
+          deletedMessages.map(async (deletedMessage) => {
+            let isNew = affectedMessages.get(bytesToHex(deletedMessage.hash));
+            if (isNew === undefined) {
+              log.warn(`Message ${bytesToHex(message.hash)} was not already in set, inserting as deleted row.`);
+              isNew = await MessageProcessor.storeMessage(deletedMessage, trx, "delete", log);
+            }
+            const state = this.getMessageState(deletedMessage, "delete");
+            await handler.handleMessageMerge(deletedMessage, trx, "delete", state, isNew, wasMissed);
+          }),
+        );
+
+        const eventSet = new Set(deletedMessages.map((m) => bytesToHex(m.hash)));
+        for (const hash of [...affectedMessages.keys()].filter((m) => !eventSet.has(m))) {
+          log.warn(`Message ${hash} was updated, but was not in deleted messages from merge event.`);
+        }
       }
       const isNew = await MessageProcessor.storeMessage(message, trx, operation, log);
       const state = this.getMessageState(message, operation);

--- a/packages/shuttle/src/shuttle/hubEventProcessor.ts
+++ b/packages/shuttle/src/shuttle/hubEventProcessor.ts
@@ -51,7 +51,12 @@ export class HubEventProcessor {
     wasMissed = false,
   ) {
     await db.transaction().execute(async (trx) => {
-      if (deletedMessages.length > 0 && (operation !== "merge" || !MessageProcessor.isCompactStateMessage(message))) {
+      if (
+        deletedMessages.length > 0 &&
+        (process.env["SHUTTLE_PROCESS_EACH_DELETE"] ||
+          operation !== "merge" ||
+          !MessageProcessor.isCompactStateMessage(message))
+      ) {
         await Promise.all(
           deletedMessages.map(async (deletedMessage) => {
             const isNew = await MessageProcessor.storeMessage(deletedMessage, trx, "delete", log);
@@ -62,19 +67,14 @@ export class HubEventProcessor {
       } else if (operation === "merge" && MessageProcessor.isCompactStateMessage(message)) {
         const affectedMessages = await MessageProcessor.deleteDifferenceMessages(message, trx, log);
         await Promise.all(
-          deletedMessages.map(async (deletedMessage) => {
-            let isNew = affectedMessages.get(bytesToHex(deletedMessage.hash));
-            if (isNew === undefined) {
-              log.warn(`Message ${bytesToHex(message.hash)} was not already in set, inserting as deleted row.`);
-              isNew = await MessageProcessor.storeMessage(deletedMessage, trx, "delete", log);
-            }
+          affectedMessages.map(async (deletedMessage) => {
             const state = this.getMessageState(deletedMessage, "delete");
             await handler.handleMessageMerge(deletedMessage, trx, "delete", state, isNew, wasMissed);
           }),
         );
 
-        const eventSet = new Set(deletedMessages.map((m) => bytesToHex(m.hash)));
-        for (const hash of [...affectedMessages.keys()].filter((m) => !eventSet.has(m))) {
+        const eventSet = new Set(affectedMessages.map((m) => bytesToHex(m.hash)));
+        for (const hash of deletedMessages.filter((m) => !eventSet.has(bytesToHex(m.hash)))) {
           log.warn(`Message ${hash} was updated, but was not in deleted messages from merge event.`);
         }
       }

--- a/packages/shuttle/src/shuttle/hubEventProcessor.ts
+++ b/packages/shuttle/src/shuttle/hubEventProcessor.ts
@@ -69,7 +69,7 @@ export class HubEventProcessor {
         await Promise.all(
           affectedMessages.map(async (deletedMessage) => {
             const state = this.getMessageState(deletedMessage, "delete");
-            await handler.handleMessageMerge(deletedMessage, trx, "delete", state, isNew, wasMissed);
+            await handler.handleMessageMerge(deletedMessage, trx, "delete", state, true, wasMissed);
           }),
         );
 

--- a/packages/shuttle/src/shuttle/messageProcessor.ts
+++ b/packages/shuttle/src/shuttle/messageProcessor.ts
@@ -1,8 +1,9 @@
-import { Message, validations } from "@farcaster/hub-nodejs";
-import { DB, InsertableMessageRow } from "./db";
+import { Message, MessageType, isLinkCompactStateMessage, validations } from "@farcaster/hub-nodejs";
+import { DB, InsertableMessageRow, HubTables } from "./db";
 import { bytesToHex, convertProtobufMessageBodyToJson, farcasterTimeToDate } from "../utils";
 import { pino } from "pino";
 import { StoreMessageOperation } from "./";
+import { Expression, ExpressionBuilder, SqlBool, sql } from "kysely";
 
 export class MessageProcessor {
   static async storeMessage(
@@ -84,5 +85,85 @@ export class MessageProcessor {
       )
       .executeTakeFirst();
     return !!result;
+  }
+
+  // Given a compact state message, marks messages which are a difference of the subset as deleted,
+  // returning message hashes found and whether they were updated as deleted messages.
+  static async deleteDifferenceMessages(
+    message: Message,
+    trx: DB,
+    log: pino.Logger | undefined = undefined,
+    validate = true,
+  ): Promise<Map<`0x${string}`, boolean>> {
+    if (!MessageProcessor.isCompactStateMessage(message)) {
+      log?.warn(`Invalid message type for set difference deletion ${message.data?.type}`);
+      throw new Error(`Invalid message type for set difference deletion ${message.data?.type}`);
+    }
+
+    if (validate) {
+      const validation = await validations.validateMessage(message);
+      if (validation.isErr()) {
+        log?.warn(`Invalid message ${bytesToHex(message.hash)}: ${validation.error.message}`);
+        throw new Error(`Invalid message: ${validation.error.message}`);
+      }
+    }
+
+    const potentialConflicts = await trx
+      .selectFrom("messages")
+      .select(["hash"])
+      .where(this.getConflictCriteria(message))
+      .execute();
+
+    const result = await trx
+      .updateTable("messages")
+      .set({
+        deletedAt: new Date(),
+      })
+      .returning(["hash"])
+      .where(this.getConflictCriteria(message))
+      .execute();
+
+    const updateSet = new Set(result.map((r) => bytesToHex(r.hash)));
+    const resultMap = new Map<`0x${string}`, boolean>();
+
+    for (const row of potentialConflicts) {
+      const hash = bytesToHex(row.hash);
+      resultMap.set(hash, updateSet.has(hash));
+    }
+
+    return resultMap;
+  }
+
+  // Returns the conflicting record criteria for a given message. Assumes message is a full state type
+  // supported for conflict discovery.
+  static getConflictCriteria(message: Message): (eb: ExpressionBuilder<HubTables, "messages">) => Expression<SqlBool> {
+    const data = message.data;
+
+    if (!data || !data.linkCompactStateBody) {
+      throw new Error("linkCompactStateBody is not defined.");
+    }
+
+    const { type, targetFids } = data.linkCompactStateBody;
+
+    return (eb) => {
+      const conditions = [
+        eb("fid", "=", data.fid),
+        eb("type", "in", [MessageType.LINK_ADD, MessageType.LINK_COMPACT_STATE, MessageType.LINK_REMOVE]),
+        eb(sql<string>`body ->> 'type'`, "=", type),
+        eb.or([
+          eb(sql<number>`body ->> 'targetFid'`, "not in", targetFids),
+          eb("type", "=", MessageType.LINK_COMPACT_STATE),
+        ]),
+        eb("deletedAt", "is", null),
+        eb("prunedAt", "is", null),
+        eb("revokedAt", "is", null),
+        eb("timestamp", "<", farcasterTimeToDate(data.timestamp)),
+      ];
+      return eb.and(conditions);
+    };
+  }
+
+  static isCompactStateMessage(message: Message): boolean {
+    return isLinkCompactStateMessage(message);
   }
 }


### PR DESCRIPTION
## Why is this change needed?

Follow up from review of #2124, we want to confirm first that moving the responsibility of message processing marking messages as deleted for the set difference from full-state-bearing messages is a no-op, and while we're at it, might as well combine the potential thousands of SQL updates into a single query.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces explicit handling of message removals for compact state in the message processor, along with warnings for mismatching deletes.

### Detailed summary
- Added handling for removals of compact state messages
- Warns on mismatching deletes
- Introduced new methods for processing compact state messages

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->