### PR TITLE
fix: Include peerid in bootstrap multiaddr

### DIFF
--- a/.changeset/metal-meals-beg.md
+++ b/.changeset/metal-meals-beg.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Include peerid in bootstrap multiaddr

--- a/apps/hubble/src/bootstrapPeers.mainnet.ts
+++ b/apps/hubble/src/bootstrapPeers.mainnet.ts
@@ -1,6 +1,6 @@
 // List of bootstrap peers for mainnet
 export const MAINNET_BOOTSTRAP_PEERS = [
-  "/dns/hoyt.farcaster.xyz/tcp/2282",
-  "/dns/lamia.farcaster.xyz/tcp/2282",
-  "/dns/bootstrap.neynar.com/tcp/2282",
+  "/dns/hoyt.farcaster.xyz/tcp/2282/p2p/12D3KooWRnSZUxjVJjbSHhVKpXtvibMarSfLSKDBeMpfVaNm1Joo",
+  "/dns/lamia.farcaster.xyz/tcp/2282/p2p/12D3KooWJECuSHn5edaorpufE9ceAoqR5zcAuD4ThoyDzVaz77GV",
+  "/dns/bootstrap.neynar.com/tcp/2282/p2p/12D3KooWNsC2vzuHdKDfSM6xnMZwMjWK8zZCYHyLXuhRMeVRebGK",
 ];


### PR DESCRIPTION
## Why is this change needed?

Newer version of libp2p requires the peer id in the bootstrap multiaddr. Without it, the connection is denied. We suspect the existing hubs are working because the peer id has been cached in the peer store. New hubs do not successfully  startup and peer.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `bootstrapPeers.mainnet.ts` file to include the `peerid` in the bootstrap multiaddr for `MAINNET_BOOTSTRAP_PEERS`.

### Detailed summary
- Added `peerid` to `MAINNET_BOOTSTRAP_PEERS` multiaddrs for `hoyt.farcaster.xyz`, `lamia.farcaster.xyz`, and `bootstrap.neynar.com`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->