### PR TITLE
chore: remove unnecessary foundry version pin in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,9 +123,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          # Pinning until https://github.com/foundry-rs/foundry/issues/5749 is fixed
-          version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
 
       - name: Install dependencies
         run: yarn install


### PR DESCRIPTION
## Why is this change needed?

A foundry version was pinned in CI due to [this bug](https://github.com/foundry-rs/foundry/issues/5749). it has been fixed for almost a year now, so we don't need to do this anymore. 

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the installation process in the CI workflow by removing the pinned version of Foundry and installing dependencies with `yarn`.

### Detailed summary
- Removed pinned version of Foundry installation in CI workflow
- Changed installation of dependencies to use `yarn install` command

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->