### PR TITLE
chore: bump shuttle version

### DIFF
--- a/.changeset/chatty-snails-give.md
+++ b/.changeset/chatty-snails-give.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-feat: switch shuttle to use stream fetch

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.6.1
+
+### Patch Changes
+
+- 78342c3d: feat: switch shuttle to use stream fetch
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Why is this change needed?

Bump shuttle version to release package with streaming fetch support.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `@farcaster/shuttle` package to `0.6.1` and implements a feature to switch shuttle to use stream fetch.

### Detailed summary
- Updated package version to `0.6.1`
- Implemented feature to switch shuttle to use stream fetch

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->