### PR TITLE
chore: Release shuttle 0.6

### DIFF
--- a/.changeset/purple-spoons-clap.md
+++ b/.changeset/purple-spoons-clap.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-fix: reconciliation wasn't actually using time bounds for hub rpcs

--- a/.changeset/stupid-crews-kneel.md
+++ b/.changeset/stupid-crews-kneel.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": minor
----
-
-feat: Support event level callbacks in shuttle

--- a/.changeset/ten-ligers-count.md
+++ b/.changeset/ten-ligers-count.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-fix: Update onHubEvent to accept a txn for consistency

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @farcaster/hub-shuttle
 
+## 0.6.0
+
+### Minor Changes
+
+- 7eba6ee0: feat: Support event level callbacks in shuttle
+
+### Patch Changes
+
+- 49ecf50e: fix: reconciliation wasn't actually using time bounds for hub rpcs
+- 2bf64461: fix: Update onHubEvent to accept a txn for consistency
+
 ## 0.5.13
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.5.13",
+  "version": "0.6.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Why is this change needed?

Release shuttle 0.6 with support for handling hub event level callbacks. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `@farcaster/shuttle` to `0.6.0`, introducing support for event level callbacks and fixing reconciliation issues in hub rpcs.

### Detailed summary
- Updated version to 0.6.0
- Added support for event level callbacks
- Fixed reconciliation not using time bounds for hub rpcs
- Updated `onHubEvent` to accept a transaction for consistency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->