### PR TITLE
chore: Release 1.14.2

### DIFF
--- a/.changeset/metal-meals-beg.md
+++ b/.changeset/metal-meals-beg.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Include peerid in bootstrap multiaddr

--- a/.changeset/modern-cows-argue.md
+++ b/.changeset/modern-cows-argue.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Ensure onchain + username proofs are always assigned to the same shard for linear ordering

--- a/.changeset/tame-seas-raise.md
+++ b/.changeset/tame-seas-raise.md
@@ -1,6 +1,0 @@
----
-"@farcaster/core": patch
-"@farcaster/hubble": patch
----
-
-upgrade libp2p/gossipsub and dependencies

--- a/.changeset/violet-steaks-rule.md
+++ b/.changeset/violet-steaks-rule.md
@@ -1,7 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
-"@farcaster/core": patch
-"@farcaster/hubble": patch
----
-
-chore: upgrade viem to v2

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @farcaster/hubble
 
+## 1.14.2
+
+### Patch Changes
+
+- fb2645ee: fix: Include peerid in bootstrap multiaddr
+- 501ceff2: fix: Ensure onchain + username proofs are always assigned to the same shard for linear ordering
+- 61959467: upgrade libp2p/gossipsub and dependencies
+- 939dde84: chore: upgrade viem to v2
+- Updated dependencies [939dde84]
+  - @farcaster/hub-nodejs@0.11.23
+
 ## 1.14.1
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -75,7 +75,7 @@
     "@chainsafe/libp2p-noise": "15.1.0",
     "@datastructures-js/priority-queue": "^6.3.1",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.11.21",
+    "@farcaster/hub-nodejs": "^0.11.23",
     "@fastify/cors": "^8.4.0",
     "@figma/hot-shots": "^9.0.0-figma.1",
     "@grpc/grpc-js": "~1.11.1",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/core
 
+## 0.14.20
+
+### Patch Changes
+
+- 61959467: upgrade libp2p/gossipsub and dependencies
+- 939dde84: chore: upgrade viem to v2
+
 ## 0.14.19
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.14.19",
+  "version": "0.14.20",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @farcaster/hub-nodejs
 
+## 0.11.23
+
+### Patch Changes
+
+- 939dde84: chore: upgrade viem to v2
+- Updated dependencies [61959467]
+- Updated dependencies [939dde84]
+  - @farcaster/core@0.14.20
+
 ## 0.11.22
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.11.22",
+  "version": "0.11.23",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -20,7 +20,7 @@
     "url": "https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/hub-nodejs"
   },
   "dependencies": {
-    "@farcaster/core": "0.14.19",
+    "@farcaster/core": "0.14.20",
     "@grpc/grpc-js": "~1.11.1",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"


### PR DESCRIPTION
## Why is this change needed?

Release 1.14.2

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates dependencies and versions across different packages. 

### Detailed summary
- Updated `@farcaster/core` version to `0.14.20`
- Updated `@farcaster/hub-nodejs` version to `0.11.23`
- Upgraded `libp2p/gossipsub` and dependencies
- Chore: upgraded `viem` to v2

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->