### PR TITLE
feat(shuttle): Support running before/after hooks when processing events

### DIFF
--- a/.changeset/dry-insects-design.md
+++ b/.changeset/dry-insects-design.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+Add support for running before/after hooks when processing events

--- a/packages/shuttle/src/shuttle/hubSubscriber.ts
+++ b/packages/shuttle/src/shuttle/hubSubscriber.ts
@@ -6,9 +6,9 @@ import { EventStreamConnection } from "./eventStream";
 import { sleep } from "../utils";
 import { RedisClient } from "./redis";
 import { HubClient } from "./hub";
+import { ProcessResult } from "./index";
 
 interface HubEventsEmitter {
-  event: (hubEvent: HubEvent) => void;
   onError: (error: Error, stopped: boolean) => void;
 }
 
@@ -170,6 +170,14 @@ export class BaseHubSubscriber extends HubSubscriber {
   }
 }
 
+type PreProcessHandler = (event: HubEvent, eventBytes: Uint8Array) => Promise<ProcessResult>;
+type PostProcessHandler = (event: HubEvent, eventBytes: Uint8Array) => Promise<void>;
+
+type EventStreamHubSubscriberOptions = {
+  beforeProcess?: PreProcessHandler;
+  afterProcess?: PostProcessHandler;
+};
+
 export class EventStreamHubSubscriber extends BaseHubSubscriber {
   private eventStream: EventStreamConnection;
   private redis: RedisClient;
@@ -181,6 +189,8 @@ export class EventStreamHubSubscriber extends BaseHubSubscriber {
   public maxTimeBetweenBatchFlushes = 200; // Millis
   public maxBatchBytesBeforeForceFlush = 2 ** 20; // 2 MiB
   private eventBatchBytes = 0;
+  private beforeProcess?: PreProcessHandler;
+  private afterProcess?: PostProcessHandler;
 
   constructor(
     label: string,
@@ -192,6 +202,7 @@ export class EventStreamHubSubscriber extends BaseHubSubscriber {
     eventTypes?: HubEventType[],
     totalShards?: number,
     shardIndex?: number,
+    options?: EventStreamHubSubscriberOptions,
   ) {
     super(label, hubClient.client, log, eventTypes, totalShards, shardIndex);
     this.eventStream = eventStream;
@@ -199,6 +210,8 @@ export class EventStreamHubSubscriber extends BaseHubSubscriber {
     this.streamKey = `hub:${hubClient.host}:evt:msg:${shardKey}`;
     this.redisKey = `${hubClient.host}:${shardKey}`;
     this.eventsToAdd = [];
+    this.beforeProcess = options?.beforeProcess;
+    this.afterProcess = options?.afterProcess;
   }
 
   public override async getLastEventId(): Promise<number | undefined> {
@@ -213,6 +226,10 @@ export class EventStreamHubSubscriber extends BaseHubSubscriber {
 
   public override async processHubEvent(event: HubEvent): Promise<boolean> {
     const eventBytes = Buffer.from(HubEvent.encode(event).finish());
+
+    const preprocessResult = await this.beforeProcess?.call(this, event, eventBytes);
+    if (preprocessResult?.skipped) return false; // Skip event
+
     this.eventBatchBytes += eventBytes.length;
     this.eventsToAdd.push([event, eventBytes]);
     if (
@@ -236,6 +253,12 @@ export class EventStreamHubSubscriber extends BaseHubSubscriber {
       const [evt, eventBytes] = eventBatch[eventBatch.length - 1]!;
       const lastEventId = evt.id;
       await this.redis.setLastProcessedEvent(this.redisKey, lastEventId);
+
+      if (this.afterProcess) {
+        for (const [evt, evtBytes] of eventBatch) {
+          await this.afterProcess.call(this, evt, evtBytes);
+        }
+      }
     }
 
     return true;


### PR DESCRIPTION
## Why is this change needed?

We want the ability to provide custom pre/post-processing logic when processing events. Expose optional hooks that can be specified. This has the added benefit that the `beforeProcess` hook can be used to skip processing of an event.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `@farcaster/shuttle` package by adding support for running before/after hooks when processing events.

### Detailed summary
- Added `beforeProcess` and `afterProcess` handlers to `EventStreamHubSubscriber` and `HubEventStreamConsumer`
- Implemented handling of preprocess and postprocess actions for event processing
- Introduced `EventStreamHubSubscriberOptions` and `EventStreamConsumerOptions` interfaces
- Updated `HubEventStreamConsumer` to extend `TypedEmitter` for custom event tracking

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->