### PR TITLE
feat(shuttle): Make shuttle and example-app capable of using postgres schema other than "public"

### DIFF
--- a/.changeset/warm-stingrays-crash.md
+++ b/.changeset/warm-stingrays-crash.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+feat(shuttle): Enables shuttle and its example-app to optionally use a postgres schema other than "public"

--- a/packages/shuttle/README.md
+++ b/packages/shuttle/README.md
@@ -28,11 +28,19 @@ If you want to run the test the app, do the following:
 ```bash
 
 # Ensure you have node 21 installed, use nvm to install it
+nvm install 21
 
-# Within the package directory 
+# If necessary, build packages/core dependency
+( cd packages/core && yarn install && yarn build; )
+
+# If necessary, build packages/hub-nodejs dependency
+( cd packages/hub-nodejs && yarn install && yarn build; )
+
+# Do remainder within the packages/shuttle directory
+cd packages/shuttle
 yarn install && yarn build
 
-# Start the dependencies
+# Start the db dependencies
 docker compose up postgres redis
  
 # To perform reconciliation/backfill, start the worker (can run multiple processes to speed this up)

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -18,9 +18,10 @@
   "dependencies": {
     "@farcaster/hot-shots": "^10.0.0",
     "@farcaster/hub-nodejs": "^0.11.17",
-    "kysely": "^0.26.1",
-    "commander": "^11.0.0",
+    "commander": "11.0.0",
+    "dotenv": "16.4.5",
     "ioredis": "^5.3.2",
+    "kysely": "^0.26.1",
     "neverthrow": "^6.0.0",
     "pg": "^8.12.0",
     "pg-cursor": "^2.10.3",
@@ -40,12 +41,13 @@
     "prepublishOnly": "yarn run build"
   },
   "devDependencies": {
+    "@commander-js/extra-typings": "11.0.0",
     "@types/humanize-duration": "^3.27.1",
     "@types/pg": "^8.10.3",
     "@types/pg-cursor": "^2.7.0",
     "@types/node": "^20.11.30",
-    "bullmq": "^5.7.1",
     "biome-config-custom": "*",
+    "bullmq": "^5.7.1",
     "prettier-config-custom": "*"
   }
 }

--- a/packages/shuttle/src/example-app/app.ts
+++ b/packages/shuttle/src/example-app/app.ts
@@ -25,6 +25,7 @@ import {
   HUB_SSL,
   MAX_FID,
   POSTGRES_URL,
+  POSTGRES_SCHEMA,
   REDIS_URL,
   SHARD_INDEX,
   TOTAL_SHARDS,
@@ -40,13 +41,21 @@ const hubId = "shuttle";
 
 export class App implements MessageHandler {
   private readonly db: DB;
+  private readonly dbSchema: string;
   private hubSubscriber: HubSubscriber;
   private streamConsumer: HubEventStreamConsumer;
   public redis: RedisClient;
   private readonly hubId;
 
-  constructor(db: DB, redis: RedisClient, hubSubscriber: HubSubscriber, streamConsumer: HubEventStreamConsumer) {
+  constructor(
+    db: DB,
+    dbSchema: string,
+    redis: RedisClient,
+    hubSubscriber: HubSubscriber,
+    streamConsumer: HubEventStreamConsumer,
+  ) {
     this.db = db;
+    this.dbSchema = dbSchema;
     this.redis = redis;
     this.hubSubscriber = hubSubscriber;
     this.hubId = hubId;
@@ -55,13 +64,14 @@ export class App implements MessageHandler {
 
   static create(
     dbUrl: string,
+    dbSchema: string,
     redisUrl: string,
     hubUrl: string,
     totalShards: number,
     shardIndex: number,
     hubSSL = false,
   ) {
-    const db = getDbClient(dbUrl);
+    const db = getDbClient(dbUrl, dbSchema);
     const hub = getHubClient(hubUrl, { ssl: hubSSL });
     const redis = RedisClient.create(redisUrl);
     const eventStreamForWrite = new EventStreamConnection(redis.client);
@@ -80,7 +90,7 @@ export class App implements MessageHandler {
     );
     const streamConsumer = new HubEventStreamConsumer(hub, eventStreamForRead, shardKey);
 
-    return new App(db, redis, hubSubscriber, streamConsumer);
+    return new App(db, dbSchema, redis, hubSubscriber, streamConsumer);
   }
 
   async handleMessageMerge(
@@ -198,7 +208,7 @@ export class App implements MessageHandler {
   }
 
   async ensureMigrations() {
-    const result = await migrateToLatest(this.db, log);
+    const result = await migrateToLatest(this.db, this.dbSchema, log);
     if (result.isErr()) {
       log.error("Failed to migrate database", result.error);
       throw result.error;
@@ -216,14 +226,14 @@ export class App implements MessageHandler {
 if (import.meta.url.endsWith(url.pathToFileURL(process.argv[1] || "").toString())) {
   async function start() {
     log.info(`Creating app connecting to: ${POSTGRES_URL}, ${REDIS_URL}, ${HUB_HOST}`);
-    const app = App.create(POSTGRES_URL, REDIS_URL, HUB_HOST, TOTAL_SHARDS, SHARD_INDEX, HUB_SSL);
+    const app = App.create(POSTGRES_URL, POSTGRES_SCHEMA, REDIS_URL, HUB_HOST, TOTAL_SHARDS, SHARD_INDEX, HUB_SSL);
     log.info("Starting shuttle");
     await app.start();
   }
 
   async function backfill() {
     log.info(`Creating app connecting to: ${POSTGRES_URL}, ${REDIS_URL}, ${HUB_HOST}`);
-    const app = App.create(POSTGRES_URL, REDIS_URL, HUB_HOST, TOTAL_SHARDS, SHARD_INDEX, HUB_SSL);
+    const app = App.create(POSTGRES_URL, POSTGRES_SCHEMA, REDIS_URL, HUB_HOST, TOTAL_SHARDS, SHARD_INDEX, HUB_SSL);
     const fids = BACKFILL_FIDS ? BACKFILL_FIDS.split(",").map((fid) => parseInt(fid)) : [];
     log.info(`Backfilling fids: ${fids}`);
     const backfillQueue = getQueue(app.redis.client);
@@ -237,7 +247,7 @@ if (import.meta.url.endsWith(url.pathToFileURL(process.argv[1] || "").toString()
 
   async function worker() {
     log.info(`Starting worker connecting to: ${POSTGRES_URL}, ${REDIS_URL}, ${HUB_HOST}`);
-    const app = App.create(POSTGRES_URL, REDIS_URL, HUB_HOST, TOTAL_SHARDS, SHARD_INDEX, HUB_SSL);
+    const app = App.create(POSTGRES_URL, POSTGRES_SCHEMA, REDIS_URL, HUB_HOST, TOTAL_SHARDS, SHARD_INDEX, HUB_SSL);
     const worker = getWorker(app, app.redis.client, log, CONCURRENCY);
     await worker.run();
   }

--- a/packages/shuttle/src/example-app/db.ts
+++ b/packages/shuttle/src/example-app/db.ts
@@ -7,10 +7,11 @@ import { fileURLToPath } from "node:url";
 import { HubTables } from "@farcaster/hub-shuttle";
 import { Fid } from "../shuttle";
 
-const createMigrator = async (db: Kysely<HubTables>, log: Logger) => {
+const createMigrator = async (db: Kysely<HubTables>, dbSchema: string, log: Logger) => {
   const currentDir = path.dirname(fileURLToPath(import.meta.url));
   const migrator = new Migrator({
     db,
+    migrationTableSchema: dbSchema,
     provider: new FileMigrationProvider({
       fs,
       path,
@@ -21,8 +22,12 @@ const createMigrator = async (db: Kysely<HubTables>, log: Logger) => {
   return migrator;
 };
 
-export const migrateToLatest = async (db: Kysely<HubTables>, log: Logger): Promise<Result<void, unknown>> => {
-  const migrator = await createMigrator(db, log);
+export const migrateToLatest = async (
+  db: Kysely<HubTables>,
+  dbSchema: string,
+  log: Logger,
+): Promise<Result<void, unknown>> => {
+  const migrator = await createMigrator(db, dbSchema, log);
 
   const { error, results } = await migrator.migrateToLatest();
 

--- a/packages/shuttle/src/example-app/env.ts
+++ b/packages/shuttle/src/example-app/env.ts
@@ -9,6 +9,7 @@ export const HUB_HOST = process.env["HUB_HOST"] || "localhost:2283";
 export const HUB_SSL = process.env["HUB_SSL"] === "true" ? true : false;
 
 export const POSTGRES_URL = process.env["POSTGRES_URL"] || "postgres://localhost:5432";
+export const POSTGRES_SCHEMA = process.env["POSTGRES_SCHEMA"] || "public";
 export const REDIS_URL = process.env["REDIS_URL"] || "redis://localhost:6379";
 
 export const TOTAL_SHARDS = parseInt(process.env["SHARDS"] || "0");

--- a/packages/shuttle/src/example-app/migrations/001_initial_migration.ts
+++ b/packages/shuttle/src/example-app/migrations/001_initial_migration.ts
@@ -47,7 +47,7 @@ export const up = async (db: Kysely<any>) => {
   // Used for generating random bytes in ULID creation
   await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db);
 
-  await sql`CREATE FUNCTION generate_ulid() RETURNS uuid
+  await sql`CREATE OR REPLACE FUNCTION generate_ulid() RETURNS uuid
     LANGUAGE sql STRICT PARALLEL SAFE
     RETURN ((lpad(to_hex((floor((EXTRACT(epoch FROM clock_timestamp()) * (1000)::numeric)))::bigint), 12, '0'::text) || encode(public.gen_random_bytes(10), 'hex'::text)))::uuid;
   `.execute(db);

