### PR TITLE
fix: update hub storage requirement to 200 GB

### DIFF
--- a/.changeset/tiny-elephants-roll.md
+++ b/.changeset/tiny-elephants-roll.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: update hub storage requirement to 200 GB

--- a/apps/hubble/www/docs/intro/install.md
+++ b/apps/hubble/www/docs/intro/install.md
@@ -8,7 +8,7 @@ Hubble can be installed in 30 minutes, and a full sync can take 1-2 hours to com
 
 - 16 GB of RAM
 - 4 CPU cores or vCPUs
-- 160 GB of free storage
+- 200 GB of free storage
 - A public IP address with ports 2282 - 2285 exposed
 
 See [tutorials](./tutorials.html) for instructions on how to set up cloud providers to run Hubble.

--- a/apps/hubble/www/docs/tutorials/gcp.md
+++ b/apps/hubble/www/docs/tutorials/gcp.md
@@ -48,7 +48,7 @@ resource "google_compute_instance" "farcaster-hub-vm" {
   boot_disk {
     initialize_params {
       image = "ubuntu-2004-focal-v20231213"  # Ubuntu 20.04 LTS image URL
-      size = 160  # 160 GB disk size
+      size = 200  # 200 GB disk size
     }
   }
 


### PR DESCRIPTION
## Why is this change needed?

- update hub storage requirement to 200 GB

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the storage requirement for the Hubble app to 200 GB and adjusts related documentation to reflect the change.

### Detailed summary
- Updated Hubble app storage requirement to 200 GB
- Adjusted disk size in GCP tutorial to 200 GB
- Updated storage requirement in installation guide to 200 GB

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->