### PR TITLE
chore: switch timeout to 25s

### DIFF
--- a/.changeset/tricky-chairs-own.md
+++ b/.changeset/tricky-chairs-own.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/hub-nodejs": patch
+"@farcaster/hubble": patch
+---
+
+chore: tweak timeout to 25s

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1735,7 +1735,7 @@ export class Hub implements HubInterface {
       try {
         return await this.getHubRpcClient(`${rpcAddressInfo.value.address}:${rpcAddressInfo.value.port}`, {
           "grpc.keepalive_time_ms": 5000,
-          "grpc.keepalive_timeout_ms": 5000,
+          "grpc.keepalive_timeout_ms": 25000,
           ...options,
         });
       } catch (e) {
@@ -1773,7 +1773,7 @@ export class Hub implements HubInterface {
     try {
       return await this.getHubRpcClient(addressInfoToString(ai), {
         "grpc.keepalive_time_ms": 5000,
-        "grpc.keepalive_timeout_ms": 5000,
+        "grpc.keepalive_timeout_ms": 25000,
         ...options,
       });
     } catch (e) {

--- a/packages/hub-nodejs/src/client.ts
+++ b/packages/hub-nodejs/src/client.ts
@@ -127,7 +127,7 @@ export const getServer = (): grpc.Server => {
   // set it anyway.
   const server = new grpc.Server({
     "grpc.keepalive_time_ms": 5 * 1000,
-    "grpc.keepalive_timeout_ms": 5 * 1000,
+    "grpc.keepalive_timeout_ms": 25 * 1000,
     "grpc.client_idle_timeout_ms": 60 * 1000,
   });
 


### PR DESCRIPTION
## Why is this change needed?

In the timeout saga, getting the timeout _above_ the NLB because it disregards everything you tell it seems to be the key.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to tweak the timeout settings in the `hub-nodejs` and `hubble` packages to 25 seconds for better performance.

### Detailed summary
- Updated `grpc.keepalive_timeout_ms` to 25 seconds in `hub-nodejs/src/client.ts`
- Updated `grpc.keepalive_timeout_ms` to 25 seconds in `hubble/src/hubble.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->