### PR TITLE
feat: increase frame message URL max length

### DIFF
--- a/.changeset/red-eels-move.md
+++ b/.changeset/red-eels-move.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/core": patch
+---
+
+feat: extend frame message URL max length

--- a/packages/core/src/validations.test.ts
+++ b/packages/core/src/validations.test.ts
@@ -1301,7 +1301,7 @@ describe("validateFrameActionBody", () => {
   });
   test("fails when url is too long", async () => {
     const body = Factories.FrameActionBody.build({
-      url: Buffer.from(faker.datatype.string(257)),
+      url: Buffer.from(faker.datatype.string(1025)),
     });
     const result = validations.validateFrameActionBody(body);
     expect(result._unsafeUnwrapErr().message).toMatch("invalid url");

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -837,7 +837,7 @@ export const validateFrameActionBody = (body: protobufs.FrameActionBody): HubRes
     return err(new HubError("bad_request.validation_failure", "invalid button index"));
   }
 
-  if (validateBytesAsString(body.url, 256, true).isErr()) {
+  if (validateBytesAsString(body.url, 1024, true).isErr()) {
     return err(new HubError("bad_request.validation_failure", "invalid url"));
   }
   if (validateBytesAsString(body.inputText, 256).isErr()) {


### PR DESCRIPTION
## Why is this change needed?

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR extends the maximum length of the frame message URL to 1024 characters for better validation accuracy.

### Detailed summary
- Increased maximum URL length validation from 256 to 1024 characters
- Updated test case with longer URL length for validation testing

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->