### PR TITLE
fix: don't include timestamp in log tags

### DIFF
--- a/apps/hubble/src/network/sync/syncHealthJob.ts
+++ b/apps/hubble/src/network/sync/syncHealthJob.ts
@@ -72,7 +72,9 @@ export class MeasureSyncHealthJobScheduler {
         const type = typeValue ? UserDataType[typeValue] : "unknown type";
 
         log.info(
-          { type, fid: result.value.data?.fid, timestamp: result.value.data?.timestamp, hash, peerId },
+          {
+            msgDetails: { type, fid: result.value.data?.fid, timestamp: result.value.data?.timestamp, hash, peerId },
+          },
           "Successfully submitted message via SyncHealth",
         );
 


### PR DESCRIPTION
## Why is this change needed?

Datadog seems to be dropping the success logs. They show up in aws logs. I strongly suspect this is because of the toplevel timestamp field. I think either Datadog is using that to infer the actual time of the log and dropping it because it's too far back in time or it's not able to handle the message because there are 2 timestamp related fields. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the logging structure in `syncHealthJob.ts` to include `msgDetails` object for better message submission tracking.

### Detailed summary
- Updated logging to include `msgDetails` object for message submission tracking.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->