### PR TITLE
fix(shuttle): Don't throttle CPU when there are no events to process

### DIFF
--- a/.changeset/friendly-horses-hide.md
+++ b/.changeset/friendly-horses-hide.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+Fix CPU throttling regression introduced in 0.5.6 by trim optimization

--- a/packages/shuttle/src/shuttle/eventStream.ts
+++ b/packages/shuttle/src/shuttle/eventStream.ts
@@ -389,7 +389,10 @@ export class HubEventStreamConsumer extends TypedEmitter<HubEventStreamConsumerE
 
         if (eventsRead === 0) {
           if (this.stopped) break;
-          await this.processStale(onEvent);
+          const totalProcessed = await this.processStale(onEvent);
+          if (totalProcessed === 0) {
+            sleep(10); // Don't thrash CPU if there's no events to process
+          }
         }
       } catch (e: unknown) {
         this.log.error(e, "Error processing event, skipping");


### PR DESCRIPTION
## Why is this change needed?

We accidentally introduced a change in 0.5.6 which lead to higher CPU usage since we're no longer sleeping.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to fix a CPU throttling regression introduced in version 0.5.6 of `@farcaster/shuttle`.

### Detailed summary
- Added logic to prevent CPU thrashing when no events are present in `eventStream.ts`.
- Introduced a sleep function to pause processing when no events are available.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->