### PR TITLE
perf: Add message merge timing at the store level

### DIFF
--- a/.changeset/late-bananas-lick.md
+++ b/.changeset/late-bananas-lick.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+perf: Add message merge timing at the store level

--- a/apps/hubble/src/storage/stores/rustStoreBase.ts
+++ b/apps/hubble/src/storage/stores/rustStoreBase.ts
@@ -67,6 +67,10 @@ export abstract class RustStoreBase<TAdd extends Message, TRemove extends Messag
     return this._pruneSizeLimit;
   }
 
+  get postfix(): UserMessagePostfix {
+    return this._postfix;
+  }
+
   async mergeMessages(messages: Message[]): Promise<Map<number, HubResult<number>>> {
     const mergeResults: Map<number, HubResult<number>> = new Map();
 


### PR DESCRIPTION
## Why is this change needed?

Add store level message merge timing metrics

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving performance by adding message merge timing at the store level.

### Detailed summary
- Added message merge timing at the store level for performance tracking
- Imported `statsd` for timing storage merge messages
- Calculated duration of message merge operation
- Updated storage engine to include timing data for each store

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->