### PR TITLE
fix(docs): update link to tutorials in installation documentation

### DIFF
--- a/apps/hubble/www/docs/intro/install.md
+++ b/apps/hubble/www/docs/intro/install.md
@@ -11,7 +11,7 @@ Hubble can be installed in 30 minutes, and a full sync can take 1-2 hours to com
 - 200 GB of free storage
 - A public IP address with ports 2282 - 2285 exposed
 
-See [tutorials](./tutorials.html) for instructions on how to set up cloud providers to run Hubble.
+See [tutorials](./tutorials.md) for instructions on how to set up cloud providers to run Hubble.
 
 You will need RPC endpoints for Ethereum nodes on L2 OP Mainnet, L1 Mainnet and L1 Goerli. We recommend using a service like [Alchemy](https://www.alchemy.com/) or [Infura](https://www.infura.io/).
 


### PR DESCRIPTION
## Why is this change needed?

The link in the installation documentation currently points to `./tutorials.html`, which is incorrect. The correct link should be `./tutorials.md`.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update a file path in the documentation from `tutorials.html` to `tutorials.md`.

### Detailed summary
- Updated file path from `tutorials.html` to `tutorials.md` in `apps/hubble/www/docs/intro/install.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->