### PR TITLE
feat(shuttle): Support event level callback in shuttle

### DIFF
--- a/.changeset/stupid-crews-kneel.md
+++ b/.changeset/stupid-crews-kneel.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": minor
+---
+
+feat: Support event level callbacks in shuttle

--- a/packages/shuttle/src/example-app/db.ts
+++ b/packages/shuttle/src/example-app/db.ts
@@ -60,8 +60,22 @@ export type CastRow = {
   text: string;
 };
 
+export type OnChainEventRow = {
+  id: Generated<string>;
+  createdAt: Generated<Date>;
+  updatedAt: Generated<Date>;
+  timestamp: Date;
+  fid: Fid;
+  blockNumber: number;
+  logIndex: number;
+  type: number;
+  txHash: Uint8Array;
+  body: Record<string, string | number>;
+};
+
 export interface Tables extends HubTables {
   casts: CastRow;
+  onchain_events: OnChainEventRow;
 }
 
 export type AppDb = Kysely<Tables>;

--- a/packages/shuttle/src/example-app/migrations/003_onchain_events.ts
+++ b/packages/shuttle/src/example-app/migrations/003_onchain_events.ts
@@ -1,0 +1,27 @@
+import { Kysely, sql } from "kysely";
+
+// biome-ignore lint/suspicious/noExplicitAny: legacy code, avoid using ignore for new code
+export const up = async (db: Kysely<any>) => {
+  // Casts -------------------------------------------------------------------------------------
+  await db.schema
+    .createTable("onchain_events")
+    .addColumn("id", "uuid", (col) => col.defaultTo(sql`generate_ulid()`))
+    .addColumn("createdAt", "timestamptz", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("updatedAt", "timestamptz", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("timestamp", "timestamptz", (col) => col.notNull())
+    .addColumn("fid", "bigint", (col) => col.notNull())
+    .addColumn("blockNumber", "bigint", (col) => col.notNull())
+    .addColumn("logIndex", "integer", (col) => col.notNull())
+    .addColumn("type", "integer", (col) => col.notNull())
+    .addColumn("txHash", "bytea", (col) => col.notNull())
+    .addColumn("body", "json", (col) => col.notNull())
+    .execute();
+
+  await db.schema
+    .createIndex("onchain_events_block_log_index")
+    .on("onchain_events")
+    .columns(["blockNumber", "logIndex"])
+    .execute();
+
+  await db.schema.createIndex("onchain_events_fid_type").on("onchain_events").columns(["fid", "type"]).execute();
+};

--- a/packages/shuttle/src/shuttle/hubEventProcessor.ts
+++ b/packages/shuttle/src/shuttle/hubEventProcessor.ts
@@ -6,6 +6,8 @@ import {
   isLinkCompactStateMessage,
   isLinkRemoveMessage,
   isMergeMessageHubEvent,
+  isMergeOnChainHubEvent,
+  isMergeUsernameProofHubEvent,
   isPruneMessageHubEvent,
   isReactionAddMessage,
   isReactionRemoveMessage,
@@ -23,6 +25,10 @@ import { bytesToHex } from "../utils";
 
 export class HubEventProcessor {
   static async processHubEvent(db: DB, event: HubEvent, handler: MessageHandler) {
+    const shouldSkip = await handler.onHubEvent(event);
+    if (shouldSkip) {
+      return;
+    }
     if (isMergeMessageHubEvent(event)) {
       await this.processMessage(
         db,

--- a/packages/shuttle/src/shuttle/index.ts
+++ b/packages/shuttle/src/shuttle/index.ts
@@ -1,4 +1,4 @@
-import { Message } from "@farcaster/hub-nodejs";
+import { HubEvent, Message } from "@farcaster/hub-nodejs";
 import { DB } from "./db";
 
 export * from "./db";
@@ -26,6 +26,10 @@ export type ProcessResult = {
 // is semantically a delete of the existing add, and state will be set to "deleted" in that case)
 
 export interface MessageHandler {
+  // Called for every hub event. Return true to skip processing the event.
+  // Returning true will not insert into the messages table. Should always return false unless you have a good reason.
+  onHubEvent(event: HubEvent): Promise<boolean>;
+
   handleMessageMerge(
     message: Message,
     txn: DB,


### PR DESCRIPTION
## Why is this change needed?

Support event level callbacks in Shuttle. This allows flexibility in skipping event processing if desired, and custom handling for onchain events and username proofs.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for event level callbacks in the shuttle package.

### Detailed summary
- Added `OnChainEventRow` type to `db.ts`
- Updated `HubEventProcessor` to support event level callbacks
- Added `onHubEvent` method to `MessageHandler`
- Added migration script for `onchain_events` table
- Updated `App` class to handle `MergeOnChainHubEvent` events

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->