### PR TITLE
chore(shuttle): Stop recording stream size

### DIFF
--- a/.changeset/gorgeous-taxis-kiss.md
+++ b/.changeset/gorgeous-taxis-kiss.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+Stop recording stream size

--- a/packages/shuttle/src/shuttle/eventStream.ts
+++ b/packages/shuttle/src/shuttle/eventStream.ts
@@ -273,15 +273,6 @@ export class HubEventStreamConsumer extends TypedEmitter<HubEventStreamConsumerE
   private async _runLoop(onEvent: (event: HubEvent) => Promise<Result<ProcessResult, Error>>) {
     while (!this.stopped) {
       try {
-        const sizeStartTime = Date.now();
-        const size = await this.stream.streamSize(this.streamKey);
-        statsd.gauge("hub.event.stream.size", size, { hub: this.hub.host, source: this.shardKey });
-        const sizeTime = Date.now() - sizeStartTime;
-
-        statsd.timing("hub.event.stream.size_time", sizeTime, {
-          hub: this.hub.host,
-          source: this.shardKey,
-        });
         let eventsRead = 0;
 
         const startTime = Date.now();


### PR DESCRIPTION
## Why is this change needed?

Looking at profiling data, this actually takes up a non-trivial amount of wall clock time (10% of total time). Since the stream is automatically trimmed, recording the size isn't particularly useful except as perhaps an early warning on memory, but there are generally other metrics one could use (number of events processed, etc.) to infer that there is a slowdown in processing.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR stops recording stream size in the `eventStream.ts` file of the `@farcaster/shuttle` package.

### Detailed summary
- Removed recording stream size in eventStream.ts
- Removed statsd gauge and timing metrics for stream size and time calculations

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->