### PR TITLE
fix: Always assign on-chain events to shard 0 for linear ordering

### DIFF
--- a/.changeset/modern-cows-argue.md
+++ b/.changeset/modern-cows-argue.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Ensure onchain + username proofs are always assigned to the same shard for linear ordering

--- a/packages/shuttle/docker-compose.yml
+++ b/packages/shuttle/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   postgres:
     image: 'postgres:16-alpine'


### PR DESCRIPTION
## Why is this change needed?

Sharding works when the ordering of events in different shards are independent of each other.

In the case of onchain events and username proofs, however, these events can affect multiple FIDs at a time
(e.g. transfers) which means depending on which shard they are assigned to, they might get processed out of order.

Fix this by always using the same shard (shard 0) for onchain events + username proofs. This isn't perfect since it means shard 0 is a SPOF, but that's better than a potential race condition in the processing of events, and the volume of onchain events is much lower than regular hub events.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on ensuring onchain and username proofs are always assigned to the same shard for linear ordering.

### Detailed summary
- Updated logic to assign onchain and username proofs to the same shard for linear ordering
- Added a function to check if an event is ordered
- Adjusted tests to reflect the new shard assignment logic

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->