### PR TITLE
fix(shuttle): Add missing `await` to per-iteration `sleep()` call

### DIFF
--- a/.changeset/fresh-dragons-compare.md
+++ b/.changeset/fresh-dragons-compare.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+fix(shuttle): Add missing `await` to per-iteration `sleep()` call

--- a/packages/shuttle/src/shuttle/eventStream.ts
+++ b/packages/shuttle/src/shuttle/eventStream.ts
@@ -391,7 +391,7 @@ export class HubEventStreamConsumer extends TypedEmitter<HubEventStreamConsumerE
           if (this.stopped) break;
           const totalProcessed = await this.processStale(onEvent);
           if (totalProcessed === 0) {
-            sleep(10); // Don't thrash CPU if there's no events to process
+            await sleep(10); // Don't thrash CPU if there's no events to process
           }
         }
       } catch (e: unknown) {


### PR DESCRIPTION
## Why is this change needed?

The fix for high CPU usage due to busy-waiting (release v0.5.9) wasn't effective because `sleep()` returns a Promise which wasn't being `await`ed, so the containing `while` loop was still iterating unchecked thousands of times per second. This should fix for good.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a bug in the `shuttle` package where an `await` was missing in the `sleep()` call, potentially causing CPU thrashing.

### Detailed summary
- Added missing `await` to `sleep()` call in `eventStream.ts` to prevent CPU thrashing.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->