### PR TITLE
chore: fix issues with repository setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      # Ensure that Rust version matches dev environment specified in rust-toolchain.toml
+      # Make sure this matches what we do locally and what we build with our Docker image
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.77.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,10 @@ jobs:
         options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      # Needed for WarpBuild ARM runners
-      - if: ${{ startsWith(runner.arch, 'ARM') }}
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+      # Ensure that Rust version matches dev environment specified in rust-toolchain.toml
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: 1.77.0
 
       - uses: actions/checkout@v4
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,17 +42,20 @@ Before you get down to coding, take a minute to consider this:
 
 First, ensure that the following are installed globally on your machine:
 
-- [Node.js 18.7+](https://nodejs.org/en/download/releases)
+- [Node.js 20.11+](https://nodejs.org/en/download/releases) using [nvm](https://github.com/nvm-sh/nvm)
 - [Yarn](https://classic.yarnpkg.com/lang/en/docs/install)
 - [Foundry](https://book.getfoundry.sh/getting-started/installation#using-foundryup)
 - [Protobuf compiler](https://protobuf.dev/downloads/)
 - [Rust](https://www.rust-lang.org/tools/install)
+- [CMake](https://formulae.brew.sh/formula/cmake)
 
 Then, from the root folder run:
 
 - `yarn install` to install dependencies
 - `yarn build` to build Hubble and its dependencies
 - `yarn test` to ensure that the test suite runs correctly
+
+NOTE: running `yarn test` currently fails due to an environment issue with shuttle. you can still run yarn test successfully from all the other repositories.
 
 ### 2.2. Signing Commits
 
@@ -78,7 +81,7 @@ max-cache-ttl 100000000
 
 ### 2.3. Navigating the Monorepo
 
-The repository is a monorepo with a primary application in the `/apps/` folder that imports several packages `/packages/`. It is composed of yarn workspaces and uses [TurboRepo](https://turbo.build/) as its build system.
+The repository is a monorepo with a primary application in the `/apps/` folder that imports several packages `/packages/`. It is written primarily in Typescript and uses Yarn to orchestrate tasks and [TurboRepo](https://turbo.build/) as its build system. Some performance intensive code is written in Rust and compiled with Cargo.
 
 You can run commands like `yarn test` and `yarn build` which TurboRepo will automatically parallelize and execute across all workspaces. To execute the application, you'll need to navigate into the app folder and follow the instructions there. The TurboRepo documentation covers other important topics like:
 

--- a/Dockerfile.hubble
+++ b/Dockerfile.hubble
@@ -31,6 +31,7 @@ RUN mkdir /home/node/app
 WORKDIR /home/node/app
 
 # Install Rust
+# Make sure this matches what we do locally and in CI
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.70.0
 ENV PATH="/home/node/.cargo/bin:${PATH}"
 

--- a/Dockerfile.hubble
+++ b/Dockerfile.hubble
@@ -32,7 +32,7 @@ WORKDIR /home/node/app
 
 # Install Rust
 # Make sure this matches what we do locally and in CI
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.70.0
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.77.0
 ENV PATH="/home/node/.cargo/bin:${PATH}"
 
 # Rust flags to allow building with musl, which is needed for alpine

--- a/README.md
+++ b/README.md
@@ -1,24 +1,29 @@
 # Hubble Monorepo
 
-This monorepo contains Hubble, an official Farcaster Hub implementation, and other packages used to communicate with Hubble.
-
+This monorepo contains [Hubble](https://docs.farcaster.xyz/hubble/hubble), a Farcaster Hub implementation, and other packages used to communicate with Hubble.
 
 ## Getting Started
 
-1. To run Hubble, see the [Hubble docs](https://www.thehubble.xyz/).
-1. To use Hubble, see the [hub-nodejs docs](./packages/hub-nodejs/docs/README.md).
-1. To use the HTTP API to read Hubble data, see the [HTTP API docs](https://www.thehubble.xyz/docs/httpapi/httpapi.html)
+See [CONTRIBUTING.md](./CONTRIBUTING.md) to set up your developer environment and learn about how to contribute. 
 
-## Packages
+## Code Organization
+
+The repository is a monorepo with a primary application in the `/apps/` folder that imports several packages `/packages/`. It is written primarily in Typescript and uses Yarn to orchestrate tasks and [TurboRepo](https://turbo.build/) as its build system. Some performance intensive code is written in Rust and compiled with Cargo.
+
+### Applications
+
+| App Name                                      | Description                                                                    |
+| --------------------------------------------- | ------------------------------------------------------------------------------ |
+| [@farcaster/hubble](./apps/hubble)             | A Farcaster Hub implementation |
+
+To run Hubble, please see the [Hubble docs](https://docs.farcaster.xyz/hubble/hubble).
+
+### Packages
 
 | Package Name                                  | Description                                                                    |
 | --------------------------------------------- | ------------------------------------------------------------------------------ |
-| [@farcaster/hubble](./apps/hubble)             | A Farcaster Hub implementation |
+| [@farcaster/shuttle](./packages/shuttle)       | A package that streams Hubble events to Postgres |
 | [@farcaster/hub-nodejs](./packages/hub-nodejs) | A Node.js client library for Hubble |
 | [@farcaster/hub-web](./packages/hub-web)       | A Browser client library for Hubble |
 | [@farcaster/core](./packages/core)             | Shared code between all packages |
 
-
-## Contributing
-
-Please see [CONTRIBUTING.md](./CONTRIBUTING.md)

--- a/apps/hubble/README.md
+++ b/apps/hubble/README.md
@@ -1,20 +1,15 @@
 # Hubble
 
+Hubble is an implementation of a [Farcaster Hub](https://docs.farcaster.xyz/hubble/hubble) written in Typescript and Rust. 
 
-[Install](https://www.thehubble.xyz/intro/install.html) | [Documentation](https://www.thehubble.xyz/)
+## Get Started
 
-## What is Hubble?
+Hubble is part of the hub-monorepo repository. To set up your developer environment: 
 
-Hubble is a Typescript implementation of a [Farcaster Hub](https://github.com/farcasterxyz/protocol).
+1. Follow the instructions in the [CONTRIBUTING.md](../../CONTRIBUTING.md) first. 
+2. From this folder, run `yarn test`.
 
-
-A Hub will download an entire copy of the network to your machine and keep it in sync. Messages can be created and uploaded to a Hub and they will propagate to all other Hubs. Running a Hub gives you a private instance that you can query as much as you like and helps decentralize the network.
-
-
-
-## Support 
-
-If you have any questions or need help, please reach out to us on [Telegram](https://t.me/farcasterdevchat).
+If the typescript and rust tests pass successfully, you are ready to go.
 
 ## Contributing
 

--- a/apps/hubble/rust-toolchain.toml
+++ b/apps/hubble/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.77.0"

--- a/apps/hubble/rust-toolchain.toml
+++ b/apps/hubble/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
+# Make sure this matches what we do in CI and what we build with our Docker image
 channel = "1.77.0"

--- a/apps/hubble/src/addon/rust-toolchain.toml
+++ b/apps/hubble/src/addon/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 # Make sure this matches what we do in CI and what we build with our Docker image
-channel = "1.70.0"
+channel = "1.77.0"

--- a/apps/hubble/src/addon/rust-toolchain.toml
+++ b/apps/hubble/src/addon/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
+# Make sure this matches what we do in CI and what we build with our Docker image
 channel = "1.70.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "engines": {
     "npm": ">=8.0.0",
-    "node": ">=18.7"
+    "node": ">=20.11"
   },
   "devDependencies": {
     "@changesets/changelog-git": "^0.1.14",


### PR DESCRIPTION
## Why is this change needed?

Following the instructions to setup a repository resulted in errors. This change: 

- Adds CMake to setup instructions
- Requires Rust 1.77.0 locally since 1.78.0+ cause build errors
- Requires Rust 1.77.0 in CI for parity
- Requires Node 20+ locally for parity with CI
- Updates some README text for clarity

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update Node.js, Rust toolchains, and CI configurations, ensuring consistency across environments. Additionally, it enhances documentation clarity and fixes environment issues.

### Detailed summary
- Updated Node.js to version 20.11
- Updated Rust toolchain to version 1.77.0 for consistency
- Aligned CI configurations with local and Docker image setups
- Improved README.md for better understanding
- Fixed environment issue with running `yarn test` in shuttle

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->