### PR TITLE
fix: Increase message threshold to reduce snapshot bandwidth usage

### DIFF
--- a/.changeset/light-cobras-judge.md
+++ b/.changeset/light-cobras-judge.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Increase message threshold to reduce snapshot bandwidth usage

--- a/apps/hubble/src/defaultConfig.ts
+++ b/apps/hubble/src/defaultConfig.ts
@@ -10,7 +10,7 @@ const DEFAULT_GOSSIP_PORT = 2282;
 const DEFAULT_RPC_PORT = 2283;
 const DEFAULT_HTTP_API_PORT = 2281;
 const DEFAULT_NETWORK = 3; // Farcaster Devnet
-export const DEFAULT_CATCHUP_SYNC_SNAPSHOT_MESSAGE_LIMIT = 25_000_000;
+export const DEFAULT_CATCHUP_SYNC_SNAPSHOT_MESSAGE_LIMIT = 50_000_000;
 
 export const Config = {
   /** Path to a PeerId file */


### PR DESCRIPTION
## Why is this change needed?

Snapshots are using too much bandwitdh, increase the threshold to about 10% of current messages (~470M)

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
