### PR TITLE
feat: Implement storage extension FIP

### DIFF
--- a/.changeset/smooth-crews-burn.md
+++ b/.changeset/smooth-crews-burn.md
@@ -1,0 +1,8 @@
+---
+"@farcaster/hub-nodejs": minor
+"@farcaster/hub-web": minor
+"@farcaster/core": minor
+"@farcaster/hubble": patch
+---
+
+feat: Implement Storage Extension FIP

--- a/apps/hubble/src/rpc/test/server.test.ts
+++ b/apps/hubble/src/rpc/test/server.test.ts
@@ -66,7 +66,7 @@ beforeEach(async () => {
   custodyEvent = Factories.IdRegistryOnChainEvent.build({ fid }, { transient: { to: custodySignerKey } });
   signerEvent = Factories.SignerOnChainEvent.build({ fid }, { transient: { signer: signerKey } });
   storageEvent = Factories.StorageRentOnChainEvent.build(
-    { fid, blockTimestamp: LEGACY_STORAGE_UNIT_CUTOFF_TIMESTAMP + 1 },
+    { fid, blockTimestamp: LEGACY_STORAGE_UNIT_CUTOFF_TIMESTAMP - 1 },
     { transient: { units: 1 } },
   );
   await engine.mergeOnChainEvent(custodyEvent);
@@ -146,7 +146,7 @@ describe("server rpc tests", () => {
       const storageLimits = limitsResponse.limits;
       expect(storageLimits).toContainEqual(
         StorageLimit.create({
-          limit: getDefaultStoreLimit(StoreType.CASTS, StorageUnitType.UNIT_TYPE_2024),
+          limit: getDefaultStoreLimit(StoreType.CASTS, StorageUnitType.UNIT_TYPE_LEGACY),
           storeType: StoreType.CASTS,
           name: "CASTS",
           used: 2,
@@ -156,7 +156,7 @@ describe("server rpc tests", () => {
       );
       expect(storageLimits).toContainEqual(
         StorageLimit.create({
-          limit: getDefaultStoreLimit(StoreType.REACTIONS, StorageUnitType.UNIT_TYPE_2024),
+          limit: getDefaultStoreLimit(StoreType.REACTIONS, StorageUnitType.UNIT_TYPE_LEGACY),
           storeType: StoreType.REACTIONS,
           name: "REACTIONS",
           used: 0,
@@ -166,7 +166,7 @@ describe("server rpc tests", () => {
       );
       expect(storageLimits).toContainEqual(
         StorageLimit.create({
-          limit: getDefaultStoreLimit(StoreType.LINKS, StorageUnitType.UNIT_TYPE_2024),
+          limit: getDefaultStoreLimit(StoreType.LINKS, StorageUnitType.UNIT_TYPE_LEGACY),
           storeType: StoreType.LINKS,
           name: "LINKS",
           used: 0,
@@ -176,7 +176,7 @@ describe("server rpc tests", () => {
       );
       expect(storageLimits).toContainEqual(
         StorageLimit.create({
-          limit: getDefaultStoreLimit(StoreType.USER_DATA, StorageUnitType.UNIT_TYPE_2024),
+          limit: getDefaultStoreLimit(StoreType.USER_DATA, StorageUnitType.UNIT_TYPE_LEGACY),
           storeType: StoreType.USER_DATA,
           name: "USER_DATA",
           used: 0,
@@ -186,7 +186,7 @@ describe("server rpc tests", () => {
       );
       expect(storageLimits).toContainEqual(
         StorageLimit.create({
-          limit: getDefaultStoreLimit(StoreType.VERIFICATIONS, StorageUnitType.UNIT_TYPE_2024),
+          limit: getDefaultStoreLimit(StoreType.VERIFICATIONS, StorageUnitType.UNIT_TYPE_LEGACY),
           storeType: StoreType.VERIFICATIONS,
           name: "VERIFICATIONS",
           used: 1,
@@ -196,7 +196,7 @@ describe("server rpc tests", () => {
       );
       expect(storageLimits).toContainEqual(
         StorageLimit.create({
-          limit: getDefaultStoreLimit(StoreType.USERNAME_PROOFS, StorageUnitType.UNIT_TYPE_2024),
+          limit: getDefaultStoreLimit(StoreType.USERNAME_PROOFS, StorageUnitType.UNIT_TYPE_LEGACY),
           storeType: StoreType.USERNAME_PROOFS,
           name: "USERNAME_PROOFS",
           used: 0,
@@ -218,7 +218,11 @@ describe("server rpc tests", () => {
       const newLimits = limitsResponse2.limits;
       expect(newLimits.length).toEqual(6);
       for (const limit of newLimits) {
-        expect(limit.limit).toEqual(getDefaultStoreLimit(limit.storeType, StorageUnitType.UNIT_TYPE_2024) * 3);
+        // 1 unit of legacy storage from the first event, 2 units of 2024 storage from the second event
+        const expectedLimit =
+          getDefaultStoreLimit(limit.storeType, StorageUnitType.UNIT_TYPE_LEGACY) +
+          getDefaultStoreLimit(limit.storeType, StorageUnitType.UNIT_TYPE_2024) * 2;
+        expect(limit.limit).toEqual(expectedLimit);
       }
     });
   });

--- a/apps/hubble/src/rpc/test/server.test.ts
+++ b/apps/hubble/src/rpc/test/server.test.ts
@@ -15,6 +15,7 @@ import {
   StoreType,
   getDefaultStoreLimit,
   HubError,
+  StorageUnitType,
 } from "@farcaster/hub-nodejs";
 import Engine from "../../storage/engine/index.js";
 import { MockHub } from "../../test/mocks.js";
@@ -141,7 +142,7 @@ describe("server rpc tests", () => {
       const storageLimits = limitsResponse.limits;
       expect(storageLimits).toContainEqual(
         StorageLimit.create({
-          limit: getDefaultStoreLimit(StoreType.CASTS),
+          limit: getDefaultStoreLimit(StoreType.CASTS, StorageUnitType.UNIT_TYPE_2024),
           storeType: StoreType.CASTS,
           name: "CASTS",
           used: 2,
@@ -151,7 +152,7 @@ describe("server rpc tests", () => {
       );
       expect(storageLimits).toContainEqual(
         StorageLimit.create({
-          limit: getDefaultStoreLimit(StoreType.REACTIONS),
+          limit: getDefaultStoreLimit(StoreType.REACTIONS, StorageUnitType.UNIT_TYPE_2024),
           storeType: StoreType.REACTIONS,
           name: "REACTIONS",
           used: 0,
@@ -161,7 +162,7 @@ describe("server rpc tests", () => {
       );
       expect(storageLimits).toContainEqual(
         StorageLimit.create({
-          limit: getDefaultStoreLimit(StoreType.LINKS),
+          limit: getDefaultStoreLimit(StoreType.LINKS, StorageUnitType.UNIT_TYPE_2024),
           storeType: StoreType.LINKS,
           name: "LINKS",
           used: 0,
@@ -171,7 +172,7 @@ describe("server rpc tests", () => {
       );
       expect(storageLimits).toContainEqual(
         StorageLimit.create({
-          limit: getDefaultStoreLimit(StoreType.USER_DATA),
+          limit: getDefaultStoreLimit(StoreType.USER_DATA, StorageUnitType.UNIT_TYPE_2024),
           storeType: StoreType.USER_DATA,
           name: "USER_DATA",
           used: 0,
@@ -181,7 +182,7 @@ describe("server rpc tests", () => {
       );
       expect(storageLimits).toContainEqual(
         StorageLimit.create({
-          limit: getDefaultStoreLimit(StoreType.VERIFICATIONS),
+          limit: getDefaultStoreLimit(StoreType.VERIFICATIONS, StorageUnitType.UNIT_TYPE_2024),
           storeType: StoreType.VERIFICATIONS,
           name: "VERIFICATIONS",
           used: 1,
@@ -191,7 +192,7 @@ describe("server rpc tests", () => {
       );
       expect(storageLimits).toContainEqual(
         StorageLimit.create({
-          limit: getDefaultStoreLimit(StoreType.USERNAME_PROOFS),
+          limit: getDefaultStoreLimit(StoreType.USERNAME_PROOFS, StorageUnitType.UNIT_TYPE_2024),
           storeType: StoreType.USERNAME_PROOFS,
           name: "USERNAME_PROOFS",
           used: 0,
@@ -212,7 +213,7 @@ describe("server rpc tests", () => {
       const newLimits = limitsResponse2.limits;
       expect(newLimits.length).toEqual(6);
       for (const limit of newLimits) {
-        expect(limit.limit).toEqual(getDefaultStoreLimit(limit.storeType) * 3);
+        expect(limit.limit).toEqual(getDefaultStoreLimit(limit.storeType, StorageUnitType.UNIT_TYPE_2024) * 3);
       }
     });
   });

--- a/apps/hubble/src/rustfunctions.ts
+++ b/apps/hubble/src/rustfunctions.ts
@@ -411,9 +411,9 @@ export const rsPruneMessages = async (
   store: RustDynStore,
   fid: number,
   cachedCount: number,
-  units: number,
+  maxCount: number,
 ): Promise<Buffer> => {
-  return await lib.pruneMessages.call(store, fid, cachedCount, units);
+  return await lib.pruneMessages.call(store, fid, cachedCount, maxCount);
 };
 
 export const rsGetAllMessagesByFid = async (

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -173,15 +173,14 @@ class Engine extends TypedEmitter<EngineEvents> {
     this._onchainEventsStore = new OnChainEventStore(db, this.eventHandler);
     this._usernameProofStore = new UsernameProofStore(db, this.eventHandler);
 
-    // Calculate total storage available per unit of store. Note that OnChainEventStore
-    // is not included in this calculation because it is not pruned.
+    // Total set size for all stores. We should probably reduce this to just the size of the cast store.
     this._totalPruneSize =
-      this._linkStore.pruneSizeLimit +
-      this._reactionStore.pruneSizeLimit +
-      this._castStore.pruneSizeLimit +
-      this._userDataStore.pruneSizeLimit +
-      this._verificationStore.pruneSizeLimit +
-      this._usernameProofStore.pruneSizeLimit;
+      getDefaultStoreLimit(StoreType.CASTS, StorageUnitType.UNIT_TYPE_LEGACY) +
+      getDefaultStoreLimit(StoreType.LINKS, StorageUnitType.UNIT_TYPE_LEGACY) +
+      getDefaultStoreLimit(StoreType.REACTIONS, StorageUnitType.UNIT_TYPE_LEGACY) +
+      getDefaultStoreLimit(StoreType.USER_DATA, StorageUnitType.UNIT_TYPE_LEGACY) +
+      getDefaultStoreLimit(StoreType.USERNAME_PROOFS, StorageUnitType.UNIT_TYPE_LEGACY) +
+      getDefaultStoreLimit(StoreType.VERIFICATIONS, StorageUnitType.UNIT_TYPE_LEGACY);
 
     log.info({ totalPruneSize: this._totalPruneSize }, "total default storage limit size");
 

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -38,6 +38,7 @@ import {
   SignerOnChainEvent,
   StorageLimit,
   StorageLimitsResponse,
+  StorageUnitType,
   StoreType,
   UserDataAddMessage,
   UserDataType,
@@ -51,9 +52,9 @@ import {
 import { err, ok, ResultAsync } from "neverthrow";
 import fs from "fs";
 import { Worker } from "worker_threads";
-import { forEachMessageBySigner, makeUserKey, messageDecode, typeToSetPostfix } from "../db/message.js";
+import { forEachMessageBySigner, typeToSetPostfix } from "../db/message.js";
 import RocksDB from "../db/rocksdb.js";
-import { UserMessagePostfixMax, UserPostfix } from "../db/types.js";
+import { UserPostfix } from "../db/types.js";
 import CastStore from "../stores/castStore.js";
 import LinkStore from "../stores/linkStore.js";
 import ReactionStore from "../stores/reactionStore.js";
@@ -292,20 +293,22 @@ class Engine extends TypedEmitter<EngineEvents> {
 
         // Extract the FID that this message was signed by
         const fid = message.data?.fid ?? 0;
-        const storageUnits = await this.eventHandler.getCurrentStorageUnitsForFid(fid);
+        const storageSlot = await this.eventHandler.getCurrentStorageSlotForFid(fid);
 
-        if (storageUnits.isErr()) {
-          mergeResults.set(i, err(storageUnits.error));
+        if (storageSlot.isErr()) {
+          mergeResults.set(i, err(storageSlot.error));
           return;
         }
 
-        if (storageUnits.value === 0) {
+        const totalUnits = storageSlot.value.legacy_units + storageSlot.value.units;
+
+        if (totalUnits === 0) {
           mergeResults.set(i, err(new HubError("bad_request.prunable", "no storage")));
           return;
         }
 
         // We rate limit the number of messages that can be merged per FID
-        const limiter = getRateLimiterForTotalMessages(storageUnits.value * this._totalPruneSize);
+        const limiter = getRateLimiterForTotalMessages(totalUnits * this._totalPruneSize);
         const isRateLimited = await isRateLimitedByKey(`${fid}`, limiter);
         if (isRateLimited) {
           log.warn({ fid }, "rate limit exceeded for FID");
@@ -861,13 +864,17 @@ class Engine extends TypedEmitter<EngineEvents> {
       return err(validatedFid.error);
     }
 
-    const units = await this.eventHandler.getCurrentStorageUnitsForFid(fid);
+    const slot = await this.eventHandler.getCurrentStorageSlotForFid(fid);
 
-    if (units.isErr()) {
-      return err(units.error);
+    if (slot.isErr()) {
+      return err(slot.error);
     }
 
-    const storeLimits = getStoreLimits(units.value);
+    const unitDetails = [
+      { unitType: StorageUnitType.UNIT_TYPE_LEGACY, unitSize: slot.value.legacy_units },
+      { unitType: StorageUnitType.UNIT_TYPE_2024, unitSize: slot.value.units },
+    ];
+    const storeLimits = getStoreLimits(unitDetails);
     const limits: StorageLimit[] = [];
     for (const limit of storeLimits) {
       const usageResult = await this.eventHandler.getUsage(fid, limit.storeType);
@@ -887,8 +894,9 @@ class Engine extends TypedEmitter<EngineEvents> {
       );
     }
     return ok({
-      units: units.value,
+      units: slot.value.units + slot.value.legacy_units,
       limits: limits,
+      unitDetails: unitDetails,
     });
   }
 
@@ -1193,7 +1201,8 @@ class Engine extends TypedEmitter<EngineEvents> {
     // LinkCompactStateMessages can't be more than 100 storage units
     if (
       isLinkCompactStateMessage(message) &&
-      message.data.linkCompactStateBody.targetFids.length > getDefaultStoreLimit(StoreType.LINKS) * 100
+      message.data.linkCompactStateBody.targetFids.length >
+        getDefaultStoreLimit(StoreType.LINKS, StorageUnitType.UNIT_TYPE_LEGACY) * 100
     ) {
       return err(
         new HubError("bad_request.validation_failure", "LinkCompactStateMessage is too big. Limit = 100 storage units"),

--- a/apps/hubble/src/storage/jobs/pruneMessagesJob.test.ts
+++ b/apps/hubble/src/storage/jobs/pruneMessagesJob.test.ts
@@ -6,6 +6,7 @@ import {
   Message,
   MessageType,
   PruneMessageHubEvent,
+  StorageUnitType,
   StoreType,
 } from "@farcaster/hub-nodejs";
 import { jestRocksDB } from "../db/jestUtils.js";
@@ -32,7 +33,7 @@ const seedMessagesFromTimestamp = async (engine: Engine, fid: number, signer: Ed
   );
   const linkAdd = await Factories.LinkAddMessage.create({ data: { fid, timestamp } }, { transient: { signer } });
   const proofs = await Factories.VerificationAddEthAddressMessage.createList(
-    getDefaultStoreLimit(StoreType.VERIFICATIONS) + 1,
+    getDefaultStoreLimit(StoreType.VERIFICATIONS, StorageUnitType.UNIT_TYPE_2024) + 1,
     { data: { fid, timestamp } },
     { transient: { signer } },
   );
@@ -109,7 +110,7 @@ describe("doJobs", () => {
 
         const verifications = await engine.getVerificationsByFid(fid);
         expect(verifications._unsafeUnwrap().messages.length).toEqual(
-          getDefaultStoreLimit(StoreType.VERIFICATIONS) + 1,
+          getDefaultStoreLimit(StoreType.VERIFICATIONS, StorageUnitType.UNIT_TYPE_2024) + 1,
         );
       }
 

--- a/apps/hubble/src/storage/stores/castStore.ts
+++ b/apps/hubble/src/storage/stores/castStore.ts
@@ -1,4 +1,4 @@
-import { CastAddMessage, CastId, CastRemoveMessage, getDefaultStoreLimit, StoreType } from "@farcaster/hub-nodejs";
+import { CastAddMessage, CastId, CastRemoveMessage } from "@farcaster/hub-nodejs";
 import { ResultAsync } from "neverthrow";
 import RocksDB from "../db/rocksdb.js";
 import { UserPostfix } from "../db/types.js";
@@ -19,7 +19,7 @@ import { messageDecode } from "../../storage/db/message.js";
 
 class CastStore extends RustStoreBase<CastAddMessage, CastRemoveMessage> {
   constructor(db: RocksDB, eventHandler: StoreEventHandler, options: StorePruneOptions = {}) {
-    const pruneSizeLimit = options.pruneSizeLimit ?? getDefaultStoreLimit(StoreType.CASTS);
+    const pruneSizeLimit = options.pruneSizeLimit ?? 0;
     const rustCastStore = rsCreateCastStore(db.rustDb, eventHandler.getRustStoreEventHandler(), pruneSizeLimit);
 
     super(db, rustCastStore, UserPostfix.CastMessage, eventHandler, pruneSizeLimit);

--- a/apps/hubble/src/storage/stores/linkStore.ts
+++ b/apps/hubble/src/storage/stores/linkStore.ts
@@ -1,10 +1,4 @@
-import {
-  getDefaultStoreLimit,
-  LinkAddMessage,
-  LinkCompactStateMessage,
-  LinkRemoveMessage,
-  StoreType,
-} from "@farcaster/hub-nodejs";
+import { LinkAddMessage, LinkCompactStateMessage, LinkRemoveMessage } from "@farcaster/hub-nodejs";
 import { makeFidKey, messageDecode } from "../../storage/db/message.js";
 import { UserPostfix } from "../db/types.js";
 import { MessagesPage, PageOptions, StorePruneOptions } from "./types.js";
@@ -38,7 +32,7 @@ import storeEventHandler from "./storeEventHandler.js";
  */
 class LinkStore extends RustStoreBase<LinkAddMessage, LinkRemoveMessage> {
   constructor(db: RocksDB, eventHandler: storeEventHandler, options: StorePruneOptions = {}) {
-    const pruneSizeLimit = options.pruneSizeLimit ?? getDefaultStoreLimit(StoreType.LINKS);
+    const pruneSizeLimit = options.pruneSizeLimit ?? 0;
     const rustReactionStore = rsLinkStore.CreateLinkStore(
       db.rustDb,
       eventHandler.getRustStoreEventHandler(),

--- a/apps/hubble/src/storage/stores/reactionStore.ts
+++ b/apps/hubble/src/storage/stores/reactionStore.ts
@@ -1,12 +1,4 @@
-import {
-  CastId,
-  Message,
-  ReactionAddMessage,
-  ReactionRemoveMessage,
-  ReactionType,
-  StoreType,
-  getDefaultStoreLimit,
-} from "@farcaster/hub-nodejs";
+import { CastId, ReactionAddMessage, ReactionRemoveMessage, ReactionType } from "@farcaster/hub-nodejs";
 import {
   rsCreateReactionStore,
   rsGetReactionAdd,
@@ -26,7 +18,7 @@ import { messageDecode } from "../../storage/db/message.js";
 
 class ReactionStore extends RustStoreBase<ReactionAddMessage, ReactionRemoveMessage> {
   constructor(db: RocksDB, eventHandler: StoreEventHandler, options: StorePruneOptions = {}) {
-    const pruneSizeLimit = options.pruneSizeLimit ?? getDefaultStoreLimit(StoreType.REACTIONS);
+    const pruneSizeLimit = options.pruneSizeLimit ?? 0;
     const rustReactionStore = rsCreateReactionStore(db.rustDb, eventHandler.getRustStoreEventHandler(), pruneSizeLimit);
 
     super(db, rustReactionStore, UserPostfix.ReactionMessage, eventHandler, pruneSizeLimit);

--- a/apps/hubble/src/storage/stores/rustStoreBase.ts
+++ b/apps/hubble/src/storage/stores/rustStoreBase.ts
@@ -168,7 +168,7 @@ export abstract class RustStoreBase<TAdd extends Message, TRemove extends Messag
 
   async pruneMessages(fid: number): HubAsyncResult<number[]> {
     const cachedCount = await this._eventHandler.getCacheMessageCount(fid, this._postfix, false);
-    const maxCount = await this._eventHandler.getMaxMessageCount(fid, this._postfix);
+    let maxCount = await this._eventHandler.getMaxMessageCount(fid, this._postfix);
 
     // Require storage cache to be synced to prune
     if (cachedCount.isErr()) {
@@ -177,6 +177,10 @@ export abstract class RustStoreBase<TAdd extends Message, TRemove extends Messag
 
     if (maxCount.isErr()) {
       return err(maxCount.error);
+    }
+
+    if (this._pruneSizeLimit > 0 && this._pruneSizeLimit < maxCount.value) {
+      maxCount = ok(this._pruneSizeLimit);
     }
 
     // Return immediately if there are no messages to prune

--- a/apps/hubble/src/storage/stores/storageCache.test.ts
+++ b/apps/hubble/src/storage/stores/storageCache.test.ts
@@ -51,6 +51,7 @@ describe("syncFromDb", () => {
       for (let i = 0; i < fidUsage.usage.storage; i++) {
         const storageRentEvent = Factories.StorageRentOnChainEvent.build({
           fid: fidUsage.fid,
+          blockTimestamp: Date.now() / 1000 - 30 * 24 * 60 * 60, // 30 days ago
           storageRentEventBody: Factories.StorageRentEventBody.build({
             expiry: getFarcasterTime()._unsafeUnwrap() + 365 * 24 * 60 * 60 - i,
             units: 2,
@@ -73,7 +74,9 @@ describe("syncFromDb", () => {
       await expect(cache.getMessageCount(fidUsage.fid, UserPostfix.UserDataMessage)).resolves.toEqual(
         ok(fidUsage.usage.userData),
       );
-      await expect(cache.getCurrentStorageUnitsForFid(fidUsage.fid)).resolves.toEqual(ok(4));
+      const slot = (await cache.getCurrentStorageSlotForFid(fidUsage.fid))._unsafeUnwrap();
+      expect(slot.legacy_units).toEqual(4);
+      expect(slot.units).toEqual(0);
     }
   });
 });
@@ -92,9 +95,19 @@ describe("getCurrentStorageUnitsForFid", () => {
       await db.commit(putOnChainEventTransaction(db.transaction(), event));
     }
     await cache.syncFromDb();
-    await expect(cache.getCurrentStorageUnitsForFid(fid)).resolves.toEqual(ok(4));
+    await expect(cache.getCurrentStorageSlotForFid(fid)).resolves.toEqual(ok(4));
     await new Promise((resolve) => setTimeout(resolve, 2000));
-    await expect(cache.getCurrentStorageUnitsForFid(fid)).resolves.toEqual(ok(2));
+    await expect(cache.getCurrentStorageSlotForFid(fid)).resolves.toEqual(ok(2));
+  });
+
+  test("user with storage units before 2024 migration has 2 years of storage at old limits", async () => {
+    throw new Error("Not implemented");
+  });
+  test("user with storage units after 2024 migration has 1 year of storage at new limits", async () => {
+    throw new Error("Not implemented");
+  });
+  test("user with mix of storage unit types has right limits", async () => {
+    throw new Error("Not implemented");
   });
 });
 

--- a/apps/hubble/src/storage/stores/storageCache.ts
+++ b/apps/hubble/src/storage/stores/storageCache.ts
@@ -97,8 +97,13 @@ export class StorageCache {
     } else {
       await forEachOnChainEvent(this._db, OnChainEventType.EVENT_TYPE_STORAGE_RENT, (event) => {
         const existingSlot = this._activeStorageSlots.get(event.fid);
-        if (isStorageRentOnChainEvent(event) && event.storageRentEventBody.expiry > time.value) {
+        if (isStorageRentOnChainEvent(event)) {
           const rentEventSlot = storageSlotFromEvent(event);
+
+          if (rentEventSlot.invalidateAt < time.value) {
+            return;
+          }
+
           if (existingSlot) {
             this._activeStorageSlots.set(event.fid, {
               units: rentEventSlot.units + existingSlot.units,

--- a/apps/hubble/src/storage/stores/storeEventHandler.test.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.test.ts
@@ -187,14 +187,14 @@ describe("getCurrentStorageUnitsForFid", () => {
   const fid = Factories.Fid.build();
 
   test("returns 0 if no storage event", async () => {
-    expect(await eventHandler.getCurrentStorageUnitsForFid(fid)).toEqual(ok(0));
+    expect(await eventHandler.getCurrentStorageSlotForFid(fid)).toEqual(ok(0));
   });
 
   test("returns actual storage based on units rented", async () => {
     const storageEvent = Factories.StorageRentOnChainEvent.build({ fid });
     const onChainEventStore = new OnChainEventStore(db, eventHandler);
     await onChainEventStore.mergeOnChainEvent(storageEvent);
-    expect(await eventHandler.getCurrentStorageUnitsForFid(fid)).toEqual(ok(storageEvent.storageRentEventBody.units));
+    expect(await eventHandler.getCurrentStorageSlotForFid(fid)).toEqual(ok(storageEvent.storageRentEventBody.units));
   });
 });
 

--- a/apps/hubble/src/storage/stores/storeEventHandler.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.ts
@@ -330,7 +330,12 @@ class StoreEventHandler extends TypedEmitter<StoreEvents> {
       return err(maxMessageCount.error);
     }
 
-    if (messageCount.value < maxMessageCount.value) {
+    let maxCount = maxMessageCount.value;
+    if (sizeLimit > 0 && sizeLimit < maxCount) {
+      maxCount = sizeLimit;
+    }
+
+    if (messageCount.value < maxCount) {
       return ok(false);
     }
 

--- a/apps/hubble/src/storage/stores/userDataStore.ts
+++ b/apps/hubble/src/storage/stores/userDataStore.ts
@@ -1,12 +1,4 @@
-import {
-  UserNameProof,
-  UserDataAddMessage,
-  UserDataType,
-  getDefaultStoreLimit,
-  StoreType,
-  Message,
-  HubEvent,
-} from "@farcaster/hub-nodejs";
+import { UserNameProof, UserDataAddMessage, UserDataType, HubEvent } from "@farcaster/hub-nodejs";
 import { ResultAsync } from "neverthrow";
 import { UserPostfix } from "../db/types.js";
 import { MessagesPage, PageOptions, StorePruneOptions } from "../stores/types.js";
@@ -45,7 +37,7 @@ import { messageDecode } from "../../storage/db/message.js";
  */
 class UserDataStore extends RustStoreBase<UserDataAddMessage, never> {
   constructor(db: RocksDB, eventHandler: StoreEventHandler, options: StorePruneOptions = {}) {
-    const pruneSizeLimit = options.pruneSizeLimit ?? getDefaultStoreLimit(StoreType.USER_DATA);
+    const pruneSizeLimit = options.pruneSizeLimit ?? 0;
 
     const rustUserDataStore = rsCreateUserDataStore(db.rustDb, eventHandler.getRustStoreEventHandler(), pruneSizeLimit);
 

--- a/apps/hubble/src/storage/stores/usernameProofStore.test.ts
+++ b/apps/hubble/src/storage/stores/usernameProofStore.test.ts
@@ -186,10 +186,6 @@ describe("usernameProofStore", () => {
     describe("with size limit", () => {
       const sizePrunedStore = new UsernameProofStore(db, eventHandler, { pruneSizeLimit: 2 });
 
-      test("defaults size limit", async () => {
-        expect(set.pruneSizeLimit).toEqual(getDefaultStoreLimit(StoreType.USERNAME_PROOFS));
-      });
-
       test("no-ops when no messages have been merged", async () => {
         const result = await sizePrunedStore.pruneMessages(fid);
         expect(result._unsafeUnwrap()).toEqual([]);

--- a/apps/hubble/src/storage/stores/usernameProofStore.ts
+++ b/apps/hubble/src/storage/stores/usernameProofStore.ts
@@ -1,10 +1,4 @@
-import {
-  getDefaultStoreLimit,
-  StoreType,
-  UserNameProof,
-  UsernameProofMessage,
-  UserNameType,
-} from "@farcaster/hub-nodejs";
+import { UserNameProof, UsernameProofMessage, UserNameType } from "@farcaster/hub-nodejs";
 import { ResultAsync } from "neverthrow";
 import { UserPostfix } from "../db/types.js";
 import {
@@ -22,7 +16,7 @@ import { messageDecode } from "../../storage/db/message.js";
 
 class UsernameProofStore extends RustStoreBase<UsernameProofMessage, never> {
   constructor(db: RocksDB, eventHandler: StoreEventHandler, options: StorePruneOptions = {}) {
-    const pruneSizeLimit = options.pruneSizeLimit ?? getDefaultStoreLimit(StoreType.USERNAME_PROOFS);
+    const pruneSizeLimit = options.pruneSizeLimit ?? 0;
     const rustUsernameProofStore = rsCreateUsernameProofStore(
       db.rustDb,
       eventHandler.getRustStoreEventHandler(),

--- a/apps/hubble/src/storage/stores/verificationStore.ts
+++ b/apps/hubble/src/storage/stores/verificationStore.ts
@@ -1,10 +1,4 @@
-import {
-  HubAsyncResult,
-  StoreType,
-  VerificationAddAddressMessage,
-  VerificationRemoveMessage,
-  getDefaultStoreLimit,
-} from "@farcaster/hub-nodejs";
+import { HubAsyncResult, VerificationAddAddressMessage, VerificationRemoveMessage } from "@farcaster/hub-nodejs";
 import {
   rsCreateVerificationStore,
   rsGetVerificationAdd,
@@ -24,7 +18,7 @@ import { messageDecode } from "../../storage/db/message.js";
 
 class VerificationStore extends RustStoreBase<VerificationAddAddressMessage, VerificationRemoveMessage> {
   constructor(db: RocksDB, eventHandler: StoreEventHandler, options: StorePruneOptions = {}) {
-    const pruneSizeLimit = options.pruneSizeLimit ?? getDefaultStoreLimit(StoreType.VERIFICATIONS);
+    const pruneSizeLimit = options.pruneSizeLimit ?? 0;
     const rustVerificationStore = rsCreateVerificationStore(
       db.rustDb,
       eventHandler.getRustStoreEventHandler(),

--- a/packages/core/src/factories.ts
+++ b/packages/core/src/factories.ts
@@ -802,8 +802,16 @@ const StorageRentEventBodyFactory = Factory.define<protobufs.StorageRentEventBod
 
 const StorageRentOnChainEventFactory = Factory.define<StorageRentOnChainEvent, { units?: number }>(
   ({ transientParams }) => {
+    const oneYearAgo = new Date();
+    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const randomDate = faker.date.between(oneYearAgo, yesterday);
+    const randomDateInSeconds = Math.floor(randomDate.getTime() / 1000);
+
     return OnChainEventFactory.build({
       type: OnChainEventType.EVENT_TYPE_STORAGE_RENT,
+      blockTimestamp: randomDateInSeconds,
       storageRentEventBody: transientParams.units
         ? StorageRentEventBodyFactory.build({ units: transientParams.units })
         : StorageRentEventBodyFactory.build(),

--- a/packages/core/src/limits.test.ts
+++ b/packages/core/src/limits.test.ts
@@ -1,0 +1,101 @@
+import { getDefaultStoreLimit, getStoreLimit, getStoreLimits } from "./limits";
+import { StorageUnitType, StoreType } from "./protobufs";
+
+describe("getDefaultStoreLimit", () => {
+  test("returns correct defaults", () => {
+    expect(getDefaultStoreLimit(StoreType.CASTS, StorageUnitType.UNIT_TYPE_LEGACY)).toEqual(5000);
+    expect(getDefaultStoreLimit(StoreType.CASTS, StorageUnitType.UNIT_TYPE_2024)).toEqual(2000);
+
+    expect(getDefaultStoreLimit(StoreType.LINKS, StorageUnitType.UNIT_TYPE_LEGACY)).toEqual(2500);
+    expect(getDefaultStoreLimit(StoreType.LINKS, StorageUnitType.UNIT_TYPE_2024)).toEqual(1000);
+
+    expect(getDefaultStoreLimit(StoreType.REACTIONS, StorageUnitType.UNIT_TYPE_LEGACY)).toEqual(2500);
+    expect(getDefaultStoreLimit(StoreType.REACTIONS, StorageUnitType.UNIT_TYPE_2024)).toEqual(1000);
+
+    expect(getDefaultStoreLimit(StoreType.USER_DATA, StorageUnitType.UNIT_TYPE_LEGACY)).toEqual(50);
+    expect(getDefaultStoreLimit(StoreType.USER_DATA, StorageUnitType.UNIT_TYPE_2024)).toEqual(50);
+
+    expect(getDefaultStoreLimit(StoreType.USERNAME_PROOFS, StorageUnitType.UNIT_TYPE_LEGACY)).toEqual(5);
+    expect(getDefaultStoreLimit(StoreType.USERNAME_PROOFS, StorageUnitType.UNIT_TYPE_2024)).toEqual(5);
+
+    expect(getDefaultStoreLimit(StoreType.VERIFICATIONS, StorageUnitType.UNIT_TYPE_LEGACY)).toEqual(25);
+    expect(getDefaultStoreLimit(StoreType.VERIFICATIONS, StorageUnitType.UNIT_TYPE_2024)).toEqual(25);
+  });
+});
+
+describe("getStoreLimit", () => {
+  test("returns correct limits for multiple unit typos", () => {
+    // single unit type
+    expect(getStoreLimit(StoreType.CASTS, [{ unitType: StorageUnitType.UNIT_TYPE_LEGACY, unitSize: 1 }])).toEqual(5000);
+
+    // multiple unit types
+    expect(
+      getStoreLimit(StoreType.CASTS, [
+        { unitType: StorageUnitType.UNIT_TYPE_LEGACY, unitSize: 1 },
+        { unitType: StorageUnitType.UNIT_TYPE_2024, unitSize: 2 },
+      ]),
+    ).toEqual(9000); // 5000 + (2000 * 2)
+
+    // multiple units of the same type
+    expect(getStoreLimit(StoreType.LINKS, [{ unitType: StorageUnitType.UNIT_TYPE_2024, unitSize: 3 }])).toEqual(3000); // 1000 * 3
+
+    // mix of unit types and sizes
+    expect(
+      getStoreLimit(StoreType.REACTIONS, [
+        { unitType: StorageUnitType.UNIT_TYPE_LEGACY, unitSize: 2 },
+        { unitType: StorageUnitType.UNIT_TYPE_2024, unitSize: 1 },
+      ]),
+    ).toEqual(6000); // (2500 * 2) + 1000
+
+    // NONE store type
+    expect(
+      getStoreLimit(StoreType.NONE, [
+        { unitType: StorageUnitType.UNIT_TYPE_LEGACY, unitSize: 10 },
+        { unitType: StorageUnitType.UNIT_TYPE_2024, unitSize: 10 },
+      ]),
+    ).toEqual(0);
+  });
+});
+
+describe("getStoreLimits", () => {
+  test("returns correct limits for all store types", () => {
+    const unitDetails = [
+      { unitType: StorageUnitType.UNIT_TYPE_LEGACY, unitSize: 1 },
+      { unitType: StorageUnitType.UNIT_TYPE_2024, unitSize: 2 },
+    ];
+
+    const limits = getStoreLimits(unitDetails);
+
+    expect(limits).toHaveLength(6); // Expecting 6 store types (excluding NONE)
+
+    expect(limits).toContainEqual({ storeType: StoreType.CASTS, limit: 9000 }); // 5000 + (2000 * 2)
+    expect(limits).toContainEqual({ storeType: StoreType.LINKS, limit: 4500 }); // 2500 + (1000 * 2)
+    expect(limits).toContainEqual({ storeType: StoreType.REACTIONS, limit: 4500 }); // 2500 + (1000 * 2)
+    expect(limits).toContainEqual({ storeType: StoreType.USER_DATA, limit: 150 }); // 50 + (50 * 2)
+    expect(limits).toContainEqual({ storeType: StoreType.USERNAME_PROOFS, limit: 15 }); // 5 + (5 * 2)
+    expect(limits).toContainEqual({ storeType: StoreType.VERIFICATIONS, limit: 75 }); // 25 + (25 * 2)
+  });
+
+  test("returns zero limits for empty unit details", () => {
+    const limits = getStoreLimits([]);
+
+    expect(limits).toHaveLength(6);
+
+    limits.forEach((limit) => {
+      expect(limit.limit).toBe(0);
+    });
+  });
+
+  test("handles single unit type correctly", () => {
+    const unitDetails = [{ unitType: StorageUnitType.UNIT_TYPE_2024, unitSize: 3 }];
+
+    const limits = getStoreLimits(unitDetails);
+
+    expect(limits).toContainEqual({ storeType: StoreType.CASTS, limit: 6000 }); // 2000 * 3
+    expect(limits).toContainEqual({ storeType: StoreType.LINKS, limit: 3000 }); // 1000 * 3
+    expect(limits).toContainEqual({ storeType: StoreType.REACTIONS, limit: 3000 }); // 1000 * 3
+    expect(limits).toContainEqual({ storeType: StoreType.USER_DATA, limit: 150 }); // 50 * 3
+    expect(limits).toContainEqual({ storeType: StoreType.USERNAME_PROOFS, limit: 15 }); // 5 * 3
+    expect(limits).toContainEqual({ storeType: StoreType.VERIFICATIONS, limit: 75 }); // 25 * 3
+  });
+});

--- a/packages/core/src/limits.ts
+++ b/packages/core/src/limits.ts
@@ -1,53 +1,71 @@
-import { StoreType } from "./protobufs";
+import { StorageUnitDetails, StorageUnitType, StoreType } from "./protobufs";
 
-const CASTS_SIZE_LIMIT_DEFAULT = 5_000;
-const LINKS_SIZE_LIMIT_DEFAULT = 2_500;
-const REACTIONS_SIZE_LIMIT_DEFAULT = 2_500;
-const USER_DATA_SIZE_LIMIT_DEFAULT = 50;
-const USERNAME_PROOFS_SIZE_LIMIT_DEFAULT = 5;
-const VERIFICATIONS_SIZE_LIMIT_DEFAULT = 25;
+const STORAGE_UNIT_DEFAULTS = {
+  [StoreType.CASTS]: {
+    [StorageUnitType.UNIT_TYPE_LEGACY]: 5000,
+    [StorageUnitType.UNIT_TYPE_2024]: 2000,
+  },
+  [StoreType.LINKS]: {
+    [StorageUnitType.UNIT_TYPE_LEGACY]: 2500,
+    [StorageUnitType.UNIT_TYPE_2024]: 1000,
+  },
+  [StoreType.REACTIONS]: {
+    [StorageUnitType.UNIT_TYPE_LEGACY]: 2500,
+    [StorageUnitType.UNIT_TYPE_2024]: 1000,
+  },
+  [StoreType.USER_DATA]: {
+    [StorageUnitType.UNIT_TYPE_LEGACY]: 50,
+    [StorageUnitType.UNIT_TYPE_2024]: 50,
+  },
+  [StoreType.USERNAME_PROOFS]: {
+    [StorageUnitType.UNIT_TYPE_LEGACY]: 5,
+    [StorageUnitType.UNIT_TYPE_2024]: 5,
+  },
+  [StoreType.VERIFICATIONS]: {
+    [StorageUnitType.UNIT_TYPE_LEGACY]: 25,
+    [StorageUnitType.UNIT_TYPE_2024]: 25,
+  },
+  [StoreType.NONE]: {
+    [StorageUnitType.UNIT_TYPE_LEGACY]: 0,
+    [StorageUnitType.UNIT_TYPE_2024]: 0,
+  },
+};
 
-export const getStoreLimits = (units: number) => [
+export const getStoreLimits = (unit_details: StorageUnitDetails[]) => [
   {
     storeType: StoreType.CASTS,
-    limit: getDefaultStoreLimit(StoreType.CASTS) * units,
+    limit: getStoreLimit(StoreType.CASTS, unit_details),
   },
   {
     storeType: StoreType.LINKS,
-    limit: getDefaultStoreLimit(StoreType.LINKS) * units,
+    limit: getStoreLimit(StoreType.LINKS, unit_details),
   },
   {
     storeType: StoreType.REACTIONS,
-    limit: getDefaultStoreLimit(StoreType.REACTIONS) * units,
+    limit: getStoreLimit(StoreType.REACTIONS, unit_details),
   },
   {
     storeType: StoreType.USER_DATA,
-    limit: getDefaultStoreLimit(StoreType.USER_DATA) * units,
+    limit: getStoreLimit(StoreType.USER_DATA, unit_details),
   },
   {
     storeType: StoreType.USERNAME_PROOFS,
-    limit: getDefaultStoreLimit(StoreType.USERNAME_PROOFS) * units,
+    limit: getStoreLimit(StoreType.USERNAME_PROOFS, unit_details),
   },
   {
     storeType: StoreType.VERIFICATIONS,
-    limit: getDefaultStoreLimit(StoreType.VERIFICATIONS) * units,
+    limit: getStoreLimit(StoreType.VERIFICATIONS, unit_details),
   },
 ];
-export const getDefaultStoreLimit = (storeType: StoreType) => {
-  switch (storeType) {
-    case StoreType.CASTS:
-      return CASTS_SIZE_LIMIT_DEFAULT;
-    case StoreType.LINKS:
-      return LINKS_SIZE_LIMIT_DEFAULT;
-    case StoreType.REACTIONS:
-      return REACTIONS_SIZE_LIMIT_DEFAULT;
-    case StoreType.USER_DATA:
-      return USER_DATA_SIZE_LIMIT_DEFAULT;
-    case StoreType.USERNAME_PROOFS:
-      return USERNAME_PROOFS_SIZE_LIMIT_DEFAULT;
-    case StoreType.VERIFICATIONS:
-      return VERIFICATIONS_SIZE_LIMIT_DEFAULT;
-    default:
-      throw new Error(`Unknown store type: ${storeType}`);
+
+export const getStoreLimit = (storeType: StoreType, unit_details: StorageUnitDetails[]) => {
+  let limit = 0;
+  for (const unit of unit_details) {
+    limit += getDefaultStoreLimit(storeType, unit.unitType) * unit.unitSize;
   }
+  return limit;
+};
+
+export const getDefaultStoreLimit = (storeType: StoreType, unit_type: StorageUnitType) => {
+  return STORAGE_UNIT_DEFAULTS[storeType][unit_type];
 };

--- a/packages/core/src/protobufs/generated/request_response.ts
+++ b/packages/core/src/protobufs/generated/request_response.ts
@@ -75,6 +75,35 @@ export function storeTypeToJSON(object: StoreType): string {
   }
 }
 
+export enum StorageUnitType {
+  UNIT_TYPE_LEGACY = 0,
+  UNIT_TYPE_2024 = 1,
+}
+
+export function storageUnitTypeFromJSON(object: any): StorageUnitType {
+  switch (object) {
+    case 0:
+    case "UNIT_TYPE_LEGACY":
+      return StorageUnitType.UNIT_TYPE_LEGACY;
+    case 1:
+    case "UNIT_TYPE_2024":
+      return StorageUnitType.UNIT_TYPE_2024;
+    default:
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum StorageUnitType");
+  }
+}
+
+export function storageUnitTypeToJSON(object: StorageUnitType): string {
+  switch (object) {
+    case StorageUnitType.UNIT_TYPE_LEGACY:
+      return "UNIT_TYPE_LEGACY";
+    case StorageUnitType.UNIT_TYPE_2024:
+      return "UNIT_TYPE_2024";
+    default:
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum StorageUnitType");
+  }
+}
+
 export interface Empty {
 }
 
@@ -239,6 +268,12 @@ export interface OnChainEventResponse {
 export interface StorageLimitsResponse {
   limits: StorageLimit[];
   units: number;
+  unitDetails: StorageUnitDetails[];
+}
+
+export interface StorageUnitDetails {
+  unitType: StorageUnitType;
+  unitSize: number;
 }
 
 export interface StorageLimit {
@@ -2638,7 +2673,7 @@ export const OnChainEventResponse = {
 };
 
 function createBaseStorageLimitsResponse(): StorageLimitsResponse {
-  return { limits: [], units: 0 };
+  return { limits: [], units: 0, unitDetails: [] };
 }
 
 export const StorageLimitsResponse = {
@@ -2648,6 +2683,9 @@ export const StorageLimitsResponse = {
     }
     if (message.units !== 0) {
       writer.uint32(16).uint32(message.units);
+    }
+    for (const v of message.unitDetails) {
+      StorageUnitDetails.encode(v!, writer.uint32(26).fork()).ldelim();
     }
     return writer;
   },
@@ -2673,6 +2711,13 @@ export const StorageLimitsResponse = {
 
           message.units = reader.uint32();
           continue;
+        case 3:
+          if (tag != 26) {
+            break;
+          }
+
+          message.unitDetails.push(StorageUnitDetails.decode(reader, reader.uint32()));
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -2686,6 +2731,9 @@ export const StorageLimitsResponse = {
     return {
       limits: Array.isArray(object?.limits) ? object.limits.map((e: any) => StorageLimit.fromJSON(e)) : [],
       units: isSet(object.units) ? Number(object.units) : 0,
+      unitDetails: Array.isArray(object?.unitDetails)
+        ? object.unitDetails.map((e: any) => StorageUnitDetails.fromJSON(e))
+        : [],
     };
   },
 
@@ -2697,6 +2745,11 @@ export const StorageLimitsResponse = {
       obj.limits = [];
     }
     message.units !== undefined && (obj.units = Math.round(message.units));
+    if (message.unitDetails) {
+      obj.unitDetails = message.unitDetails.map((e) => e ? StorageUnitDetails.toJSON(e) : undefined);
+    } else {
+      obj.unitDetails = [];
+    }
     return obj;
   },
 
@@ -2708,6 +2761,78 @@ export const StorageLimitsResponse = {
     const message = createBaseStorageLimitsResponse();
     message.limits = object.limits?.map((e) => StorageLimit.fromPartial(e)) || [];
     message.units = object.units ?? 0;
+    message.unitDetails = object.unitDetails?.map((e) => StorageUnitDetails.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBaseStorageUnitDetails(): StorageUnitDetails {
+  return { unitType: 0, unitSize: 0 };
+}
+
+export const StorageUnitDetails = {
+  encode(message: StorageUnitDetails, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.unitType !== 0) {
+      writer.uint32(8).int32(message.unitType);
+    }
+    if (message.unitSize !== 0) {
+      writer.uint32(16).uint32(message.unitSize);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): StorageUnitDetails {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseStorageUnitDetails();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.unitType = reader.int32() as any;
+          continue;
+        case 2:
+          if (tag != 16) {
+            break;
+          }
+
+          message.unitSize = reader.uint32();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): StorageUnitDetails {
+    return {
+      unitType: isSet(object.unitType) ? storageUnitTypeFromJSON(object.unitType) : 0,
+      unitSize: isSet(object.unitSize) ? Number(object.unitSize) : 0,
+    };
+  },
+
+  toJSON(message: StorageUnitDetails): unknown {
+    const obj: any = {};
+    message.unitType !== undefined && (obj.unitType = storageUnitTypeToJSON(message.unitType));
+    message.unitSize !== undefined && (obj.unitSize = Math.round(message.unitSize));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<StorageUnitDetails>, I>>(base?: I): StorageUnitDetails {
+    return StorageUnitDetails.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<StorageUnitDetails>, I>>(object: I): StorageUnitDetails {
+    const message = createBaseStorageUnitDetails();
+    message.unitType = object.unitType ?? 0;
+    message.unitSize = object.unitSize ?? 0;
     return message;
   },
 };

--- a/packages/hub-nodejs/src/generated/request_response.ts
+++ b/packages/hub-nodejs/src/generated/request_response.ts
@@ -75,6 +75,35 @@ export function storeTypeToJSON(object: StoreType): string {
   }
 }
 
+export enum StorageUnitType {
+  UNIT_TYPE_LEGACY = 0,
+  UNIT_TYPE_2024 = 1,
+}
+
+export function storageUnitTypeFromJSON(object: any): StorageUnitType {
+  switch (object) {
+    case 0:
+    case "UNIT_TYPE_LEGACY":
+      return StorageUnitType.UNIT_TYPE_LEGACY;
+    case 1:
+    case "UNIT_TYPE_2024":
+      return StorageUnitType.UNIT_TYPE_2024;
+    default:
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum StorageUnitType");
+  }
+}
+
+export function storageUnitTypeToJSON(object: StorageUnitType): string {
+  switch (object) {
+    case StorageUnitType.UNIT_TYPE_LEGACY:
+      return "UNIT_TYPE_LEGACY";
+    case StorageUnitType.UNIT_TYPE_2024:
+      return "UNIT_TYPE_2024";
+    default:
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum StorageUnitType");
+  }
+}
+
 export interface Empty {
 }
 
@@ -239,6 +268,12 @@ export interface OnChainEventResponse {
 export interface StorageLimitsResponse {
   limits: StorageLimit[];
   units: number;
+  unitDetails: StorageUnitDetails[];
+}
+
+export interface StorageUnitDetails {
+  unitType: StorageUnitType;
+  unitSize: number;
 }
 
 export interface StorageLimit {
@@ -2638,7 +2673,7 @@ export const OnChainEventResponse = {
 };
 
 function createBaseStorageLimitsResponse(): StorageLimitsResponse {
-  return { limits: [], units: 0 };
+  return { limits: [], units: 0, unitDetails: [] };
 }
 
 export const StorageLimitsResponse = {
@@ -2648,6 +2683,9 @@ export const StorageLimitsResponse = {
     }
     if (message.units !== 0) {
       writer.uint32(16).uint32(message.units);
+    }
+    for (const v of message.unitDetails) {
+      StorageUnitDetails.encode(v!, writer.uint32(26).fork()).ldelim();
     }
     return writer;
   },
@@ -2673,6 +2711,13 @@ export const StorageLimitsResponse = {
 
           message.units = reader.uint32();
           continue;
+        case 3:
+          if (tag != 26) {
+            break;
+          }
+
+          message.unitDetails.push(StorageUnitDetails.decode(reader, reader.uint32()));
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -2686,6 +2731,9 @@ export const StorageLimitsResponse = {
     return {
       limits: Array.isArray(object?.limits) ? object.limits.map((e: any) => StorageLimit.fromJSON(e)) : [],
       units: isSet(object.units) ? Number(object.units) : 0,
+      unitDetails: Array.isArray(object?.unitDetails)
+        ? object.unitDetails.map((e: any) => StorageUnitDetails.fromJSON(e))
+        : [],
     };
   },
 
@@ -2697,6 +2745,11 @@ export const StorageLimitsResponse = {
       obj.limits = [];
     }
     message.units !== undefined && (obj.units = Math.round(message.units));
+    if (message.unitDetails) {
+      obj.unitDetails = message.unitDetails.map((e) => e ? StorageUnitDetails.toJSON(e) : undefined);
+    } else {
+      obj.unitDetails = [];
+    }
     return obj;
   },
 
@@ -2708,6 +2761,78 @@ export const StorageLimitsResponse = {
     const message = createBaseStorageLimitsResponse();
     message.limits = object.limits?.map((e) => StorageLimit.fromPartial(e)) || [];
     message.units = object.units ?? 0;
+    message.unitDetails = object.unitDetails?.map((e) => StorageUnitDetails.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBaseStorageUnitDetails(): StorageUnitDetails {
+  return { unitType: 0, unitSize: 0 };
+}
+
+export const StorageUnitDetails = {
+  encode(message: StorageUnitDetails, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.unitType !== 0) {
+      writer.uint32(8).int32(message.unitType);
+    }
+    if (message.unitSize !== 0) {
+      writer.uint32(16).uint32(message.unitSize);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): StorageUnitDetails {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseStorageUnitDetails();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.unitType = reader.int32() as any;
+          continue;
+        case 2:
+          if (tag != 16) {
+            break;
+          }
+
+          message.unitSize = reader.uint32();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): StorageUnitDetails {
+    return {
+      unitType: isSet(object.unitType) ? storageUnitTypeFromJSON(object.unitType) : 0,
+      unitSize: isSet(object.unitSize) ? Number(object.unitSize) : 0,
+    };
+  },
+
+  toJSON(message: StorageUnitDetails): unknown {
+    const obj: any = {};
+    message.unitType !== undefined && (obj.unitType = storageUnitTypeToJSON(message.unitType));
+    message.unitSize !== undefined && (obj.unitSize = Math.round(message.unitSize));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<StorageUnitDetails>, I>>(base?: I): StorageUnitDetails {
+    return StorageUnitDetails.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<StorageUnitDetails>, I>>(object: I): StorageUnitDetails {
+    const message = createBaseStorageUnitDetails();
+    message.unitType = object.unitType ?? 0;
+    message.unitSize = object.unitSize ?? 0;
     return message;
   },
 };

--- a/packages/hub-web/src/generated/request_response.ts
+++ b/packages/hub-web/src/generated/request_response.ts
@@ -75,6 +75,35 @@ export function storeTypeToJSON(object: StoreType): string {
   }
 }
 
+export enum StorageUnitType {
+  UNIT_TYPE_LEGACY = 0,
+  UNIT_TYPE_2024 = 1,
+}
+
+export function storageUnitTypeFromJSON(object: any): StorageUnitType {
+  switch (object) {
+    case 0:
+    case "UNIT_TYPE_LEGACY":
+      return StorageUnitType.UNIT_TYPE_LEGACY;
+    case 1:
+    case "UNIT_TYPE_2024":
+      return StorageUnitType.UNIT_TYPE_2024;
+    default:
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum StorageUnitType");
+  }
+}
+
+export function storageUnitTypeToJSON(object: StorageUnitType): string {
+  switch (object) {
+    case StorageUnitType.UNIT_TYPE_LEGACY:
+      return "UNIT_TYPE_LEGACY";
+    case StorageUnitType.UNIT_TYPE_2024:
+      return "UNIT_TYPE_2024";
+    default:
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum StorageUnitType");
+  }
+}
+
 export interface Empty {
 }
 
@@ -239,6 +268,12 @@ export interface OnChainEventResponse {
 export interface StorageLimitsResponse {
   limits: StorageLimit[];
   units: number;
+  unitDetails: StorageUnitDetails[];
+}
+
+export interface StorageUnitDetails {
+  unitType: StorageUnitType;
+  unitSize: number;
 }
 
 export interface StorageLimit {
@@ -2638,7 +2673,7 @@ export const OnChainEventResponse = {
 };
 
 function createBaseStorageLimitsResponse(): StorageLimitsResponse {
-  return { limits: [], units: 0 };
+  return { limits: [], units: 0, unitDetails: [] };
 }
 
 export const StorageLimitsResponse = {
@@ -2648,6 +2683,9 @@ export const StorageLimitsResponse = {
     }
     if (message.units !== 0) {
       writer.uint32(16).uint32(message.units);
+    }
+    for (const v of message.unitDetails) {
+      StorageUnitDetails.encode(v!, writer.uint32(26).fork()).ldelim();
     }
     return writer;
   },
@@ -2673,6 +2711,13 @@ export const StorageLimitsResponse = {
 
           message.units = reader.uint32();
           continue;
+        case 3:
+          if (tag != 26) {
+            break;
+          }
+
+          message.unitDetails.push(StorageUnitDetails.decode(reader, reader.uint32()));
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -2686,6 +2731,9 @@ export const StorageLimitsResponse = {
     return {
       limits: Array.isArray(object?.limits) ? object.limits.map((e: any) => StorageLimit.fromJSON(e)) : [],
       units: isSet(object.units) ? Number(object.units) : 0,
+      unitDetails: Array.isArray(object?.unitDetails)
+        ? object.unitDetails.map((e: any) => StorageUnitDetails.fromJSON(e))
+        : [],
     };
   },
 
@@ -2697,6 +2745,11 @@ export const StorageLimitsResponse = {
       obj.limits = [];
     }
     message.units !== undefined && (obj.units = Math.round(message.units));
+    if (message.unitDetails) {
+      obj.unitDetails = message.unitDetails.map((e) => e ? StorageUnitDetails.toJSON(e) : undefined);
+    } else {
+      obj.unitDetails = [];
+    }
     return obj;
   },
 
@@ -2708,6 +2761,78 @@ export const StorageLimitsResponse = {
     const message = createBaseStorageLimitsResponse();
     message.limits = object.limits?.map((e) => StorageLimit.fromPartial(e)) || [];
     message.units = object.units ?? 0;
+    message.unitDetails = object.unitDetails?.map((e) => StorageUnitDetails.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBaseStorageUnitDetails(): StorageUnitDetails {
+  return { unitType: 0, unitSize: 0 };
+}
+
+export const StorageUnitDetails = {
+  encode(message: StorageUnitDetails, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.unitType !== 0) {
+      writer.uint32(8).int32(message.unitType);
+    }
+    if (message.unitSize !== 0) {
+      writer.uint32(16).uint32(message.unitSize);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): StorageUnitDetails {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseStorageUnitDetails();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.unitType = reader.int32() as any;
+          continue;
+        case 2:
+          if (tag != 16) {
+            break;
+          }
+
+          message.unitSize = reader.uint32();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): StorageUnitDetails {
+    return {
+      unitType: isSet(object.unitType) ? storageUnitTypeFromJSON(object.unitType) : 0,
+      unitSize: isSet(object.unitSize) ? Number(object.unitSize) : 0,
+    };
+  },
+
+  toJSON(message: StorageUnitDetails): unknown {
+    const obj: any = {};
+    message.unitType !== undefined && (obj.unitType = storageUnitTypeToJSON(message.unitType));
+    message.unitSize !== undefined && (obj.unitSize = Math.round(message.unitSize));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<StorageUnitDetails>, I>>(base?: I): StorageUnitDetails {
+    return StorageUnitDetails.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<StorageUnitDetails>, I>>(object: I): StorageUnitDetails {
+    const message = createBaseStorageUnitDetails();
+    message.unitType = object.unitType ?? 0;
+    message.unitSize = object.unitSize ?? 0;
     return message;
   },
 };

--- a/protobufs/schemas/request_response.proto
+++ b/protobufs/schemas/request_response.proto
@@ -175,6 +175,7 @@ message OnChainEventResponse {
 message StorageLimitsResponse {
   repeated StorageLimit limits = 1;
   uint32 units = 2;
+  repeated StorageUnitDetails unit_details = 3;
 }
 
 enum StoreType {
@@ -185,6 +186,16 @@ enum StoreType {
   STORE_TYPE_USER_DATA = 4;
   STORE_TYPE_VERIFICATIONS = 5;
   STORE_TYPE_USERNAME_PROOFS = 6;
+}
+
+enum StorageUnitType {
+  UNIT_TYPE_LEGACY = 0;
+  UNIT_TYPE_2024 = 1;
+}
+
+message StorageUnitDetails {
+  StorageUnitType unit_type = 1;
+  uint32 unit_size = 2;
 }
 
 message StorageLimit {


### PR DESCRIPTION
## Why is this change needed?

Implements https://github.com/farcasterxyz/protocol/discussions/191

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to implement the Storage Extension FIP. 

### Detailed summary
- Added `StorageUnitDetails` message in `request_response.proto`
- Updated storage-related functions in various Rust files
- Modified default limits in different store types
- Introduced new date calculations in `factories.ts`

> The following files were skipped due to too many changes: `apps/hubble/src/storage/stores/storeEventHandler.test.ts`, `packages/core/src/limits.ts`, `apps/hubble/src/storage/stores/storageCache.test.ts`, `apps/hubble/src/storage/stores/storeEventHandler.ts`, `apps/hubble/src/rpc/test/server.test.ts`, `packages/core/src/limits.test.ts`, `apps/hubble/src/storage/engine/index.ts`, `packages/hub-web/src/generated/request_response.ts`, `packages/hub-nodejs/src/generated/request_response.ts`, `packages/core/src/protobufs/generated/request_response.ts`, `apps/hubble/src/storage/stores/storageCache.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->