### PR TITLE
perf(shuttle): Trim stream at regular intervals instead of every iteration

### DIFF
--- a/.changeset/dry-foxes-appear.md
+++ b/.changeset/dry-foxes-appear.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+Trim stream at regular interval instead of every loop

--- a/packages/shuttle/README.md
+++ b/packages/shuttle/README.md
@@ -16,7 +16,7 @@ There are 3 main components:
 - a reconciler that can backfill messages and ensures the messages are in sync with the hub
 
 The event processor has a hook for your code to plug into the message processing loop. You must implement the `MessageHandler` interface
-and provide it to the system. The system will call your `handleMessageMerge` method for each message it processes, within the same transaction 
+and provide it to the system. The system will call your `handleMessageMerge` method for each message it processes, within the same transaction
 where the message is written to the db. The function is always expected to succeed, it is not possible to instruct it to "skip"  a message.
 If your function fails, the message will not be written to the db and will be retried at a later time.
 
@@ -42,13 +42,13 @@ yarn install && yarn build
 
 # Start the db dependencies
 docker compose up postgres redis
- 
+
 # To perform reconciliation/backfill, start the worker (can run multiple processes to speed this up)
 POSTGRES_URL=postgres://shuttle:password@0.0.0.0:6541 REDIS_URL=0.0.0.0:16379 HUB_HOST=<host>:<port> HUB_SSL=false yarn start worker
 
 # Kick off the backfill process (configure with MAX_FID=100 or BACKFILL_FIDS=1,2,3)
-POSTGRES_URL=postgres://shuttle:password@0.0.0.0:6541 REDIS_URL=0.0.0.0:16379 HUB_HOST=<host>:<port> HUB_SSL=false yarn start backfill 
- 
+POSTGRES_URL=postgres://shuttle:password@0.0.0.0:6541 REDIS_URL=0.0.0.0:16379 HUB_HOST=<host>:<port> HUB_SSL=false yarn start backfill
+
 # Start the app and sync messages from the event stream
 POSTGRES_URL=postgres://shuttle:password@0.0.0.0:6541 REDIS_URL=0.0.0.0:16379 HUB_HOST=<host>:<port> HUB_SSL=false yarn start start
 ```


### PR DESCRIPTION
## Why is this change needed?

Performance profiling indicates that we're spending a non-trivial amount of time (5-10% of wall clock time) trimming the stream. This doesn't need to happen as frequently as it's currently happening, so switch to an interval timer so that we're not slowing down general processing in any meaningful way.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR optimizes the event stream processing in `HubEventStreamConsumer` by adding a regular interval to trim old events efficiently.

### Detailed summary
- Added `interval` property to schedule event processing at regular intervals
- Implemented interval logic to clear old events and process stale events
- Updated `stop` method to clear the interval
- Simplified event processing logic in the message loop

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->