### PR TITLE
chore: tweak client-side config to set baseline timeout

### DIFF
--- a/.changeset/olive-bottles-greet.md
+++ b/.changeset/olive-bottles-greet.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+tweak client-side config to set baseline timeout

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1733,7 +1733,11 @@ export class Hub implements HubInterface {
 
     if (rpcAddressInfo.value.address) {
       try {
-        return await this.getHubRpcClient(`${rpcAddressInfo.value.address}:${rpcAddressInfo.value.port}`);
+        return await this.getHubRpcClient(`${rpcAddressInfo.value.address}:${rpcAddressInfo.value.port}`, {
+          "grpc.keepalive_time_ms": 5000,
+          "grpc.keepalive_timeout_ms": 5000,
+          ...options,
+        });
       } catch (e) {
         log.error({ error: e, peer, peerId }, "unable to connect to peer");
         return undefined;
@@ -1767,7 +1771,11 @@ export class Hub implements HubInterface {
     };
 
     try {
-      return await this.getHubRpcClient(addressInfoToString(ai), options);
+      return await this.getHubRpcClient(addressInfoToString(ai), {
+        "grpc.keepalive_time_ms": 5000,
+        "grpc.keepalive_timeout_ms": 5000,
+        ...options,
+      });
     } catch (e) {
       log.error({ error: e, peer, peerId, addressInfo: ai }, "unable to connect to peer");
       // If the peer is unreachable (e.g. behind a firewall), remove it from our address book


### PR DESCRIPTION
## Why is this change needed?

Adjacent to #2250, this adjusts the client-side timeouts for parity – intermediary termination routes such as NLBs may impose their own timeout that is causing weird misbehaviors.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR tweaks the client-side configuration in `hubble.ts` to set baseline timeout values for gRPC connections.

### Detailed summary
- Updated client-side configuration to include `grpc.keepalive_time_ms` and `grpc.keepalive_timeout_ms`
- Set both values to 5000ms for gRPC connections
- Applied the changes in two different locations within the `getHubRpcClient` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->