### PR TITLE
fix: do not let deleted fname events allow old fname events to be re-added

### DIFF
--- a/.changeset/serious-falcons-drum.md
+++ b/.changeset/serious-falcons-drum.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: do not let deleted fname events allow old fname events to be re-added

--- a/apps/hubble/src/addon/src/store/name_registry_events.rs
+++ b/apps/hubble/src/addon/src/store/name_registry_events.rs
@@ -75,12 +75,15 @@ pub fn put_username_proof_transaction(
 pub fn delete_username_proof_transaction(
     txn: &mut RocksDbTransactionBatch,
     username_proof: &UserNameProof,
+    existing_fid: Option<u32>,
 ) {
     let buf = username_proof.encode_to_vec();
 
     let primary_key = make_fname_username_proof_key(&username_proof.name);
     txn.put(primary_key.clone(), buf);
 
-    let secondary_key = make_fname_username_proof_by_fid_key(username_proof.fid as u32);
-    txn.delete(secondary_key);
+    if existing_fid.is_some() {
+        let secondary_key = make_fname_username_proof_by_fid_key(existing_fid.unwrap());
+        txn.delete(secondary_key);
+    }
 }

--- a/apps/hubble/src/addon/src/store/name_registry_events.rs
+++ b/apps/hubble/src/addon/src/store/name_registry_events.rs
@@ -76,8 +76,10 @@ pub fn delete_username_proof_transaction(
     txn: &mut RocksDbTransactionBatch,
     username_proof: &UserNameProof,
 ) {
+    let buf = username_proof.encode_to_vec();
+
     let primary_key = make_fname_username_proof_key(&username_proof.name);
-    txn.delete(primary_key);
+    txn.put(primary_key.clone(), buf);
 
     let secondary_key = make_fname_username_proof_by_fid_key(username_proof.fid as u32);
     txn.delete(secondary_key);

--- a/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
+++ b/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
@@ -75,7 +75,9 @@ describe("fnameRegistryEventsProvider", () => {
       await provider.start();
       expect(await engine.getUserNameProof(utf8ToBytes("test1"))).toBeTruthy();
       expect(await engine.getUserNameProof(utf8ToBytes("test2"))).toBeTruthy();
-      await expect(engine.getUserNameProof(utf8ToBytes("test4"))).rejects.toThrowError("NotFound");
+      const failCase = await engine.getUserNameProof(utf8ToBytes("test4"));
+      expect(failCase.isErr()).toBeTruthy();
+      expect(failCase._unsafeUnwrapErr().errCode).toEqual("not_found");
       expect((await hub.getHubState())._unsafeUnwrap().lastFnameProof).toEqual(transferEvents[3]?.id);
     });
 
@@ -96,7 +98,9 @@ describe("fnameRegistryEventsProvider", () => {
   describe("mergeTransfers", () => {
     it("deletes a proof from the db when a username is unregistered", async () => {
       await provider.start();
-      await expect(engine.getUserNameProof(utf8ToBytes("test3"))).rejects.toThrowError("NotFound");
+      const failCase = await engine.getUserNameProof(utf8ToBytes("test3"));
+      expect(failCase.isErr()).toBeTruthy();
+      expect(failCase._unsafeUnwrapErr().errCode).toEqual("not_found");
     });
 
     it("does not fail if there are errors merging events", async () => {
@@ -119,7 +123,9 @@ describe("fnameRegistryEventsProvider", () => {
       invalidEvent.server_signature = "0x8773442740c17c9d0f0b87022c722f9a136206ed";
       mockFnameRegistryClient.setTransfersToReturn([[invalidEvent]]);
       await provider.start();
-      await expect(engine.getUserNameProof(utf8ToBytes("test1"))).rejects.toThrowError("NotFound");
+      const failCase = await engine.getUserNameProof(utf8ToBytes("test1"));
+      expect(failCase.isErr()).toBeTruthy();
+      expect(failCase._unsafeUnwrapErr().errCode).toEqual("not_found");
     });
 
     it("succeeds for a known proof", async () => {

--- a/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
+++ b/apps/hubble/src/eth/fnameRegistryEventsProvider.test.ts
@@ -1,17 +1,13 @@
-import {
-  FNameRegistryClientInterface,
-  FNameRegistryEventsProvider,
-  FNameTransfer,
-  FNameTransferRequest,
-} from "./fnameRegistryEventsProvider.js";
+import { FNameRegistryEventsProvider, FNameTransfer } from "./fnameRegistryEventsProvider.js";
 import { jestRocksDB } from "../storage/db/jestUtils.js";
 import Engine from "../storage/engine/index.js";
 import { FarcasterNetwork } from "@farcaster/core";
 import { MockFnameRegistryClient, MockHub } from "../test/mocks.js";
-import { getUserNameProof } from "../storage/db/nameRegistryEvent.js";
 import { utf8ToBytes } from "@noble/curves/abstract/utils";
 import { generatePrivateKey, privateKeyToAccount, Address } from "viem/accounts";
 import { HubState } from "@farcaster/hub-nodejs";
+import StoreEventHandler from "storage/stores/storeEventHandler.js";
+import UserDataStore from "storage/stores/userDataStore.js";
 
 describe("fnameRegistryEventsProvider", () => {
   const db = jestRocksDB("protobufs.fnameRegistry.test");
@@ -77,9 +73,9 @@ describe("fnameRegistryEventsProvider", () => {
   describe("syncHistoricalEvents", () => {
     it("fetches all events from the beginning", async () => {
       await provider.start();
-      expect(await getUserNameProof(db, utf8ToBytes("test1"))).toBeTruthy();
-      expect(await getUserNameProof(db, utf8ToBytes("test2"))).toBeTruthy();
-      await expect(getUserNameProof(db, utf8ToBytes("test4"))).rejects.toThrowError("NotFound");
+      expect(await engine.getUserNameProof(utf8ToBytes("test1"))).toBeTruthy();
+      expect(await engine.getUserNameProof(utf8ToBytes("test2"))).toBeTruthy();
+      await expect(engine.getUserNameProof(utf8ToBytes("test4"))).rejects.toThrowError("NotFound");
       expect((await hub.getHubState())._unsafeUnwrap().lastFnameProof).toEqual(transferEvents[3]?.id);
     });
 
@@ -87,7 +83,7 @@ describe("fnameRegistryEventsProvider", () => {
       await hub.putHubState(HubState.create({ lastFnameProof: transferEvents[0]?.id ?? 0 }));
       mockFnameRegistryClient.setMinimumSince(transferEvents[0]?.id ?? 0);
       await provider.start();
-      expect(await getUserNameProof(db, utf8ToBytes("test2"))).toBeTruthy();
+      expect(await engine.getUserNameProof(utf8ToBytes("test2"))).toBeTruthy();
       expect((await hub.getHubState())._unsafeUnwrap().lastFnameProof).toEqual(transferEvents[3]?.id);
     });
 
@@ -100,14 +96,14 @@ describe("fnameRegistryEventsProvider", () => {
   describe("mergeTransfers", () => {
     it("deletes a proof from the db when a username is unregistered", async () => {
       await provider.start();
-      await expect(getUserNameProof(db, utf8ToBytes("test3"))).rejects.toThrowError("NotFound");
+      await expect(engine.getUserNameProof(utf8ToBytes("test3"))).rejects.toThrowError("NotFound");
     });
 
     it("does not fail if there are errors merging events", async () => {
       // Return duplicate events
       mockFnameRegistryClient.setTransfersToReturn([transferEvents, transferEvents]);
       await provider.start();
-      expect(await getUserNameProof(db, utf8ToBytes("test2"))).toBeTruthy();
+      expect(await engine.getUserNameProof(utf8ToBytes("test2"))).toBeTruthy();
     });
 
     it("does not merge when the signature is invalid", async () => {
@@ -123,7 +119,7 @@ describe("fnameRegistryEventsProvider", () => {
       invalidEvent.server_signature = "0x8773442740c17c9d0f0b87022c722f9a136206ed";
       mockFnameRegistryClient.setTransfersToReturn([[invalidEvent]]);
       await provider.start();
-      await expect(getUserNameProof(db, utf8ToBytes("test1"))).rejects.toThrowError("NotFound");
+      await expect(engine.getUserNameProof(utf8ToBytes("test1"))).rejects.toThrowError("NotFound");
     });
 
     it("succeeds for a known proof", async () => {
@@ -143,7 +139,7 @@ describe("fnameRegistryEventsProvider", () => {
       mockFnameRegistryClient.setTransfersToReturn([[proof]]);
       mockFnameRegistryClient.setSignerAddress("0xBc5274eFc266311015793d89E9B591fa46294741");
       await provider.start();
-      expect(await getUserNameProof(db, utf8ToBytes("farcaster"))).toBeTruthy();
+      expect(await engine.getUserNameProof(utf8ToBytes("farcaster"))).toBeTruthy();
     });
   });
 

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -50,7 +50,6 @@ import { finishAllProgressBars } from "../../utils/progressBars.js";
 import { FNameRegistryEventsProvider } from "../../eth/fnameRegistryEventsProvider.js";
 import { PeerScore, PeerScorer } from "./peerScore.js";
 import { getOnChainEvent } from "../../storage/db/onChainEvent.js";
-import { getUserNameProof } from "../../storage/db/nameRegistryEvent.js";
 import { MaxPriorityQueue } from "@datastructures-js/priority-queue";
 import { TTLMap } from "../../utils/ttl_map.js";
 import * as buffer from "node:buffer";
@@ -1851,7 +1850,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
           revokedSyncIds += 1;
         }
       } else if (unpacked.type === SyncIdType.FName) {
-        const result = await ResultAsync.fromPromise(getUserNameProof(this._db, unpacked.name), (e) => e as HubError);
+        const result = await this._hub.engine.getUserNameProof(unpacked.name);
         let validSyncId = result.isOk();
         if (result.isOk()) {
           validSyncId = result.value.fid === unpacked.fid;

--- a/apps/hubble/src/storage/db/nameRegistryEvent.ts
+++ b/apps/hubble/src/storage/db/nameRegistryEvent.ts
@@ -2,6 +2,7 @@ import { UserNameProof } from "@farcaster/hub-nodejs";
 import RocksDB, { RocksDbTransaction } from "../db/rocksdb.js";
 import { RootPrefix } from "../db/types.js";
 import { makeFidKey } from "./message.js";
+import { rsGetUserNameProof } from "rustfunctions.js";
 
 export const makeFNameUserNameProofKey = (name: Uint8Array): Buffer => {
   return Buffer.concat([Buffer.from([RootPrefix.FNameUserNameProof]), Buffer.from(name)]);
@@ -9,12 +10,6 @@ export const makeFNameUserNameProofKey = (name: Uint8Array): Buffer => {
 
 export const makeFNameUserNameProofByFidKey = (fid: number): Buffer => {
   return Buffer.concat([Buffer.from([RootPrefix.FNameUserNameProofByFid]), makeFidKey(fid)]);
-};
-
-export const getUserNameProof = async (db: RocksDB, name: Uint8Array): Promise<UserNameProof> => {
-  const primaryKey = makeFNameUserNameProofKey(name);
-  const buffer = await db.get(primaryKey);
-  return UserNameProof.decode(new Uint8Array(buffer));
 };
 
 export const getFNameProofByFid = async (db: RocksDB, fid: number): Promise<UserNameProof> => {

--- a/apps/hubble/src/storage/engine/index.test.ts
+++ b/apps/hubble/src/storage/engine/index.test.ts
@@ -41,7 +41,6 @@ import { getMessage, makeTsHash, typeToSetPostfix } from "../db/message.js";
 import { StoreEvents } from "../stores/storeEventHandler.js";
 import { IdRegisterOnChainEvent, makeVerificationAddressClaim } from "@farcaster/core";
 import { setReferenceDateForTest } from "../../utils/versions.js";
-import { getUserNameProof } from "../db/nameRegistryEvent.js";
 import { publicClient } from "../../test/utils.js";
 import { jest } from "@jest/globals";
 import { FNameRegistryEventsProvider, FNameTransfer } from "../../eth/fnameRegistryEventsProvider.js";
@@ -164,7 +163,7 @@ describe("mergeUserNameProof", () => {
   test("succeeds", async () => {
     const userNameProof = Factories.UserNameProof.build();
     await expect(engine.mergeUserNameProof(userNameProof)).resolves.toBeInstanceOf(Ok);
-    expect(await getUserNameProof(db, userNameProof.name)).toBeTruthy();
+    expect(await engine.getUserNameProof(userNameProof.name)).toBeTruthy();
   });
 });
 

--- a/apps/hubble/src/storage/stores/usernameProofStore.test.ts
+++ b/apps/hubble/src/storage/stores/usernameProofStore.test.ts
@@ -107,19 +107,6 @@ describe("usernameProofStore", () => {
       expect(proof).toEqual(ensProof);
     });
 
-    test("does not replace existing proof for name if timestamp is older and existing proof was deleted", async () => {
-      await set.merge(ensProof);
-
-      const deleteProof = await buildProof(0, fname, currentFarcasterTime + 1, UserNameType.USERNAME_TYPE_ENS_L1);
-      expect(deleteProof).not.toEqual(ensProof);
-      await set.merge(deleteProof);
-
-      await expect(set.merge(ensProof)).rejects.toThrowError("message conflicts with a more recent add");
-
-      const proof = await set.getUsernameProof(fname, UserNameType.USERNAME_TYPE_ENS_L1);
-      expect(proof).toEqual(deleteProof);
-    });
-
     test("does not merge duplicates", async () => {
       await set.merge(ensProof);
       await expect(set.merge(ensProof)).rejects.toThrowError("message has already been merged");

--- a/apps/hubble/src/storage/stores/usernameProofStore.test.ts
+++ b/apps/hubble/src/storage/stores/usernameProofStore.test.ts
@@ -107,6 +107,19 @@ describe("usernameProofStore", () => {
       expect(proof).toEqual(ensProof);
     });
 
+    test("does not replace existing proof for name if timestamp is older and existing proof was deleted", async () => {
+      await set.merge(ensProof);
+
+      const deleteProof = await buildProof(0, fname, currentFarcasterTime + 1, UserNameType.USERNAME_TYPE_ENS_L1);
+      expect(deleteProof).not.toEqual(ensProof);
+      await set.merge(deleteProof);
+
+      await expect(set.merge(ensProof)).rejects.toThrowError("message conflicts with a more recent add");
+
+      const proof = await set.getUsernameProof(fname, UserNameType.USERNAME_TYPE_ENS_L1);
+      expect(proof).toEqual(deleteProof);
+    });
+
     test("does not merge duplicates", async () => {
       await set.merge(ensProof);
       await expect(set.merge(ensProof)).rejects.toThrowError("message has already been merged");


### PR DESCRIPTION
## Why is this change needed?

The fname events are not coming through correctly for a few names, and by consequence we're seeing a few old fname events being endlessly replayed. The deletion of the fname record (when fid = 0 in proof) completely removes the record rather than its association with a fid, and by consequence replaying the older event re-adds the fname. This resolves the hub side of the behavior by correctly holding on to the new fname event, but deleting the association with a fid.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the `hubble` app by fixing issues related to username proof handling and syncing historical events.

### Detailed summary
- Fixed issue where deleted fname events allowed re-adding old fname events
- Improved syncing historical events in `syncEngine.ts`
- Updated `mergeUserNameProof` functionality in tests
- Added `rsGetUserNameProof` import in `nameRegistryEvent.ts`
- Enhanced `UserDataStore` functionality in `user_data_store.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->