### PR TITLE
feat: add more counts to sync health job logs

### DIFF
--- a/apps/hubble/src/network/sync/syncHealthJob.ts
+++ b/apps/hubble/src/network/sync/syncHealthJob.ts
@@ -61,7 +61,7 @@ export class MeasureSyncHealthJobScheduler {
   }
 
   processSumbitResults(results: HubResult<Message>[]) {
-    const errorReasons = new Set();
+    const errorReasons = [];
     const successInfo = [];
     for (const result of results) {
       if (result.isOk()) {
@@ -78,10 +78,18 @@ export class MeasureSyncHealthJobScheduler {
           hash,
         });
       } else {
-        errorReasons.add(result.error.message);
+        errorReasons.push(result.error.message);
       }
     }
-    return { errorReasons: [...errorReasons], successInfo };
+
+    const uniqueErrorReasons = new Set(errorReasons);
+
+    return {
+      numErrors: errorReasons.length,
+      numSuccesses: successInfo.length,
+      errorReasons: [...uniqueErrorReasons],
+      successInfo,
+    };
   }
 
   async doJobs() {


### PR DESCRIPTION
## Why is this change needed?

It's useful to have the counts so we can plot over them and get high-level signal on how many errors and successes there are. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the `processSubmitResults` method in `syncHealthJob.ts` to improve error handling and provide a more detailed summary of sync health job results.

### Detailed summary
- Changed `errorReasons` from a Set to an array for better error tracking
- Added counting of errors and successes
- Removed duplicate error messages by using a Set
- Improved structure and readability of the return object

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->