### PR TITLE
fix(example): fix the argument for makeLinkRemove when removing a follow

### DIFF
--- a/.changeset/tricky-parrots-carry.md
+++ b/.changeset/tricky-parrots-carry.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hub-nodejs": patch
+---
+
+Fixed the argument for `makeLinkRemove` in the example code `write-data` of the `hub-nodejs` package. The incorrect argument `"unfollow"` was changed to `"follow"` to match the expected behavior and avoid confusion for developers.

--- a/.changeset/tricky-parrots-carry.md
+++ b/.changeset/tricky-parrots-carry.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
----
-
-Fixed the argument for `makeLinkRemove` in the example code `write-data` of the `hub-nodejs` package. The incorrect argument `"unfollow"` was changed to `"follow"` to match the expected behavior and avoid confusion for developers.

--- a/packages/hub-nodejs/examples/write-data/index.ts
+++ b/packages/hub-nodejs/examples/write-data/index.ts
@@ -250,8 +250,8 @@ const NETWORK = FarcasterNetwork.TESTNET; // Network of the Hub
   const follow = await makeLinkAdd({ type: "follow", targetFid: 1 }, dataOptions, ed25519Signer);
   otherMessages.push(follow);
 
-  // Remove a follow by creating a link remove message with type "unfollow" to the fid you want to unfollow
-  const unfollow = await makeLinkRemove({ type: "unfollow", targetFid: 1 }, dataOptions, ed25519Signer);
+  // Remove a follow by creating a link remove message with type "follow" to the fid you want to unfollow
+  const unfollow = await makeLinkRemove({ type: "follow", targetFid: 1 }, dataOptions, ed25519Signer);
   otherMessages.push(unfollow);
 
   otherMessages.map((messageResult) => messageResult.map((message) => client.submitMessage(message)));


### PR DESCRIPTION
## Why is this change needed?

The change is a bug fix in the example code `write-data` in the `hub-nodejs` package (packages/hub-nodejs/examples/write-data). When I was trying to use this package, I was stuck with the original code for a while and finally found it our by checking the source code. So I think the change is needed because it can benefit others (especially new developers) who want to build on Farcaster instead of getting stuck. 

You can see here too that the test code for `packages/core/src/builders.ts` https://github.com/farcasterxyz/hub-monorepo/blob/76ad1ac2a2d2b219b204239c1e8ccdffc3e309b2/packages/core/src/builders.test.ts#L362 is taking `'follow'` instead of `'unfollow'`

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to correct the type of message being created when removing a follow in the `write-data` example.

### Detailed summary
- Updated the type of message from "unfollow" to "follow" when removing a follow in the `write-data` example.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->