### PR TITLE
feat: add hub service agreement - there will be no rewards for running a hub

### DIFF
--- a/.changeset/poor-queens-lick.md
+++ b/.changeset/poor-queens-lick.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: add hub service agreement - there will be no rewards for running a hub

--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -120,6 +120,26 @@ fetch_latest_docker_compose_and_dashboard() {
     fetch_file_from_repo "$GRAFANA_INI_PATH" "grafana/grafana.ini"
 }
 
+prompt_for_hub_operator_agreement() {
+  # Check if stdin is a terminal
+  if [ -t 0 ]; then
+    while true; do
+        printf "⚠️  IMPORTANT: You will NOT get any rewards for running this hub\n"
+        printf "> Please type \"Yes\" to continue: "
+        read -r response
+        case $(printf "%s" "$response" | tr '[:upper:]' '[:lower:]') in
+            yes|y)
+                printf "✅ You have agreed to the terms of service. Proceeding with hub startup...\n"
+                return 0
+                ;;
+            *)
+                printf "[i] Incorrect input. Please try again.\n"
+                ;;
+        esac
+    done
+  fi
+}
+
 validate_and_store() {
     local rpc_name=$1
     local expected_chain_id=$2
@@ -498,6 +518,9 @@ if [ "$1" == "up" ]; then
    # Setup the docker-compose command
     set_compose_command
 
+    # Prompt for hub operator agreement
+    prompt_for_hub_operator_agreement
+
     # Run docker compose up -d hubble
     $COMPOSE_CMD up -d hubble statsd grafana
 
@@ -542,6 +565,9 @@ if [ "$1" == "upgrade" ]; then
 
     # Call the function to set the COMPOSE_CMD variable
     set_compose_command
+
+    # Prompt for hub operator agreement
+    prompt_for_hub_operator_agreement
 
     # Update the env file if needed
     write_env_file


### PR DESCRIPTION
## Why is this change needed?

⚠️ THERE WILL BE NO REWARDS FOR RUNNING A HUB

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a hub service agreement feature to the Hubble script, requiring hub operators to agree to terms before starting the hub.

### Detailed summary
- Added function `prompt_for_hub_operator_agreement` to prompt hub operators to agree to terms
- Prompt displays a warning about no rewards for running the hub
- Operators must type "Yes" to proceed
- Implemented input validation for agreement
- Integration of agreement prompt before starting or upgrading the hub

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->