### PR TITLE
fix: have reconciliation actually use time bounds

### DIFF
--- a/.changeset/purple-spoons-clap.md
+++ b/.changeset/purple-spoons-clap.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+fix: reconciliation wasn't actually using time bounds for hub rpcs

--- a/packages/shuttle/src/shuttle/messageReconciliation.ts
+++ b/packages/shuttle/src/shuttle/messageReconciliation.ts
@@ -58,7 +58,7 @@ export class MessageReconciliation {
 
     const hubMessagesByHash: Record<string, Message> = {};
     // First, reconcile messages that are in the hub but not in the database
-    for await (const messages of this.allHubMessagesOfTypeForFid(fid, type)) {
+    for await (const messages of this.allHubMessagesOfTypeForFid(fid, type, startTimestamp, stopTimestamp)) {
       const messageHashes = messages.map((msg) => msg.hash);
 
       if (messageHashes.length === 0) {


### PR DESCRIPTION
The time bounds provided for the hub rpcs weren't actually being used. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing reconciliation in the `shuttle` package by ensuring time bounds are used for hub rpcs.

### Detailed summary
- Added `startTimestamp` and `stopTimestamp` parameters to `allHubMessagesOfTypeForFid` method call.
- Updated reconciliation logic to use time bounds for hub rpcs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->