### PR TITLE
chore: Release 0.5.4

### DIFF
--- a/.changeset/dry-insects-design.md
+++ b/.changeset/dry-insects-design.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-Add support for running before/after hooks when processing events

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.5.4
+
+### Patch Changes
+
+- 41f32cd0: Add support for running before/after hooks when processing events
+
 ## 0.5.3
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Why is this change needed?

We want to allow users to add pre-post processing logic when processing hub events using Shuttle.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of the `@farcaster/shuttle` package to `0.5.4` and adds support for running before/after hooks when processing events.

### Detailed summary
- Updated `@farcaster/shuttle` package version to `0.5.4`
- Added support for running before/after hooks when processing events

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->