### PR TITLE
fix: Add env var to specify hubble node arguments

### DIFF
--- a/.changeset/happy-files-sell.md
+++ b/.changeset/happy-files-sell.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Add env var to specify hubble node arguments

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -29,7 +29,7 @@
     "lint:ci": "yarn lint:customjs && biome ci src/",
     "lint:customjs": "node scripts/linter.cjs",
     "snapshot-url": "node --no-warnings build/cli.js snapshot-url",
-    "start": "node --max-old-space-size=8192 --no-warnings build/cli.js start",
+    "start": "node --max-old-space-size=8192 --no-warnings $HUBBLE_NODE_ARGS build/cli.js start",
     "identity": "node --no-warnings build/cli.js identity",
     "dbreset": "node build/cli.js dbreset",
     "events-reset": "node build/cli.js events-reset",

--- a/apps/hubble/pm2.config.cjs
+++ b/apps/hubble/pm2.config.cjs
@@ -19,6 +19,7 @@ module.exports = {
       args: process.env.HUBBLE_ARGS,
       env: {
         "CATCHUP_SYNC_WITH_SNAPSHOT": process.env.CATCHUP_SYNC_WITH_SNAPSHOT ? (process.env.CATCHUP_SYNC_WITH_SNAPSHOT === "true") : "true",
+        "HUBBLE_NODE_ARGS": process.env.HUBBLE_NODE_ARGS || "",
       },
       watch: false,
       log_type: "json",


### PR DESCRIPTION
## Why is this change needed?

Allow specifying hubble specific node options. Global NODE_OPTIONS doesn't work for cases like --inspect because pm2 is also using node

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding an environment variable to specify Hubble node arguments. 

### Detailed summary
- Added `HUBBLE_NODE_ARGS` environment variable in `pm2.config.cjs`
- Updated `start` script in `package.json` to include `$HUBBLE_NODE_ARGS`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->