### PR TITLE
feat: add a new metric for tracking count of successfully merged messages

### DIFF
--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1974,6 +1974,7 @@ export class Hub implements HubInterface {
     // Convert the merge results to an Array of HubResults with the key
     const finalResults: HubResult<number>[] = [];
     const finalFailures = new Map<string, number>();
+    const totalTimeMilis = Date.now() - start;
     let success = 0;
     for (let i = 0; i < allResults.size; i++) {
       const result = allResults.get(i) as HubResult<number>;
@@ -1985,10 +1986,10 @@ export class Hub implements HubInterface {
         finalFailures.set(errCode, count + 1);
       }
       finalResults.push(result);
-    }
 
-    const totalTimeMilis = Date.now() - start;
-    statsd().timing("hub.merge_message", totalTimeMilis / finalResults.length);
+      // Register one metric event per message that was merged
+      statsd().timing("hub.merge_message", totalTimeMilis / allResults.size);
+    }
 
     // When submitting a messageBundle via RPC, we want to gossip it to other nodes
     if (success > 0 && source === "rpc") {


### PR DESCRIPTION
## Why is this change needed?

We're currently using hubble.hub.merge_message.count for the message count metric and it  looks skewed because some hubs have more messages submitted as bundles than others and each bundle only count as a single message rather than as the number of individual messages inside them. Create a new metric to track successfully merged messages (we already have a metric for errors). 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to increment a statsd metric when a message submission is successful in the `Hub` class of the Hubble app.

### Detailed summary
- Increment statsd metric on successful message submission in `submit_message` method.
- Added statsd metric incrementation in the `mergeResult` match block.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->