### PR TITLE
fix: force acknowledgement of no rewards for existing hubs

### DIFF
--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -120,24 +120,77 @@ fetch_latest_docker_compose_and_dashboard() {
     fetch_file_from_repo "$GRAFANA_INI_PATH" "grafana/grafana.ini"
 }
 
+# Prompt for hub operator agreement
 prompt_for_hub_operator_agreement() {
-  # Check if stdin is a terminal
-  if [ -t 0 ]; then
-    while true; do
-        printf "⚠️  IMPORTANT: You will NOT get any rewards for running this hub\n"
-        printf "> Please type \"Yes\" to continue: "
-        read -r response
-        case $(printf "%s" "$response" | tr '[:upper:]' '[:lower:]') in
-            yes|y)
-                printf "✅ You have agreed to the terms of service. Proceeding with hub startup...\n"
-                return 0
-                ;;
-            *)
-                printf "[i] Incorrect input. Please try again.\n"
-                ;;
-        esac
-    done
-  fi
+    (
+        env_file=".env"
+
+        update_env_file() {
+            key="AGREE_NO_REWARDS_FOR_ME"
+            value="true"
+            temp_file="${env_file}.tmp"
+
+            if [ -f "$env_file" ]; then
+                # File exists, update or append
+                updated=0
+                while IFS= read -r line || [ -n "$line" ]; do
+                    if [ "${line%%=*}" = "$key" ]; then
+                        echo "$key=$value" >>"$temp_file"
+                        updated=1
+                    else
+                        echo "$line" >>"$temp_file"
+                    fi
+                done <"$env_file"
+
+                if [ $updated -eq 0 ]; then
+                    echo "$key=$value" >>"$temp_file"
+                fi
+
+                mv "$temp_file" "$env_file"
+            else
+                # File doesn't exist, create it
+                echo "$key=$value" >"$env_file"
+            fi
+        }
+
+        prompt_agreement() {
+            tried=0
+            while true; do
+                printf "⚠️  IMPORTANT: You will NOT get any rewards for running this hub\n"
+                printf "> Please type \"Yes\" to continue: "
+                read -r response
+                case $(printf "%s" "$response" | tr '[:upper:]' '[:lower:]') in
+                yes | y)
+                    printf "✅ You have agreed to the terms of service. Proceeding...\n"
+                    update_env_file
+                    return 0
+                    ;;
+                *)
+                    tried=$((tried + 1))
+                    if [ $tried -gt 10 ]; then
+                        printf "❌ You have not agreed to the terms of service. Please run script again manually to agree and continue.\n"
+                        exit 1
+                    fi
+                    printf "[i] Incorrect input. Please try again.\n"
+                    ;;
+                esac
+            done
+        }
+
+        if grep -q "AGREE_NO_REWARDS_FOR_ME=true" "$env_file"; then
+            printf "✅ You have agreed to the terms of service. Proceeding...\n"
+            return 0
+        else
+            # Check if stdin is a terminal
+            if [ -t 0 ]; then
+                prompt_agreement
+                return $?
+            fi
+
+            printf "❌ You have not agreed to the terms of service. Please run script again manually to agree and continue.\n"
+            return 1
+        fi
+    )
 }
 
 validate_and_store() {
@@ -513,13 +566,13 @@ reexec_as_root_if_needed() {
 # Call the function at the beginning of your script
 reexec_as_root_if_needed "$@"
 
+# Prompt for hub operator agreement
+prompt_for_hub_operator_agreement || exit $?
+
 # Check for the "up" command-line argument
 if [ "$1" == "up" ]; then
    # Setup the docker-compose command
     set_compose_command
-
-    # Prompt for hub operator agreement
-    prompt_for_hub_operator_agreement
 
     # Run docker compose up -d hubble
     $COMPOSE_CMD up -d hubble statsd grafana
@@ -565,9 +618,6 @@ if [ "$1" == "upgrade" ]; then
 
     # Call the function to set the COMPOSE_CMD variable
     set_compose_command
-
-    # Prompt for hub operator agreement
-    prompt_for_hub_operator_agreement
 
     # Update the env file if needed
     write_env_file


### PR DESCRIPTION
## Why is this change needed?

- Force acknowledgement of no rewards for hubs that are already running 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a prompt for hub operator agreement before proceeding with hub startup. 

### Detailed summary
- Added a function `prompt_for_hub_operator_agreement()` to handle agreement prompt
- Introduced `update_env_file()` to update or create `.env` file with agreement status
- Improved user interaction with clear messages and input validation
- Ensured hub operator agreement before executing hub-related commands

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->