### PR TITLE
fix: downgrade node version in CI to fix tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,9 @@ jobs:
         include:
           - node_version: 20
             runs_on: 'warp-ubuntu-latest-x64-16x'
-          - node_version: 22
+          - node_version: 22.4.1 # HACK: There's an issue with node 22.7.0
             runs_on: 'warp-ubuntu-latest-arm64-16x' # Only works on ARM for now
-          - node_version: 22
+          - node_version: 22.4.1 # HACK: There's an issue with node 22.7.0
             runs_on: 'warp-ubuntu-latest-x64-16x'
 
     runs-on: ${{ matrix.runs_on }}


### PR DESCRIPTION
## Why is this change needed?

CI is broken because there's some issue with proto serialization in node 22.7.0. I used the same version that's in the hub deployment dockerfile. 

https://github.com/protobufjs/protobuf.js/issues/2025

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Node.js version in the CI workflow to 22.4.1 due to an issue with 22.7.0. It also specifies different Node.js versions for x64 and ARM architectures.

### Detailed summary
- Updated Node.js version in CI workflow to 22.4.1
- Added comments about the issue with Node.js 22.7.0
- Specified different Node.js versions for x64 and ARM architectures

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->