### PR TITLE
Fix: Add logging when connecting to a gossip address fails

### DIFF
--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -510,6 +510,7 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
     if (result.success) {
       return ok(undefined);
     } else {
+      log.error(`Failed to connect to address: ${result.errorMessage}`);
       return err(new HubError("unavailable", result.errorMessage as string));
     }
   }


### PR DESCRIPTION
## Why is this change needed?

We don't know why the connection attempt failed

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds an error log message when connecting to an address fails in the `gossipNode.ts` file.

### Detailed summary
- Added an error log message when connection to an address fails in the `gossipNode.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->