### PR TITLE
chore: release 1.13.7

### DIFF
--- a/.changeset/few-points-fold.md
+++ b/.changeset/few-points-fold.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": minor
----
-
-feat: Assign shards using jump consistent hashing algorithm

--- a/.changeset/red-eels-move.md
+++ b/.changeset/red-eels-move.md
@@ -1,5 +1,0 @@
----
-"@farcaster/core": patch
----
-
-feat: extend frame message URL max length

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/hubble
 
+## 1.13.7
+
+### Patch Changes
+
+- 312340d2: feat: Assign shards using jump consistent hashing algorithm
+  - @farcaster/hub-nodejs@0.11.20
+
 ## 1.13.6
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.13.6",
+  "version": "1.13.7",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -75,7 +75,7 @@
     "@chainsafe/libp2p-noise": "^11.0.0 ",
     "@datastructures-js/priority-queue": "^6.3.1",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.11.19",
+    "@farcaster/hub-nodejs": "^0.11.20",
     "@fastify/cors": "^8.4.0",
     "@figma/hot-shots": "^9.0.0-figma.1",
     "@grpc/grpc-js": "~1.8.22",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/core
 
+## 0.14.18
+
+### Patch Changes
+
+- fb0a083a: feat: extend frame message URL max length
+
 ## 0.14.17
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.14.17",
+  "version": "0.14.18",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/hub-nodejs
 
+## 0.11.20
+
+### Patch Changes
+
+- Updated dependencies [fb0a083a]
+  - @farcaster/core@0.14.18
+
 ## 0.11.19
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.11.19",
+  "version": "0.11.20",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -20,7 +20,7 @@
     "url": "https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/hub-nodejs"
   },
   "dependencies": {
-    "@farcaster/core": "0.14.17",
+    "@farcaster/core": "0.14.18",
     "@grpc/grpc-js": "~1.8.22",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"


### PR DESCRIPTION
## Why is this change needed?

- hub 1.13.7
- core 0.14.18
- hub-nodejs 0.11.20

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR increases version numbers for various packages and dependencies. It also includes changes related to extending frame message URL max length and assigning shards using a hashing algorithm.

### Detailed summary
- Increased version numbers for packages and dependencies
- Extended frame message URL max length
- Assigned shards using jump consistent hashing algorithm

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->