### PR TITLE
chore: revert "fix: Upgrade grpc-js to 1.11 (#2214)"

### DIFF
--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -78,7 +78,7 @@
     "@farcaster/hub-nodejs": "^0.11.23",
     "@fastify/cors": "^8.4.0",
     "@figma/hot-shots": "^9.0.0-figma.1",
-    "@grpc/grpc-js": "~1.11.1",
+    "@grpc/grpc-js": "~1.8.22",
     "@libp2p/interface": "1.6.2",
     "@libp2p/interface-compliance-tests": "5.4.10",
     "@libp2p/autonat": "^1.1.3",

--- a/apps/hubble/src/rpc/bufferedStreamWriter.ts
+++ b/apps/hubble/src/rpc/bufferedStreamWriter.ts
@@ -72,8 +72,7 @@ export class BufferedStreamWriter {
 
   private destroyStream() {
     this.dataWaitingForDrain = [];
-    this.stream.emit("error", new Error("Stream is backed up, please consume events faster. Closing stream."));
-    this.stream.end();
+    this.stream.destroy(new Error("Stream is backed up, please consume events faster. Closing stream."));
   }
 
   public getCacheSize(): number {

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -329,6 +329,36 @@ class IpConnectionLimiter {
   }
 }
 
+export const toTrieNodeMetadataResponse = (metadata?: NodeMetadata): TrieNodeMetadataResponse => {
+  const childrenTrie = [];
+
+  if (!metadata) {
+    return TrieNodeMetadataResponse.create({});
+  }
+
+  if (metadata.children) {
+    for (const [, child] of metadata.children) {
+      childrenTrie.push(
+        TrieNodeMetadataResponse.create({
+          prefix: child.prefix,
+          numMessages: child.numMessages,
+          hash: child.hash,
+          children: [],
+        }),
+      );
+    }
+  }
+
+  const metadataResponse = TrieNodeMetadataResponse.create({
+    prefix: metadata.prefix,
+    numMessages: metadata.numMessages,
+    hash: metadata.hash,
+    children: childrenTrie,
+  });
+
+  return metadataResponse;
+};
+
 export default class Server {
   private hub: HubInterface | undefined;
   private engine: Engine | undefined;

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -41,8 +41,6 @@ import {
   OnChainEvent,
   HubResult,
   HubAsyncResult,
-  ServerWritableStream,
-  SubscribeRequest,
 } from "@farcaster/hub-nodejs";
 import { err, ok, Result, ResultAsync } from "neverthrow";
 import { APP_NICKNAME, APP_VERSION, HubInterface } from "../hubble.js";
@@ -331,40 +329,6 @@ class IpConnectionLimiter {
   }
 }
 
-export function destroyStream(stream: ServerWritableStream<SubscribeRequest, HubEvent>, error: Error) {
-  stream.emit("error", error);
-  stream.end();
-}
-
-export const toTrieNodeMetadataResponse = (metadata?: NodeMetadata): TrieNodeMetadataResponse => {
-  const childrenTrie = [];
-
-  if (!metadata) {
-    return TrieNodeMetadataResponse.create({});
-  }
-
-  if (metadata.children) {
-    for (const [, child] of metadata.children) {
-      childrenTrie.push(
-        TrieNodeMetadataResponse.create({
-          prefix: child.prefix,
-          numMessages: child.numMessages,
-          hash: child.hash,
-          children: [],
-        }),
-      );
-    }
-  }
-
-  const metadataResponse = TrieNodeMetadataResponse.create({
-    prefix: metadata.prefix,
-    numMessages: metadata.numMessages,
-    hash: metadata.hash,
-    children: childrenTrie,
-  });
-
-  return metadataResponse;
-};
 export default class Server {
   private hub: HubInterface | undefined;
   private engine: Engine | undefined;
@@ -1342,7 +1306,8 @@ export default class Server {
           log.info({ r: request, peer }, "subscribe: starting stream");
         } else {
           log.info({ r: request, peer, err: allowed.error.message }, "subscribe: rejected stream");
-          destroyStream(stream, allowed.error);
+
+          stream.destroy(new Error(allowed.error.message));
           return;
         }
 
@@ -1354,11 +1319,11 @@ export default class Server {
         const totalShards = request.totalShards || 0;
         if (totalShards > MAX_EVENT_STREAM_SHARDS) {
           log.info({ r: request, peer, err: "invalid totalShards" }, "subscribe: rejected stream");
-          destroyStream(stream, new Error(`totalShards must be less than ${MAX_EVENT_STREAM_SHARDS}`));
+          stream.destroy(new Error(`totalShards must be less than ${MAX_EVENT_STREAM_SHARDS}`));
         }
         if (totalShards > 0 && (request.shardIndex === undefined || request.shardIndex >= totalShards)) {
           log.info({ r: request, peer, err: "invalid shard index" }, "subscribe: rejected stream");
-          destroyStream(stream, new Error("invalid shard index"));
+          stream.destroy(new Error("invalid shard index"));
         }
         const shardIndex = request.shardIndex || 0;
 
@@ -1396,7 +1361,7 @@ export default class Server {
         if (this.engine && request.fromId !== undefined && request.fromId >= 0) {
           const eventsIteratorOpts = this.engine.eventHandler.getEventsIteratorOpts({ fromId: request.fromId });
           if (eventsIteratorOpts.isErr()) {
-            destroyStream(stream, eventsIteratorOpts.error);
+            stream.destroy(eventsIteratorOpts.error);
             return;
           }
 
@@ -1410,7 +1375,7 @@ export default class Server {
             );
 
             const error = new HubError("unavailable.network_failure", `stream timeout for peer: ${stream.getPeer()}`);
-            destroyStream(stream, error);
+            stream.destroy(error);
           }, HUBEVENTS_READER_TIMEOUT);
 
           // Track our RSS usage, to detect a situation where we're writing a lot of data to the stream,
@@ -1455,7 +1420,7 @@ export default class Server {
                   // We'll destroy the stream.
                   const error = new HubError("unavailable.network_failure", "stream memory usage too much");
                   logger.error({ errCode: error.errCode }, error.message);
-                  destroyStream(stream, error);
+                  stream.destroy(error);
 
                   return true;
                 }

--- a/apps/hubble/src/rpc/test/bufferedStreamWriter.test.ts
+++ b/apps/hubble/src/rpc/test/bufferedStreamWriter.test.ts
@@ -29,9 +29,7 @@ class MockStream {
     }
   }
 
-  emit(evt: string, error: Error) {}
-
-  end() {
+  destroy() {
     this.isDestroyed = true;
   }
 

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@farcaster/core": "0.14.20",
-    "@grpc/grpc-js": "~1.11.1",
+    "@grpc/grpc-js": "~1.8.22",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2666,23 +2666,24 @@
   resolved "https://registry.npmjs.org/@figma/hot-shots/-/hot-shots-9.0.0-figma.1.tgz#e642c65469536503de12e2ecdaa2717c96a993eb"
   integrity sha512-tyOOM2hclLbv0lSkJg4jdR/RibsuPM5q9VHnwP6oqEKwPIMp32mHKWr01Oie4WWbDa3QB8g2Wx3VYLrjEo9HUg==
 
-"@grpc/grpc-js@~1.11.1":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.11.1.tgz#a92f33e98f1959feffcd1b25a33b113d2c977b70"
-  integrity sha512-gyt/WayZrVPH2w/UTLansS7F9Nwld472JxxaETamrM8HNlsa+jSLNyKAZmhxI2Me4c3mQHFiS1wWHDY1g1Kthw==
+"@grpc/grpc-js@~1.8.22":
+  version "1.8.22"
+  resolved "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.22.tgz#847930c9af46e14df05b57fc12325db140ceff1d"
+  integrity sha512-oAjDdN7fzbUi+4hZjKG96MR6KTEubAeMpQEb+77qy+3r0Ua5xTFuie6JOLr4ZZgl5g+W5/uRTS2M1V8mVAFPuA==
   dependencies:
-    "@grpc/proto-loader" "^0.7.13"
-    "@js-sdsl/ordered-map" "^4.4.2"
+    "@grpc/proto-loader" "^0.7.0"
+    "@types/node" ">=12.12.47"
 
-"@grpc/proto-loader@^0.7.13":
-  version "0.7.13"
-  resolved "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz#f6a44b2b7c9f7b609f5748c6eac2d420e37670cf"
-  integrity sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==
+"@grpc/proto-loader@^0.7.0":
+  version "0.7.4"
+  resolved "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.4.tgz#4946a84fbf47c3ddd4e6a97acb79d69a9f47ebf2"
+  integrity sha512-MnWjkGwqQ3W8fx94/c1CwqLsNmHHv2t0CFn+9++6+cDphC1lolpg9M2OU0iebIjK//pBNX9e94ho+gjx6vz39w==
   dependencies:
+    "@types/long" "^4.0.1"
     lodash.camelcase "^4.3.0"
-    long "^5.0.0"
-    protobufjs "^7.2.5"
-    yargs "^17.7.2"
+    long "^4.0.0"
+    protobufjs "^7.0.0"
+    yargs "^16.2.0"
 
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
@@ -3071,11 +3072,6 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
-
-"@js-sdsl/ordered-map@^4.4.2":
-  version "4.4.2"
-  resolved "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
-  integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
 
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.5"
@@ -5273,7 +5269,7 @@
   resolved "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.7.tgz#978bf75f7247385c61d23b6a060ba9eedb03e2f4"
   integrity sha512-9PuLtBboc/+JJ7FshmJWv769gDonTpItN0Ol5TMwclpSQNjVyB2SRxSKBcTtbSysSL5R7Oea06kTTFNciCoYwA==
 
-"@types/node@*", "@types/node@>=13.7.0", "@types/node@^20.11.30":
+"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^20.11.30":
   version "20.11.30"
   resolved "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz#9c33467fc23167a347e73834f788f4b9f399d66f"
   integrity sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==
@@ -15357,24 +15353,6 @@ protobufjs@^7.0.0:
   version "7.2.5"
   resolved "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz#45d5c57387a6d29a17aab6846dcc283f9b8e7f2d"
   integrity sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==
-  dependencies:
-    "@protobufjs/aspromise" "^1.1.2"
-    "@protobufjs/base64" "^1.1.2"
-    "@protobufjs/codegen" "^2.0.4"
-    "@protobufjs/eventemitter" "^1.1.0"
-    "@protobufjs/fetch" "^1.1.0"
-    "@protobufjs/float" "^1.0.2"
-    "@protobufjs/inquire" "^1.1.0"
-    "@protobufjs/path" "^1.1.2"
-    "@protobufjs/pool" "^1.1.0"
-    "@protobufjs/utf8" "^1.1.0"
-    "@types/node" ">=13.7.0"
-    long "^5.0.0"
-
-protobufjs@^7.2.5:
-  version "7.3.2"
-  resolved "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.2.tgz#60f3b7624968868f6f739430cfbc8c9370e26df4"
-  integrity sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"


### PR DESCRIPTION
## Why is this change needed?

This reverts commit 2fa29ad4cba95d09b29e3bb40ee303b9c4ac46d7. It seems the grpc-js library may have issues in the more recent releases

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates dependencies related to gRPC and makes changes to stream handling in the `bufferedStreamWriter` test file and the `server` file.

### Detailed summary
- Updated `@grpc/grpc-js` dependency to version `~1.8.22` in `hub-nodejs` and `hubble` packages.
- Replaced `stream.end()` with `stream.destroy()` in `bufferedStreamWriter.ts`.
- Removed `destroyStream` function and replaced its usage with `stream.destroy()` in `server.ts`.
- Updated `@grpc/proto-loader` dependency to version `^0.7.0`.
- Updated `protobufjs` dependency to version `^7.0.0`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->