### PR TITLE
fix(shuttle): Correct example app to use await

### DIFF
--- a/packages/shuttle/src/example-app/app.ts
+++ b/packages/shuttle/src/example-app/app.ts
@@ -147,7 +147,7 @@ export class App implements MessageHandler {
     log.info("Starting stream consumer");
     // Stream consumer reads from the redis stream and inserts them into postgres
     await this.streamConsumer.start(async (event) => {
-      void this.processHubEvent(event);
+      await this.processHubEvent(event);
       return ok({ skipped: false });
     });
   }


### PR DESCRIPTION
## Why is this change needed?

This is leading to confusion. If you don't `await`, you can overwhelm the event loop.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR ensures the `processHubEvent` method is awaited when called in the stream consumer, preventing it from being executed void. 

### Detailed summary
- Changed `this.processHubEvent(event);` to `await this.processHubEvent(event);` in the stream consumer to ensure proper execution.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->