### PR TITLE
chore: fix unhandled type error in tests

### DIFF
--- a/apps/hubble/src/storage/engine/messageDataBytes.test.ts
+++ b/apps/hubble/src/storage/engine/messageDataBytes.test.ts
@@ -105,7 +105,7 @@ describe("messageDataBytes", () => {
 
       const castAddDecoded = Message.decode(castAddBytes);
       expect(castAddDecoded.data).toBeUndefined();
-      expect(bytesCompare(castAddDecoded.dataBytes as Uint8Array, castAddClone.dataBytes)).toEqual(0);
+      expect(bytesCompare(castAddDecoded.dataBytes as Uint8Array, castAddClone.dataBytes as Uint8Array)).toEqual(0);
 
       // Then, get it via the engine. The castAdd should be fetched correctly and the data body should be populated
       const fetched = await engine.getCast(fid, castAdd.hash);


### PR DESCRIPTION
## Why is this change needed?

Fixing this type error that started showing up in my local environment. Unclear why it started triggering now, but the fix is to just cast it and do the comparison.  

There's a small edge case here that if the types were not strict Uint8Arrays the tests might still pass. But that doesn't seem to be the spirit of what we're testing here. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates a test file in `messageDataBytes.test.ts` to fix a comparison issue in a test case related to decoding message data bytes.

### Detailed summary
- Fixed comparison issue in a test case by ensuring both sides are of type Uint8Array.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->