### PR TITLE
fix:docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ No contribution is too small and we welcome your help. There's always something 
 
 - Opening issues or adding details to existing issues
 - Fixing bugs in the code
-- Making tests or the ci builds faster
+- Making tests or the CI builds faster
 - Improving the documentation
 - Keeping packages up-to-date
 - Proposing and implementing new features
@@ -55,7 +55,7 @@ Then, from the root folder run:
 - `yarn build` to build Hubble and its dependencies
 - `yarn test` to ensure that the test suite runs correctly
 
-NOTE: running `yarn test` currently fails due to an environment issue with shuttle. you can still run yarn test successfully from all the other repositories.
+NOTE: Running `yarn test` currently fails due to an environment issue with shuttle. you can still run `yarn test` successfully from all the other repositories.
 
 ### 2.2. Signing Commits
 
@@ -107,7 +107,7 @@ All changes that involve features or bugfixes should be accompanied by tests, an
 
 If your PR has changes to gRPC or protobuf files, you must update the [public documentation website](./apps/hubble/www/). See the [Protobuf README](./protobufs/README.md) for instructions on how to auto-gen the documentation.
 
-All PR's should have supporting documentation that makes reviewing and understanding the code easy. You should:
+All PRs should have supporting documentation that makes reviewing and understanding the code easy. You should:
 
 - Update high-level changes in the [contract docs](docs/docs.md).
 - Always use TSDoc style comments for functions, variables, constants, events and params.
@@ -116,7 +116,7 @@ All PR's should have supporting documentation that makes reviewing and understan
 - Comments explaining the 'why' when code is not obvious.
 - Do not comment obvious changes (e.g. `starts the db` before the line `db.start()`)
 - Add a `Safety: ..` comment explaining every use of `as`.
-- Prefer active, present-tense doing form (`Gets the connection`) over other forms (`Connection is obtained`, `Get the connection`, `We get the connection`, `will get a connection`)
+- Prefer active, present-tense doing form (e.g. `Gets the connection`) over other forms (e.g. `Connection is obtained`, `Get the connection`, `We get the connection`, `will get a connection`)
 
 ### 3.3. Handling Errors
 
@@ -183,7 +183,7 @@ const result = safeJsonStringify(json);
 
 ---
 
-Prefer `result.match` to handle HubResult since it is explicit about how all branches are handled
+Prefer `result.match` to handle `HubResult` since it is explicit about how all branches are handled
 
 ```ts
 const result = computationThatMightFail().match(

--- a/apps/hubble/www/docs/docs/architecture.md
+++ b/apps/hubble/www/docs/docs/architecture.md
@@ -15,9 +15,9 @@ CRDT sets are implemented to meet the specification in the Farcaster protocol. T
 
 ### P2P Engine
 
-Hubble connects to other peers over a GossipSub network established using [LibP2P](https://github.com/libp2p/libp2p). Messages merged into the Storage Engine are immediately gossiped to all of is peers.
+Hubble connects to other peers over a GossipSub network established using [LibP2P](https://github.com/libp2p/libp2p). Messages merged into the Storage Engine are immediately gossiped to all of its peers.
 
-Hubble will only peer with trusted peers and employ a simple network topology during beta. It peers only with known instances which must be configured at startup. In later releases, the network topology will be modified to operate closer to a trustless mesh.
+Hubble will only peer with trusted peers and employ a simple network topology during beta. It peers only with known instances, which must be configured at startup. In later releases, the network topology will be modified to operate closer to a trustless mesh.
 
 ### Sync Engine
 


### PR DESCRIPTION
## Why is this change needed?

Fixes #2276 

Corrected several grammatical and textual errors in the documentation files. This change is needed to ensure that the documentation is clear, professional, and free of errors, which will enhance the user experience and make the documentation easier to understand for all contributors.


## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves code consistency and clarity in documentation across the project. 

### Detailed summary
- Corrected grammar in `architecture.md`
- Updated formatting in `CONTRIBUTING.md`
- Ensured consistent use of backticks in documentation

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->