### PR TITLE
fix: Update onHubEvent to accept a txn for consistency

### DIFF
--- a/.changeset/ten-ligers-count.md
+++ b/.changeset/ten-ligers-count.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+fix: Update onHubEvent to accept a txn for consistency

--- a/packages/shuttle/src/example-app/app.ts
+++ b/packages/shuttle/src/example-app/app.ts
@@ -105,7 +105,7 @@ export class App implements MessageHandler {
     return new App(db, dbSchema, redis, hubSubscriber, streamConsumer);
   }
 
-  async onHubEvent(event: HubEvent): Promise<boolean> {
+  async onHubEvent(event: HubEvent, txn: DB): Promise<boolean> {
     if (isMergeOnChainHubEvent(event)) {
       const onChainEvent = event.mergeOnChainEventBody.onChainEvent;
       let body = {};
@@ -133,7 +133,7 @@ export class App implements MessageHandler {
         };
       }
       try {
-        await (this.db as AppDb)
+        await (txn as AppDb)
           .insertInto("onchain_events")
           .values({
             fid: onChainEvent.fid,

--- a/packages/shuttle/src/shuttle.integration.test.ts
+++ b/packages/shuttle/src/shuttle.integration.test.ts
@@ -77,7 +77,7 @@ class FakeHubSubscriber extends HubSubscriber implements MessageHandler {
     this.shouldSkip = shouldSkip;
   }
 
-  async onHubEvent(_event: HubEvent): Promise<boolean> {
+  async onHubEvent(_event: HubEvent, _txn: DB): Promise<boolean> {
     return this.shouldSkip;
   }
 

--- a/packages/shuttle/src/shuttle/index.ts
+++ b/packages/shuttle/src/shuttle/index.ts
@@ -28,7 +28,7 @@ export type ProcessResult = {
 export interface MessageHandler {
   // Called for every hub event. Return true to skip processing the event.
   // Returning true will not insert into the messages table. Should always return false unless you have a good reason.
-  onHubEvent(event: HubEvent): Promise<boolean>;
+  onHubEvent(event: HubEvent, txn: DB): Promise<boolean>;
 
   handleMessageMerge(
     message: Message,


### PR DESCRIPTION
## Why is this change needed?

Process both the hub event and the messages in that event within the same db transaction.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `onHubEvent` method in the `shuttle` package to accept a transaction for consistency.

### Detailed summary
- Updated `onHubEvent` method in `shuttle` package to accept a transaction parameter
- Updated method calls in `HubEventProcessor` to pass the transaction parameter for consistency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->