### PR TITLE
feat: Expose event id functions

### DIFF
--- a/.changeset/old-fireants-burn.md
+++ b/.changeset/old-fireants-burn.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+feat: Expost event id functions

--- a/apps/hubble/src/console/console.ts
+++ b/apps/hubble/src/console/console.ts
@@ -9,6 +9,7 @@ import {
   fromFarcasterTime,
   bytesToHexString,
   hexStringToBytes,
+  makeEventId,
 } from "@farcaster/hub-nodejs";
 import path from "path";
 import * as repl from "repl";
@@ -21,6 +22,7 @@ import { RpcClientCommand } from "./rpcClientCommand.js";
 import { WarpcastTestCommand } from "./warpcastTestCommand.js";
 import { SyncId } from "../network/sync/syncId.js";
 import { TrackHubDelayCommand } from "./trackHubDelayCommand.js";
+import { extractEventTimestamp } from "@farcaster/core";
 
 export const DEFAULT_RPC_CONSOLE = "127.0.0.1:2283";
 
@@ -98,6 +100,8 @@ export const startConsole = async (addressString: string, useInsecure: boolean) 
   replServer.context["fromFarcasterTime"] = fromFarcasterTime;
   replServer.context["bytesToHex"] = bytesToHexString;
   replServer.context["hexToBytes"] = hexStringToBytes;
+  replServer.context["extractEventTimestamp"] = extractEventTimestamp;
+  replServer.context["makeEventId"] = makeEventId;
 
   // Run the info command to start
 

--- a/apps/hubble/src/storage/stores/storeEventHandler.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.ts
@@ -11,6 +11,7 @@ import {
   isMergeUsernameProofHubEvent,
   isPruneMessageHubEvent,
   isRevokeMessageHubEvent,
+  makeEventId,
   MergeMessageHubEvent,
   MergeOnChainEventHubEvent,
   MergeUsernameProofHubEvent,
@@ -106,22 +107,6 @@ export type StoreEvents = {
 };
 
 export type HubEventArgs = Omit<HubEvent, "id">;
-
-// Chosen to keep number under Number.MAX_SAFE_INTEGER
-const TIMESTAMP_BITS = 41;
-const SEQUENCE_BITS = 12;
-
-const makeEventId = (timestamp: number, seq: number): number => {
-  const binaryTimestamp = timestamp.toString(2);
-  let binarySeq = seq.toString(2);
-  if (binarySeq.length) {
-    while (binarySeq.length < SEQUENCE_BITS) {
-      binarySeq = `0${binarySeq}`;
-    }
-  }
-
-  return parseInt(binaryTimestamp + binarySeq, 2);
-};
 
 const makeEventKey = (id?: number): Buffer => {
   const buffer = Buffer.alloc(1 + (id ? 8 : 0));
@@ -369,7 +354,7 @@ class StoreEventHandler extends TypedEmitter<StoreEvents> {
   }
 
   async pruneEvents(timeLimit?: number): HubAsyncResult<void> {
-    const toId = makeEventId(Date.now() - FARCASTER_EPOCH - (timeLimit ?? PRUNE_TIME_LIMIT_DEFAULT), 0);
+    const toId = makeEventId(Date.now() - (timeLimit ?? PRUNE_TIME_LIMIT_DEFAULT), 0);
 
     const iteratorOpts = this.getEventsIteratorOpts({ toId });
 

--- a/packages/core/src/time.ts
+++ b/packages/core/src/time.ts
@@ -36,10 +36,26 @@ export const fromFarcasterTime = (time: number): HubResult<number> => {
   return ok(time * 1000 + FARCASTER_EPOCH);
 };
 
-/** Extracts the timestamp from an event ID. */
+// Chosen to keep number under Number.MAX_SAFE_INTEGER
+const TIMESTAMP_BITS = 41;
+const SEQUENCE_BITS = 12;
+
+/** Extracts a unix timestamp (ms resolution) from an event ID. */
 export const extractEventTimestamp = (eventId: number): number => {
   const binaryEventId = eventId.toString(2);
-  const SEQUENCE_BITS = 12;
   const binaryTimestamp = binaryEventId.slice(0, binaryEventId.length - SEQUENCE_BITS);
   return parseInt(binaryTimestamp, 2) + FARCASTER_EPOCH;
+};
+
+/** Generates a hub event id from a unix timestamp (ms resolution) and an optional sequence number */
+export const makeEventId = (timestamp: number, seq = 0): number => {
+  const binaryTimestamp = (timestamp - FARCASTER_EPOCH).toString(2);
+  let binarySeq = seq.toString(2);
+  if (binarySeq.length) {
+    while (binarySeq.length < SEQUENCE_BITS) {
+      binarySeq = `0${binarySeq}`;
+    }
+  }
+
+  return parseInt(binaryTimestamp + binarySeq, 2);
 };


### PR DESCRIPTION
## Why is this change needed?

Make timestamp to event id converstion function publicly accessible

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds new event ID functions and refactors timestamp handling in the `core` and `hubble` packages.

### Detailed summary
- Added `extractEventTimestamp` and `makeEventId` functions in `core`
- Updated `console.ts` and `storeEventHandler.ts` to use the new functions
- Refactored timestamp handling for event IDs

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->