### PR TITLE
chore: upgrade dockerfile to use node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         include:
           - node_version: 20
             runs_on: 'warp-ubuntu-latest-x64-16x'
-          - node_version: 21
+          - node_version: 22
             runs_on: 'warp-ubuntu-latest-arm64-16x' # Only works on ARM for now
           - node_version: 22
             runs_on: 'warp-ubuntu-latest-x64-16x'

--- a/Dockerfile.hubble
+++ b/Dockerfile.hubble
@@ -62,7 +62,7 @@ RUN rm -rf node_modules && yarn install --production --ignore-scripts --prefer-o
 ########## Stage 3: Copy over the built code to a leaner alpine image #########
 ###############################################################################
 
-FROM node:21.6-slim as app
+FROM node:22.4.1-slim as app
 
 RUN apt-get update && apt-get install -y curl procps
 


### PR DESCRIPTION
## Why is this change needed?

Node 21 is not an LTS build and was used because we had issues with Node 20 on ARM. 

Changing to using Node 22 will allow us to use only LTS builds, which also solves issues with some dependencies like rimraf 6 explicitly disallowing node 21.  

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Node.js version in the Dockerfile and GitHub Actions workflow to 22.4.1, ensuring compatibility and possibly leveraging new features.

### Detailed summary
- Updated Node.js version in Dockerfile from 21.6 to 22.4.1
- Updated Node.js version in GitHub Actions workflow from 21 to 22

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->