### PR TITLE
fix: fix sync id retrieval for sync health job

### DIFF
--- a/.changeset/unlucky-peas-report.md
+++ b/.changeset/unlucky-peas-report.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: query for all impacted sync ids via sync health job/command

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,8 @@
     "source.organizeImports.biome": "explicit"
   },
   "cSpell.words": ["farcaster", "gossipsub", "protobufs"],
-  "rust-analyzer.linkedProjects": ["${workspaceFolder}/apps/hubble/src/addon/Cargo.toml"]
+  "rust-analyzer.linkedProjects": ["${workspaceFolder}/apps/hubble/src/addon/Cargo.toml"],
+  "[rust]": {
+    "editor.defaultFormatter": "rust-lang.rust-analyzer"
+  }
 }

--- a/apps/hubble/src/addon/src/trie/trie_node.rs
+++ b/apps/hubble/src/addon/src/trie/trie_node.rs
@@ -9,6 +9,8 @@ use std::collections::HashMap;
 use super::merkle_trie::TrieSnapshot;
 
 pub const TIMESTAMP_LENGTH: usize = 10;
+
+// This value is mirrored in [rpc/server.ts], make sure to change it in both places
 const MAX_VALUES_RETURNED_PER_CALL: usize = 1024;
 
 /// Represents a node in a MerkleTrie. Automatically updates the hashes when items are added,

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -960,12 +960,14 @@ app
   .option("--peers <ip:port,...>", "Peers to compare with (default: pick random connected peers)")
   .option("--username <username>", "Username for primary node")
   .option("--password <password>", "Password for primary node")
