### PR TITLE
chore: release 1.13.8

### DIFF
--- a/.changeset/old-fireants-burn.md
+++ b/.changeset/old-fireants-burn.md
@@ -1,6 +1,0 @@
----
-"@farcaster/core": patch
-"@farcaster/hubble": patch
----
-
-feat: Expost event id functions

--- a/.changeset/stupid-pianos-doubt.md
+++ b/.changeset/stupid-pianos-doubt.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-- upgrade libp2p to 0.44.0

--- a/.changeset/tidy-apricots-unite.md
+++ b/.changeset/tidy-apricots-unite.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-fix: on conflict criteria is ambiguous and cannot be used for upsert

--- a/.changeset/tiny-elephants-roll.md
+++ b/.changeset/tiny-elephants-roll.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: update hub storage requirement to 200 GB

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @farcaster/hubble
 
+## 1.13.8
+
+### Patch Changes
+
+- 76ad1ac2: feat: Expost event id functions
+- e2b1c7c6: - upgrade libp2p to 0.44.0
+- 97d0a7ea: fix: update hub storage requirement to 200 GB
+  - @farcaster/hub-nodejs@0.11.21
+
 ## 1.13.7
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.13.7",
+  "version": "1.13.8",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -75,7 +75,7 @@
     "@chainsafe/libp2p-noise": "^11.0.0 ",
     "@datastructures-js/priority-queue": "^6.3.1",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.11.20",
+    "@farcaster/hub-nodejs": "^0.11.21",
     "@fastify/cors": "^8.4.0",
     "@figma/hot-shots": "^9.0.0-figma.1",
     "@grpc/grpc-js": "~1.8.22",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/core
 
+## 0.14.19
+
+### Patch Changes
+
+- 76ad1ac2: feat: Expost event id functions
+
 ## 0.14.18
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.14.18",
+  "version": "0.14.19",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/hub-nodejs
 
+## 0.11.21
+
+### Patch Changes
+
+- Updated dependencies [76ad1ac2]
+  - @farcaster/core@0.14.19
+
 ## 0.11.20
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.11.20",
+  "version": "0.11.21",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -20,7 +20,7 @@
     "url": "https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/hub-nodejs"
   },
   "dependencies": {
-    "@farcaster/core": "0.14.18",
+    "@farcaster/core": "0.14.19",
     "@grpc/grpc-js": "~1.8.22",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/hub-shuttle
 
+## 0.5.7
+
+### Patch Changes
+
+- ee0947ec: fix: on conflict criteria is ambiguous and cannot be used for upsert
+  - @farcaster/hub-nodejs@0.11.21
+
 ## 0.5.6
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@farcaster/hot-shots": "^10.0.0",
-    "@farcaster/hub-nodejs": "^0.11.17",
+    "@farcaster/hub-nodejs": "^0.11.21",
     "commander": "11.0.0",
     "dotenv": "16.4.5",
     "ioredis": "^5.3.2",


### PR DESCRIPTION
## Why is this change needed?

- release 1.13.8

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update version numbers and dependencies across various packages.

### Detailed summary
- Updated version to `0.14.19` in `@farcaster/core`
- Updated version to `0.11.21` in `@farcaster/hub-nodejs`
- Updated version to `0.5.7` in `@farcaster/shuttle`
- Updated version to `1.13.8` in `@farcaster/hubble`
- Added event id functions in `@farcaster/core`
- Fixed conflict criteria issue in `@farcaster/shuttle`
- Upgraded libp2p to `0.44.0` in `@farcaster/hubble`
- Increased hub storage requirement to `200 GB` in `@farcaster/hubble`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->