### PR TITLE
fix: Do not validate messages in shuttle by default

### DIFF
--- a/.changeset/mighty-pants-knock.md
+++ b/.changeset/mighty-pants-knock.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+fix: Do not validate messages in shuttle by default

--- a/packages/shuttle/src/shuttle.integration.test.ts
+++ b/packages/shuttle/src/shuttle.integration.test.ts
@@ -324,7 +324,7 @@ describe("shuttle", () => {
         type: HubEventType.MERGE_MESSAGE,
         mergeMessageBody: {
           message: compactMessage,
-          deletedMessages: [removeMessage, addMessage3],
+          deletedMessages: [],
         },
       }),
     );

--- a/packages/shuttle/src/shuttle/hubEventProcessor.ts
+++ b/packages/shuttle/src/shuttle/hubEventProcessor.ts
@@ -68,11 +68,6 @@ export class HubEventProcessor {
             await handler.handleMessageMerge(deletedMessage, trx, "delete", state, true, wasMissed);
           }),
         );
-
-        const eventSet = new Set(affectedMessages.map((m) => bytesToHex(m.hash)));
-        for (const hash of deletedMessages.filter((m) => !eventSet.has(bytesToHex(m.hash)))) {
-          log.warn(`Message ${hash} was updated, but was not in deleted messages from merge event.`);
-        }
       }
       const isNew = await MessageProcessor.storeMessage(message, trx, operation, log, shouldValidate);
       const state = this.getMessageState(message, operation);


### PR DESCRIPTION
## Why is this change needed?

This should significantly improve performance. This was originally intended as additional protection when listening to untrusted hubs. But given most users are listening to their own or trusted hub providers, no need to enable this by default. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR disables message validation by default in `shuttle`. 

### Detailed summary
- Shuttle now does not validate messages by default
- Added environment variable to enable message validation
- Updated message processing logic in `hubEventProcessor.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->