### PR TITLE
fix: adjust grpc keepalive time to 5s

### DIFF
--- a/.changeset/good-meals-cheat.md
+++ b/.changeset/good-meals-cheat.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hub-nodejs": patch
+---
+
+fix: adjust grpc keepalive time to 5s to encourage faster failover from uncooperative peers

--- a/packages/hub-nodejs/src/client.ts
+++ b/packages/hub-nodejs/src/client.ts
@@ -126,7 +126,7 @@ export const getServer = (): grpc.Server => {
   // max_connection_age_ms will interfere with subscribe() which is a long-lived call, but maybe we should
   // set it anyway.
   const server = new grpc.Server({
-    "grpc.keepalive_time_ms": 10 * 1000,
+    "grpc.keepalive_time_ms": 5 * 1000,
     "grpc.keepalive_timeout_ms": 5 * 1000,
     "grpc.client_idle_timeout_ms": 60 * 1000,
   });


### PR DESCRIPTION
## Why is this change needed?

gRPC keepalive heartbeat time was set to 10s, with a client-side response time of 5s. This allows servers that are unresponsive to go unrecognized for longer, causing sync time to dramatically increase with respect to hub volume. Lowering this value should be safe for a patch, but lowering the client response time will require a minor revision due to incompatibility with client-side expectations

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adjusting the gRPC keepalive time to 5 seconds in `@farcaster/hub-nodejs` package to improve failover speed.

### Detailed summary
- Adjusted gRPC keepalive time to 5 seconds in `client.ts` to encourage faster failover from uncooperative peers.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->