### PR TITLE
fix: Update Node version used in intermediate build step

### DIFF
--- a/Dockerfile.hubble
+++ b/Dockerfile.hubble
@@ -5,7 +5,7 @@
 ############## Stage 1: Create pruned version of monorepo #####################
 ###############################################################################
 
-FROM node:21.6-slim AS prune
+FROM node:22.4.1-slim AS prune
 
 USER node
 RUN mkdir /home/node/app


### PR DESCRIPTION
## Why is this change needed?

This was supposed to be Node 22.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Node.js version in the Dockerfile from 21.6 to 22.4.1 for the `prune` stage.

### Detailed summary
- Updated Node.js version in Dockerfile.hubble from 21.6 to 22.4.1 for the `prune` stage.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->