### PR TITLE
feat: add a job to measure sync health periodically

### DIFF
--- a/.changeset/six-timers-jog.md
+++ b/.changeset/six-timers-jog.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: added a sync health measurement job

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -154,6 +154,7 @@ export interface HubInterface {
     options?: Partial<ClientOptions>,
   ): Promise<HubRpcClient | undefined>;
   updateApplicationPeerScore(peerId: String, score: number): HubAsyncResult<void>;
+  bootstrapAddrs(): Multiaddr[];
 }
 
 export interface HubOptions {
@@ -578,6 +579,10 @@ export class Hub implements HubInterface {
     await this.syncEngine.diffSyncIfRequired(this, peerId);
   }
 
+  bootstrapAddrs(): Multiaddr[] {
+    return this.options.bootstrapAddrs ?? [];
+  }
+
   /* Start the GossipNode and RPC server  */
   async start() {
     // See if we have to fetch the IP address
@@ -774,14 +779,12 @@ export class Hub implements HubInterface {
     await this.l2RegistryProvider.start();
     await this.fNameRegistryEventsProvider.start();
 
-    const bootstrapAddrs = this.options.bootstrapAddrs ?? [];
-
     const peerId = this.options.peerId
       ? exportToProtobuf(this.options.peerId as RSAPeerId | Ed25519PeerId | Secp256k1PeerId)
       : undefined;
 
     // Start the Gossip node
-    await this.gossipNode.start(bootstrapAddrs, {
+    await this.gossipNode.start(this.bootstrapAddrs(), {
       peerId,
       ipMultiAddr: this.options.ipMultiAddr,
       announceIp: this.options.announceIp,

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -97,6 +97,7 @@ import { DEFAULT_CATCHUP_SYNC_SNAPSHOT_MESSAGE_LIMIT } from "./defaultConfig.js"
 import { diagnosticReporter } from "./utils/diagnosticReport.js";
 import { startupCheck, StartupCheckStatus } from "./utils/startupCheck.js";
 import { AddressInfo } from "node:net";
+import { MeasureSyncHealthJobScheduler } from "./network/sync/syncHealthJob.js";
 
 export type HubSubmitSource = "gossip" | "rpc" | "eth-provider" | "l2-provider" | "sync" | "fname-registry";
 
@@ -378,6 +379,7 @@ export class Hub implements HubInterface {
   private checkIncomingPortsJobScheduler: CheckIncomingPortsJobScheduler;
   private updateNetworkConfigJobScheduler: UpdateNetworkConfigJobScheduler;
   private dbSnapshotBackupJobScheduler: DbSnapshotBackupJobScheduler;
+  private measureSyncHealthJobScheduler: MeasureSyncHealthJobScheduler;
 
   private submitMessageLogger = new SubmitMessageSuccessLogCache(log);
 
@@ -540,6 +542,7 @@ export class Hub implements HubInterface {
       this.syncEngine,
       this.options,
     );
+    this.measureSyncHealthJobScheduler = new MeasureSyncHealthJobScheduler(this.syncEngine, this);
 
     if (options.testUsers) {
       this.testDataJobScheduler = new PeriodicTestDataJobScheduler(this.rpcServer, options.testUsers as TestUser[]);
@@ -805,6 +808,7 @@ export class Hub implements HubInterface {
     const randomMinute = Math.floor(Math.random() * 30);
     this.gossipContactInfoJobScheduler.start(`${randomMinute} */30 * * * *`); // Random minute every 30 minutes
     this.checkIncomingPortsJobScheduler.start();
+    this.measureSyncHealthJobScheduler.start();
 
     // Mainnet only jobs
     if (this.options.network === FarcasterNetwork.MAINNET) {
@@ -1216,6 +1220,7 @@ export class Hub implements HubInterface {
     this.checkIncomingPortsJobScheduler.stop();
     this.updateNetworkConfigJobScheduler.stop();
     this.dbSnapshotBackupJobScheduler.stop();
+    this.measureSyncHealthJobScheduler.stop();
 
     // Stop the engine
     await this.engine.stop();

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -759,6 +759,7 @@ describe("Multi peer sync engine", () => {
     const farcasterTime = getFarcasterTime()._unsafeUnwrap() - 1000;
 
     await addMessagesWithTimeDelta(engine1, [150, 170, 180, 200]);
+    await sleepWhile(() => syncEngine1.syncTrieQSize > 0, SLEEPWHILE_TIMEOUT);
 
     const start = new Date(fromFarcasterTime(farcasterTime + 150)._unsafeUnwrap());
     const stop = new Date(fromFarcasterTime(farcasterTime + 200)._unsafeUnwrap());
@@ -769,6 +770,7 @@ describe("Multi peer sync engine", () => {
     expect(messageStats1.isErr());
 
     await addMessagesWithTimeDelta(engine2, [150, 170]);
+    await sleepWhile(() => syncEngine2.syncTrieQSize > 0, SLEEPWHILE_TIMEOUT);
 
     const messageStats2 = (
       await computeSyncHealthMessageStats(start, stop, metadataRetriever1, metadataRetriever2)
@@ -779,6 +781,7 @@ describe("Multi peer sync engine", () => {
     expect(messageStats2.peerNumMessages).toEqual(2);
 
     await addMessagesWithTimeDelta(engine2, [180, 185, 200]);
+    await sleepWhile(() => syncEngine2.syncTrieQSize > 0, SLEEPWHILE_TIMEOUT);
 
     const messageStats3 = (
       await computeSyncHealthMessageStats(start, stop, metadataRetriever1, metadataRetriever2)

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -11,6 +11,7 @@ import {
   OnChainEvent,
   UserNameProof,
   MessageData,
+  fromFarcasterTime,
 } from "@farcaster/hub-nodejs";
 import { APP_NICKNAME, APP_VERSION, HubInterface } from "../../hubble.js";
 import SyncEngine from "./syncEngine.js";
@@ -22,6 +23,7 @@ import { MockHub } from "../../test/mocks.js";
 import { sleep, sleepWhile } from "../../utils/crypto.js";
 import { ensureMessageData } from "../../storage/db/message.js";
 import { EMPTY_HASH } from "./merkleTrie.js";
+import { SyncEngineMetadataRetriever, computeSyncHealthMessageStats } from "../../utils/syncHealth.js";
 
 const TEST_TIMEOUT_SHORT = 10 * 1000;
 const TEST_TIMEOUT_LONG = 60 * 1000;
@@ -737,6 +739,54 @@ describe("Multi peer sync engine", () => {
       clientForServer2.$.close();
       await server2.stop();
     }
+  });
+
+  test("perform sync health computation", async () => {
+    const metadataRetriever1 = new SyncEngineMetadataRetriever(syncEngine1);
+    const metadataRetriever2 = new SyncEngineMetadataRetriever(syncEngine2);
+
+    const setupEngine = async (engine: Engine) => {
+      await engine.mergeOnChainEvent(custodyEvent);
+      await engine.mergeOnChainEvent(signerEvent);
+      await engine.mergeOnChainEvent(storageEvent);
+    };
+
+    // Engine1 has no messages
+    await setupEngine(engine1);
+    await setupEngine(engine2);
+
+    // This is the start time from addMessagesWithTimeDelta
+    const farcasterTime = getFarcasterTime()._unsafeUnwrap() - 1000;
+
+    await addMessagesWithTimeDelta(engine1, [150, 170, 180, 200]);
+
+    const start = new Date(fromFarcasterTime(farcasterTime + 150)._unsafeUnwrap());
+    const stop = new Date(fromFarcasterTime(farcasterTime + 200)._unsafeUnwrap());
+
+    const messageStats1 = await computeSyncHealthMessageStats(start, stop, metadataRetriever1, metadataRetriever2);
+
+    // This happens because there are no messages under the common prefix for engine2
+    expect(messageStats1.isErr());
+
+    await addMessagesWithTimeDelta(engine2, [150, 170]);
+
+    const messageStats2 = (
+      await computeSyncHealthMessageStats(start, stop, metadataRetriever1, metadataRetriever2)
+    )._unsafeUnwrap();
+
+    // Query is inclusive of the start time and exclusive of the stop time. We cound 150, 170, 180 on engine1 and  150, 170 on engine 2
+    expect(messageStats2.primaryNumMessages).toEqual(3);
+    expect(messageStats2.peerNumMessages).toEqual(2);
+
+    await addMessagesWithTimeDelta(engine2, [180, 185, 200]);
+
+    const messageStats3 = (
+      await computeSyncHealthMessageStats(start, stop, metadataRetriever1, metadataRetriever2)
+    )._unsafeUnwrap();
+
+    // engine2 has all the messages engine1 has in addition to 185.
+    expect(messageStats3.primaryNumMessages).toEqual(3);
+    expect(messageStats3.peerNumMessages).toEqual(4);
   });
 
   xtest(

--- a/apps/hubble/src/network/sync/syncHealthJob.ts
+++ b/apps/hubble/src/network/sync/syncHealthJob.ts
@@ -1,0 +1,99 @@
+import cron from "node-cron";
+import { logger } from "../../utils/logger.js";
+import SyncEngine from "./syncEngine.js";
+import {
+  RpcMetadataRetriever,
+  SyncEngineMetadataRetriever,
+  computeSyncHealthMessageStats,
+} from "../../utils/syncHealth.js";
+import { HubInterface } from "hubble.js";
+import { peerIdFromString } from "@libp2p/peer-id";
+
+const log = logger.child({
+  component: "SyncHealth",
+});
+
+type SchedulerStatus = "started" | "stopped";
+
+export class MeasureSyncHealthJobScheduler {
+  private _cronTask?: cron.ScheduledTask;
+  private _metadataRetriever: SyncEngineMetadataRetriever;
+  private _maxNumPeers = 10;
+  private _startSecondsAgo = 60 * 15;
+  private _spanSeconds = 60 * 10;
+  private _hub: HubInterface;
+
+  constructor(syncEngine: SyncEngine, hub: HubInterface) {
+    this._metadataRetriever = new SyncEngineMetadataRetriever(syncEngine);
+    this._hub = hub;
+  }
+
+  start(cronSchedule?: string) {
+    // Run every 10 minutes at a random minute
+    const defaultSchedule = "*/10 * * * *";
+    this._cronTask = cron.schedule(cronSchedule ?? defaultSchedule, () => this.doJobs(), {
+      timezone: "Etc/UTC",
+    });
+  }
+
+  stop() {
+    if (this._cronTask) {
+      this._cronTask.stop();
+    }
+  }
+
+  status(): SchedulerStatus {
+    return this._cronTask ? "started" : "stopped";
+  }
+
+  async doJobs() {
+    log.info({}, "Starting compute sync health job");
+
+    const peerIds = Array.from(this._metadataRetriever._syncEngine.getCurrentHubPeerContacts());
+
+    // Shuffle and pick peers
+    const peersToContact = peerIds
+      .map((value) => ({ value, sort: Math.random() }))
+      .sort((a, b) => a.sort - b.sort)
+      .map(({ value }) => value)
+      .slice(0, this._maxNumPeers);
+
+    const startTime = Date.now() - this._startSecondsAgo * 1000;
+    const stopTime = startTime + this._spanSeconds * 1000;
+
+    for (const [peerId, contactInfo] of peersToContact) {
+      const rpcClient = await this._hub.getRPCClientForPeer(peerIdFromString(peerId), contactInfo);
+
+      if (rpcClient === undefined) {
+        log.info("Couldn't get rpc client, skipping peer", peerId, contactInfo);
+        continue;
+      }
+
+      const peerMetadataRetriever = new RpcMetadataRetriever(rpcClient);
+      computeSyncHealthMessageStats;
+
+      const syncHealthMessageStats = await computeSyncHealthMessageStats(
+        new Date(startTime),
+        new Date(stopTime),
+        this._metadataRetriever,
+        peerMetadataRetriever,
+      );
+
+      if (syncHealthMessageStats.isErr()) {
+        log.info(syncHealthMessageStats.error, "Error computing sync stats");
+        continue;
+      }
+
+      log.info(
+        {
+          hubNumMessages: syncHealthMessageStats.value.primaryNumMessages,
+          peerNumMessages: syncHealthMessageStats.value.peerNumMessages,
+          syncHealth: syncHealthMessageStats.value.computeDiff(),
+          syncHealthPercentage: syncHealthMessageStats.value.computeDiffPercentage(),
+          contactInfo,
+        },
+        "Computed sync health stats for peer",
+      );
+    }
+  }
+}

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -335,6 +335,35 @@ export function destroyStream(stream: ServerWritableStream<SubscribeRequest, Hub
   stream.end();
 }
 
+export const toTrieNodeMetadataResponse = (metadata?: NodeMetadata): TrieNodeMetadataResponse => {
+  const childrenTrie = [];
+
+  if (!metadata) {
+    return TrieNodeMetadataResponse.create({});
+  }
+
+  if (metadata.children) {
+    for (const [, child] of metadata.children) {
+      childrenTrie.push(
+        TrieNodeMetadataResponse.create({
+          prefix: child.prefix,
+          numMessages: child.numMessages,
+          hash: child.hash,
+          children: [],
+        }),
+      );
+    }
+  }
+
+  const metadataResponse = TrieNodeMetadataResponse.create({
+    prefix: metadata.prefix,
+    numMessages: metadata.numMessages,
+    hash: metadata.hash,
+    children: childrenTrie,
+  });
+
+  return metadataResponse;
+};
 export default class Server {
   private hub: HubInterface | undefined;
   private engine: Engine | undefined;
@@ -658,36 +687,6 @@ export default class Server {
       getSyncMetadataByPrefix: (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getSyncMetadataByPrefix", req: call.request }, `RPC call from ${peer}`);
-
-        const toTrieNodeMetadataResponse = (metadata?: NodeMetadata): TrieNodeMetadataResponse => {
-          const childrenTrie = [];
-
-          if (!metadata) {
-            return TrieNodeMetadataResponse.create({});
-          }
-
-          if (metadata.children) {
-            for (const [, child] of metadata.children) {
-              childrenTrie.push(
-                TrieNodeMetadataResponse.create({
-                  prefix: child.prefix,
-                  numMessages: child.numMessages,
-                  hash: child.hash,
-                  children: [],
-                }),
-              );
-            }
-          }
-
-          const metadataResponse = TrieNodeMetadataResponse.create({
-            prefix: metadata.prefix,
-            numMessages: metadata.numMessages,
-            hash: metadata.hash,
-            children: childrenTrie,
-          });
-
-          return metadataResponse;
-        };
 
         const request = call.request;
 

--- a/apps/hubble/src/test/mocks.ts
+++ b/apps/hubble/src/test/mocks.ts
@@ -29,6 +29,7 @@ import {
 } from "../eth/fnameRegistryEventsProvider.js";
 import { Address, PrivateKeyAccount, generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { bytesToHex } from "viem/utils";
+import { Multiaddr } from "@multiformats/multiaddr";
 
 export class MockHub implements HubInterface {
   public db: RocksDB;
@@ -40,6 +41,10 @@ export class MockHub implements HubInterface {
     this.db = db;
     this.engine = engine ?? new Engine(db, FarcasterNetwork.TESTNET);
     this.gossipNode = gossipNode;
+  }
+
+  bootstrapAddrs(): Multiaddr[] {
+    return [];
   }
 
   async submitMessageBundle(


### PR DESCRIPTION
## Why is this change needed?

There have been reports of missing messages from several users. We'd like to proactively detect when hubs are missing messages and identify why. 

For reviewers: 
- The diff in `syncHealth.ts` is a bit noisy because I removed a level of indentation in `printSyncHealth`
- I did not test the job, I just tested the `computeSyncHealthMessageStats` function which does the somewhat complicated querying.
- I did not incorporate into datadog, I just added logging. I thought it made sense to make sure that the pipeline works via logging as a first step and integrate into datadog as a follow up. 
- I did not write the code to select hubs in a smart way or to snap to the 10min interval that we want. Also thought this could be a follow-up. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a sync health measurement job to the `@farcaster/hubble` package.

### Detailed summary
- Added a sync health measurement job to the `@farcaster/hubble` package
- Updated functions related to sync health computation and metadata retrieval
- Implemented a scheduler for measuring sync health at intervals

> The following files were skipped due to too many changes: `apps/hubble/src/utils/syncHealth.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->