### PR TITLE
fix(shuttle): Fix example app to work with Shuttle 0.5.0+

### DIFF
--- a/packages/shuttle/src/example-app/package.json
+++ b/packages/shuttle/src/example-app/package.json
@@ -4,7 +4,7 @@
   "main": "./app.ts",
   "license": "MIT",
   "dependencies": {
-    "@farcaster/shuttle": "^0.2.0",
+    "@farcaster/shuttle": "^0.5.0",
     "@figma/hot-shots": "^9.0.0-figma.1",
     "commander": "^11.0.0",
     "ioredis": "^5.3.2",

--- a/packages/shuttle/src/example-app/worker.ts
+++ b/packages/shuttle/src/example-app/worker.ts
@@ -1,11 +1,11 @@
-import { Redis } from "ioredis";
+import { Cluster, Redis } from "ioredis";
 import { Job, Queue, Worker } from "bullmq";
 import { App } from "./app";
 import { pino } from "pino";
 
 const QUEUE_NAME = "default";
 
-export function getWorker(app: App, redis: Redis, log: pino.Logger, concurrency = 1) {
+export function getWorker(app: App, redis: Redis | Cluster, log: pino.Logger, concurrency = 1) {
   const worker = new Worker(
     QUEUE_NAME,
     async (job: Job) => {
@@ -38,7 +38,7 @@ export function getWorker(app: App, redis: Redis, log: pino.Logger, concurrency 
   return worker;
 }
 
-export function getQueue(redis: Redis) {
+export function getQueue(redis: Redis | Cluster) {
   return new Queue("default", {
     connection: redis,
     defaultJobOptions: { attempts: 3, backoff: { delay: 1000, type: "exponential" } },


### PR DESCRIPTION
## Why is this change needed?

Our build process didn't catch this. Will need to investigate separately.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update dependencies and support clustering in the `getWorker` and `getQueue` functions.

### Detailed summary
- Updated `@farcaster/shuttle` dependency to `^0.5.0`
- Added support for `Cluster` in `getWorker` function
- Added support for `Cluster` in `getQueue` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->