### PR TITLE
fix: Move storage unit type helper functions to hub-nodejs package

### DIFF
--- a/.changeset/brown-spies-approve.md
+++ b/.changeset/brown-spies-approve.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+fix: Move storage unit type helper functions to hub-nodejs package

--- a/apps/hubble/src/rpc/test/server.test.ts
+++ b/apps/hubble/src/rpc/test/server.test.ts
@@ -16,6 +16,7 @@ import {
   getDefaultStoreLimit,
   HubError,
   StorageUnitType,
+  LEGACY_STORAGE_UNIT_CUTOFF_TIMESTAMP,
 } from "@farcaster/hub-nodejs";
 import Engine from "../../storage/engine/index.js";
 import { MockHub } from "../../test/mocks.js";
@@ -25,7 +26,6 @@ import { Err, Ok } from "neverthrow";
 import { sleep } from "../../utils/crypto.js";
 import * as http from "http";
 import { AddressInfo, createServer } from "net";
-import { LEGACY_STORAGE_UNIT_CUTOFF_TIMESTAMP } from "../../storage/stores/storageCache.js";
 
 const db = jestRocksDB("protobufs.rpc.server.test");
 const network = FarcasterNetwork.TESTNET;

--- a/apps/hubble/src/storage/stores/storageCache.test.ts
+++ b/apps/hubble/src/storage/stores/storageCache.test.ts
@@ -1,9 +1,15 @@
 import { ok } from "neverthrow";
-import { Factories, HubEvent, HubEventType, getFarcasterTime } from "@farcaster/hub-nodejs";
+import {
+  Factories,
+  HubEvent,
+  HubEventType,
+  getFarcasterTime,
+  LEGACY_STORAGE_UNIT_CUTOFF_TIMESTAMP,
+} from "@farcaster/hub-nodejs";
 import { jestRocksDB } from "../db/jestUtils.js";
 import { makeTsHash, putMessage } from "../db/message.js";
 import { UserPostfix } from "../db/types.js";
-import { LEGACY_STORAGE_UNIT_CUTOFF_TIMESTAMP, StorageCache } from "./storageCache.js";
+import { StorageCache } from "./storageCache.js";
 import { putOnChainEventTransaction } from "../db/onChainEvent.js";
 import { sleep } from "../../utils/crypto.js";
 import { jest } from "@jest/globals";

--- a/apps/hubble/src/storage/stores/storageCache.ts
+++ b/apps/hubble/src/storage/stores/storageCache.ts
@@ -1,4 +1,6 @@
 import {
+  getStorageUnitExpiry,
+  getStorageUnitType,
   HubError,
   HubEvent,
   isMergeMessageHubEvent,
@@ -23,29 +25,9 @@ import { forEachOnChainEvent } from "../db/onChainEvent.js";
 import { addProgressBar } from "../../utils/progressBars.js";
 
 const MAX_PENDING_MESSAGE_COUNT_SCANS = 100;
-export const LEGACY_STORAGE_UNIT_CUTOFF_TIMESTAMP = 1724889600; // 2024-08-29 00:00:00 UTC
-const ONE_YEAR_IN_SECONDS = 365 * 24 * 60 * 60;
 
 const makeKey = (fid: number, set: UserMessagePostfix): string => {
   return Buffer.concat([makeFidKey(fid), Buffer.from([set])]).toString("hex");
-};
-
-const getStorageUnitType = (event: StorageRentOnChainEvent) => {
-  if (event.blockTimestamp < LEGACY_STORAGE_UNIT_CUTOFF_TIMESTAMP) {
-    return StorageUnitType.UNIT_TYPE_LEGACY;
-  } else {
-    return StorageUnitType.UNIT_TYPE_2024;
-  }
-};
-
-const getStorageUnitExpiry = (event: StorageRentOnChainEvent) => {
-  if (event.blockTimestamp < LEGACY_STORAGE_UNIT_CUTOFF_TIMESTAMP) {
-    // Legacy storage units expire after 2 years
-    return event.blockTimestamp + ONE_YEAR_IN_SECONDS * 2;
-  } else {
-    // 2024 storage units expire after 1 year
-    return event.blockTimestamp + ONE_YEAR_IN_SECONDS;
-  }
 };
 
 const storageSlotFromEvent = (event: StorageRentOnChainEvent): StorageSlot => {

--- a/apps/hubble/src/storage/stores/storeEventHandler.test.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.test.ts
@@ -4,6 +4,7 @@ import {
   FARCASTER_EPOCH,
   HubEvent,
   HubEventType,
+  LEGACY_STORAGE_UNIT_CUTOFF_TIMESTAMP,
   StoreType,
   toFarcasterTime,
 } from "@farcaster/hub-nodejs";
@@ -17,7 +18,6 @@ import { extractEventTimestamp, getFarcasterTime } from "@farcaster/core";
 import OnChainEventStore from "./onChainEventStore.js";
 import CastStore from "./castStore.js";
 import { rsCreateStoreEventHandler, rsGetNextEventId } from "../../rustfunctions.js";
-import { LEGACY_STORAGE_UNIT_CUTOFF_TIMESTAMP } from "./storageCache.js";
 
 const db = jestRocksDB("stores.storeEventHandler.test");
 const eventHandler = new StoreEventHandler(db);

--- a/packages/core/src/limits.ts
+++ b/packages/core/src/limits.ts
@@ -1,4 +1,7 @@
-import { StorageUnitDetails, StorageUnitType, StoreType } from "./protobufs";
+import { StorageRentOnChainEvent, StorageUnitDetails, StorageUnitType, StoreType } from "./protobufs";
+
+export const LEGACY_STORAGE_UNIT_CUTOFF_TIMESTAMP = 1724889600; // 2024-08-29 00:00:00 UTC
+const ONE_YEAR_IN_SECONDS = 365 * 24 * 60 * 60;
 
 const STORAGE_UNIT_DEFAULTS = {
   [StoreType.CASTS]: {
@@ -68,4 +71,22 @@ export const getStoreLimit = (storeType: StoreType, unit_details: StorageUnitDet
 
 export const getDefaultStoreLimit = (storeType: StoreType, unit_type: StorageUnitType) => {
   return STORAGE_UNIT_DEFAULTS[storeType][unit_type];
+};
+
+export const getStorageUnitType = (event: StorageRentOnChainEvent) => {
+  if (event.blockTimestamp < LEGACY_STORAGE_UNIT_CUTOFF_TIMESTAMP) {
+    return StorageUnitType.UNIT_TYPE_LEGACY;
+  } else {
+    return StorageUnitType.UNIT_TYPE_2024;
+  }
+};
+
+export const getStorageUnitExpiry = (event: StorageRentOnChainEvent) => {
+  if (event.blockTimestamp < LEGACY_STORAGE_UNIT_CUTOFF_TIMESTAMP) {
+    // Legacy storage units expire after 2 years
+    return event.blockTimestamp + ONE_YEAR_IN_SECONDS * 2;
+  } else {
+    // 2024 storage units expire after 1 year
+    return event.blockTimestamp + ONE_YEAR_IN_SECONDS;
+  }
 };


### PR DESCRIPTION
## Why is this change needed?

Expose storage unit helper functions via hub-nodejs

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on moving storage unit type helper functions to the `hub-nodejs` package.

### Detailed summary
- Moved storage unit type helper functions to `hub-nodejs` package
- Added `LEGACY_STORAGE_UNIT_CUTOFF_TIMESTAMP` constant
- Updated functions related to storage unit type and expiry calculations

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->