### PR TITLE
feat: add more logging for sync health job

### DIFF
--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -2050,7 +2050,7 @@ export class Hub implements HubInterface {
           submittedMessage: messageToLog(submittedMessage),
           source,
         });
-        logMessage.warn({ errCode: e.errCode, source }, `submitMessage error: ${e.message}`);
+        logMessage.warn({ errCode: e.errCode, source, message: e.message }, `submitMessage error: ${e.message}`);
         const tags: { [key: string]: string } = {
           error_code: e.errCode,
           message_type: type,

--- a/apps/hubble/src/utils/syncHealth.ts
+++ b/apps/hubble/src/utils/syncHealth.ts
@@ -197,10 +197,7 @@ export class SyncEngineMetadataRetriever implements MetadataRetriever {
 
   getAllSyncIdsByPrefix = async (prefix: Buffer) => {
     const result = await this._syncEngine.getAllSyncIdsByPrefix(prefix);
-    if (result) {
-      return ok(SyncIds.create({ syncIds: result ?? [] }));
-    }
-    return err(new HubError("unavailable", "No sync ids for prefix"));
+    return ok(SyncIds.create({ syncIds: result }));
   };
 
   submitMessage = async (message: Message) => {


### PR DESCRIPTION
## Why is this change needed?

(1) It's useful to see the peer id in all error messages to help debug errors. 
(2) It's difficult to work with log fields that are lists in datadog. It's easier to aggregate over success and error data if they're in separate log lines rather than inside a nested field. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance logging and error handling in the `hubble` application's sync functionality.

### Detailed summary
- Added `message` field to `logMessage.warn` for better error logging.
- Improved error handling in `getAllSyncIdsByPrefix`.
- Enhanced logging in `processSubmitResults` and `doJobs` functions.
- Updated `resultsPushingToUs` in `MeasureSyncHealthJobScheduler`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->