### PR TITLE
feat: add start and stop time to bulk rpcs with large volumes of data

### DIFF
--- a/.changeset/rude-garlics-doubt.md
+++ b/.changeset/rude-garlics-doubt.md
@@ -1,0 +1,8 @@
+---
+"@farcaster/hub-nodejs": patch
+"@farcaster/hub-web": patch
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+feat: added start/stop time filters for bulk queries

--- a/apps/hubble/src/addon/src/lib.rs
+++ b/apps/hubble/src/addon/src/lib.rs
@@ -150,10 +150,6 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("getLinkAddsByFid", LinkStore::js_get_link_adds_by_fid)?;
     cx.export_function("getLinkRemovesByFid", LinkStore::js_get_link_removes_by_fid)?;
     cx.export_function(
-        "getAllLinkMessagesByFid",
-        LinkStore::js_get_all_link_messages_by_fid,
-    )?;
-    cx.export_function(
         "getLinkCompactStateMessageByFid",
         LinkStore::js_get_link_compact_state_message_by_fid,
     )?;

--- a/apps/hubble/src/addon/src/store/link_store.rs
+++ b/apps/hubble/src/addon/src/store/link_store.rs
@@ -160,16 +160,6 @@ impl LinkStore {
         )
     }
 
-    pub fn get_all_link_messages_by_fid(
-        store: &Store,
-        fid: u32,
-        page_options: &PageOptions,
-        start_time: Option<u32>,
-        stop_time: Option<u32>,
-    ) -> Result<MessagesPage, HubError> {
-        store.get_all_messages_by_fid(fid, start_time, stop_time, page_options)
-    }
-
     pub fn get_link_compact_state_message_by_fid(
         store: &Store,
         fid: u32,
@@ -667,49 +657,6 @@ impl LinkStore {
 
         THREAD_POOL.lock().unwrap().execute(move || {
             let messages = Self::get_links_by_target(&store, &target, link_type, &page_options);
-
-            deferred_settle_messages(deferred, &channel, messages);
-        });
-
-        Ok(promise)
-    }
-
-    pub fn js_get_all_link_messages_by_fid(mut cx: FunctionContext) -> JsResult<JsPromise> {
-        let store = get_store(&mut cx)?;
-
-        let fid = cx.argument::<JsNumber>(0).unwrap().value(&mut cx) as u32;
-        let page_options = get_page_options(&mut cx, 1)?;
-        let start_time = match cx.argument_opt(2) {
-            Some(arg) => match arg.downcast::<JsNumber, _>(&mut cx) {
-                Ok(v) => Some(v.value(&mut cx) as u32),
-                _ => None,
-            },
-            None => None,
-        };
-        let stop_time = match cx.argument_opt(3) {
-            Some(arg) => match arg.downcast::<JsNumber, _>(&mut cx) {
-                Ok(v) => Some(v.value(&mut cx) as u32),
-                _ => None,
-            },
-            None => None,
-        };
-
-        // fid must be specified
-        if fid == 0 {
-            return cx.throw_error("fid is required");
-        }
-
-        let channel = cx.channel();
-        let (deferred, promise) = cx.promise();
-
-        THREAD_POOL.lock().unwrap().execute(move || {
-            let messages = Self::get_all_link_messages_by_fid(
-                &store,
-                fid,
-                &page_options,
-                start_time,
-                stop_time,
-            );
 
             deferred_settle_messages(deferred, &channel, messages);
         });

--- a/apps/hubble/src/addon/src/store/message.rs
+++ b/apps/hubble/src/addon/src/store/message.rs
@@ -415,3 +415,19 @@ pub fn delete_message_transaction(
 
     Ok(())
 }
+
+pub fn is_message_in_time_range(
+    start_time: Option<u32>,
+    stop_time: Option<u32>,
+    message: &MessageProto,
+) -> bool {
+    let start_time = start_time.unwrap_or(std::u32::MIN);
+    let stop_time = stop_time.unwrap_or(std::u32::MAX);
+    match &message.data {
+        None => {
+            // We expect all valid messages to have data
+            return false;
+        }
+        Some(data) => return data.timestamp >= start_time && data.timestamp <= stop_time,
+    };
+}

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -952,7 +952,7 @@ export default class Server {
 
         const { fid, pageSize, pageToken, reverse } = call.request;
 
-        const userDataResult = await this.engine?.getUserDataByFid(fid, undefined, undefined, {
+        const userDataResult = await this.engine?.getUserDataByFid(fid, {
           pageSize,
           pageToken,
           reverse,
@@ -1202,11 +1202,16 @@ export default class Server {
         log.debug({ method: "getAllCastMessagesByFid", req: call.request }, `RPC call from ${peer}`);
 
         const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
-        const result = await this.engine?.getAllCastMessagesByFid(fid, startTimestamp, stopTimestamp, {
-          pageSize,
-          pageToken,
-          reverse,
-        });
+        const result = await this.engine?.getAllCastMessagesByFid(
+          fid,
+          {
+            pageSize,
+            pageToken,
+            reverse,
+          },
+          startTimestamp,
+          stopTimestamp,
+        );
         result?.match(
           (page: MessagesPage<CastAddMessage | CastRemoveMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1221,11 +1226,16 @@ export default class Server {
         log.debug({ method: "getAllReactionMessagesByFid", req: call.request }, `RPC call from ${peer}`);
 
         const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
-        const result = await this.engine?.getAllReactionMessagesByFid(fid, startTimestamp, stopTimestamp, {
-          pageSize,
-          pageToken,
-          reverse,
-        });
+        const result = await this.engine?.getAllReactionMessagesByFid(
+          fid,
+          {
+            pageSize,
+            pageToken,
+            reverse,
+          },
+          startTimestamp,
+          stopTimestamp,
+        );
         result?.match(
           (page: MessagesPage<ReactionAddMessage | ReactionRemoveMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1240,11 +1250,16 @@ export default class Server {
         log.debug({ method: "getAllVerificationMessagesByFid", req: call.request }, `RPC call from ${peer}`);
 
         const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
-        const result = await this.engine?.getAllVerificationMessagesByFid(fid, startTimestamp, stopTimestamp, {
-          pageSize,
-          pageToken,
-          reverse,
-        });
+        const result = await this.engine?.getAllVerificationMessagesByFid(
+          fid,
+          {
+            pageSize,
+            pageToken,
+            reverse,
+          },
+          startTimestamp,
+          stopTimestamp,
+        );
         result?.match(
           (page: MessagesPage<VerificationAddAddressMessage | VerificationRemoveMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1259,11 +1274,16 @@ export default class Server {
         log.debug({ method: "getAllUserDataMessagesByFid", req: call.request }, `RPC call from ${peer}`);
 
         const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
-        const result = await this.engine?.getUserDataByFid(fid, startTimestamp, stopTimestamp, {
-          pageSize,
-          pageToken,
-          reverse,
-        });
+        const result = await this.engine?.getUserDataByFid(
+          fid,
+          {
+            pageSize,
+            pageToken,
+            reverse,
+          },
+          startTimestamp,
+          stopTimestamp,
+        );
         result?.match(
           (page: MessagesPage<UserDataAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1278,11 +1298,16 @@ export default class Server {
         log.debug({ method: "getAllLinkMessagesByFid", req: call.request }, `RPC call from ${peer}`);
 
         const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
-        const result = await this.engine?.getAllLinkMessagesByFid(fid, startTimestamp, stopTimestamp, {
-          pageSize,
-          pageToken,
-          reverse,
-        });
+        const result = await this.engine?.getAllLinkMessagesByFid(
+          fid,
+          {
+            pageSize,
+            pageToken,
+            reverse,
+          },
+          startTimestamp,
+          stopTimestamp,
+        );
         result?.match(
           (page: MessagesPage<LinkAddMessage | LinkRemoveMessage>) => {
             callback(null, messagesPageToResponse(page));

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -952,7 +952,7 @@ export default class Server {
 
         const { fid, pageSize, pageToken, reverse } = call.request;
 
-        const userDataResult = await this.engine?.getUserDataByFid(fid, {
+        const userDataResult = await this.engine?.getUserDataByFid(fid, undefined, undefined, {
           pageSize,
           pageToken,
           reverse,
@@ -1201,8 +1201,8 @@ export default class Server {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getAllCastMessagesByFid", req: call.request }, `RPC call from ${peer}`);
 
-        const { fid, pageSize, pageToken, reverse } = call.request;
-        const result = await this.engine?.getAllCastMessagesByFid(fid, {
+        const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
+        const result = await this.engine?.getAllCastMessagesByFid(fid, startTimestamp, stopTimestamp, {
           pageSize,
           pageToken,
           reverse,
@@ -1220,8 +1220,8 @@ export default class Server {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getAllReactionMessagesByFid", req: call.request }, `RPC call from ${peer}`);
 
-        const { fid, pageSize, pageToken, reverse } = call.request;
-        const result = await this.engine?.getAllReactionMessagesByFid(fid, {
+        const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
+        const result = await this.engine?.getAllReactionMessagesByFid(fid, startTimestamp, stopTimestamp, {
           pageSize,
           pageToken,
           reverse,
@@ -1239,8 +1239,8 @@ export default class Server {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getAllVerificationMessagesByFid", req: call.request }, `RPC call from ${peer}`);
 
-        const { fid, pageSize, pageToken, reverse } = call.request;
-        const result = await this.engine?.getAllVerificationMessagesByFid(fid, {
+        const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
+        const result = await this.engine?.getAllVerificationMessagesByFid(fid, startTimestamp, stopTimestamp, {
           pageSize,
           pageToken,
           reverse,
@@ -1258,8 +1258,8 @@ export default class Server {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getAllUserDataMessagesByFid", req: call.request }, `RPC call from ${peer}`);
 
-        const { fid, pageSize, pageToken, reverse } = call.request;
-        const result = await this.engine?.getUserDataByFid(fid, {
+        const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
+        const result = await this.engine?.getUserDataByFid(fid, startTimestamp, stopTimestamp, {
           pageSize,
           pageToken,
           reverse,
@@ -1277,8 +1277,8 @@ export default class Server {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getAllLinkMessagesByFid", req: call.request }, `RPC call from ${peer}`);
 
-        const { fid, pageSize, pageToken, reverse } = call.request;
-        const result = await this.engine?.getAllLinkMessagesByFid(fid, {
+        const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
+        const result = await this.engine?.getAllLinkMessagesByFid(fid, startTimestamp, stopTimestamp, {
           pageSize,
           pageToken,
           reverse,

--- a/apps/hubble/src/rpc/test/bulkService.test.ts
+++ b/apps/hubble/src/rpc/test/bulkService.test.ts
@@ -15,7 +15,7 @@ import {
   OnChainEvent,
   ReactionAddMessage,
   ReactionRemoveMessage,
-  TimestampFidRequest,
+  FidTimestampRequest,
   UserDataAddMessage,
   UserDataType,
   VerificationAddAddressMessage,
@@ -94,12 +94,12 @@ describe("getAllCastMessagesByFid", () => {
   test("succeeds", async () => {
     await engine.mergeMessage(castAdd);
     await engine.mergeMessage(castRemove);
-    const result = await client.getAllCastMessagesByFid(TimestampFidRequest.create({ fid }));
+    const result = await client.getAllCastMessagesByFid(FidTimestampRequest.create({ fid }));
     assertMessagesMatchResult(result, [castAdd, castRemove]);
   });
 
   test("returns empty array without messages", async () => {
-    const result = await client.getAllCastMessagesByFid(TimestampFidRequest.create({ fid }));
+    const result = await client.getAllCastMessagesByFid(FidTimestampRequest.create({ fid }));
     expect(result._unsafeUnwrap().messages.length).toEqual(0);
   });
 
@@ -108,24 +108,24 @@ describe("getAllCastMessagesByFid", () => {
     await engine.mergeMessage(castRemove);
     // Start timestamp is applied and it's inclusive
     const result1 = await client.getAllCastMessagesByFid(
-      TimestampFidRequest.create({ fid, startTimestamp: timestamp + 1 }),
+      FidTimestampRequest.create({ fid, startTimestamp: timestamp + 1 }),
     );
     assertMessagesMatchResult(result1, [castRemove]);
 
     // If there's no stop time, we include everything past start time
     const result2 = await client.getAllCastMessagesByFid(
-      TimestampFidRequest.create({ fid, startTimestamp: timestamp }),
+      FidTimestampRequest.create({ fid, startTimestamp: timestamp }),
     );
     assertMessagesMatchResult(result2, [castAdd, castRemove]);
     getFarcasterTime;
 
     // Stop timestamp is applied and it's inclusive
-    const result3 = await client.getAllCastMessagesByFid(TimestampFidRequest.create({ fid, stopTimestamp: timestamp }));
+    const result3 = await client.getAllCastMessagesByFid(FidTimestampRequest.create({ fid, stopTimestamp: timestamp }));
     assertMessagesMatchResult(result3, [castAdd]);
 
     // If there's no start time, we include everything before stop time
     const result4 = await client.getAllCastMessagesByFid(
-      TimestampFidRequest.create({ fid, stopTimestamp: timestamp + 1 }),
+      FidTimestampRequest.create({ fid, stopTimestamp: timestamp + 1 }),
     );
     assertMessagesMatchResult(result4, [castAdd, castRemove]);
   });
@@ -156,12 +156,12 @@ describe("getAllReactionMessagesByFid", () => {
   test("succeeds", async () => {
     await engine.mergeMessage(reactionAdd);
     await engine.mergeMessage(reactionRemove);
-    const result = await client.getAllReactionMessagesByFid(TimestampFidRequest.create({ fid }));
+    const result = await client.getAllReactionMessagesByFid(FidTimestampRequest.create({ fid }));
     assertMessagesMatchResult(result, [reactionAdd, reactionRemove]);
   });
 
   test("returns empty array without messages", async () => {
-    const result = await client.getAllReactionMessagesByFid(TimestampFidRequest.create({ fid }));
+    const result = await client.getAllReactionMessagesByFid(FidTimestampRequest.create({ fid }));
     expect(result._unsafeUnwrap().messages.length).toEqual(0);
   });
 
@@ -170,26 +170,26 @@ describe("getAllReactionMessagesByFid", () => {
     await engine.mergeMessage(reactionRemove);
     // Start timestamp is applied and it's inclusive
     const result1 = await client.getAllReactionMessagesByFid(
-      TimestampFidRequest.create({ fid, startTimestamp: timestamp + 1 }),
+      FidTimestampRequest.create({ fid, startTimestamp: timestamp + 1 }),
     );
     assertMessagesMatchResult(result1, [reactionRemove]);
 
     // If there's no stop time, we include everything past start time
     const result2 = await client.getAllReactionMessagesByFid(
-      TimestampFidRequest.create({ fid, startTimestamp: timestamp }),
+      FidTimestampRequest.create({ fid, startTimestamp: timestamp }),
     );
     assertMessagesMatchResult(result2, [reactionAdd, reactionRemove]);
     getFarcasterTime;
 
     // Stop timestamp is applied and it's inclusive
     const result3 = await client.getAllReactionMessagesByFid(
-      TimestampFidRequest.create({ fid, stopTimestamp: timestamp }),
+      FidTimestampRequest.create({ fid, stopTimestamp: timestamp }),
     );
     assertMessagesMatchResult(result3, [reactionAdd]);
 
     // If there's no start time, we include everything before stop time
     const result4 = await client.getAllReactionMessagesByFid(
-      TimestampFidRequest.create({ fid, stopTimestamp: timestamp + 1 }),
+      FidTimestampRequest.create({ fid, stopTimestamp: timestamp + 1 }),
     );
     assertMessagesMatchResult(result4, [reactionAdd, reactionRemove]);
   });
@@ -220,12 +220,12 @@ describe("getAllVerificationMessagesByFid", () => {
   test("succeeds", async () => {
     await engine.mergeMessage(verificationAdd);
     await engine.mergeMessage(verificationRemove);
-    const result = await client.getAllVerificationMessagesByFid(TimestampFidRequest.create({ fid }));
+    const result = await client.getAllVerificationMessagesByFid(FidTimestampRequest.create({ fid }));
     assertMessagesMatchResult(result, [verificationAdd, verificationRemove]);
   });
 
   test("returns empty array without messages", async () => {
-    const result = await client.getAllVerificationMessagesByFid(TimestampFidRequest.create({ fid }));
+    const result = await client.getAllVerificationMessagesByFid(FidTimestampRequest.create({ fid }));
     expect(result._unsafeUnwrap().messages.length).toEqual(0);
   });
 
@@ -234,26 +234,26 @@ describe("getAllVerificationMessagesByFid", () => {
     await engine.mergeMessage(verificationRemove);
     // Start timestamp is applied and it's inclusive
     const result1 = await client.getAllVerificationMessagesByFid(
-      TimestampFidRequest.create({ fid, startTimestamp: timestamp + 1 }),
+      FidTimestampRequest.create({ fid, startTimestamp: timestamp + 1 }),
     );
     assertMessagesMatchResult(result1, [verificationRemove]);
 
     // If there's no stop time, we include everything past start time
     const result2 = await client.getAllVerificationMessagesByFid(
-      TimestampFidRequest.create({ fid, startTimestamp: timestamp }),
+      FidTimestampRequest.create({ fid, startTimestamp: timestamp }),
     );
     assertMessagesMatchResult(result2, [verificationAdd, verificationRemove]);
     getFarcasterTime;
 
     // Stop timestamp is applied and it's inclusive
     const result3 = await client.getAllVerificationMessagesByFid(
-      TimestampFidRequest.create({ fid, stopTimestamp: timestamp }),
+      FidTimestampRequest.create({ fid, stopTimestamp: timestamp }),
     );
     assertMessagesMatchResult(result3, [verificationAdd]);
 
     // If there's no start time, we include everything before stop time
     const result4 = await client.getAllVerificationMessagesByFid(
-      TimestampFidRequest.create({ fid, stopTimestamp: timestamp + 1 }),
+      FidTimestampRequest.create({ fid, stopTimestamp: timestamp + 1 }),
     );
     assertMessagesMatchResult(result4, [verificationAdd, verificationRemove]);
   });
@@ -282,12 +282,12 @@ describe("getAllUserDataMessagesByFid", () => {
 
   test("succeeds", async () => {
     await engine.mergeMessage(userDataAdd1);
-    const result = await client.getAllUserDataMessagesByFid(TimestampFidRequest.create({ fid }));
+    const result = await client.getAllUserDataMessagesByFid(FidTimestampRequest.create({ fid }));
     assertMessagesMatchResult(result, [userDataAdd1]);
   });
 
   test("returns empty array without messages", async () => {
-    const result = await client.getAllUserDataMessagesByFid(TimestampFidRequest.create({ fid }));
+    const result = await client.getAllUserDataMessagesByFid(FidTimestampRequest.create({ fid }));
     expect(result._unsafeUnwrap().messages.length).toEqual(0);
   });
 
@@ -297,25 +297,25 @@ describe("getAllUserDataMessagesByFid", () => {
 
     // Start timestamp is applied and it's inclusive
     const result1 = await client.getAllUserDataMessagesByFid(
-      TimestampFidRequest.create({ fid, startTimestamp: timestamp + 1 }),
+      FidTimestampRequest.create({ fid, startTimestamp: timestamp + 1 }),
     );
     assertMessagesMatchResult(result1, [userDataAdd2]);
 
     // If there's no stop time, we include everything past start time
     const result2 = await client.getAllUserDataMessagesByFid(
-      TimestampFidRequest.create({ fid, startTimestamp: timestamp }),
+      FidTimestampRequest.create({ fid, startTimestamp: timestamp }),
     );
     assertMessagesMatchResult(result2, [userDataAdd1, userDataAdd2]);
 
     // Stop timestamp is applied and it's inclusive
     const result3 = await client.getAllUserDataMessagesByFid(
-      TimestampFidRequest.create({ fid, stopTimestamp: timestamp }),
+      FidTimestampRequest.create({ fid, stopTimestamp: timestamp }),
     );
     assertMessagesMatchResult(result3, [userDataAdd1]);
 
     // If there's no start time, we include everything before stop time
     const result4 = await client.getAllUserDataMessagesByFid(
-      TimestampFidRequest.create({ fid, stopTimestamp: timestamp + 1 }),
+      FidTimestampRequest.create({ fid, stopTimestamp: timestamp + 1 }),
     );
     assertMessagesMatchResult(result4, [userDataAdd1, userDataAdd2]);
   });
@@ -348,12 +348,12 @@ describe("getAllLinkMessagesByFid", () => {
   test("succeeds", async () => {
     await engine.mergeMessage(linkAdd);
     await engine.mergeMessage(linkRemove);
-    const result = await client.getAllLinkMessagesByFid(TimestampFidRequest.create({ fid }));
+    const result = await client.getAllLinkMessagesByFid(FidTimestampRequest.create({ fid }));
     assertMessagesMatchResult(result, [linkAdd, linkRemove]);
   });
 
   test("returns empty array without messages", async () => {
-    const result = await client.getAllLinkMessagesByFid(TimestampFidRequest.create({ fid }));
+    const result = await client.getAllLinkMessagesByFid(FidTimestampRequest.create({ fid }));
     expect(result._unsafeUnwrap().messages.length).toEqual(0);
   });
 
@@ -362,24 +362,24 @@ describe("getAllLinkMessagesByFid", () => {
     await engine.mergeMessage(linkRemove);
     // Start timestamp is applied and it's inclusive
     const result1 = await client.getAllLinkMessagesByFid(
-      TimestampFidRequest.create({ fid, startTimestamp: timestamp + 1 }),
+      FidTimestampRequest.create({ fid, startTimestamp: timestamp + 1 }),
     );
     assertMessagesMatchResult(result1, [linkRemove]);
 
     // If there's no stop time, we include everything past start time
     const result2 = await client.getAllLinkMessagesByFid(
-      TimestampFidRequest.create({ fid, startTimestamp: timestamp }),
+      FidTimestampRequest.create({ fid, startTimestamp: timestamp }),
     );
     assertMessagesMatchResult(result2, [linkAdd, linkRemove]);
     getFarcasterTime;
 
     // Stop timestamp is applied and it's inclusive
-    const result3 = await client.getAllLinkMessagesByFid(TimestampFidRequest.create({ fid, stopTimestamp: timestamp }));
+    const result3 = await client.getAllLinkMessagesByFid(FidTimestampRequest.create({ fid, stopTimestamp: timestamp }));
     assertMessagesMatchResult(result3, [linkAdd]);
 
     // If there's no start time, we include everything before stop time
     const result4 = await client.getAllLinkMessagesByFid(
-      TimestampFidRequest.create({ fid, stopTimestamp: timestamp + 1 }),
+      FidTimestampRequest.create({ fid, stopTimestamp: timestamp + 1 }),
     );
     assertMessagesMatchResult(result4, [linkAdd, linkRemove]);
   });

--- a/apps/hubble/src/rpc/test/bulkService.test.ts
+++ b/apps/hubble/src/rpc/test/bulkService.test.ts
@@ -128,6 +128,12 @@ describe("getAllCastMessagesByFid", () => {
       FidTimestampRequest.create({ fid, stopTimestamp: timestamp + 1 }),
     );
     assertMessagesMatchResult(result4, [castAdd, castRemove]);
+
+    // If the start time is 0, we include everything before stop time
+    const result5 = await client.getAllCastMessagesByFid(
+      FidTimestampRequest.create({ fid, startTimestamp: 0, stopTimestamp: timestamp + 1 }),
+    );
+    assertMessagesMatchResult(result5, [castAdd, castRemove]);
   });
 });
 
@@ -192,6 +198,12 @@ describe("getAllReactionMessagesByFid", () => {
       FidTimestampRequest.create({ fid, stopTimestamp: timestamp + 1 }),
     );
     assertMessagesMatchResult(result4, [reactionAdd, reactionRemove]);
+
+    // If the start time is 0, we include everything before stop time
+    const result5 = await client.getAllReactionMessagesByFid(
+      FidTimestampRequest.create({ fid, startTimestamp: 0, stopTimestamp: timestamp + 1 }),
+    );
+    assertMessagesMatchResult(result5, [reactionAdd, reactionRemove]);
   });
 });
 
@@ -256,6 +268,12 @@ describe("getAllVerificationMessagesByFid", () => {
       FidTimestampRequest.create({ fid, stopTimestamp: timestamp + 1 }),
     );
     assertMessagesMatchResult(result4, [verificationAdd, verificationRemove]);
+
+    // If the start time is 0, we include everything before stop time
+    const result5 = await client.getAllVerificationMessagesByFid(
+      FidTimestampRequest.create({ fid, startTimestamp: 0, stopTimestamp: timestamp + 1 }),
+    );
+    assertMessagesMatchResult(result5, [verificationAdd, verificationRemove]);
   });
 });
 
@@ -318,6 +336,12 @@ describe("getAllUserDataMessagesByFid", () => {
       FidTimestampRequest.create({ fid, stopTimestamp: timestamp + 1 }),
     );
     assertMessagesMatchResult(result4, [userDataAdd1, userDataAdd2]);
+
+    // If the start time is 0, we include everything before stop time
+    const result5 = await client.getAllUserDataMessagesByFid(
+      FidTimestampRequest.create({ fid, startTimestamp: 0, stopTimestamp: timestamp + 1 }),
+    );
+    assertMessagesMatchResult(result5, [userDataAdd1, userDataAdd2]);
   });
 });
 
@@ -382,5 +406,11 @@ describe("getAllLinkMessagesByFid", () => {
       FidTimestampRequest.create({ fid, stopTimestamp: timestamp + 1 }),
     );
     assertMessagesMatchResult(result4, [linkAdd, linkRemove]);
+
+    // If the start time is 0, we include everything before stop time
+    const result5 = await client.getAllLinkMessagesByFid(
+      FidTimestampRequest.create({ fid, startTimestamp: 0, stopTimestamp: timestamp + 1 }),
+    );
+    assertMessagesMatchResult(result5, [linkAdd, linkRemove]);
   });
 });

--- a/apps/hubble/src/rustfunctions.ts
+++ b/apps/hubble/src/rustfunctions.ts
@@ -420,8 +420,10 @@ export const rsGetAllMessagesByFid = async (
   store: RustDynStore,
   fid: number,
   pageOptions: PageOptions,
+  startTime?: number,
+  stopTime?: number,
 ): Promise<RustMessagesPage> => {
-  return await lib.getAllMessagesByFid.call(store, fid, pageOptions);
+  return await lib.getAllMessagesByFid.call(store, fid, pageOptions, startTime, stopTime);
 };
 
 export const rsGetReactionAdd = async (
@@ -491,8 +493,10 @@ export const rsGetUserDataAddsByFid = async (
   store: RustDynStore,
   fid: number,
   pageOptions: PageOptions,
+  startTime?: number,
+  stopTime?: number,
 ): Promise<RustMessagesPage> => {
-  return await lib.getUserDataAddsByFid.call(store, fid, pageOptions);
+  return await lib.getUserDataAddsByFid.call(store, fid, pageOptions, startTime, stopTime);
 };
 
 export const rsGetUserNameProof = async (store: RustDynStore, name: Uint8Array): Promise<Buffer> => {
@@ -636,8 +640,10 @@ export namespace rsLinkStore {
     store: RustDynStore,
     fid: number,
     pageOptions: PageOptions,
+    startTime?: number,
+    stopTime?: number,
   ): Promise<RustMessagesPage> => {
-    return await lib.getAllLinkMessagesByFid.call(store, fid, pageOptions);
+    return await lib.getAllLinkMessagesByFid.call(store, fid, pageOptions, startTime, stopTime);
   };
 
   export const GetLinkCompactStateMessageByFid = async (

--- a/apps/hubble/src/rustfunctions.ts
+++ b/apps/hubble/src/rustfunctions.ts
@@ -636,16 +636,6 @@ export namespace rsLinkStore {
     return await lib.getLinkRemove.call(store, fid, type, target);
   };
 
-  export const GetAllLinkMessagesByFid = async (
-    store: RustDynStore,
-    fid: number,
-    pageOptions: PageOptions,
-    startTime?: number,
-    stopTime?: number,
-  ): Promise<RustMessagesPage> => {
-    return await lib.getAllLinkMessagesByFid.call(store, fid, pageOptions, startTime, stopTime);
-  };
-
   export const GetLinkCompactStateMessageByFid = async (
     store: RustDynStore,
     fid: number,

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -611,6 +611,30 @@ class Engine extends TypedEmitter<EngineEvents> {
   /*                             Cast Store Methods                             */
   /* -------------------------------------------------------------------------- */
 
+  validateStartAndStopTime(startTime?: number, stopTime?: number) {
+    let validatedStartTime;
+    if (startTime) {
+      const validatedStartTimeResult = validations.validateFarcasterTime(startTime);
+      if (validatedStartTimeResult.isErr()) {
+        return err(validatedStartTimeResult.error);
+      }
+
+      validatedStartTime = validatedStartTimeResult.value;
+    }
+
+    let validatedStopTime;
+    if (stopTime) {
+      const validatedStopTimeResult = validations.validateFarcasterTime(stopTime);
+      if (validatedStopTimeResult.isErr()) {
+        return err(validatedStopTimeResult.error);
+      }
+
+      validatedStopTime = validatedStopTimeResult.value;
+    }
+
+    return ok({ validatedStartTime, validatedStopTime });
+  }
+
   async getCast(fid: number, hash: Uint8Array): HubAsyncResult<CastAddMessage> {
     const validatedFid = validations.validateFid(fid);
     if (validatedFid.isErr()) {
@@ -664,28 +688,18 @@ class Engine extends TypedEmitter<EngineEvents> {
       return err(validatedFid.error);
     }
 
-    let validatedStartTime;
-    if (startTime) {
-      const validatedStartTimeResult = validations.validateFarcasterTime(startTime);
-      if (validatedStartTimeResult.isErr()) {
-        return err(validatedStartTimeResult.error);
-      }
-
-      validatedStartTime = validatedStartTimeResult.value;
-    }
-
-    let validatedStopTime;
-    if (stopTime) {
-      const validatedStopTimeResult = validations.validateFarcasterTime(stopTime);
-      if (validatedStopTimeResult.isErr()) {
-        return err(validatedStopTimeResult.error);
-      }
-
-      validatedStopTime = validatedStopTimeResult.value;
+    const validatedTimes = this.validateStartAndStopTime(startTime, stopTime);
+    if (validatedTimes.isErr()) {
+      return err(validatedTimes.error);
     }
 
     return ResultAsync.fromPromise(
-      this._castStore.getAllCastMessagesByFid(fid, pageOptions, validatedStartTime, validatedStopTime),
+      this._castStore.getAllCastMessagesByFid(
+        fid,
+        pageOptions,
+        validatedTimes.value.validatedStartTime,
+        validatedTimes.value.validatedStopTime,
+      ),
       (e) => e as HubError,
     );
   }
@@ -753,28 +767,18 @@ class Engine extends TypedEmitter<EngineEvents> {
       return err(validatedFid.error);
     }
 
-    let validatedStartTime;
-    if (startTime) {
-      const validatedStartTimeResult = validations.validateFarcasterTime(startTime);
-      if (validatedStartTimeResult.isErr()) {
-        return err(validatedStartTimeResult.error);
-      }
-
-      validatedStartTime = validatedStartTimeResult.value;
-    }
-
-    let validatedStopTime;
-    if (stopTime) {
-      const validatedStopTimeResult = validations.validateFarcasterTime(stopTime);
-      if (validatedStopTimeResult.isErr()) {
-        return err(validatedStopTimeResult.error);
-      }
-
-      validatedStopTime = validatedStopTimeResult.value;
+    const validatedTimes = this.validateStartAndStopTime(startTime, stopTime);
+    if (validatedTimes.isErr()) {
+      return err(validatedTimes.error);
     }
 
     return ResultAsync.fromPromise(
-      this._reactionStore.getAllReactionMessagesByFid(fid, pageOptions, validatedStartTime, validatedStopTime),
+      this._reactionStore.getAllReactionMessagesByFid(
+        fid,
+        pageOptions,
+        validatedTimes.value.validatedStartTime,
+        validatedTimes.value.validatedStopTime,
+      ),
       (e) => e as HubError,
     );
   }
@@ -821,28 +825,18 @@ class Engine extends TypedEmitter<EngineEvents> {
       return err(validatedFid.error);
     }
 
-    let validatedStartTime;
-    if (startTime) {
-      const validatedStartTimeResult = validations.validateFarcasterTime(startTime);
-      if (validatedStartTimeResult.isErr()) {
-        return err(validatedStartTimeResult.error);
-      }
-
-      validatedStartTime = validatedStartTimeResult.value;
-    }
-
-    let validatedStopTime;
-    if (stopTime) {
-      const validatedStopTimeResult = validations.validateFarcasterTime(stopTime);
-      if (validatedStopTimeResult.isErr()) {
-        return err(validatedStopTimeResult.error);
-      }
-
-      validatedStopTime = validatedStopTimeResult.value;
+    const validatedTimes = this.validateStartAndStopTime(startTime, stopTime);
+    if (validatedTimes.isErr()) {
+      return err(validatedTimes.error);
     }
 
     return ResultAsync.fromPromise(
-      this._verificationStore.getAllVerificationMessagesByFid(fid, pageOptions, validatedStartTime, validatedStopTime),
+      this._verificationStore.getAllVerificationMessagesByFid(
+        fid,
+        pageOptions,
+        validatedTimes.value.validatedStartTime,
+        validatedTimes.value.validatedStopTime,
+      ),
       (e) => e as HubError,
     );
   }
@@ -916,28 +910,18 @@ class Engine extends TypedEmitter<EngineEvents> {
       return err(validatedFid.error);
     }
 
-    let validatedStartTime;
-    if (startTime) {
-      const validatedStartTimeResult = validations.validateFarcasterTime(startTime);
-      if (validatedStartTimeResult.isErr()) {
-        return err(validatedStartTimeResult.error);
-      }
-
-      validatedStartTime = validatedStartTimeResult.value;
-    }
-
-    let validatedStopTime;
-    if (stopTime) {
-      const validatedStopTimeResult = validations.validateFarcasterTime(stopTime);
-      if (validatedStopTimeResult.isErr()) {
-        return err(validatedStopTimeResult.error);
-      }
-
-      validatedStopTime = validatedStopTimeResult.value;
+    const validatedTimes = this.validateStartAndStopTime(startTime, stopTime);
+    if (validatedTimes.isErr()) {
+      return err(validatedTimes.error);
     }
 
     return ResultAsync.fromPromise(
-      this._userDataStore.getUserDataAddsByFid(fid, pageOptions, validatedStartTime, validatedStopTime),
+      this._userDataStore.getUserDataAddsByFid(
+        fid,
+        pageOptions,
+        validatedTimes.value.validatedStartTime,
+        validatedTimes.value.validatedStopTime,
+      ),
       (e) => e as HubError,
     );
   }
@@ -1136,28 +1120,18 @@ class Engine extends TypedEmitter<EngineEvents> {
       return err(validatedFid.error);
     }
 
-    let validatedStartTime;
-    if (startTime) {
-      const validatedStartTimeResult = validations.validateFarcasterTime(startTime);
-      if (validatedStartTimeResult.isErr()) {
-        return err(validatedStartTimeResult.error);
-      }
-
-      validatedStartTime = validatedStartTimeResult.value;
-    }
-
-    let validatedStopTime;
-    if (stopTime) {
-      const validatedStopTimeResult = validations.validateFarcasterTime(stopTime);
-      if (validatedStopTimeResult.isErr()) {
-        return err(validatedStopTimeResult.error);
-      }
-
-      validatedStopTime = validatedStopTimeResult.value;
+    const validatedTimes = this.validateStartAndStopTime(startTime, stopTime);
+    if (validatedTimes.isErr()) {
+      return err(validatedTimes.error);
     }
 
     return ResultAsync.fromPromise(
-      this._linkStore.getAllLinkMessagesByFid(fid, pageOptions, validatedStartTime, validatedStopTime),
+      this._linkStore.getAllLinkMessagesByFid(
+        fid,
+        pageOptions,
+        validatedTimes.value.validatedStartTime,
+        validatedTimes.value.validatedStopTime,
+      ),
       (e) => e as HubError,
     );
   }

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -653,9 +653,9 @@ class Engine extends TypedEmitter<EngineEvents> {
 
   async getAllCastMessagesByFid(
     fid: number,
+    pageOptions: PageOptions = {},
     startTime?: number,
     stopTime?: number,
-    pageOptions: PageOptions = {},
   ): HubAsyncResult<MessagesPage<CastAddMessage | CastRemoveMessage>> {
     const validatedFid = validations.validateFid(fid);
     if (validatedFid.isErr()) {
@@ -722,9 +722,9 @@ class Engine extends TypedEmitter<EngineEvents> {
 
   async getAllReactionMessagesByFid(
     fid: number,
+    pageOptions: PageOptions = {},
     startTime?: number,
     stopTime?: number,
-    pageOptions: PageOptions = {},
   ): HubAsyncResult<MessagesPage<ReactionAddMessage | ReactionRemoveMessage>> {
     const validatedFid = validations.validateFid(fid);
     if (validatedFid.isErr()) {
@@ -770,9 +770,9 @@ class Engine extends TypedEmitter<EngineEvents> {
 
   async getAllVerificationMessagesByFid(
     fid: number,
+    pageOptions: PageOptions = {},
     startTime?: number,
     stopTime?: number,
-    pageOptions: PageOptions = {},
   ): HubAsyncResult<MessagesPage<VerificationAddAddressMessage | VerificationRemoveMessage>> {
     const validatedFid = validations.validateFid(fid);
     if (validatedFid.isErr()) {
@@ -845,9 +845,9 @@ class Engine extends TypedEmitter<EngineEvents> {
 
   async getUserDataByFid(
     fid: number,
+    pageOptions: PageOptions = {},
     startTime?: number,
     stopTime?: number,
-    pageOptions: PageOptions = {},
   ): HubAsyncResult<MessagesPage<UserDataAddMessage>> {
     const validatedFid = validations.validateFid(fid);
     if (validatedFid.isErr()) {
@@ -1040,9 +1040,9 @@ class Engine extends TypedEmitter<EngineEvents> {
 
   async getAllLinkMessagesByFid(
     fid: number,
+    pageOptions: PageOptions = {},
     startTime?: number,
     stopTime?: number,
-    pageOptions: PageOptions = {},
   ): HubAsyncResult<MessagesPage<LinkAddMessage | LinkRemoveMessage>> {
     const versionCheck = ensureAboveTargetFarcasterVersion("2023.4.19");
     if (versionCheck.isErr()) {

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -6,6 +6,7 @@ import {
   CastId,
   CastRemoveMessage,
   FarcasterNetwork,
+  fromFarcasterTime,
   getDefaultStoreLimit,
   getStoreLimits,
   hexStringToBytes,
@@ -39,6 +40,7 @@ import {
   StorageLimit,
   StorageLimitsResponse,
   StoreType,
+  toFarcasterTime,
   UserDataAddMessage,
   UserDataType,
   UserNameProof,
@@ -662,8 +664,28 @@ class Engine extends TypedEmitter<EngineEvents> {
       return err(validatedFid.error);
     }
 
+    let validatedStartTime;
+    if (startTime) {
+      const validatedStartTimeResult = validations.validateFarcasterTime(startTime);
+      if (validatedStartTimeResult.isErr()) {
+        return err(validatedStartTimeResult.error);
+      }
+
+      validatedStartTime = validatedStartTimeResult.value;
+    }
+
+    let validatedStopTime;
+    if (stopTime) {
+      const validatedStopTimeResult = validations.validateFarcasterTime(stopTime);
+      if (validatedStopTimeResult.isErr()) {
+        return err(validatedStopTimeResult.error);
+      }
+
+      validatedStopTime = validatedStopTimeResult.value;
+    }
+
     return ResultAsync.fromPromise(
-      this._castStore.getAllCastMessagesByFid(fid, pageOptions, startTime, stopTime),
+      this._castStore.getAllCastMessagesByFid(fid, pageOptions, validatedStartTime, validatedStopTime),
       (e) => e as HubError,
     );
   }
@@ -731,8 +753,28 @@ class Engine extends TypedEmitter<EngineEvents> {
       return err(validatedFid.error);
     }
 
+    let validatedStartTime;
+    if (startTime) {
+      const validatedStartTimeResult = validations.validateFarcasterTime(startTime);
+      if (validatedStartTimeResult.isErr()) {
+        return err(validatedStartTimeResult.error);
+      }
+
+      validatedStartTime = validatedStartTimeResult.value;
+    }
+
+    let validatedStopTime;
+    if (stopTime) {
+      const validatedStopTimeResult = validations.validateFarcasterTime(stopTime);
+      if (validatedStopTimeResult.isErr()) {
+        return err(validatedStopTimeResult.error);
+      }
+
+      validatedStopTime = validatedStopTimeResult.value;
+    }
+
     return ResultAsync.fromPromise(
-      this._reactionStore.getAllReactionMessagesByFid(fid, pageOptions, startTime, stopTime),
+      this._reactionStore.getAllReactionMessagesByFid(fid, pageOptions, validatedStartTime, validatedStopTime),
       (e) => e as HubError,
     );
   }
@@ -779,8 +821,28 @@ class Engine extends TypedEmitter<EngineEvents> {
       return err(validatedFid.error);
     }
 
+    let validatedStartTime;
+    if (startTime) {
+      const validatedStartTimeResult = validations.validateFarcasterTime(startTime);
+      if (validatedStartTimeResult.isErr()) {
+        return err(validatedStartTimeResult.error);
+      }
+
+      validatedStartTime = validatedStartTimeResult.value;
+    }
+
+    let validatedStopTime;
+    if (stopTime) {
+      const validatedStopTimeResult = validations.validateFarcasterTime(stopTime);
+      if (validatedStopTimeResult.isErr()) {
+        return err(validatedStopTimeResult.error);
+      }
+
+      validatedStopTime = validatedStopTimeResult.value;
+    }
+
     return ResultAsync.fromPromise(
-      this._verificationStore.getAllVerificationMessagesByFid(fid, pageOptions, startTime, stopTime),
+      this._verificationStore.getAllVerificationMessagesByFid(fid, pageOptions, validatedStartTime, validatedStopTime),
       (e) => e as HubError,
     );
   }
@@ -854,8 +916,28 @@ class Engine extends TypedEmitter<EngineEvents> {
       return err(validatedFid.error);
     }
 
+    let validatedStartTime;
+    if (startTime) {
+      const validatedStartTimeResult = validations.validateFarcasterTime(startTime);
+      if (validatedStartTimeResult.isErr()) {
+        return err(validatedStartTimeResult.error);
+      }
+
+      validatedStartTime = validatedStartTimeResult.value;
+    }
+
+    let validatedStopTime;
+    if (stopTime) {
+      const validatedStopTimeResult = validations.validateFarcasterTime(stopTime);
+      if (validatedStopTimeResult.isErr()) {
+        return err(validatedStopTimeResult.error);
+      }
+
+      validatedStopTime = validatedStopTimeResult.value;
+    }
+
     return ResultAsync.fromPromise(
-      this._userDataStore.getUserDataAddsByFid(fid, pageOptions, startTime, stopTime),
+      this._userDataStore.getUserDataAddsByFid(fid, pageOptions, validatedStartTime, validatedStopTime),
       (e) => e as HubError,
     );
   }
@@ -1054,8 +1136,28 @@ class Engine extends TypedEmitter<EngineEvents> {
       return err(validatedFid.error);
     }
 
+    let validatedStartTime;
+    if (startTime) {
+      const validatedStartTimeResult = validations.validateFarcasterTime(startTime);
+      if (validatedStartTimeResult.isErr()) {
+        return err(validatedStartTimeResult.error);
+      }
+
+      validatedStartTime = validatedStartTimeResult.value;
+    }
+
+    let validatedStopTime;
+    if (stopTime) {
+      const validatedStopTimeResult = validations.validateFarcasterTime(stopTime);
+      if (validatedStopTimeResult.isErr()) {
+        return err(validatedStopTimeResult.error);
+      }
+
+      validatedStopTime = validatedStopTimeResult.value;
+    }
+
     return ResultAsync.fromPromise(
-      this._linkStore.getAllLinkMessagesByFid(fid, pageOptions, startTime, stopTime),
+      this._linkStore.getAllLinkMessagesByFid(fid, pageOptions, validatedStartTime, validatedStopTime),
       (e) => e as HubError,
     );
   }

--- a/apps/hubble/src/storage/stores/castStore.ts
+++ b/apps/hubble/src/storage/stores/castStore.ts
@@ -72,8 +72,10 @@ class CastStore extends RustStoreBase<CastAddMessage, CastRemoveMessage> {
   async getAllCastMessagesByFid(
     fid: number,
     pageOptions: PageOptions = {},
+    startTime?: number,
+    stopTime?: number,
   ): Promise<MessagesPage<CastAddMessage | CastRemoveMessage>> {
-    return await this.getAllMessagesByFid(fid, pageOptions);
+    return await this.getAllMessagesByFid(fid, pageOptions, startTime, stopTime);
   }
 
   /** Gets all CastAdd messages for a parent cast (fid and tsHash) */

--- a/apps/hubble/src/storage/stores/linkStore.ts
+++ b/apps/hubble/src/storage/stores/linkStore.ts
@@ -125,8 +125,16 @@ class LinkStore extends RustStoreBase<LinkAddMessage, LinkRemoveMessage> {
   async getAllLinkMessagesByFid(
     fid: number,
     pageOptions: PageOptions = {},
+    startTime?: number,
+    stopTime?: number,
   ): Promise<MessagesPage<LinkAddMessage | LinkRemoveMessage>> {
-    const messages_page = await rsLinkStore.GetAllLinkMessagesByFid(this._rustStore, fid, pageOptions);
+    const messages_page = await rsLinkStore.GetAllLinkMessagesByFid(
+      this._rustStore,
+      fid,
+      pageOptions,
+      startTime,
+      stopTime,
+    );
 
     const messages =
       messages_page.messageBytes?.map((message_bytes) => {

--- a/apps/hubble/src/storage/stores/linkStore.ts
+++ b/apps/hubble/src/storage/stores/linkStore.ts
@@ -10,7 +10,7 @@ import { UserPostfix } from "../db/types.js";
 import { MessagesPage, PageOptions, StorePruneOptions } from "./types.js";
 import { ResultAsync } from "neverthrow";
 import RocksDB from "../db/rocksdb.js";
-import { rsLinkStore, rustErrorToHubError } from "../../rustfunctions.js";
+import { rsGetAllMessagesByFid, rsLinkStore, rustErrorToHubError } from "../../rustfunctions.js";
 import { RustStoreBase } from "./rustStoreBase.js";
 import storeEventHandler from "./storeEventHandler.js";
 
@@ -128,13 +128,7 @@ class LinkStore extends RustStoreBase<LinkAddMessage, LinkRemoveMessage> {
     startTime?: number,
     stopTime?: number,
   ): Promise<MessagesPage<LinkAddMessage | LinkRemoveMessage>> {
-    const messages_page = await rsLinkStore.GetAllLinkMessagesByFid(
-      this._rustStore,
-      fid,
-      pageOptions,
-      startTime,
-      stopTime,
-    );
+    const messages_page = await rsGetAllMessagesByFid(this._rustStore, fid, pageOptions, startTime, stopTime);
 
     const messages =
       messages_page.messageBytes?.map((message_bytes) => {

--- a/apps/hubble/src/storage/stores/reactionStore.ts
+++ b/apps/hubble/src/storage/stores/reactionStore.ts
@@ -105,8 +105,10 @@ class ReactionStore extends RustStoreBase<ReactionAddMessage, ReactionRemoveMess
   async getAllReactionMessagesByFid(
     fid: number,
     pageOptions: PageOptions = {},
+    startTime?: number,
+    stopTime?: number,
   ): Promise<MessagesPage<ReactionAddMessage | ReactionRemoveMessage>> {
-    return await this.getAllMessagesByFid(fid, pageOptions);
+    return await this.getAllMessagesByFid(fid, pageOptions, startTime, stopTime);
   }
 
   async getReactionsByTarget(

--- a/apps/hubble/src/storage/stores/rustStoreBase.ts
+++ b/apps/hubble/src/storage/stores/rustStoreBase.ts
@@ -215,8 +215,13 @@ export abstract class RustStoreBase<TAdd extends Message, TRemove extends Messag
     return messageDecode(new Uint8Array(message_bytes.value));
   }
 
-  async getAllMessagesByFid(fid: number, pageOptions: PageOptions = {}): Promise<MessagesPage<TAdd | TRemove>> {
-    const messages_page = await rsGetAllMessagesByFid(this._rustStore, fid, pageOptions);
+  async getAllMessagesByFid(
+    fid: number,
+    pageOptions: PageOptions = {},
+    startTime?: number,
+    stopTime?: number,
+  ): Promise<MessagesPage<TAdd | TRemove>> {
+    const messages_page = await rsGetAllMessagesByFid(this._rustStore, fid, pageOptions, startTime, stopTime);
 
     const messages =
       messages_page.messageBytes?.map((message_bytes) => {

--- a/apps/hubble/src/storage/stores/userDataStore.ts
+++ b/apps/hubble/src/storage/stores/userDataStore.ts
@@ -68,8 +68,13 @@ class UserDataStore extends RustStoreBase<UserDataAddMessage, never> {
   }
 
   /** Finds all UserDataAdd messages for an fid */
-  async getUserDataAddsByFid(fid: number, pageOptions: PageOptions = {}): Promise<MessagesPage<UserDataAddMessage>> {
-    const messages_page = await rsGetUserDataAddsByFid(this._rustStore, fid, pageOptions);
+  async getUserDataAddsByFid(
+    fid: number,
+    pageOptions: PageOptions = {},
+    startTime?: number,
+    stopTime?: number,
+  ): Promise<MessagesPage<UserDataAddMessage>> {
+    const messages_page = await rsGetUserDataAddsByFid(this._rustStore, fid, pageOptions, startTime, stopTime);
 
     const messages =
       messages_page.messageBytes?.map((message_bytes) => {

--- a/apps/hubble/src/storage/stores/verificationStore.ts
+++ b/apps/hubble/src/storage/stores/verificationStore.ts
@@ -87,8 +87,10 @@ class VerificationStore extends RustStoreBase<VerificationAddAddressMessage, Ver
   async getAllVerificationMessagesByFid(
     fid: number,
     pageOptions: PageOptions = {},
+    startTime?: number,
+    stopTime?: number,
   ): Promise<MessagesPage<VerificationAddAddressMessage | VerificationRemoveMessage>> {
-    return await this.getAllMessagesByFid(fid, pageOptions);
+    return await this.getAllMessagesByFid(fid, pageOptions, startTime, stopTime);
   }
 
   async migrateVerifications(): HubAsyncResult<{ total: number; duplicates: number }> {

--- a/packages/core/src/protobufs/generated/request_response.ts
+++ b/packages/core/src/protobufs/generated/request_response.ts
@@ -162,7 +162,7 @@ export interface FidRequest {
   reverse?: boolean | undefined;
 }
 
-export interface TimestampFidRequest {
+export interface FidTimestampRequest {
   fid: number;
   pageSize?: number | undefined;
   pageToken?: Uint8Array | undefined;
@@ -1560,7 +1560,7 @@ export const FidRequest = {
   },
 };
 
-function createBaseTimestampFidRequest(): TimestampFidRequest {
+function createBaseFidTimestampRequest(): FidTimestampRequest {
   return {
     fid: 0,
     pageSize: undefined,
@@ -1571,8 +1571,8 @@ function createBaseTimestampFidRequest(): TimestampFidRequest {
   };
 }
 
-export const TimestampFidRequest = {
-  encode(message: TimestampFidRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+export const FidTimestampRequest = {
+  encode(message: FidTimestampRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.fid !== 0) {
       writer.uint32(8).uint64(message.fid);
     }
@@ -1594,10 +1594,10 @@ export const TimestampFidRequest = {
     return writer;
   },
 
-  decode(input: _m0.Reader | Uint8Array, length?: number): TimestampFidRequest {
+  decode(input: _m0.Reader | Uint8Array, length?: number): FidTimestampRequest {
     const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseTimestampFidRequest();
+    const message = createBaseFidTimestampRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1652,7 +1652,7 @@ export const TimestampFidRequest = {
     return message;
   },
 
-  fromJSON(object: any): TimestampFidRequest {
+  fromJSON(object: any): FidTimestampRequest {
     return {
       fid: isSet(object.fid) ? Number(object.fid) : 0,
       pageSize: isSet(object.pageSize) ? Number(object.pageSize) : undefined,
@@ -1663,7 +1663,7 @@ export const TimestampFidRequest = {
     };
   },
 
-  toJSON(message: TimestampFidRequest): unknown {
+  toJSON(message: FidTimestampRequest): unknown {
     const obj: any = {};
     message.fid !== undefined && (obj.fid = Math.round(message.fid));
     message.pageSize !== undefined && (obj.pageSize = Math.round(message.pageSize));
@@ -1675,12 +1675,12 @@ export const TimestampFidRequest = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<TimestampFidRequest>, I>>(base?: I): TimestampFidRequest {
-    return TimestampFidRequest.fromPartial(base ?? {});
+  create<I extends Exact<DeepPartial<FidTimestampRequest>, I>>(base?: I): FidTimestampRequest {
+    return FidTimestampRequest.fromPartial(base ?? {});
   },
 
-  fromPartial<I extends Exact<DeepPartial<TimestampFidRequest>, I>>(object: I): TimestampFidRequest {
-    const message = createBaseTimestampFidRequest();
+  fromPartial<I extends Exact<DeepPartial<FidTimestampRequest>, I>>(object: I): FidTimestampRequest {
+    const message = createBaseFidTimestampRequest();
     message.fid = object.fid ?? 0;
     message.pageSize = object.pageSize ?? undefined;
     message.pageToken = object.pageToken ?? undefined;

--- a/packages/core/src/protobufs/generated/request_response.ts
+++ b/packages/core/src/protobufs/generated/request_response.ts
@@ -162,6 +162,15 @@ export interface FidRequest {
   reverse?: boolean | undefined;
 }
 
+export interface TimestampFidRequest {
+  fid: number;
+  pageSize?: number | undefined;
+  pageToken?: Uint8Array | undefined;
+  reverse?: boolean | undefined;
+  startTimestamp?: number | undefined;
+  stopTimestamp?: number | undefined;
+}
+
 export interface FidsRequest {
   pageSize?: number | undefined;
   pageToken?: Uint8Array | undefined;
@@ -1547,6 +1556,137 @@ export const FidRequest = {
     message.pageSize = object.pageSize ?? undefined;
     message.pageToken = object.pageToken ?? undefined;
     message.reverse = object.reverse ?? undefined;
+    return message;
+  },
+};
+
+function createBaseTimestampFidRequest(): TimestampFidRequest {
+  return {
+    fid: 0,
+    pageSize: undefined,
+    pageToken: undefined,
+    reverse: undefined,
+    startTimestamp: undefined,
+    stopTimestamp: undefined,
+  };
+}
+
+export const TimestampFidRequest = {
+  encode(message: TimestampFidRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.fid !== 0) {
+      writer.uint32(8).uint64(message.fid);
+    }
+    if (message.pageSize !== undefined) {
+      writer.uint32(16).uint32(message.pageSize);
+    }
+    if (message.pageToken !== undefined) {
+      writer.uint32(26).bytes(message.pageToken);
+    }
+    if (message.reverse !== undefined) {
+      writer.uint32(32).bool(message.reverse);
+    }
+    if (message.startTimestamp !== undefined) {
+      writer.uint32(40).uint64(message.startTimestamp);
+    }
+    if (message.stopTimestamp !== undefined) {
+      writer.uint32(48).uint64(message.stopTimestamp);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): TimestampFidRequest {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseTimestampFidRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.fid = longToNumber(reader.uint64() as Long);
+          continue;
+        case 2:
+          if (tag != 16) {
+            break;
+          }
+
+          message.pageSize = reader.uint32();
+          continue;
+        case 3:
+          if (tag != 26) {
+            break;
+          }
+
+          message.pageToken = reader.bytes();
+          continue;
+        case 4:
+          if (tag != 32) {
+            break;
+          }
+
+          message.reverse = reader.bool();
+          continue;
+        case 5:
+          if (tag != 40) {
+            break;
+          }
+
+          message.startTimestamp = longToNumber(reader.uint64() as Long);
+          continue;
+        case 6:
+          if (tag != 48) {
+            break;
+          }
+
+          message.stopTimestamp = longToNumber(reader.uint64() as Long);
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): TimestampFidRequest {
+    return {
+      fid: isSet(object.fid) ? Number(object.fid) : 0,
+      pageSize: isSet(object.pageSize) ? Number(object.pageSize) : undefined,
+      pageToken: isSet(object.pageToken) ? bytesFromBase64(object.pageToken) : undefined,
+      reverse: isSet(object.reverse) ? Boolean(object.reverse) : undefined,
+      startTimestamp: isSet(object.startTimestamp) ? Number(object.startTimestamp) : undefined,
+      stopTimestamp: isSet(object.stopTimestamp) ? Number(object.stopTimestamp) : undefined,
+    };
+  },
+
+  toJSON(message: TimestampFidRequest): unknown {
+    const obj: any = {};
+    message.fid !== undefined && (obj.fid = Math.round(message.fid));
+    message.pageSize !== undefined && (obj.pageSize = Math.round(message.pageSize));
+    message.pageToken !== undefined &&
+      (obj.pageToken = message.pageToken !== undefined ? base64FromBytes(message.pageToken) : undefined);
+    message.reverse !== undefined && (obj.reverse = message.reverse);
+    message.startTimestamp !== undefined && (obj.startTimestamp = Math.round(message.startTimestamp));
+    message.stopTimestamp !== undefined && (obj.stopTimestamp = Math.round(message.stopTimestamp));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<TimestampFidRequest>, I>>(base?: I): TimestampFidRequest {
+    return TimestampFidRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<TimestampFidRequest>, I>>(object: I): TimestampFidRequest {
+    const message = createBaseTimestampFidRequest();
+    message.fid = object.fid ?? 0;
+    message.pageSize = object.pageSize ?? undefined;
+    message.pageToken = object.pageToken ?? undefined;
+    message.reverse = object.reverse ?? undefined;
+    message.startTimestamp = object.startTimestamp ?? undefined;
+    message.stopTimestamp = object.stopTimestamp ?? undefined;
     return message;
   },
 };

--- a/packages/core/src/validations.test.ts
+++ b/packages/core/src/validations.test.ts
@@ -99,6 +99,18 @@ describe("validateFname", () => {
   });
 });
 
+describe("validateFarcasterTime", () => {
+  test("zero is a valid time", () => {
+    expect(validations.validateFarcasterTime(0).isOk()).toBeTruthy();
+  });
+
+  test("millisecond precision time is rejected", () => {
+    expect(validations.validateFarcasterTime(1724120917791)).toEqual(
+      err(new HubError("bad_request.invalid_param", "time too far in future")),
+    );
+  });
+});
+
 describe("validateENSname", () => {
   test("succeeds with valid byte array input", () => {
     const ensName = Factories.EnsName.build();

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -5,7 +5,7 @@ import { err, ok, Result } from "neverthrow";
 import { bytesCompare, bytesToUtf8String, utf8StringToBytes } from "./bytes";
 import { ed25519, eip712 } from "./crypto";
 import { HubAsyncResult, HubError, HubResult } from "./errors";
-import { getFarcasterTime, toFarcasterTime } from "./time";
+import { fromFarcasterTime, getFarcasterTime, toFarcasterTime } from "./time";
 import {
   makeVerificationAddressClaim,
   recreateSolanaClaimMessage,
@@ -195,6 +195,22 @@ export const validateEd25519PublicKey = (publicKey?: Uint8Array | null): HubResu
   }
 
   return ok(publicKey);
+};
+
+export const validateFarcasterTime = (farcasterTime: number) => {
+  // Roundtrip the farcasterTime and bubble any errors up to catch invalid farcaster time inputs.
+  const unixTime = fromFarcasterTime(farcasterTime);
+  if (unixTime.isErr()) {
+    return err(unixTime.error);
+  }
+
+  const rtFarcasterTime = toFarcasterTime(unixTime.value);
+
+  if (rtFarcasterTime.isErr()) {
+    return err(rtFarcasterTime.error);
+  }
+
+  return ok(rtFarcasterTime.value);
 };
 
 export const validateMessage = async (

--- a/packages/hub-nodejs/src/generated/request_response.ts
+++ b/packages/hub-nodejs/src/generated/request_response.ts
@@ -162,7 +162,7 @@ export interface FidRequest {
   reverse?: boolean | undefined;
 }
 
-export interface TimestampFidRequest {
+export interface FidTimestampRequest {
   fid: number;
   pageSize?: number | undefined;
   pageToken?: Uint8Array | undefined;
@@ -1560,7 +1560,7 @@ export const FidRequest = {
   },
 };
 
-function createBaseTimestampFidRequest(): TimestampFidRequest {
+function createBaseFidTimestampRequest(): FidTimestampRequest {
   return {
     fid: 0,
     pageSize: undefined,
@@ -1571,8 +1571,8 @@ function createBaseTimestampFidRequest(): TimestampFidRequest {
   };
 }
 
-export const TimestampFidRequest = {
-  encode(message: TimestampFidRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+export const FidTimestampRequest = {
+  encode(message: FidTimestampRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.fid !== 0) {
       writer.uint32(8).uint64(message.fid);
     }
@@ -1594,10 +1594,10 @@ export const TimestampFidRequest = {
     return writer;
   },
 
-  decode(input: _m0.Reader | Uint8Array, length?: number): TimestampFidRequest {
+  decode(input: _m0.Reader | Uint8Array, length?: number): FidTimestampRequest {
     const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseTimestampFidRequest();
+    const message = createBaseFidTimestampRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1652,7 +1652,7 @@ export const TimestampFidRequest = {
     return message;
   },
 
-  fromJSON(object: any): TimestampFidRequest {
+  fromJSON(object: any): FidTimestampRequest {
     return {
       fid: isSet(object.fid) ? Number(object.fid) : 0,
       pageSize: isSet(object.pageSize) ? Number(object.pageSize) : undefined,
@@ -1663,7 +1663,7 @@ export const TimestampFidRequest = {
     };
   },
 
-  toJSON(message: TimestampFidRequest): unknown {
+  toJSON(message: FidTimestampRequest): unknown {
     const obj: any = {};
     message.fid !== undefined && (obj.fid = Math.round(message.fid));
     message.pageSize !== undefined && (obj.pageSize = Math.round(message.pageSize));
@@ -1675,12 +1675,12 @@ export const TimestampFidRequest = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<TimestampFidRequest>, I>>(base?: I): TimestampFidRequest {
-    return TimestampFidRequest.fromPartial(base ?? {});
+  create<I extends Exact<DeepPartial<FidTimestampRequest>, I>>(base?: I): FidTimestampRequest {
+    return FidTimestampRequest.fromPartial(base ?? {});
   },
 
-  fromPartial<I extends Exact<DeepPartial<TimestampFidRequest>, I>>(object: I): TimestampFidRequest {
-    const message = createBaseTimestampFidRequest();
+  fromPartial<I extends Exact<DeepPartial<FidTimestampRequest>, I>>(object: I): FidTimestampRequest {
+    const message = createBaseFidTimestampRequest();
     message.fid = object.fid ?? 0;
     message.pageSize = object.pageSize ?? undefined;
     message.pageToken = object.pageToken ?? undefined;

--- a/packages/hub-nodejs/src/generated/request_response.ts
+++ b/packages/hub-nodejs/src/generated/request_response.ts
@@ -162,6 +162,15 @@ export interface FidRequest {
   reverse?: boolean | undefined;
 }
 
+export interface TimestampFidRequest {
+  fid: number;
+  pageSize?: number | undefined;
+  pageToken?: Uint8Array | undefined;
+  reverse?: boolean | undefined;
+  startTimestamp?: number | undefined;
+  stopTimestamp?: number | undefined;
+}
+
 export interface FidsRequest {
   pageSize?: number | undefined;
   pageToken?: Uint8Array | undefined;
@@ -1547,6 +1556,137 @@ export const FidRequest = {
     message.pageSize = object.pageSize ?? undefined;
     message.pageToken = object.pageToken ?? undefined;
     message.reverse = object.reverse ?? undefined;
+    return message;
+  },
+};
+
+function createBaseTimestampFidRequest(): TimestampFidRequest {
+  return {
+    fid: 0,
+    pageSize: undefined,
+    pageToken: undefined,
+    reverse: undefined,
+    startTimestamp: undefined,
+    stopTimestamp: undefined,
+  };
+}
+
+export const TimestampFidRequest = {
+  encode(message: TimestampFidRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.fid !== 0) {
+      writer.uint32(8).uint64(message.fid);
+    }
+    if (message.pageSize !== undefined) {
+      writer.uint32(16).uint32(message.pageSize);
+    }
+    if (message.pageToken !== undefined) {
+      writer.uint32(26).bytes(message.pageToken);
+    }
+    if (message.reverse !== undefined) {
+      writer.uint32(32).bool(message.reverse);
+    }
+    if (message.startTimestamp !== undefined) {
+      writer.uint32(40).uint64(message.startTimestamp);
+    }
+    if (message.stopTimestamp !== undefined) {
+      writer.uint32(48).uint64(message.stopTimestamp);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): TimestampFidRequest {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseTimestampFidRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.fid = longToNumber(reader.uint64() as Long);
+          continue;
+        case 2:
+          if (tag != 16) {
+            break;
+          }
+
+          message.pageSize = reader.uint32();
+          continue;
+        case 3:
+          if (tag != 26) {
+            break;
+          }
+
+          message.pageToken = reader.bytes();
+          continue;
+        case 4:
+          if (tag != 32) {
+            break;
+          }
+
+          message.reverse = reader.bool();
+          continue;
+        case 5:
+          if (tag != 40) {
+            break;
+          }
+
+          message.startTimestamp = longToNumber(reader.uint64() as Long);
+          continue;
+        case 6:
+          if (tag != 48) {
+            break;
+          }
+
+          message.stopTimestamp = longToNumber(reader.uint64() as Long);
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): TimestampFidRequest {
+    return {
+      fid: isSet(object.fid) ? Number(object.fid) : 0,
+      pageSize: isSet(object.pageSize) ? Number(object.pageSize) : undefined,
+      pageToken: isSet(object.pageToken) ? bytesFromBase64(object.pageToken) : undefined,
+      reverse: isSet(object.reverse) ? Boolean(object.reverse) : undefined,
+      startTimestamp: isSet(object.startTimestamp) ? Number(object.startTimestamp) : undefined,
+      stopTimestamp: isSet(object.stopTimestamp) ? Number(object.stopTimestamp) : undefined,
+    };
+  },
+
+  toJSON(message: TimestampFidRequest): unknown {
+    const obj: any = {};
+    message.fid !== undefined && (obj.fid = Math.round(message.fid));
+    message.pageSize !== undefined && (obj.pageSize = Math.round(message.pageSize));
+    message.pageToken !== undefined &&
+      (obj.pageToken = message.pageToken !== undefined ? base64FromBytes(message.pageToken) : undefined);
+    message.reverse !== undefined && (obj.reverse = message.reverse);
+    message.startTimestamp !== undefined && (obj.startTimestamp = Math.round(message.startTimestamp));
+    message.stopTimestamp !== undefined && (obj.stopTimestamp = Math.round(message.stopTimestamp));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<TimestampFidRequest>, I>>(base?: I): TimestampFidRequest {
+    return TimestampFidRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<TimestampFidRequest>, I>>(object: I): TimestampFidRequest {
+    const message = createBaseTimestampFidRequest();
+    message.fid = object.fid ?? 0;
+    message.pageSize = object.pageSize ?? undefined;
+    message.pageToken = object.pageToken ?? undefined;
+    message.reverse = object.reverse ?? undefined;
+    message.startTimestamp = object.startTimestamp ?? undefined;
+    message.stopTimestamp = object.stopTimestamp ?? undefined;
     return message;
   },
 };

--- a/packages/hub-nodejs/src/generated/rpc.ts
+++ b/packages/hub-nodejs/src/generated/rpc.ts
@@ -42,6 +42,7 @@ import {
   SyncIds,
   SyncStatusRequest,
   SyncStatusResponse,
+  TimestampFidRequest,
   TrieNodeMetadataResponse,
   TrieNodePrefix,
   TrieNodeSnapshotResponse,
@@ -359,8 +360,8 @@ export const HubServiceService = {
     path: "/HubService/GetAllCastMessagesByFid",
     requestStream: false,
     responseStream: false,
-    requestSerialize: (value: FidRequest) => Buffer.from(FidRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer) => FidRequest.decode(value),
+    requestSerialize: (value: TimestampFidRequest) => Buffer.from(TimestampFidRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => TimestampFidRequest.decode(value),
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
@@ -369,8 +370,8 @@ export const HubServiceService = {
     path: "/HubService/GetAllReactionMessagesByFid",
     requestStream: false,
     responseStream: false,
-    requestSerialize: (value: FidRequest) => Buffer.from(FidRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer) => FidRequest.decode(value),
+    requestSerialize: (value: TimestampFidRequest) => Buffer.from(TimestampFidRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => TimestampFidRequest.decode(value),
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
@@ -379,8 +380,8 @@ export const HubServiceService = {
     path: "/HubService/GetAllVerificationMessagesByFid",
     requestStream: false,
     responseStream: false,
-    requestSerialize: (value: FidRequest) => Buffer.from(FidRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer) => FidRequest.decode(value),
+    requestSerialize: (value: TimestampFidRequest) => Buffer.from(TimestampFidRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => TimestampFidRequest.decode(value),
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
@@ -389,8 +390,8 @@ export const HubServiceService = {
     path: "/HubService/GetAllUserDataMessagesByFid",
     requestStream: false,
     responseStream: false,
-    requestSerialize: (value: FidRequest) => Buffer.from(FidRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer) => FidRequest.decode(value),
+    requestSerialize: (value: TimestampFidRequest) => Buffer.from(TimestampFidRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => TimestampFidRequest.decode(value),
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
@@ -399,8 +400,8 @@ export const HubServiceService = {
     path: "/HubService/GetAllLinkMessagesByFid",
     requestStream: false,
     responseStream: false,
-    requestSerialize: (value: FidRequest) => Buffer.from(FidRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer) => FidRequest.decode(value),
+    requestSerialize: (value: TimestampFidRequest) => Buffer.from(TimestampFidRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => TimestampFidRequest.decode(value),
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
@@ -586,15 +587,15 @@ export interface HubServiceServer extends UntypedServiceImplementation {
    * regular endpoints can be used to get all the messages
    * @http-api: none
    */
-  getAllCastMessagesByFid: handleUnaryCall<FidRequest, MessagesResponse>;
+  getAllCastMessagesByFid: handleUnaryCall<TimestampFidRequest, MessagesResponse>;
   /** @http-api: none */
-  getAllReactionMessagesByFid: handleUnaryCall<FidRequest, MessagesResponse>;
+  getAllReactionMessagesByFid: handleUnaryCall<TimestampFidRequest, MessagesResponse>;
   /** @http-api: none */
-  getAllVerificationMessagesByFid: handleUnaryCall<FidRequest, MessagesResponse>;
+  getAllVerificationMessagesByFid: handleUnaryCall<TimestampFidRequest, MessagesResponse>;
   /** @http-api: none */
-  getAllUserDataMessagesByFid: handleUnaryCall<FidRequest, MessagesResponse>;
+  getAllUserDataMessagesByFid: handleUnaryCall<TimestampFidRequest, MessagesResponse>;
   /** @http-api: none */
-  getAllLinkMessagesByFid: handleUnaryCall<FidRequest, MessagesResponse>;
+  getAllLinkMessagesByFid: handleUnaryCall<TimestampFidRequest, MessagesResponse>;
   /** @http-api: none */
   getLinkCompactStateMessageByFid: handleUnaryCall<FidRequest, MessagesResponse>;
   /** Sync Methods */
@@ -1067,80 +1068,80 @@ export interface HubServiceClient extends Client {
    * @http-api: none
    */
   getAllCastMessagesByFid(
-    request: FidRequest,
+    request: TimestampFidRequest,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   getAllCastMessagesByFid(
-    request: FidRequest,
+    request: TimestampFidRequest,
     metadata: Metadata,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   getAllCastMessagesByFid(
-    request: FidRequest,
+    request: TimestampFidRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   /** @http-api: none */
   getAllReactionMessagesByFid(
-    request: FidRequest,
+    request: TimestampFidRequest,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   getAllReactionMessagesByFid(
-    request: FidRequest,
+    request: TimestampFidRequest,
     metadata: Metadata,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   getAllReactionMessagesByFid(
-    request: FidRequest,
+    request: TimestampFidRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   /** @http-api: none */
   getAllVerificationMessagesByFid(
-    request: FidRequest,
+    request: TimestampFidRequest,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   getAllVerificationMessagesByFid(
-    request: FidRequest,
+    request: TimestampFidRequest,
     metadata: Metadata,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   getAllVerificationMessagesByFid(
-    request: FidRequest,
+    request: TimestampFidRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   /** @http-api: none */
   getAllUserDataMessagesByFid(
-    request: FidRequest,
+    request: TimestampFidRequest,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   getAllUserDataMessagesByFid(
-    request: FidRequest,
+    request: TimestampFidRequest,
     metadata: Metadata,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   getAllUserDataMessagesByFid(
-    request: FidRequest,
+    request: TimestampFidRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   /** @http-api: none */
   getAllLinkMessagesByFid(
-    request: FidRequest,
+    request: TimestampFidRequest,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   getAllLinkMessagesByFid(
-    request: FidRequest,
+    request: TimestampFidRequest,
     metadata: Metadata,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   getAllLinkMessagesByFid(
-    request: FidRequest,
+    request: TimestampFidRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,

--- a/packages/hub-nodejs/src/generated/rpc.ts
+++ b/packages/hub-nodejs/src/generated/rpc.ts
@@ -24,6 +24,7 @@ import {
   FidRequest,
   FidsRequest,
   FidsResponse,
+  FidTimestampRequest,
   HubInfoRequest,
   HubInfoResponse,
   IdRegistryEventByAddressRequest,
@@ -42,7 +43,6 @@ import {
   SyncIds,
   SyncStatusRequest,
   SyncStatusResponse,
-  TimestampFidRequest,
   TrieNodeMetadataResponse,
   TrieNodePrefix,
   TrieNodeSnapshotResponse,
@@ -360,8 +360,8 @@ export const HubServiceService = {
     path: "/HubService/GetAllCastMessagesByFid",
     requestStream: false,
     responseStream: false,
-    requestSerialize: (value: TimestampFidRequest) => Buffer.from(TimestampFidRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer) => TimestampFidRequest.decode(value),
+    requestSerialize: (value: FidTimestampRequest) => Buffer.from(FidTimestampRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => FidTimestampRequest.decode(value),
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
@@ -370,8 +370,8 @@ export const HubServiceService = {
     path: "/HubService/GetAllReactionMessagesByFid",
     requestStream: false,
     responseStream: false,
-    requestSerialize: (value: TimestampFidRequest) => Buffer.from(TimestampFidRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer) => TimestampFidRequest.decode(value),
+    requestSerialize: (value: FidTimestampRequest) => Buffer.from(FidTimestampRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => FidTimestampRequest.decode(value),
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
@@ -380,8 +380,8 @@ export const HubServiceService = {
     path: "/HubService/GetAllVerificationMessagesByFid",
     requestStream: false,
     responseStream: false,
-    requestSerialize: (value: TimestampFidRequest) => Buffer.from(TimestampFidRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer) => TimestampFidRequest.decode(value),
+    requestSerialize: (value: FidTimestampRequest) => Buffer.from(FidTimestampRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => FidTimestampRequest.decode(value),
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
@@ -390,8 +390,8 @@ export const HubServiceService = {
     path: "/HubService/GetAllUserDataMessagesByFid",
     requestStream: false,
     responseStream: false,
-    requestSerialize: (value: TimestampFidRequest) => Buffer.from(TimestampFidRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer) => TimestampFidRequest.decode(value),
+    requestSerialize: (value: FidTimestampRequest) => Buffer.from(FidTimestampRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => FidTimestampRequest.decode(value),
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
@@ -400,8 +400,8 @@ export const HubServiceService = {
     path: "/HubService/GetAllLinkMessagesByFid",
     requestStream: false,
     responseStream: false,
-    requestSerialize: (value: TimestampFidRequest) => Buffer.from(TimestampFidRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer) => TimestampFidRequest.decode(value),
+    requestSerialize: (value: FidTimestampRequest) => Buffer.from(FidTimestampRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => FidTimestampRequest.decode(value),
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
@@ -587,15 +587,15 @@ export interface HubServiceServer extends UntypedServiceImplementation {
    * regular endpoints can be used to get all the messages
    * @http-api: none
    */
-  getAllCastMessagesByFid: handleUnaryCall<TimestampFidRequest, MessagesResponse>;
+  getAllCastMessagesByFid: handleUnaryCall<FidTimestampRequest, MessagesResponse>;
   /** @http-api: none */
-  getAllReactionMessagesByFid: handleUnaryCall<TimestampFidRequest, MessagesResponse>;
+  getAllReactionMessagesByFid: handleUnaryCall<FidTimestampRequest, MessagesResponse>;
   /** @http-api: none */
-  getAllVerificationMessagesByFid: handleUnaryCall<TimestampFidRequest, MessagesResponse>;
+  getAllVerificationMessagesByFid: handleUnaryCall<FidTimestampRequest, MessagesResponse>;
   /** @http-api: none */
-  getAllUserDataMessagesByFid: handleUnaryCall<TimestampFidRequest, MessagesResponse>;
+  getAllUserDataMessagesByFid: handleUnaryCall<FidTimestampRequest, MessagesResponse>;
   /** @http-api: none */
-  getAllLinkMessagesByFid: handleUnaryCall<TimestampFidRequest, MessagesResponse>;
+  getAllLinkMessagesByFid: handleUnaryCall<FidTimestampRequest, MessagesResponse>;
   /** @http-api: none */
   getLinkCompactStateMessageByFid: handleUnaryCall<FidRequest, MessagesResponse>;
   /** Sync Methods */
@@ -1068,80 +1068,80 @@ export interface HubServiceClient extends Client {
    * @http-api: none
    */
   getAllCastMessagesByFid(
-    request: TimestampFidRequest,
+    request: FidTimestampRequest,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   getAllCastMessagesByFid(
-    request: TimestampFidRequest,
+    request: FidTimestampRequest,
     metadata: Metadata,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   getAllCastMessagesByFid(
-    request: TimestampFidRequest,
+    request: FidTimestampRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   /** @http-api: none */
   getAllReactionMessagesByFid(
-    request: TimestampFidRequest,
+    request: FidTimestampRequest,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   getAllReactionMessagesByFid(
-    request: TimestampFidRequest,
+    request: FidTimestampRequest,
     metadata: Metadata,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   getAllReactionMessagesByFid(
-    request: TimestampFidRequest,
+    request: FidTimestampRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   /** @http-api: none */
   getAllVerificationMessagesByFid(
-    request: TimestampFidRequest,
+    request: FidTimestampRequest,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   getAllVerificationMessagesByFid(
-    request: TimestampFidRequest,
+    request: FidTimestampRequest,
     metadata: Metadata,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   getAllVerificationMessagesByFid(
-    request: TimestampFidRequest,
+    request: FidTimestampRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   /** @http-api: none */
   getAllUserDataMessagesByFid(
-    request: TimestampFidRequest,
+    request: FidTimestampRequest,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   getAllUserDataMessagesByFid(
-    request: TimestampFidRequest,
+    request: FidTimestampRequest,
     metadata: Metadata,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   getAllUserDataMessagesByFid(
-    request: TimestampFidRequest,
+    request: FidTimestampRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   /** @http-api: none */
   getAllLinkMessagesByFid(
-    request: TimestampFidRequest,
+    request: FidTimestampRequest,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   getAllLinkMessagesByFid(
-    request: TimestampFidRequest,
+    request: FidTimestampRequest,
     metadata: Metadata,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
   ): ClientUnaryCall;
   getAllLinkMessagesByFid(
-    request: TimestampFidRequest,
+    request: FidTimestampRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,

--- a/packages/hub-web/src/generated/request_response.ts
+++ b/packages/hub-web/src/generated/request_response.ts
@@ -162,7 +162,7 @@ export interface FidRequest {
   reverse?: boolean | undefined;
 }
 
-export interface TimestampFidRequest {
+export interface FidTimestampRequest {
   fid: number;
   pageSize?: number | undefined;
   pageToken?: Uint8Array | undefined;
@@ -1560,7 +1560,7 @@ export const FidRequest = {
   },
 };
 
-function createBaseTimestampFidRequest(): TimestampFidRequest {
+function createBaseFidTimestampRequest(): FidTimestampRequest {
   return {
     fid: 0,
     pageSize: undefined,
@@ -1571,8 +1571,8 @@ function createBaseTimestampFidRequest(): TimestampFidRequest {
   };
 }
 
-export const TimestampFidRequest = {
-  encode(message: TimestampFidRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+export const FidTimestampRequest = {
+  encode(message: FidTimestampRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.fid !== 0) {
       writer.uint32(8).uint64(message.fid);
     }
@@ -1594,10 +1594,10 @@ export const TimestampFidRequest = {
     return writer;
   },
 
-  decode(input: _m0.Reader | Uint8Array, length?: number): TimestampFidRequest {
+  decode(input: _m0.Reader | Uint8Array, length?: number): FidTimestampRequest {
     const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseTimestampFidRequest();
+    const message = createBaseFidTimestampRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1652,7 +1652,7 @@ export const TimestampFidRequest = {
     return message;
   },
 
-  fromJSON(object: any): TimestampFidRequest {
+  fromJSON(object: any): FidTimestampRequest {
     return {
       fid: isSet(object.fid) ? Number(object.fid) : 0,
       pageSize: isSet(object.pageSize) ? Number(object.pageSize) : undefined,
@@ -1663,7 +1663,7 @@ export const TimestampFidRequest = {
     };
   },
 
-  toJSON(message: TimestampFidRequest): unknown {
+  toJSON(message: FidTimestampRequest): unknown {
     const obj: any = {};
     message.fid !== undefined && (obj.fid = Math.round(message.fid));
     message.pageSize !== undefined && (obj.pageSize = Math.round(message.pageSize));
@@ -1675,12 +1675,12 @@ export const TimestampFidRequest = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<TimestampFidRequest>, I>>(base?: I): TimestampFidRequest {
-    return TimestampFidRequest.fromPartial(base ?? {});
+  create<I extends Exact<DeepPartial<FidTimestampRequest>, I>>(base?: I): FidTimestampRequest {
+    return FidTimestampRequest.fromPartial(base ?? {});
   },
 
-  fromPartial<I extends Exact<DeepPartial<TimestampFidRequest>, I>>(object: I): TimestampFidRequest {
-    const message = createBaseTimestampFidRequest();
+  fromPartial<I extends Exact<DeepPartial<FidTimestampRequest>, I>>(object: I): FidTimestampRequest {
+    const message = createBaseFidTimestampRequest();
     message.fid = object.fid ?? 0;
     message.pageSize = object.pageSize ?? undefined;
     message.pageToken = object.pageToken ?? undefined;

--- a/packages/hub-web/src/generated/request_response.ts
+++ b/packages/hub-web/src/generated/request_response.ts
@@ -162,6 +162,15 @@ export interface FidRequest {
   reverse?: boolean | undefined;
 }
 
+export interface TimestampFidRequest {
+  fid: number;
+  pageSize?: number | undefined;
+  pageToken?: Uint8Array | undefined;
+  reverse?: boolean | undefined;
+  startTimestamp?: number | undefined;
+  stopTimestamp?: number | undefined;
+}
+
 export interface FidsRequest {
   pageSize?: number | undefined;
   pageToken?: Uint8Array | undefined;
@@ -1547,6 +1556,137 @@ export const FidRequest = {
     message.pageSize = object.pageSize ?? undefined;
     message.pageToken = object.pageToken ?? undefined;
     message.reverse = object.reverse ?? undefined;
+    return message;
+  },
+};
+
+function createBaseTimestampFidRequest(): TimestampFidRequest {
+  return {
+    fid: 0,
+    pageSize: undefined,
+    pageToken: undefined,
+    reverse: undefined,
+    startTimestamp: undefined,
+    stopTimestamp: undefined,
+  };
+}
+
+export const TimestampFidRequest = {
+  encode(message: TimestampFidRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.fid !== 0) {
+      writer.uint32(8).uint64(message.fid);
+    }
+    if (message.pageSize !== undefined) {
+      writer.uint32(16).uint32(message.pageSize);
+    }
+    if (message.pageToken !== undefined) {
+      writer.uint32(26).bytes(message.pageToken);
+    }
+    if (message.reverse !== undefined) {
+      writer.uint32(32).bool(message.reverse);
+    }
+    if (message.startTimestamp !== undefined) {
+      writer.uint32(40).uint64(message.startTimestamp);
+    }
+    if (message.stopTimestamp !== undefined) {
+      writer.uint32(48).uint64(message.stopTimestamp);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): TimestampFidRequest {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseTimestampFidRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.fid = longToNumber(reader.uint64() as Long);
+          continue;
+        case 2:
+          if (tag != 16) {
+            break;
+          }
+
+          message.pageSize = reader.uint32();
+          continue;
+        case 3:
+          if (tag != 26) {
+            break;
+          }
+
+          message.pageToken = reader.bytes();
+          continue;
+        case 4:
+          if (tag != 32) {
+            break;
+          }
+
+          message.reverse = reader.bool();
+          continue;
+        case 5:
+          if (tag != 40) {
+            break;
+          }
+
+          message.startTimestamp = longToNumber(reader.uint64() as Long);
+          continue;
+        case 6:
+          if (tag != 48) {
+            break;
+          }
+
+          message.stopTimestamp = longToNumber(reader.uint64() as Long);
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): TimestampFidRequest {
+    return {
+      fid: isSet(object.fid) ? Number(object.fid) : 0,
+      pageSize: isSet(object.pageSize) ? Number(object.pageSize) : undefined,
+      pageToken: isSet(object.pageToken) ? bytesFromBase64(object.pageToken) : undefined,
+      reverse: isSet(object.reverse) ? Boolean(object.reverse) : undefined,
+      startTimestamp: isSet(object.startTimestamp) ? Number(object.startTimestamp) : undefined,
+      stopTimestamp: isSet(object.stopTimestamp) ? Number(object.stopTimestamp) : undefined,
+    };
+  },
+
+  toJSON(message: TimestampFidRequest): unknown {
+    const obj: any = {};
+    message.fid !== undefined && (obj.fid = Math.round(message.fid));
+    message.pageSize !== undefined && (obj.pageSize = Math.round(message.pageSize));
+    message.pageToken !== undefined &&
+      (obj.pageToken = message.pageToken !== undefined ? base64FromBytes(message.pageToken) : undefined);
+    message.reverse !== undefined && (obj.reverse = message.reverse);
+    message.startTimestamp !== undefined && (obj.startTimestamp = Math.round(message.startTimestamp));
+    message.stopTimestamp !== undefined && (obj.stopTimestamp = Math.round(message.stopTimestamp));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<TimestampFidRequest>, I>>(base?: I): TimestampFidRequest {
+    return TimestampFidRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<TimestampFidRequest>, I>>(object: I): TimestampFidRequest {
+    const message = createBaseTimestampFidRequest();
+    message.fid = object.fid ?? 0;
+    message.pageSize = object.pageSize ?? undefined;
+    message.pageToken = object.pageToken ?? undefined;
+    message.reverse = object.reverse ?? undefined;
+    message.startTimestamp = object.startTimestamp ?? undefined;
+    message.stopTimestamp = object.stopTimestamp ?? undefined;
     return message;
   },
 };

--- a/packages/hub-web/src/generated/rpc.ts
+++ b/packages/hub-web/src/generated/rpc.ts
@@ -32,6 +32,7 @@ import {
   SyncIds,
   SyncStatusRequest,
   SyncStatusResponse,
+  TimestampFidRequest,
   TrieNodeMetadataResponse,
   TrieNodePrefix,
   TrieNodeSnapshotResponse,
@@ -131,18 +132,30 @@ export interface HubService {
    * regular endpoints can be used to get all the messages
    * @http-api: none
    */
-  getAllCastMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
-  /** @http-api: none */
-  getAllReactionMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
-  /** @http-api: none */
-  getAllVerificationMessagesByFid(
-    request: DeepPartial<FidRequest>,
+  getAllCastMessagesByFid(
+    request: DeepPartial<TimestampFidRequest>,
     metadata?: grpcWeb.grpc.Metadata,
   ): Promise<MessagesResponse>;
   /** @http-api: none */
-  getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getAllReactionMessagesByFid(
+    request: DeepPartial<TimestampFidRequest>,
+    metadata?: grpcWeb.grpc.Metadata,
+  ): Promise<MessagesResponse>;
   /** @http-api: none */
-  getAllLinkMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse>;
+  getAllVerificationMessagesByFid(
+    request: DeepPartial<TimestampFidRequest>,
+    metadata?: grpcWeb.grpc.Metadata,
+  ): Promise<MessagesResponse>;
+  /** @http-api: none */
+  getAllUserDataMessagesByFid(
+    request: DeepPartial<TimestampFidRequest>,
+    metadata?: grpcWeb.grpc.Metadata,
+  ): Promise<MessagesResponse>;
+  /** @http-api: none */
+  getAllLinkMessagesByFid(
+    request: DeepPartial<TimestampFidRequest>,
+    metadata?: grpcWeb.grpc.Metadata,
+  ): Promise<MessagesResponse>;
   /** @http-api: none */
   getLinkCompactStateMessageByFid(
     request: DeepPartial<FidRequest>,
@@ -354,27 +367,51 @@ export class HubServiceClientImpl implements HubService {
     return this.rpc.unary(HubServiceGetLinksByTargetDesc, LinksByTargetRequest.fromPartial(request), metadata);
   }
 
-  getAllCastMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
-    return this.rpc.unary(HubServiceGetAllCastMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
+  getAllCastMessagesByFid(
+    request: DeepPartial<TimestampFidRequest>,
+    metadata?: grpcWeb.grpc.Metadata,
+  ): Promise<MessagesResponse> {
+    return this.rpc.unary(HubServiceGetAllCastMessagesByFidDesc, TimestampFidRequest.fromPartial(request), metadata);
   }
 
-  getAllReactionMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
-    return this.rpc.unary(HubServiceGetAllReactionMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
+  getAllReactionMessagesByFid(
+    request: DeepPartial<TimestampFidRequest>,
+    metadata?: grpcWeb.grpc.Metadata,
+  ): Promise<MessagesResponse> {
+    return this.rpc.unary(
+      HubServiceGetAllReactionMessagesByFidDesc,
+      TimestampFidRequest.fromPartial(request),
+      metadata,
+    );
   }
 
   getAllVerificationMessagesByFid(
-    request: DeepPartial<FidRequest>,
+    request: DeepPartial<TimestampFidRequest>,
     metadata?: grpcWeb.grpc.Metadata,
   ): Promise<MessagesResponse> {
-    return this.rpc.unary(HubServiceGetAllVerificationMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
+    return this.rpc.unary(
+      HubServiceGetAllVerificationMessagesByFidDesc,
+      TimestampFidRequest.fromPartial(request),
+      metadata,
+    );
   }
 
-  getAllUserDataMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
-    return this.rpc.unary(HubServiceGetAllUserDataMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
+  getAllUserDataMessagesByFid(
+    request: DeepPartial<TimestampFidRequest>,
+    metadata?: grpcWeb.grpc.Metadata,
+  ): Promise<MessagesResponse> {
+    return this.rpc.unary(
+      HubServiceGetAllUserDataMessagesByFidDesc,
+      TimestampFidRequest.fromPartial(request),
+      metadata,
+    );
   }
 
-  getAllLinkMessagesByFid(request: DeepPartial<FidRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<MessagesResponse> {
-    return this.rpc.unary(HubServiceGetAllLinkMessagesByFidDesc, FidRequest.fromPartial(request), metadata);
+  getAllLinkMessagesByFid(
+    request: DeepPartial<TimestampFidRequest>,
+    metadata?: grpcWeb.grpc.Metadata,
+  ): Promise<MessagesResponse> {
+    return this.rpc.unary(HubServiceGetAllLinkMessagesByFidDesc, TimestampFidRequest.fromPartial(request), metadata);
   }
 
   getLinkCompactStateMessageByFid(
@@ -1080,7 +1117,7 @@ export const HubServiceGetAllCastMessagesByFidDesc: UnaryMethodDefinitionish = {
   responseStream: false,
   requestType: {
     serializeBinary() {
-      return FidRequest.encode(this).finish();
+      return TimestampFidRequest.encode(this).finish();
     },
   } as any,
   responseType: {
@@ -1103,7 +1140,7 @@ export const HubServiceGetAllReactionMessagesByFidDesc: UnaryMethodDefinitionish
   responseStream: false,
   requestType: {
     serializeBinary() {
-      return FidRequest.encode(this).finish();
+      return TimestampFidRequest.encode(this).finish();
     },
   } as any,
   responseType: {
@@ -1126,7 +1163,7 @@ export const HubServiceGetAllVerificationMessagesByFidDesc: UnaryMethodDefinitio
   responseStream: false,
   requestType: {
     serializeBinary() {
-      return FidRequest.encode(this).finish();
+      return TimestampFidRequest.encode(this).finish();
     },
   } as any,
   responseType: {
@@ -1149,7 +1186,7 @@ export const HubServiceGetAllUserDataMessagesByFidDesc: UnaryMethodDefinitionish
   responseStream: false,
   requestType: {
     serializeBinary() {
-      return FidRequest.encode(this).finish();
+      return TimestampFidRequest.encode(this).finish();
     },
   } as any,
   responseType: {
@@ -1172,7 +1209,7 @@ export const HubServiceGetAllLinkMessagesByFidDesc: UnaryMethodDefinitionish = {
   responseStream: false,
   requestType: {
     serializeBinary() {
-      return FidRequest.encode(this).finish();
+      return TimestampFidRequest.encode(this).finish();
     },
   } as any,
   responseType: {

--- a/packages/hub-web/src/generated/rpc.ts
+++ b/packages/hub-web/src/generated/rpc.ts
@@ -14,6 +14,7 @@ import {
   FidRequest,
   FidsRequest,
   FidsResponse,
+  FidTimestampRequest,
   HubInfoRequest,
   HubInfoResponse,
   IdRegistryEventByAddressRequest,
@@ -32,7 +33,6 @@ import {
   SyncIds,
   SyncStatusRequest,
   SyncStatusResponse,
-  TimestampFidRequest,
   TrieNodeMetadataResponse,
   TrieNodePrefix,
   TrieNodeSnapshotResponse,
@@ -133,27 +133,27 @@ export interface HubService {
    * @http-api: none
    */
   getAllCastMessagesByFid(
-    request: DeepPartial<TimestampFidRequest>,
+    request: DeepPartial<FidTimestampRequest>,
     metadata?: grpcWeb.grpc.Metadata,
   ): Promise<MessagesResponse>;
   /** @http-api: none */
   getAllReactionMessagesByFid(
-    request: DeepPartial<TimestampFidRequest>,
+    request: DeepPartial<FidTimestampRequest>,
     metadata?: grpcWeb.grpc.Metadata,
   ): Promise<MessagesResponse>;
   /** @http-api: none */
   getAllVerificationMessagesByFid(
-    request: DeepPartial<TimestampFidRequest>,
+    request: DeepPartial<FidTimestampRequest>,
     metadata?: grpcWeb.grpc.Metadata,
   ): Promise<MessagesResponse>;
   /** @http-api: none */
   getAllUserDataMessagesByFid(
-    request: DeepPartial<TimestampFidRequest>,
+    request: DeepPartial<FidTimestampRequest>,
     metadata?: grpcWeb.grpc.Metadata,
   ): Promise<MessagesResponse>;
   /** @http-api: none */
   getAllLinkMessagesByFid(
-    request: DeepPartial<TimestampFidRequest>,
+    request: DeepPartial<FidTimestampRequest>,
     metadata?: grpcWeb.grpc.Metadata,
   ): Promise<MessagesResponse>;
   /** @http-api: none */
@@ -368,50 +368,50 @@ export class HubServiceClientImpl implements HubService {
   }
 
   getAllCastMessagesByFid(
-    request: DeepPartial<TimestampFidRequest>,
+    request: DeepPartial<FidTimestampRequest>,
     metadata?: grpcWeb.grpc.Metadata,
   ): Promise<MessagesResponse> {
-    return this.rpc.unary(HubServiceGetAllCastMessagesByFidDesc, TimestampFidRequest.fromPartial(request), metadata);
+    return this.rpc.unary(HubServiceGetAllCastMessagesByFidDesc, FidTimestampRequest.fromPartial(request), metadata);
   }
 
   getAllReactionMessagesByFid(
-    request: DeepPartial<TimestampFidRequest>,
+    request: DeepPartial<FidTimestampRequest>,
     metadata?: grpcWeb.grpc.Metadata,
   ): Promise<MessagesResponse> {
     return this.rpc.unary(
       HubServiceGetAllReactionMessagesByFidDesc,
-      TimestampFidRequest.fromPartial(request),
+      FidTimestampRequest.fromPartial(request),
       metadata,
     );
   }
 
   getAllVerificationMessagesByFid(
-    request: DeepPartial<TimestampFidRequest>,
+    request: DeepPartial<FidTimestampRequest>,
     metadata?: grpcWeb.grpc.Metadata,
   ): Promise<MessagesResponse> {
     return this.rpc.unary(
       HubServiceGetAllVerificationMessagesByFidDesc,
-      TimestampFidRequest.fromPartial(request),
+      FidTimestampRequest.fromPartial(request),
       metadata,
     );
   }
 
   getAllUserDataMessagesByFid(
-    request: DeepPartial<TimestampFidRequest>,
+    request: DeepPartial<FidTimestampRequest>,
     metadata?: grpcWeb.grpc.Metadata,
   ): Promise<MessagesResponse> {
     return this.rpc.unary(
       HubServiceGetAllUserDataMessagesByFidDesc,
-      TimestampFidRequest.fromPartial(request),
+      FidTimestampRequest.fromPartial(request),
       metadata,
     );
   }
 
   getAllLinkMessagesByFid(
-    request: DeepPartial<TimestampFidRequest>,
+    request: DeepPartial<FidTimestampRequest>,
     metadata?: grpcWeb.grpc.Metadata,
   ): Promise<MessagesResponse> {
-    return this.rpc.unary(HubServiceGetAllLinkMessagesByFidDesc, TimestampFidRequest.fromPartial(request), metadata);
+    return this.rpc.unary(HubServiceGetAllLinkMessagesByFidDesc, FidTimestampRequest.fromPartial(request), metadata);
   }
 
   getLinkCompactStateMessageByFid(
@@ -1117,7 +1117,7 @@ export const HubServiceGetAllCastMessagesByFidDesc: UnaryMethodDefinitionish = {
   responseStream: false,
   requestType: {
     serializeBinary() {
-      return TimestampFidRequest.encode(this).finish();
+      return FidTimestampRequest.encode(this).finish();
     },
   } as any,
   responseType: {
@@ -1140,7 +1140,7 @@ export const HubServiceGetAllReactionMessagesByFidDesc: UnaryMethodDefinitionish
   responseStream: false,
   requestType: {
     serializeBinary() {
-      return TimestampFidRequest.encode(this).finish();
+      return FidTimestampRequest.encode(this).finish();
     },
   } as any,
   responseType: {
@@ -1163,7 +1163,7 @@ export const HubServiceGetAllVerificationMessagesByFidDesc: UnaryMethodDefinitio
   responseStream: false,
   requestType: {
     serializeBinary() {
-      return TimestampFidRequest.encode(this).finish();
+      return FidTimestampRequest.encode(this).finish();
     },
   } as any,
   responseType: {
@@ -1186,7 +1186,7 @@ export const HubServiceGetAllUserDataMessagesByFidDesc: UnaryMethodDefinitionish
   responseStream: false,
   requestType: {
     serializeBinary() {
-      return TimestampFidRequest.encode(this).finish();
+      return FidTimestampRequest.encode(this).finish();
     },
   } as any,
   responseType: {
@@ -1209,7 +1209,7 @@ export const HubServiceGetAllLinkMessagesByFidDesc: UnaryMethodDefinitionish = {
   responseStream: false,
   requestType: {
     serializeBinary() {
-      return TimestampFidRequest.encode(this).finish();
+      return FidTimestampRequest.encode(this).finish();
     },
   } as any,
   responseType: {

--- a/protobufs/schemas/request_response.proto
+++ b/protobufs/schemas/request_response.proto
@@ -92,6 +92,15 @@ message FidRequest {
   optional bool reverse = 4;
 }
 
+message TimestampFidRequest {
+  uint64 fid = 1;
+  optional uint32 page_size = 2;
+  optional bytes page_token = 3;
+  optional bool reverse = 4;
+  optional uint64 start_timestamp = 5;
+  optional uint64 stop_timestamp = 6;
+}
+
 message FidsRequest {
   optional uint32 page_size = 1;
   optional bytes page_token = 2;

--- a/protobufs/schemas/request_response.proto
+++ b/protobufs/schemas/request_response.proto
@@ -92,7 +92,7 @@ message FidRequest {
   optional bool reverse = 4;
 }
 
-message TimestampFidRequest {
+message FidTimestampRequest {
   uint64 fid = 1;
   optional uint32 page_size = 2;
   optional bytes page_token = 3;

--- a/protobufs/schemas/rpc.proto
+++ b/protobufs/schemas/rpc.proto
@@ -82,15 +82,15 @@ service HubService {
   // The Bulk methods don't have corresponding HTTP API endpoints because the 
   // regular endpoints can be used to get all the messages
   // @http-api: none
-  rpc GetAllCastMessagesByFid(TimestampFidRequest) returns (MessagesResponse);
+  rpc GetAllCastMessagesByFid(FidTimestampRequest) returns (MessagesResponse);
   // @http-api: none
-  rpc GetAllReactionMessagesByFid(TimestampFidRequest) returns (MessagesResponse);
+  rpc GetAllReactionMessagesByFid(FidTimestampRequest) returns (MessagesResponse);
   // @http-api: none
-  rpc GetAllVerificationMessagesByFid(TimestampFidRequest) returns (MessagesResponse);
+  rpc GetAllVerificationMessagesByFid(FidTimestampRequest) returns (MessagesResponse);
   // @http-api: none
-  rpc GetAllUserDataMessagesByFid(TimestampFidRequest) returns (MessagesResponse);
+  rpc GetAllUserDataMessagesByFid(FidTimestampRequest) returns (MessagesResponse);
   // @http-api: none
-  rpc GetAllLinkMessagesByFid(TimestampFidRequest) returns (MessagesResponse);
+  rpc GetAllLinkMessagesByFid(FidTimestampRequest) returns (MessagesResponse);
   // @http-api: none
   rpc GetLinkCompactStateMessageByFid(FidRequest) returns (MessagesResponse);
 

--- a/protobufs/schemas/rpc.proto
+++ b/protobufs/schemas/rpc.proto
@@ -82,15 +82,15 @@ service HubService {
   // The Bulk methods don't have corresponding HTTP API endpoints because the 
   // regular endpoints can be used to get all the messages
   // @http-api: none
-  rpc GetAllCastMessagesByFid(FidRequest) returns (MessagesResponse);
+  rpc GetAllCastMessagesByFid(TimestampFidRequest) returns (MessagesResponse);
   // @http-api: none
-  rpc GetAllReactionMessagesByFid(FidRequest) returns (MessagesResponse);
+  rpc GetAllReactionMessagesByFid(TimestampFidRequest) returns (MessagesResponse);
   // @http-api: none
-  rpc GetAllVerificationMessagesByFid(FidRequest) returns (MessagesResponse);
+  rpc GetAllVerificationMessagesByFid(TimestampFidRequest) returns (MessagesResponse);
   // @http-api: none
-  rpc GetAllUserDataMessagesByFid(FidRequest) returns (MessagesResponse);
+  rpc GetAllUserDataMessagesByFid(TimestampFidRequest) returns (MessagesResponse);
   // @http-api: none
-  rpc GetAllLinkMessagesByFid(FidRequest) returns (MessagesResponse);
+  rpc GetAllLinkMessagesByFid(TimestampFidRequest) returns (MessagesResponse);
   // @http-api: none
   rpc GetLinkCompactStateMessageByFid(FidRequest) returns (MessagesResponse);
 


### PR DESCRIPTION
We want to be able to restrict the reconciliation job's queries to a time range of e.g. past 1-2 weeks to reduce the amount of read load on hubs. The most expensive part of the read operation is serializing the protobufs to send back to the callee and that's what we want to save on. 

Notes for reviewers:
- There are ways to optimize the time query by (1) using the indexes (2) starting at the common prefix of the start and stop time rather than iterating all the results for the fid. I think it's not worth pursuing these optimizations until we have evidence that we need them. The simple solution implemented here will eliminate the protobuf serialization and significantly less risky than the more optimized solutions. 
- `getUserDataByFid` and `getAllUserDataMessagesByFid` have the exact same implementation. I added time ranges to the one we classified as a bulk rpc but not the other one. We should consider eliminating one of these rpcs.  
- I didn't add a time range for the link compaction bulk query because (1) we don't query for link compaction messages in reconciliation (2) it seems like we don't store a lot of link compaction state-- each new link compaction message for an fid replaces the older one. 
- I'm not sure we need the time filter for user data, but I added it anyway. Happy to remove if it seems like a bad complexity tradeoff. 
- The rpc protocol change is backwards compatible. I copied the format for `TimestampFidRequest` from `FidRequest` and added new optional parameters. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds start/stop time filters for bulk queries and validation methods for time inputs.

### Detailed summary
- Added start/stop time filters for bulk queries in various modules
- Implemented validation methods for farcaster time inputs

> The following files were skipped due to too many changes: `apps/hubble/src/addon/src/store/store.rs`, `apps/hubble/src/rpc/server.ts`, `packages/hub-web/src/generated/request_response.ts`, `packages/hub-nodejs/src/generated/request_response.ts`, `packages/core/src/protobufs/generated/request_response.ts`, `packages/hub-web/src/generated/rpc.ts`, `apps/hubble/src/storage/engine/index.ts`, `packages/hub-nodejs/src/generated/rpc.ts`, `apps/hubble/src/rpc/test/bulkService.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->