### PR TITLE
feat: Assign shards using jump consistent hashing

### DIFF
--- a/.changeset/few-points-fold.md
+++ b/.changeset/few-points-fold.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": minor
+---
+
+feat: Assign shards using jump consistent hashing algorithm

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -58,6 +58,7 @@ import {
   SLOW_CLIENT_GRACE_PERIOD_MS,
 } from "./bufferedStreamWriter.js";
 import { sleep } from "../utils/crypto.js";
+import { jumpConsistentHash } from "../utils/jumpConsistentHash.js";
 import { SUBMIT_MESSAGE_RATE_LIMIT, rateLimitByIp } from "../utils/rateLimits.js";
 import { statsd } from "../utils/statsd.js";
 import { SyncId } from "../network/sync/syncId.js";
@@ -1364,7 +1365,7 @@ export default class Server {
             bufferedStreamWriter.writeToStream(event);
           } else {
             const fid = fidFromEvent(event);
-            if (fid % totalShards === shardIndex) {
+            if (jumpConsistentHash(fid, totalShards) === shardIndex) {
               bufferedStreamWriter.writeToStream(event);
             }
           }

--- a/apps/hubble/src/rpc/test/eventService.test.ts
+++ b/apps/hubble/src/rpc/test/eventService.test.ts
@@ -320,13 +320,13 @@ describe("subscribe", () => {
 describe("sharded event stream", () => {
   test("emits events only for fids that match", async () => {
     // biome-ignore lint/suspicious/noExplicitAny: legacy code, avoid using ignore for new code
-    const evenEvents: [HubEventType, any][] = [];
+    const shard0Events: [HubEventType, any][] = [];
     // biome-ignore lint/suspicious/noExplicitAny: legacy code, avoid using ignore for new code
-    const oddEvents: [HubEventType, any][] = [];
-    await setupSubscription(evenEvents, { totalShards: 2, shardIndex: 0 });
-    await setupSubscription(oddEvents, { totalShards: 2, shardIndex: 1 });
+    const shard1Events: [HubEventType, any][] = [];
+    await setupSubscription(shard0Events, { totalShards: 2, shardIndex: 0 });
+    await setupSubscription(shard1Events, { totalShards: 2, shardIndex: 1 });
 
-    // Merge even events
+    // Merge events for shard 0
     await setupMessages(202, Factories.Fname.build());
     await engine.mergeOnChainEvent(custodyEvent);
     await engine.mergeOnChainEvent(signerEvent);
@@ -334,8 +334,8 @@ describe("sharded event stream", () => {
     await engine.mergeMessage(castAdd);
     await engine.mergeUserNameProof(usernameProof);
 
-    // Merge odd  events
-    await setupMessages(303, Factories.Fname.build());
+    // Merge events for shard 1
+    await setupMessages(301, Factories.Fname.build());
     await engine.mergeOnChainEvent(custodyEvent);
     await engine.mergeOnChainEvent(signerEvent);
     await engine.mergeOnChainEvent(storageEvent);
@@ -343,33 +343,33 @@ describe("sharded event stream", () => {
     await engine.mergeUserNameProof(usernameProof);
     await sleep(100); // Wait for server to send events over stream
 
-    expect(evenEvents).toHaveLength(5);
-    expect(oddEvents).toHaveLength(5);
+    expect(shard0Events.length).toEqual(5);
+    expect(shard1Events.length).toEqual(5);
 
-    evenEvents.map(([, event]) => {
+    shard0Events.map(([, event]) => {
       expect(event.fid || event.data.fid).toBe(202);
     });
-    oddEvents.map(([, event]) => {
-      expect(event.fid || event.data.fid).toBe(303);
+    shard1Events.map(([, event]) => {
+      expect(event.fid || event.data.fid).toBe(301);
     });
 
     // Should also work when requesting events from the past
     // biome-ignore lint/suspicious/noExplicitAny: legacy code, avoid using ignore for new code
-    const evenHistoricalEvents: [HubEventType, any][] = [];
+    const shard0HistoricalEvents: [HubEventType, any][] = [];
     // biome-ignore lint/suspicious/noExplicitAny: legacy code, avoid using ignore for new code
-    const oddHistoricalEvents: [HubEventType, any][] = [];
+    const shard1HistoricalEvents: [HubEventType, any][] = [];
 
-    await setupSubscription(evenHistoricalEvents, { totalShards: 2, shardIndex: 0, fromId: 0 });
-    await setupSubscription(oddHistoricalEvents, { totalShards: 2, shardIndex: 1, fromId: 0 });
+    await setupSubscription(shard0HistoricalEvents, { totalShards: 2, shardIndex: 0, fromId: 0 });
+    await setupSubscription(shard1HistoricalEvents, { totalShards: 2, shardIndex: 1, fromId: 0 });
     await sleep(100);
 
-    expect(evenHistoricalEvents).toHaveLength(5);
-    expect(oddHistoricalEvents).toHaveLength(5);
-    evenHistoricalEvents.map(([, event]) => {
+    expect(shard0HistoricalEvents).toHaveLength(5);
+    expect(shard1HistoricalEvents).toHaveLength(5);
+    shard0HistoricalEvents.map(([, event]) => {
       expect(event.fid || event.data.fid).toBe(202);
     });
-    oddHistoricalEvents.map(([, event]) => {
-      expect(event.fid || event.data.fid).toBe(303);
+    shard1HistoricalEvents.map(([, event]) => {
+      expect(event.fid || event.data.fid).toBe(301);
     });
   });
 });

--- a/apps/hubble/src/utils/jumpConsistentHash.ts
+++ b/apps/hubble/src/utils/jumpConsistentHash.ts
@@ -1,0 +1,27 @@
+/**
+ * Takes a hash as a number and a number of shards (must be >= 1) and assigns
+ * the hash to a shard (a.k.a. bucket) such that when the number of shards
+ * changes the number of hashes whose shard assignment changes is minimized.
+ *
+ * Note that this implementation doesn't do any hashing of the key itself--you
+ * must provide the key as a number obtained by a uniformly distributed hashing
+ * function.
+ *
+ * Aside: We're only intending to use this for FID shard allocation since we
+ * care more about the consistent assignment property when number of shards
+ * change. Anecdotally, passing just the FID as the key distributes FIDs to
+ * shards uniformly enough.
+ *
+ * @see "A Fast, Minimal Memory, Consistent Hash Algorithm" https://arxiv.org/pdf/1406.2294
+ */
+export function jumpConsistentHash(key: number, shards: number): number {
+  let hash = BigInt(key);
+  let b: bigint;
+  let j = 0n;
+  do {
+    b = j;
+    hash = ((hash * 2862933555777941757n) % 2n ** 64n) + 1n;
+    j = BigInt(Math.floor(((Number(b) + 1) * Number(1n << 31n)) / Number((hash >> 33n) + 1n)));
+  } while (j < shards);
+  return Number(b);
+}


### PR DESCRIPTION
## Why is this change needed?

While modulo-based arithmetic for assigning shards is simple and works fine, it does not work well when the number of shards changes.

For example, when increasing the number of shards from 3 → 4 using modulo-based shard assignment, ~83% of FIDs will be assigned to a different shard. With consistent hashing, only ~25% will be assigned to a different shard.

Jump consistent hashing is a particular approach to consistent hashing that is stateless (requires no additional tracking of shard assignments), which is ideal for hubs, since we don't want hubs to have to manage per-client tracking of shards.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on implementing the jump consistent hashing algorithm for shard assignment in the Hubble app. 

### Detailed summary
- Implemented `jumpConsistentHash` algorithm for shard assignment based on FID
- Updated shard assignment logic in `Server` class
- Updated tests in `eventService.test.ts` for shard-based event handling

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->