### PR TITLE
fix(shuttle): Switch before/after processing hooks to use batches

### DIFF
--- a/.changeset/silver-coins-search.md
+++ b/.changeset/silver-coins-search.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+Switch before/after hooks to work with batches for efficiency


### PR DESCRIPTION
## Why is this change needed?

This will be much more efficient at high loads.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR optimizes event processing efficiency in `@farcaster/shuttle` by switching before/after hooks to work with batches.

### Detailed summary
- Updated `PreProcessHandler` and `PostProcessHandler` signatures to work with batches
- Refactored event processing logic to handle batches efficiently
- Improved event processing performance by processing events in batches

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->