### PR TITLE
fix: run sync health over a 30 minute window

### DIFF
--- a/apps/hubble/src/network/sync/syncHealthJob.ts
+++ b/apps/hubble/src/network/sync/syncHealthJob.ts
@@ -15,9 +15,9 @@ type SchedulerStatus = "started" | "stopped";
 export class MeasureSyncHealthJobScheduler {
   private _cronTask?: cron.ScheduledTask;
   private _metadataRetriever: SyncEngineMetadataRetriever;
-  // Start at 15 minutes ago and take a 10 minute span
-  private _startSecondsAgo = 60 * 15;
-  private _spanSeconds = 60 * 10;
+  // Start at 35 minutes ago and take a 30 minute span
+  private _startSecondsAgo = 60 * 35;
+  private _spanSeconds = 60 * 30;
   private _hub: HubInterface;
   private _peersInScope: string[];
 


### PR DESCRIPTION
The sync health job regularly misses messages during restarts because it takes over 15 minutes for a hub to restart and for the sync health job to find peer contact info for all the sync health peers. 

## Why is this change needed?
During reconciliation, we found messages reconciled around andil restarts because the sync health job missed them. We want the sync health job to capture these cases. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR increases the time span for syncing health data in `syncHealthJob.ts` from 10 minutes to 30 minutes.

### Detailed summary
- Increased `_startSecondsAgo` from 15 to 35 minutes
- Increased `_spanSeconds` from 10 to 30 minutes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->