### PR TITLE
feat: switch shuttle to use stream fetch

### DIFF
--- a/.changeset/chatty-snails-give.md
+++ b/.changeset/chatty-snails-give.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+feat: switch shuttle to use stream fetch

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@farcaster/hot-shots": "^10.0.0",
-    "@farcaster/hub-nodejs": "^0.12.1",
+    "@farcaster/hub-nodejs": "^0.12.2",
     "commander": "11.0.0",
     "dotenv": "16.4.5",
     "ioredis": "^5.3.2",

--- a/packages/shuttle/src/shuttle.integration.test.ts
+++ b/packages/shuttle/src/shuttle.integration.test.ts
@@ -5,6 +5,7 @@ import {
   CallOptions,
   Factories,
   FidRequest,
+  HubError,
   HubEvent,
   HubEventType,
   HubRpcClient,
@@ -26,7 +27,7 @@ import {
   MessageState,
   MessageReconciliation,
 } from "./shuttle";
-import { ok } from "neverthrow";
+import { err, ok } from "neverthrow";
 import { bytesToHex } from "./utils";
 
 let db: DB;
@@ -436,6 +437,9 @@ describe("shuttle", () => {
 
     // It's a hack, but mockito is not handling this well:
     const mockRPCClient = {
+      streamFetch: (metadata?: Metadata, options?: Partial<CallOptions>) => {
+        return err(new HubError("unavailable", "unavailable"));
+      },
       getAllLinkMessagesByFid: async (_request: FidRequest, _metadata: Metadata, _options: Partial<CallOptions>) => {
         return ok(
           MessagesResponse.create({
@@ -536,6 +540,9 @@ describe("shuttle", () => {
 
     // It's a hack, but mockito is not handling this well:
     const mockRPCClient = {
+      streamFetch: (metadata?: Metadata, options?: Partial<CallOptions>) => {
+        return err(new HubError("unavailable", "unavailable"));
+      },
       getAllLinkMessagesByFid: async (_request: FidRequest, _metadata: Metadata, _options: Partial<CallOptions>) => {
         return ok(
           MessagesResponse.create({


### PR DESCRIPTION
## Why is this change needed?

Follow up to add stream fetch support to shuttle

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `shuttle` package to use stream fetch and adds error handling for stream establishment.

### Detailed summary
- Updated `shuttle` to use stream fetch
- Added error handling for stream establishment using `HubError`
- Added new methods for different message types retrieval
- Implemented stream fetch functionality in `MessageReconciliation`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->