### PR TITLE
fix: Fix incorrect target fid check for link messages older than the compact state

### DIFF
--- a/.changeset/rare-pots-look.md
+++ b/.changeset/rare-pots-look.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Fix incorrect target fid check for link messages older than the compact state

--- a/apps/hubble/src/addon/src/store/store.rs
+++ b/apps/hubble/src/addon/src/store/store.rs
@@ -847,7 +847,7 @@ impl Store {
                     if let Some(Target::TargetFid(target_fid)) = link_body.target {
                         // If the message is older than the compact state message, and the target fid is not in the target_fids list
                         if message.data.as_ref().unwrap().timestamp < compact_state_timestamp
-                            && !target_fids.contains(&message.data.as_ref().unwrap().fid)
+                            && !target_fids.contains(&target_fid)
                         {
                             return Err(HubError {
                                 code: "bad_request.conflict".to_string(),


### PR DESCRIPTION
## Why is this change needed?

We were checking for the message creator's fid instead of the target fid and therefore rejecting valid messages older than the compact state

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes an issue with target fid check for link messages older than the compact state in the `store.rs` file and adds tests in `linkStoreCompactState.test.ts`.

### Detailed summary
- Fixed incorrect target fid check for link messages in `store.rs`
- Added tests for merging link add messages in `linkStoreCompactState.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->