### PR TITLE
submit missing messages via the sync health job and output richer logs

### DIFF
--- a/.changeset/cuddly-windows-glow.md
+++ b/.changeset/cuddly-windows-glow.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+submit missing messages via the sync health job and enrich output logs

--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,8 @@ out
 dist
 
 # Editor Cache
-.vscode
+.vscode/*
+!.vscode/settings.json
 .idea
 .fleet
 **/.vitepress/cache/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,9 +11,6 @@
   "editor.codeActionsOnSave": {
     "source.organizeImports.biome": "explicit"
   },
-  "cSpell.words": [
-    "farcaster",
-    "gossipsub",
-    "protobufs"
-  ]
+  "cSpell.words": ["farcaster", "gossipsub", "protobufs"],
+  "rust-analyzer.linkedProjects": ["${workspaceFolder}/apps/hubble/src/addon/Cargo.toml"]
 }

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -958,6 +958,8 @@ app
   .option("--primary-node <host:port>", "Node to measure all peers against (required)", "hoyt.farcaster.xyz:2283")
   .option("--outfile <filename>", "File to output measurements to", "health.out")
   .option("--peers <ip:port,...>", "Peers to compare with (default: pick random connected peers)")
+  .option("--username <username>", "Username for primary node")
+  .option("--password <password>", "Password for primary node")
   .action(async (cliOptions) => {
     await printSyncHealth(
       cliOptions.startTimeOfday,
@@ -966,6 +968,8 @@ app
       cliOptions.primaryNode,
       cliOptions.outfile,
       cliOptions.peers ? cliOptions.peers.split(",") : undefined,
+      cliOptions.username,
+      cliOptions.password,
     );
   });
 

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -957,6 +957,7 @@ app
   .option("--max-num-peers <count>", "Maximum number of peers to measure for", "20")
   .option("--primary-node <host:port>", "Node to measure all peers against (required)", "hoyt.farcaster.xyz:2283")
   .option("--outfile <filename>", "File to output measurements to", "health.out")
+  .option("--peers <ip:port,...>", "Peers to compare with (default: pick random connected peers)")
   .action(async (cliOptions) => {
     await printSyncHealth(
       cliOptions.startTimeOfday,
@@ -964,6 +965,7 @@ app
       cliOptions.maxNumPeers,
       cliOptions.primaryNode,
       cliOptions.outfile,
+      cliOptions.peers ? cliOptions.peers.split(",") : undefined,
     );
   });
 

--- a/apps/hubble/src/utils/syncHealth.ts
+++ b/apps/hubble/src/utils/syncHealth.ts
@@ -459,6 +459,7 @@ export const printSyncHealth = async (
   maxNumPeers: number,
   primaryNode: string,
   outfile?: string,
+  userSpecifiedPeers?: string[],
 ) => {
   const startTime = parseTime(startTimeOfDay);
   const stopTime = parseTime(stopTimeOfDay);
@@ -477,7 +478,7 @@ export const printSyncHealth = async (
       console.log("Primary rpc client not ready", err);
       throw Error();
     }
-    const peers = await pickPeers(primaryRpcClient, maxNumPeers);
+    const peers = userSpecifiedPeers ? ok(userSpecifiedPeers) : await pickPeers(primaryRpcClient, maxNumPeers);
     if (peers.isErr()) {
       console.log("Error querying peers");
       return;

--- a/apps/hubble/src/utils/syncHealth.ts
+++ b/apps/hubble/src/utils/syncHealth.ts
@@ -392,16 +392,19 @@ const tryPushingMissingMessages = async (
 const uniqueSyncIds = (mySyncIds: Uint8Array[], otherSyncIds: Uint8Array[]) => {
   const idsOnlyInPrimary = [];
 
-  // This is really slow. It's n^2 in the number of sync ids. It seems somwhat complicated to figure out how to hash a sync id or get a string representation that can be hashed.
+  const otherSyncIdSet = new Set();
+
+  for (const syncId of otherSyncIds) {
+    const stringSyncId = bytesToHexString(syncId);
+    if (stringSyncId.isOk()) {
+      otherSyncIdSet.add(stringSyncId.value);
+    }
+  }
 
   for (const syncId of mySyncIds) {
-    const syncIdBuffer = Buffer.from(syncId);
-    const otherSyncId = otherSyncIds.find((otherSyncId) => {
-      const otherSyncIdBuffer = Buffer.from(otherSyncId);
-      return Buffer.compare(syncIdBuffer, otherSyncIdBuffer) === 0;
-    });
-
-    if (otherSyncId === undefined) {
+    const stringSyncId = bytesToHexString(syncId);
+    if (stringSyncId.isOk() && !otherSyncIdSet.has(stringSyncId.value)) {
+      const syncIdBuffer = Buffer.from(syncId);
       idsOnlyInPrimary.push(syncIdBuffer);
     }
   }


### PR DESCRIPTION
## Why is this change needed?
1. The sync score masks some differences between which sync ids are on each node. 
2. It's hard to investigate sync health with the information we have right now. 

Actually querying for and submitting missing messages will reveal differences in the actual messages on the nodes and  logging the results will give us information about why nodes are out of sync. 

I also lumped in a small change to fix vscode config for rust analyzer. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the sync health job in the `hubble` application by adding features like comparing peers and submitting messages.

### Detailed summary
- Added options for peers, username, and password in the sync health job CLI
- Refactored metadata retrievers to support hub interactions
- Implemented message submission and processing in the sync health job
- Enhanced sync health computation and message stats gathering

> The following files were skipped due to too many changes: `apps/hubble/src/utils/syncHealth.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->