### PR TITLE
fix: rename log tag from message to errMessage

### DIFF
--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -2050,7 +2050,7 @@ export class Hub implements HubInterface {
           submittedMessage: messageToLog(submittedMessage),
           source,
         });
-        logMessage.warn({ errCode: e.errCode, source, message: e.message }, `submitMessage error: ${e.message}`);
+        logMessage.warn({ errCode: e.errCode, source, errMessage: e.message }, `submitMessage error: ${e.message}`);
         const tags: { [key: string]: string } = {
           error_code: e.errCode,
           message_type: type,

--- a/apps/hubble/src/network/sync/syncHealthJob.ts
+++ b/apps/hubble/src/network/sync/syncHealthJob.ts
@@ -78,7 +78,7 @@ export class MeasureSyncHealthJobScheduler {
 
         numSuccesses += 1;
       } else {
-        log.info({ message: result.error.message, peerId }, "Failed to submit message via SyncHealth");
+        log.info({ errMessage: result.error.message, peerId }, "Failed to submit message via SyncHealth");
 
         numErrors += 1;
       }


### PR DESCRIPTION
## Why is this change needed?

Datadog swallows the "message" tag so rename to "errMessage". 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update log message properties in `syncHealthJob.ts` and `hubble.ts` for better clarity.

### Detailed summary
- Updated log property `message` to `errMessage` in `syncHealthJob.ts`
- Added `errMessage` property to log message in `hubble.ts`
- Renamed `errCode` property to `errMessage` in log message in `hubble.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->