### PR TITLE
fix: Reduce reconciliation default pagination size

### DIFF
--- a/.changeset/good-meals-cheat.md
+++ b/.changeset/good-meals-cheat.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
----
-
-fix: adjust grpc keepalive time to 5s to encourage faster failover from uncooperative peers

--- a/.changeset/two-elephants-act.md
+++ b/.changeset/two-elephants-act.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+fix: Reduce reconciliation default pagination size

--- a/.changeset/two-elephants-act.md
+++ b/.changeset/two-elephants-act.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-fix: Reduce reconciliation default pagination size

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-nodejs
 
+## 0.11.24
+
+### Patch Changes
+
+- 47fbd34e: fix: adjust grpc keepalive time to 5s to encourage faster failover from uncooperative peers
+
 ## 0.11.23
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.11.23",
+  "version": "0.11.24",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hub-shuttle
 
+## 0.5.11
+
+### Patch Changes
+
+- 768dc875: fix: Reduce reconciliation default pagination size
+- Updated dependencies [47fbd34e]
+  - @farcaster/hub-nodejs@0.11.24
+
 ## 0.5.10
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@farcaster/hot-shots": "^10.0.0",
-    "@farcaster/hub-nodejs": "^0.11.22",
+    "@farcaster/hub-nodejs": "^0.11.24",
     "commander": "11.0.0",
     "dotenv": "16.4.5",
     "ioredis": "^5.3.2",

--- a/packages/shuttle/src/shuttle/messageReconciliation.ts
+++ b/packages/shuttle/src/shuttle/messageReconciliation.ts
@@ -2,7 +2,7 @@ import { HubRpcClient, Message, MessageType } from "@farcaster/hub-nodejs";
 import { DB, MessageRow, sql } from "./db";
 import { pino } from "pino";
 
-const MAX_PAGE_SIZE = 3_000;
+const MAX_PAGE_SIZE = 500;
 
 type DBMessage = {
   hash: Uint8Array;


### PR DESCRIPTION
## Why is this change needed?

Reduce default pagination size to prevent hub from spending too much time serializing messages

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates version numbers and configurations for the `@farcaster/hub-nodejs` and `@farcaster/shuttle` packages. It also adjusts the `MAX_PAGE_SIZE` constant in `messageReconciliation.ts`.

### Detailed summary
- Updated `MAX_PAGE_SIZE` constant in `messageReconciliation.ts` from 3000 to 500
- Updated `@farcaster/hub-nodejs` version to `0.11.24`
- Updated `@farcaster/shuttle` version to `0.5.11`
- Updated dependencies in `shuttle/package.json` and `hub-nodejs/package.json`
- Added changelog entries for versions `0.11.24` and `0.5.11`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->