### PR TITLE
feat: add more logging for on chain events

### DIFF
--- a/.changeset/wet-otters-pay.md
+++ b/.changeset/wet-otters-pay.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: add more logging for on-chain events

--- a/apps/hubble/src/eth/l2EventsProvider.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.ts
@@ -285,6 +285,10 @@ export class L2EventsProvider<chain extends Chain = Chain, transport extends Tra
   ) {
     for (const event of logs) {
       const { blockNumber, blockHash, transactionHash, transactionIndex, logIndex } = event;
+      log.info(
+        { blockNumber, blockHash, transactionHash, transactionIndex, logIndex, eventName: event.eventName },
+        `processStorageEvent for block ${blockNumber}`,
+      );
 
       // Do nothing if the block is pending
       if (
@@ -351,6 +355,11 @@ export class L2EventsProvider<chain extends Chain = Chain, transport extends Tra
   private async processKeyRegistryEvents(logs: WatchContractEventOnLogsParameter<typeof KeyRegistry.abi>, version = 0) {
     for (const event of logs) {
       const { blockNumber, blockHash, transactionHash, transactionIndex, logIndex } = event;
+
+      log.info(
+        { blockNumber, blockHash, transactionHash, transactionIndex, logIndex, eventName: event.eventName },
+        `processKeyRegistryEvent for block ${blockNumber}`,
+      );
 
       // Do nothing if the block is pending
       if (
@@ -478,6 +487,11 @@ export class L2EventsProvider<chain extends Chain = Chain, transport extends Tra
   private async processIdRegistryEvents(logs: WatchContractEventOnLogsParameter<typeof IdRegistry.abi>, version = 0) {
     for (const event of logs) {
       const { blockNumber, blockHash, transactionHash, transactionIndex, logIndex } = event;
+
+      log.info(
+        { blockNumber, blockHash, transactionHash, transactionIndex, logIndex, eventName: event.eventName },
+        `processIdRegistryEvent for block ${blockNumber}`,
+      );
 
       // Do nothing if the block is pending
       if (


### PR DESCRIPTION
## Why is this change needed?

With the current logging it's hard to determine if we dropped an on-chain event or never received it in the first place. This feature adds a log in the first place where our code is responsible for handling on-chain events to give us better insight into this moving forward. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the logging for on-chain events in the `L2EventsProvider` class in the `@farcaster/hubble` package.

### Detailed summary
- Added more detailed logging for different types of on-chain events in `L2EventsProvider`.
- Logs now include event name and specify the event type being processed.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->