### PR TITLE
fix: on conflict criteria is ambiguous and cannot be used for upsert

### DIFF
--- a/.changeset/tidy-apricots-unite.md
+++ b/.changeset/tidy-apricots-unite.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+fix: on conflict criteria is ambiguous and cannot be used for upsert


### PR DESCRIPTION
## Why is this change needed?

Shuttle defines the messages table with two unique constraints, one for the hash, another for the triple of hash, fid and type. Postgres does not allow multiple ON CONFLICT criteria, and ambiguous conflicts are essentially surfaced as uniqueness violation failures in spite of ON CONFLICT criteria given. This change alters the merge to instead attempt insert, doing nothing on any conflict, then resolving with an update if necessary and the original conflict resolution criteria is satisfied.

Addresses Issue #2167 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the conflict resolution logic in `MessageProcessor` to fix ambiguity issues during upsert operations.

### Detailed summary
- Updated conflict resolution logic to use `doNothing()` method instead of complex conditions
- Improved handling of conflict criteria for upsert operations

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->