+  .option("--use-secure-client-for-peers", "Use a secure rpc client for all peers", false)
   .action(async (cliOptions) => {
     await printSyncHealth(
       cliOptions.startTimeOfday,
       cliOptions.stopTimeOfday,
       cliOptions.maxNumPeers,
       cliOptions.primaryNode,
+      cliOptions.useSecureClientForPeers,
       cliOptions.outfile,
       cliOptions.peers ? cliOptions.peers.split(",") : undefined,
       cliOptions.username,

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -99,7 +99,14 @@ import { startupCheck, StartupCheckStatus } from "./utils/startupCheck.js";
 import { AddressInfo } from "node:net";
 import { MeasureSyncHealthJobScheduler } from "./network/sync/syncHealthJob.js";
 
-export type HubSubmitSource = "gossip" | "rpc" | "eth-provider" | "l2-provider" | "sync" | "fname-registry";
+export type HubSubmitSource =
+  | "gossip"
+  | "rpc"
+  | "eth-provider"
+  | "l2-provider"
+  | "sync"
+  | "fname-registry"
+  | "sync-health";
 
 export const APP_VERSION = JSON.parse(
   fs.readFileSync(path.join(new URL(".", import.meta.url).pathname, "..", "./package.json")).toString(),

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -76,6 +76,7 @@ export const DEFAULT_SUBSCRIBE_PERIP_LIMIT = 4; // Max 4 subscriptions per IP
 export const DEFAULT_SUBSCRIBE_GLOBAL_LIMIT = 4096; // Max 4096 subscriptions globally
 const MAX_EVENT_STREAM_SHARDS = 10;
 export const DEFAULT_SERVER_INTERNET_ADDRESS_IPV4 = "0.0.0.0";
+export const MAX_VALUES_RETURNED_PER_SYNC_ID_REQUEST = 1024;
 
 export type RpcUsers = Map<string, string[]>;
 

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -76,7 +76,7 @@ export const DEFAULT_SUBSCRIBE_PERIP_LIMIT = 4; // Max 4 subscriptions per IP
 export const DEFAULT_SUBSCRIBE_GLOBAL_LIMIT = 4096; // Max 4096 subscriptions globally
 const MAX_EVENT_STREAM_SHARDS = 10;
 export const DEFAULT_SERVER_INTERNET_ADDRESS_IPV4 = "0.0.0.0";
-export const MAX_VALUES_RETURNED_PER_SYNC_ID_REQUEST = 1024;
+export const MAX_VALUES_RETURNED_PER_SYNC_ID_REQUEST = 1024; // getAllSyncIdsByPrefix returns a max of 1024 sync ids in one response. This value is mirrored in [addon/src/trie/trie_node.rs], make sure to change it in both places.
 
 export type RpcUsers = Map<string, string[]>;
 

--- a/apps/hubble/src/utils/syncHealth.ts
+++ b/apps/hubble/src/utils/syncHealth.ts
@@ -13,6 +13,7 @@ import {
   bytesToHexString,
   SyncIds,
   MessagesResponse,
+  MessageType,
 } from "@farcaster/hub-nodejs";
 
 import { appendFile } from "fs/promises";
@@ -103,7 +104,11 @@ class Stats {
     const successTypes = new Set();
     for (const success of this.successResults(who)) {
       if (success.isOk()) {
-        successTypes.add(success.value.data?.userDataBody?.type);
+        const hashString = bytesToHexString(success.value.hash);
+        const hash = hashString.isOk() ? hashString.value : "unknown hash";
+        const typeValue = success.value.data?.type;
+        const type = typeValue ? MessageType[typeValue] : "unknown type";
+        successTypes.add({ type, hash, fid: success.value.data?.fid });
       }
     }
     return [...successTypes];

--- a/apps/hubble/src/utils/syncHealth.ts
+++ b/apps/hubble/src/utils/syncHealth.ts
@@ -204,7 +204,7 @@ export class SyncEngineMetadataRetriever implements MetadataRetriever {
   };
 
   submitMessage = async (message: Message) => {
-    return (await this._hub.submitMessage(message)).map(() => {
+    return (await this._hub.submitMessage(message, "sync-health")).map(() => {
       return message;
     });
   };

--- a/apps/hubble/src/utils/syncHealth.ts
+++ b/apps/hubble/src/utils/syncHealth.ts
@@ -330,7 +330,7 @@ const getNumMessagesInSpan = async (metadataRetriever: MetadataRetriever, startT
   return ok(numMessages);
 };
 
-const pickPeers = async (rpcClient: HubRpcClient, count: number): Promise<HubResult<(string | undefined)[]>> => {
+const pickPeers = async (rpcClient: HubRpcClient, count: number) => {
   const peers = await rpcClient.getCurrentPeers({});
   return peers.map((peers) => {
     // Shuffle peers then pick [count]
@@ -343,12 +343,48 @@ const pickPeers = async (rpcClient: HubRpcClient, count: number): Promise<HubRes
         if (peer.rpcAddress) {
           const addrInfo = addressInfoFromGossip(peer.rpcAddress);
           if (addrInfo.isOk()) {
-            return addressInfoToString(addrInfo.value);
+            return { hostAndPort: addressInfoToString(addrInfo.value), username: undefined, password: undefined };
           }
         }
         return;
       });
   });
+};
+
+const computeSyncIdsUnderPrefix = async (
+  metadataRetriever: MetadataRetriever,
+  prefix: Uint8Array,
+): Promise<HubResult<Uint8Array[]>> => {
+  const syncIds = await metadataRetriever.getAllSyncIdsByPrefix(Buffer.from(prefix));
+
+  if (syncIds.isErr()) {
+    return err(syncIds.error);
+  }
+
+  const metadata = await metadataRetriever.getMetadata(Buffer.from(prefix));
+
+  if (metadata.isErr()) {
+    return err(metadata.error);
+  }
+
+  // We need to do this weird hack because the length of the results of [getAllSyncIdsByPrefix] is capped at 1024.
+  if (syncIds.value.syncIds.length === metadata.value.numMessages) {
+    return ok(syncIds.value.syncIds);
+  } else {
+    const computedSyncIds = [];
+
+    for (const child of metadata.value.children) {
+      const childSyncIds = await computeSyncIdsUnderPrefix(metadataRetriever, child.prefix);
+
+      if (childSyncIds.isErr()) {
+        return err(childSyncIds.error);
+      }
+
+      computedSyncIds.push(...childSyncIds.value);
+    }
+
+    return ok(computedSyncIds);
+  }
 };
 
 const computeSyncIdsInSpan = async (metadataRetriever: MetadataRetriever, startTime: Date, stopTime: Date) => {
@@ -375,9 +411,9 @@ const computeSyncIdsInSpan = async (metadataRetriever: MetadataRetriever, startT
 
   const syncIds = [];
   for (const prefix of prefixes) {
-    const prefixSyncIds = await metadataRetriever.getAllSyncIdsByPrefix(Buffer.from(prefix));
+    const prefixSyncIds = await computeSyncIdsUnderPrefix(metadataRetriever, prefix);
     if (prefixSyncIds.isOk()) {
-      syncIds.push(...prefixSyncIds.value.syncIds);
+      syncIds.push(...prefixSyncIds.value);
     }
   }
 
@@ -511,11 +547,36 @@ const parseTime = (timeString: string) => {
   return;
 };
 
+const parsePeers = (peers: string[]) => {
+  const parsedPeers = [];
+
+  for (const peer of peers) {
+    const [hostAndPort, auth] = peer.split("?");
+
+    if (!hostAndPort) {
+      return err(
+        new Error(`Host and port missing ${peer}. Input must be in format <host>:<port>?<username>:<password>`),
+      );
+    }
+
+    if (auth === undefined) {
+      parsedPeers.push({ hostAndPort, username: undefined, password: undefined });
+      continue;
+    }
+
+    const [username, password] = auth.split(":");
+    parsedPeers.push({ hostAndPort, username, password });
+  }
+
+  return ok(parsedPeers);
+};
+
 export const printSyncHealth = async (
   startTimeOfDay: string,
   stopTimeOfDay: string,
   maxNumPeers: number,
   primaryNode: string,
+  useSecureClientForPeers: boolean,
   outfile?: string,
   userSpecifiedPeers?: string[],
   username?: string,
@@ -538,7 +599,13 @@ export const printSyncHealth = async (
       console.log("Primary rpc client not ready", err);
       throw Error();
     }
-    const peers = userSpecifiedPeers ? ok(userSpecifiedPeers) : await pickPeers(primaryRpcClient, maxNumPeers);
+
+    const parsedUserSpecifiedPeers = userSpecifiedPeers ? parsePeers(userSpecifiedPeers)._unsafeUnwrap() : undefined;
+
+    const peers = parsedUserSpecifiedPeers
+      ? ok(parsedUserSpecifiedPeers)
+      : await pickPeers(primaryRpcClient, maxNumPeers);
+
     if (peers.isErr()) {
       console.log("Error querying peers");
       return;
@@ -554,23 +621,27 @@ export const printSyncHealth = async (
 
       try {
         // Most hubs seem to work with the insecure one
-        peerRpcClient = getInsecureHubRpcClient(peer);
+        if (useSecureClientForPeers) {
+          peerRpcClient = getSSLHubRpcClient(peer.hostAndPort);
+        } else {
+          peerRpcClient = getInsecureHubRpcClient(peer.hostAndPort);
+        }
 
         peerRpcClient.$.waitForReady(Date.now() + RPC_TIMEOUT_SECONDS * 1000, (err) => {
           if (err) {
-            peerRpcClient = getSSLHubRpcClient(peer);
+            peerRpcClient = getSSLHubRpcClient(peer.hostAndPort);
           }
         });
       } catch (e) {
-        peerRpcClient = getSSLHubRpcClient(peer);
+        peerRpcClient = getSSLHubRpcClient(peer.hostAndPort);
       }
 
-      const peerRpcMetadataRetriever = new RpcMetadataRetriever(peerRpcClient);
+      const peerRpcMetadataRetriever = new RpcMetadataRetriever(peerRpcClient, peer.username, peer.password);
 
       const syncHealthProbe = new SyncHealthProbe(primaryRpcMetadataRetriever, peerRpcMetadataRetriever);
 
       try {
-        console.log("Connecting to peer", peer);
+        console.log("Connecting to peer", peer.hostAndPort);
         const syncHealthStats = await syncHealthProbe.computeSyncHealthMessageStats(startTime, stopTime);
         if (syncHealthStats.isOk()) {
           // Sync health is us relative to peer. If the sync health is high, means we have more messages. If it's low, we have less.
@@ -593,13 +664,21 @@ export const printSyncHealth = async (
 
                 console.log("Error investigating diff", resultToPeerSummary, resultFromPeerSummary);
                 // Report the stats anyway, but with no investigation results
-                aggregateStats = new Stats(startTime, stopTime, primaryNode, peer, syncHealthStats.value, [], []);
+                aggregateStats = new Stats(
+                  startTime,
+                  stopTime,
+                  primaryNode,
+                  peer.hostAndPort,
+                  syncHealthStats.value,
+                  [],
+                  [],
+                );
               } else {
                 aggregateStats = new Stats(
                   startTime,
                   stopTime,
                   primaryNode,
-                  peer,
+                  peer.hostAndPort,
                   syncHealthStats.value,
                   resultToPeer.value,
                   resultFromPeer.value,
@@ -607,7 +686,15 @@ export const printSyncHealth = async (
               }
             } else {
               // Report the stats anyway, but with no investigation results
-              aggregateStats = new Stats(startTime, stopTime, primaryNode, peer, syncHealthStats.value, [], []);
+              aggregateStats = new Stats(
+                startTime,
+                stopTime,
+                primaryNode,
+                peer.hostAndPort,
+                syncHealthStats.value,
+                [],
+                [],
+              );
             }
 
             // The data is valuable, let's just wait to write it. Note, data is appended to any existing file.


### PR DESCRIPTION
## Why is this change needed?

The `getAllSyncIdsByPrefix` rpc returns a max of 1024 sync ids and we weren't accounting for the fact that the list returned by the rpc might be truncated. As a result, we weren't looking at all relevant sync ids when trying to submit missing messages. 

I lumped some cleanups/improvements to the sync health command in too and an update to the vscode config for formatting rust code. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing sync health tracking in the `hubble` app. 

### Detailed summary
- Added `MAX_VALUES_RETURNED_PER_SYNC_ID_REQUEST` constant
- Updated `trie_node.rs` and `server.ts` with new constant value
- Modified sync health computations and message stats
- Introduced `sync-health` source for data submission
- Improved peer selection logic for sync health
- Enhanced handling of sync IDs with a large number of entries

> The following files were skipped due to too many changes: `apps/hubble/src/utils/syncHealth.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->