### PR TITLE
chore: release 1.13.6

### DIFF
--- a/.changeset/dull-dancers-float.md
+++ b/.changeset/dull-dancers-float.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-chore: add stats for bundle message delays, stale contact info

--- a/.changeset/new-kids-provide.md
+++ b/.changeset/new-kids-provide.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fixed issue with cli arguments order in docker-compose.yml causing hub operator fid to be unset

--- a/.changeset/poor-queens-lick.md
+++ b/.changeset/poor-queens-lick.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: add hub service agreement - there will be no rewards for running a hub

--- a/.changeset/popular-shoes-bathe.md
+++ b/.changeset/popular-shoes-bathe.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: add unique peer map to sync engine to represent current active peers

--- a/.changeset/silent-planes-promise.md
+++ b/.changeset/silent-planes-promise.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: validate gossip message for clock skew

--- a/.changeset/silver-wombats-rule.md
+++ b/.changeset/silver-wombats-rule.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-chore: Update curve25519-dalek from 4.1.1 to 4.1.3 in Rust extension

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @farcaster/hubble
 
+## 1.13.6
+
+### Patch Changes
+
+- fdcc3b52: chore: add stats for bundle message delays, stale contact info
+- 795815af: fixed issue with cli arguments order in docker-compose.yml causing hub operator fid to be unset
+- b5ff774a: feat: add hub service agreement - there will be no rewards for running a hub
+- 2a82b3dc: feat: add unique peer map to sync engine to represent current active peers
+- aa02a48d: fix: validate gossip message for clock skew
+- 2bae6fb9: chore: Update curve25519-dalek from 4.1.1 to 4.1.3 in Rust extension
+
 ## 1.13.5
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.13.5",
+  "version": "1.13.6",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",


### PR DESCRIPTION
## Why is this change needed?

Release 1.13.6

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `@farcaster/hubble` to `1.13.6` and includes various patches and features related to bundle message delays, hub service agreements, peer maps, clock skew validation, and Rust extension updates.

### Detailed summary
- Added stats for bundle message delays and stale contact info
- Fixed cli arguments order issue in docker-compose.yml
- Added hub service agreement with no rewards for running a hub
- Added unique peer map to sync engine
- Validated gossip message for clock skew
- Updated curve25519-dalek in Rust extension

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->