### PR TITLE
chore: Release 1.14.3

### DIFF
--- a/.changeset/clever-owls-approve.md
+++ b/.changeset/clever-owls-approve.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: make snapshot sync retry and parallelize

--- a/.changeset/cuddly-windows-glow.md
+++ b/.changeset/cuddly-windows-glow.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-submit missing messages via the sync health job and enrich output logs

--- a/.changeset/six-timers-jog.md
+++ b/.changeset/six-timers-jog.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: added a sync health measurement job

--- a/.changeset/unlucky-peas-report.md
+++ b/.changeset/unlucky-peas-report.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: query for all impacted sync ids via sync health job/command

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @farcaster/hubble
 
+## 1.14.3
+
+### Patch Changes
+
+- 63dd7c97: feat: make snapshot sync retry and parallelize
+- b2272f76: submit missing messages via the sync health job and enrich output logs
+- cb5ee7ac: feat: added a sync health measurement job
+- 9e0c9323: fix: query for all impacted sync ids via sync health job/command
+
 ## 1.14.2
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",


### PR DESCRIPTION
## Why is this change needed?

Release 1.14.3

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `@farcaster/hubble` to `1.14.3` and includes enhancements and fixes related to snapshot sync and sync health monitoring.

### Detailed summary
- Updated version to `1.14.3`
- Added retry and parallelization for snapshot sync
- Improved missing messages submission and output logs
- Introduced sync health measurement job
- Enhanced querying for impacted sync ids

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->