--- a/packages/shuttle/src/shuttle.integration.test.ts
+++ b/packages/shuttle/src/shuttle.integration.test.ts
@@ -34,6 +34,7 @@ let redis: RedisClient;
 const signer = Factories.Ed25519Signer.build();
 
 const POSTGRES_URL = process.env["POSTGRES_URL"] || "postgres://shuttle:password@localhost:6541";
+const POSTGRES_SCHEMA = process.env["POSTGRES_SCHEMA"] || "shuttle_test";
 const REDIS_URL = process.env["REDIS_URL"] || "localhost:16379";
 
 class FakeHubSubscriber extends HubSubscriber implements MessageHandler {
@@ -88,12 +89,12 @@ beforeAll(async () => {
   if (process.env["NODE_ENV"] !== "test") {
     throw new Error("NODE_ENV must be set to test");
   }
-  db = getDbClient(POSTGRES_URL);
+  db = getDbClient(POSTGRES_URL, POSTGRES_SCHEMA);
   await sql`DROP DATABASE IF EXISTS shuttle_test`.execute(db);
   await sql`CREATE DATABASE shuttle_test`.execute(db);
 
-  db = getDbClient(`${POSTGRES_URL}/${dbName}`);
-  const result = await migrateToLatest(db, log);
+  db = getDbClient(`${POSTGRES_URL}/${dbName}`, POSTGRES_SCHEMA);
+  const result = await migrateToLatest(db, POSTGRES_SCHEMA, log);
   expect(result.isOk()).toBe(true);
 
   redis = RedisClient.create(REDIS_URL);

--- a/packages/shuttle/src/shuttle/db.ts
+++ b/packages/shuttle/src/shuttle/db.ts
@@ -1,6 +1,7 @@
 import pg from "pg";
 import {
   CamelCasePlugin,
+  WithSchemaPlugin,
   DeleteQueryBuilder,
   Generated,
   InsertQueryBuilder,
@@ -144,7 +145,7 @@ export interface HubTables {
   messages: MessagesTable;
 }
 
-export const getDbClient = (connectionString?: string) => {
+export const getDbClient = (connectionString?: string, schema = "public") => {
   return new Kysely<HubTables>({
     dialect: new PostgresDialect({
       pool: new Pool({
@@ -153,7 +154,7 @@ export const getDbClient = (connectionString?: string) => {
       }),
       cursor: Cursor,
     }),
-    plugins: [new CamelCasePlugin()],
+    plugins: [new CamelCasePlugin(), new WithSchemaPlugin(schema)],
   });
 };
 
@@ -230,11 +231,16 @@ export async function stream<DB, UT extends keyof DB, TB extends keyof DB, O>(
   }
 }
 
-export function getEstimateOfTablesRowCount(db: DB, tablesToMonitor: Array<keyof HubTables>) {
+export function getEstimateOfTablesRowCount(db: DB, tablesToMonitor: Array<keyof HubTables>, schema = "public") {
   try {
     return sql<{ tableName: string; estimate: number }>`SELECT relname AS table_name, reltuples AS estimate
-               FROM pg_class
-               WHERE relname IN (${sql.join(tablesToMonitor)})`.execute(db);
+                FROM pg_class
+                WHERE oid IN (
+                  to_regclass('${sql.join(
+                    tablesToMonitor.map((t) => sql.id(schema, t)),
+                    sql`'), to_regclass('`,
+                  )}')
+                )`.execute(db);
   } catch (e) {
     throw extendStackTrace(e, new Error());
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1283,6 +1283,11 @@
     human-id "^1.0.2"
     prettier "^2.7.1"
 
+"@commander-js/extra-typings@11.0.0":
+  version "11.0.0"
+  resolved "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-11.0.0.tgz#eb922a59550454cad1f319d3d33e675e12e92fa0"
+  integrity sha512-06ol6Kn5gPjFY6v0vWOZ84nQwyqhZdaeZCHYH3vhwewjpOEjniF1KHZxh18887G3poWiJ8qyq5pb6ANuiddfPQ==
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
@@ -5238,6 +5243,11 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@11.0.0:
+  version "11.0.0"
+  resolved "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz#43e19c25dbedc8256203538e8d7e9346877a6f67"
+  integrity sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==
+
 commander@2.15.1:
   version "2.15.1"
   resolved "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
@@ -5247,11 +5257,6 @@ commander@^10.0.0, commander@~10.0.0:
   version "10.0.0"
   resolved "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz#71797971162cd3cf65f0b9d24eb28f8d303acdf1"
   integrity sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==
-
-commander@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz#43e19c25dbedc8256203538e8d7e9346877a6f67"
-  integrity sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==
 
 commander@^2.19.0:
   version "2.20.3"
@@ -5601,6 +5606,11 @@ dns-over-http-resolver@^2.1.0:
     native-fetch "^4.0.2"
     receptacle "^1.3.2"
     undici "^5.12.0"
+
+dotenv@16.4.5:
+  version "16.4.5"
+  resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
+  integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
 
 dprint-node@^1.0.7:
   version "1.0.7"


### PR DESCRIPTION
## Why is this change needed?

This allows using shuttle to target e.g. multi-tenant dbs. Shouldn't be a breaking change because new parameters on public functions are optional. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enables `shuttle` and its `example-app` to use a custom PostgreSQL schema. 

### Detailed summary
- Added support for custom PostgreSQL schema in shuttle and example-app
- Updated migrations to create functions with `CREATE OR REPLACE`
- Updated dependencies in `package.json`
- Added dotenv package for environment variables
- Updated README with installation instructions for node 21
- Modified database client creation to include schema parameter
- Updated table row count estimation function to include schema parameter

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->