### PR TITLE
chore: Revert timeout change

### DIFF
--- a/.changeset/olive-bottles-greet.md
+++ b/.changeset/olive-bottles-greet.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-tweak client-side config to set baseline timeout

--- a/.changeset/tricky-chairs-own.md
+++ b/.changeset/tricky-chairs-own.md
@@ -1,6 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
-"@farcaster/hubble": patch
----
-
-chore: tweak timeout to 25s

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1735,7 +1735,7 @@ export class Hub implements HubInterface {
       try {
         return await this.getHubRpcClient(`${rpcAddressInfo.value.address}:${rpcAddressInfo.value.port}`, {
           "grpc.keepalive_time_ms": 5000,
-          "grpc.keepalive_timeout_ms": 25000,
+          "grpc.keepalive_timeout_ms": 5000,
           ...options,
         });
       } catch (e) {
@@ -1773,7 +1773,7 @@ export class Hub implements HubInterface {
     try {
       return await this.getHubRpcClient(addressInfoToString(ai), {
         "grpc.keepalive_time_ms": 5000,
-        "grpc.keepalive_timeout_ms": 25000,
+        "grpc.keepalive_timeout_ms": 5000,
         ...options,
       });
     } catch (e) {

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1733,11 +1733,7 @@ export class Hub implements HubInterface {
 
     if (rpcAddressInfo.value.address) {
       try {
-        return await this.getHubRpcClient(`${rpcAddressInfo.value.address}:${rpcAddressInfo.value.port}`, {
-          "grpc.keepalive_time_ms": 5000,
-          "grpc.keepalive_timeout_ms": 5000,
-          ...options,
-        });
+        return await this.getHubRpcClient(`${rpcAddressInfo.value.address}:${rpcAddressInfo.value.port}`);
       } catch (e) {
         log.error({ error: e, peer, peerId }, "unable to connect to peer");
         return undefined;
@@ -1771,11 +1767,7 @@ export class Hub implements HubInterface {
     };
 
     try {
-      return await this.getHubRpcClient(addressInfoToString(ai), {
-        "grpc.keepalive_time_ms": 5000,
-        "grpc.keepalive_timeout_ms": 5000,
-        ...options,
-      });
+      return await this.getHubRpcClient(addressInfoToString(ai), options);
     } catch (e) {
       log.error({ error: e, peer, peerId, addressInfo: ai }, "unable to connect to peer");
       // If the peer is unreachable (e.g. behind a firewall), remove it from our address book

--- a/packages/hub-nodejs/src/client.ts
+++ b/packages/hub-nodejs/src/client.ts
@@ -127,7 +127,7 @@ export const getServer = (): grpc.Server => {
   // set it anyway.
   const server = new grpc.Server({
     "grpc.keepalive_time_ms": 5 * 1000,
-    "grpc.keepalive_timeout_ms": 25 * 1000,
+    "grpc.keepalive_timeout_ms": 5 * 1000,
     "grpc.client_idle_timeout_ms": 60 * 1000,
   });
 


### PR DESCRIPTION
## Why is this change needed?

We think this might be responsible for some instability we're seeing on our hubs. Revert it to confirm.

- **Revert "chore: switch timeout to 25s (#2259)"**
- **Revert "chore: tweak client-side config to set baseline timeout (#2257)"**

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to streamline the gRPC client configuration by removing redundant keepalive settings.

### Detailed summary
- Removed redundant `grpc.keepalive_time_ms` and `grpc.keepalive_timeout_ms` settings in multiple files.
- Simplified `getHubRpcClient` calls by removing unnecessary options.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->