### PR TITLE
feat(shuttle): Allow changing subscriber batch size or flush interval

### DIFF
--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.5.0
+
+### Minor Changes
+
+- Support customization of event batch size and time between flushes
+
 ## 0.4.4
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Why is this change needed?

The way we were writing events to the stream was resulting in a lot more separate requests to Redis since we weren't actually batching them together.

Change this so we leverage the multi-argument version of `XADD` so that throughput can be increased at higher volumes. Accompanying this are the introduction of a few more configuration options that allow us to tweak the throughput of the `HubSubscriber`.

While here, do a minor version bump since we're slightly changing how events are written to the stream.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `@farcaster/shuttle` package to version 0.5.0, introducing customization for event batch size and time between flushes.

### Detailed summary
- Updated package version to 0.5.0
- Added customization for event batch size and time between flushes
- Modified event handling logic in `EventStreamHubSubscriber`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->