### PR TITLE
Release shuttle 0.5.8

### DIFF
--- a/.changeset/gold-hounds-double.md
+++ b/.changeset/gold-hounds-double.md
@@ -1,5 +1,4 @@
 ---
-"@farcaster/hub-nodejs": patch
 "@farcaster/hubble": patch
 ---
 

--- a/.changeset/mighty-pants-knock.md
+++ b/.changeset/mighty-pants-knock.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-fix: Do not validate messages in shuttle by default

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-nodejs
 
+## 0.11.22
+
+### Patch Changes
+
+- 2fa29ad4: fix: Upgrade grpc-js to 1.11
+
 ## 0.11.21
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.11.21",
+  "version": "0.11.22",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hub-shuttle
 
+## 0.5.8
+
+### Patch Changes
+
+- 4f40c19b: fix: Do not validate messages in shuttle by default
+- Updated dependencies [2fa29ad4]
+  - @farcaster/hub-nodejs@0.11.22
+
 ## 0.5.7
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@farcaster/hot-shots": "^10.0.0",
-    "@farcaster/hub-nodejs": "^0.11.21",
+    "@farcaster/hub-nodejs": "^0.11.22",
     "commander": "11.0.0",
     "dotenv": "16.4.5",
     "ioredis": "^5.3.2",


### PR DESCRIPTION
## Why is this change needed?

Release shuttle 0.5.8 with validate message changes

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates versions in `hub-nodejs` and `shuttle` packages. Focus is on upgrading `grpc-js` in `hub-nodejs` to 1.11 and bumping versions for both packages.

### Detailed summary
- Updated `hub-nodejs` version to 0.11.22 with `grpc-js` upgrade
- Updated `shuttle` version to 0.5.8
- Removed message validation in `shuttle`
- Updated dependencies in `shuttle`
- Updated `hub-nodejs` dependency version in `shuttle`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->