### PR TITLE
feat: export makeMessage fn

### DIFF
--- a/packages/core/src/builders.ts
+++ b/packages/core/src/builders.ts
@@ -52,7 +52,7 @@ const makeMessageData = async <TData extends protobufs.MessageData>(
   return validations.validateMessageData(data as TData, publicClients);
 };
 
-const makeMessage = async <TMessage extends protobufs.Message>(
+export const makeMessage = async <TMessage extends protobufs.Message>(
   messageData: protobufs.MessageData,
   signer: Signer,
 ): HubAsyncResult<TMessage> => {


### PR DESCRIPTION
## Why is this change needed?
This function will be useful in the backend for a script that generates a message from another message and publishes with a new signer. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on making the `makeMessage` function in `builders.ts` file exportable. 

### Detailed summary
- Exported the `makeMessage` function in `builders.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->