### PR TITLE
chore: upgrade typescript to 5.5.3

### DIFF
--- a/apps/hubble/src/eth/l2EventsProvider.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.ts
@@ -788,7 +788,10 @@ export class L2EventsProvider {
     return this.withRetry(
       async () => {
         if (this._useFilters) {
-          const filter = await this._publicClient.createContractEventFilter(params);
+          const filter = (await this._publicClient.createContractEventFilter(
+            params,
+            // biome-ignore lint/suspicious/noExplicitAny: viem upgraded needed
+          )) as any;
           return this._publicClient.getFilterLogs({ filter });
         } else {
           return this._publicClient.getContractEvents(params);

--- a/apps/hubble/src/profile/gossipProfile.ts
+++ b/apps/hubble/src/profile/gossipProfile.ts
@@ -165,7 +165,7 @@ function computeStats(peerIds: string[], datas: number[][], expected: number): s
     return formattedData;
   }
 
-  const allNodes = [0, 0, 0, 0, 0];
+  const allNodes: [number, number, number, number, number] = [0, 0, 0, 0, 0];
 
   // Go over all the nodes and compute the stats
   for (let i = 0; i < peerIds?.length; i++) {

--- a/apps/hubble/src/storage/engine/messageDataBytes.test.ts
+++ b/apps/hubble/src/storage/engine/messageDataBytes.test.ts
@@ -211,7 +211,8 @@ describe("messageDataBytes", () => {
       newVarintBytes.push(value);
 
       // Add leading zero to the most significant byte
-      newVarintBytes[newVarintBytes.length - 1] |= 0x80;
+      // TS: force cast to number since we know it will exist but typescript can't infer this
+      (newVarintBytes[newVarintBytes.length - 1] as number) |= 0x80;
       newVarintBytes.push(0x00);
 
       // Create the new bytes array with the alternative varint encoding for fid

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ts-node": "^10.9.1",
     "tsup": "^6.5.0",
     "turbo": "1.10.3",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.3"
   },
   "lint-staged": {
     "*.ts": ["biome check"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -11598,10 +11598,10 @@ typed-array-length@^1.0.4:
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
 
-typescript@^5.4.5:
-  version "5.4.5"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
-  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
+typescript@^5.5.3:
+  version "5.5.3"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz#e1b0a3c394190838a0b168e771b0ad56a0af0faa"
+  integrity sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==
 
 uint8-varint@^1.0.1, uint8-varint@^1.0.2:
   version "1.0.4"


### PR DESCRIPTION
## Why is this change needed?

Upgrading Typescript to latest version

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates TypeScript to version 5.5.3, adds explicit type casting, and refactors filter creation in the codebase.

### Detailed summary
- Updated TypeScript to v5.5.3
- Added explicit type casting for number
- Refactored filter creation in L2EventsProvider

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->