### PR TITLE
chore: revert "chore: revert "fix: Upgrade grpc-js to 1.11 (#2214)" (#2263)"

### DIFF
--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -78,7 +78,7 @@
     "@farcaster/hub-nodejs": "^0.11.23",
     "@fastify/cors": "^8.4.0",
     "@figma/hot-shots": "^9.0.0-figma.1",
-    "@grpc/grpc-js": "~1.8.22",
+    "@grpc/grpc-js": "~1.11.1",
     "@libp2p/interface": "1.6.2",
     "@libp2p/interface-compliance-tests": "5.4.10",
     "@libp2p/autonat": "^1.1.3",

--- a/apps/hubble/src/rpc/bufferedStreamWriter.ts
+++ b/apps/hubble/src/rpc/bufferedStreamWriter.ts
@@ -72,7 +72,8 @@ export class BufferedStreamWriter {
 
   private destroyStream() {
     this.dataWaitingForDrain = [];
-    this.stream.destroy(new Error("Stream is backed up, please consume events faster. Closing stream."));
+    this.stream.emit("error", new Error("Stream is backed up, please consume events faster. Closing stream."));
+    this.stream.end();
   }
 
   public getCacheSize(): number {

--- a/apps/hubble/src/rpc/test/bufferedStreamWriter.test.ts
+++ b/apps/hubble/src/rpc/test/bufferedStreamWriter.test.ts
@@ -29,7 +29,9 @@ class MockStream {
     }
   }
 
-  destroy() {
+  emit(evt: string, error: Error) {}
+
+  end() {
     this.isDestroyed = true;
   }
 

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@farcaster/core": "0.14.20",
-    "@grpc/grpc-js": "~1.8.22",
+    "@grpc/grpc-js": "~1.11.1",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2666,24 +2666,23 @@
   resolved "https://registry.npmjs.org/@figma/hot-shots/-/hot-shots-9.0.0-figma.1.tgz#e642c65469536503de12e2ecdaa2717c96a993eb"
   integrity sha512-tyOOM2hclLbv0lSkJg4jdR/RibsuPM5q9VHnwP6oqEKwPIMp32mHKWr01Oie4WWbDa3QB8g2Wx3VYLrjEo9HUg==
 
-"@grpc/grpc-js@~1.8.22":
-  version "1.8.22"
-  resolved "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.22.tgz#847930c9af46e14df05b57fc12325db140ceff1d"
-  integrity sha512-oAjDdN7fzbUi+4hZjKG96MR6KTEubAeMpQEb+77qy+3r0Ua5xTFuie6JOLr4ZZgl5g+W5/uRTS2M1V8mVAFPuA==
+"@grpc/grpc-js@~1.11.1":
+  version "1.11.1"
+  resolved "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.11.1.tgz#a92f33e98f1959feffcd1b25a33b113d2c977b70"
+  integrity sha512-gyt/WayZrVPH2w/UTLansS7F9Nwld472JxxaETamrM8HNlsa+jSLNyKAZmhxI2Me4c3mQHFiS1wWHDY1g1Kthw==
   dependencies:
-    "@grpc/proto-loader" "^0.7.0"
-    "@types/node" ">=12.12.47"
+    "@grpc/proto-loader" "^0.7.13"
+    "@js-sdsl/ordered-map" "^4.4.2"
 
-"@grpc/proto-loader@^0.7.0":
-  version "0.7.4"
-  resolved "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.4.tgz#4946a84fbf47c3ddd4e6a97acb79d69a9f47ebf2"
-  integrity sha512-MnWjkGwqQ3W8fx94/c1CwqLsNmHHv2t0CFn+9++6+cDphC1lolpg9M2OU0iebIjK//pBNX9e94ho+gjx6vz39w==
+"@grpc/proto-loader@^0.7.13":
+  version "0.7.13"
+  resolved "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz#f6a44b2b7c9f7b609f5748c6eac2d420e37670cf"
+  integrity sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==
   dependencies:
-    "@types/long" "^4.0.1"
     lodash.camelcase "^4.3.0"
-    long "^4.0.0"
-    protobufjs "^7.0.0"
-    yargs "^16.2.0"
+    long "^5.0.0"
+    protobufjs "^7.2.5"
+    yargs "^17.7.2"
 
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
@@ -3072,6 +3071,11 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@js-sdsl/ordered-map@^4.4.2":
+  version "4.4.2"
+  resolved "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
+  integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
 
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.5"
@@ -5269,7 +5273,7 @@
   resolved "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.7.tgz#978bf75f7247385c61d23b6a060ba9eedb03e2f4"
   integrity sha512-9PuLtBboc/+JJ7FshmJWv769gDonTpItN0Ol5TMwclpSQNjVyB2SRxSKBcTtbSysSL5R7Oea06kTTFNciCoYwA==
 
-"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^20.11.30":
+"@types/node@*", "@types/node@>=13.7.0", "@types/node@^20.11.30":
   version "20.11.30"
   resolved "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz#9c33467fc23167a347e73834f788f4b9f399d66f"
   integrity sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==
@@ -15353,6 +15357,24 @@ protobufjs@^7.0.0:
   version "7.2.5"
   resolved "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz#45d5c57387a6d29a17aab6846dcc283f9b8e7f2d"
   integrity sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/node" ">=13.7.0"
+    long "^5.0.0"
+
+protobufjs@^7.2.5:
+  version "7.3.2"
+  resolved "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.2.tgz#60f3b7624968868f6f739430cfbc8c9370e26df4"
+  integrity sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"


### PR DESCRIPTION
## Why is this change needed?

The grpc-js downgrade did not have a measurable impact

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates dependencies and refactors stream handling in the `bufferedStreamWriter` and `server` files. 

### Detailed summary
- Updated `@grpc/grpc-js` dependency to version `~1.11.1`
- Refactored stream handling in `bufferedStreamWriter.ts`
- Added `destroyStream` function in `server.ts` for handling stream errors

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->