### PR TITLE
Revert "fix: adjust grpc keepalive time to 5s (#2250)"

### DIFF
--- a/packages/hub-nodejs/src/client.ts
+++ b/packages/hub-nodejs/src/client.ts
@@ -126,7 +126,7 @@ export const getServer = (): grpc.Server => {
   // max_connection_age_ms will interfere with subscribe() which is a long-lived call, but maybe we should
   // set it anyway.
   const server = new grpc.Server({
-    "grpc.keepalive_time_ms": 5 * 1000,
+    "grpc.keepalive_time_ms": 10 * 1000,
     "grpc.keepalive_timeout_ms": 5 * 1000,
     "grpc.client_idle_timeout_ms": 60 * 1000,
   });


### PR DESCRIPTION
This reverts commit 47fbd34e5c1a9682fc6a2debc02ebd347ed480c5.

## Why is this change needed?

Reverting one more of the keepalive changes

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR increases the `grpc.keepalive_time_ms` value from 5 to 10 seconds in the `client.ts` file.

### Detailed summary
- Increased `grpc.keepalive_time_ms` value from 5 to 10 seconds.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->