### PR TITLE
fix(hubble/libp2p): fetch addresses once per peerid in getPeerAddresses [WIP]

### DIFF
--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -401,8 +401,8 @@ export class LibP2PNode {
 
   async getPeerAddresses(peerId: PeerId): Promise<MultiAddr.Multiaddr[]> {
     const existingConnections = this._node?.getConnections(peerId);
+    const knownAddrs = await this._node?.peerStore.addressBook.get(peerId);
     for (const conn of existingConnections ?? []) {
-      const knownAddrs = await this._node?.peerStore.addressBook.get(peerId);
       if (knownAddrs && !knownAddrs.find((addr) => addr.multiaddr.equals(conn.remoteAddr))) {
         await this._node?.peerStore.addressBook.add(peerId, [conn.remoteAddr]);
       }


### PR DESCRIPTION
## Why is this change needed?

We currently fetch the address book from the peer store once per connection to the peerId. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the logic for managing known peer addresses in the `getPeerAddresses` method of the `GossipNodeWorker` class.

### Detailed summary
- Retrieve known addresses using `peerStore.addressBook.get` before iterating existing connections
- Add new known addresses to the address book if not already present

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->