### PR TITLE
fix(shuttle): Fix resetting of batch flush logic when exceeding byte limit

### DIFF
--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.5.1
+
+### Patch Changes
+
+- Fix reset of limit for total batch bytes
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/shuttle/src/shuttle/hubSubscriber.ts
+++ b/packages/shuttle/src/shuttle/hubSubscriber.ts
@@ -222,6 +222,7 @@ export class EventStreamHubSubscriber extends BaseHubSubscriber {
     ) {
       // Empties the current batch
       const eventBatch = this.eventsToAdd.splice(0, this.eventsToAdd.length);
+      this.eventBatchBytes = 0;
 
       // Copies the removed events to the stream
       await this.eventStream.add(


### PR DESCRIPTION
## Why is this change needed?

This results in the batch being flushed after each event since we don't reset the count on flush.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version to 0.5.1, fixing a bug related to the reset of the total batch bytes limit in `shuttle`.

### Detailed summary
- Updated version to 0.5.1
- Fixed reset of limit for total batch bytes in `hubSubscriber.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->