### PR TITLE
chore: remove superfluous warn log and update docs

### DIFF
--- a/.changeset/fluffy-fans-sell.md
+++ b/.changeset/fluffy-fans-sell.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+remove superfluous warn log

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -1653,8 +1653,6 @@ export default class Server {
       },
       streamSync: async (stream: ServerDuplexStream<StreamSyncRequest, StreamSyncResponse>) => {
         const timeout = setTimeout(async () => {
-          logger.warn({ timeout: STREAM_METHODS_TIMEOUT }, "stream sync: timeout, stopping stream");
-
           const error = new HubError("unavailable.network_failure", "stream timeout");
           destroyStream(stream, error);
         }, STREAM_METHODS_TIMEOUT);
@@ -1857,8 +1855,6 @@ export default class Server {
       },
       streamFetch: async (stream: ServerDuplexStream<StreamFetchRequest, StreamFetchResponse>) => {
         const timeout = setTimeout(async () => {
-          logger.warn({ timeout: STREAM_METHODS_TIMEOUT }, "stream fetch: timeout, stopping stream");
-
           const error = new HubError("unavailable.network_failure", "stream timeout");
           destroyStream(stream, error);
         }, STREAM_METHODS_TIMEOUT);

--- a/apps/hubble/www/docs/docs/api.md
+++ b/apps/hubble/www/docs/docs/api.md
@@ -316,14 +316,16 @@ Used to subscribe to real-time event updates from the Farcaster Hub
 
 ## 11. Sync Service
 
-| Method Name             | Request Type      | Response Type            | Description                                            |
-| ----------------------- | ----------------- | ------------------------ | ------------------------------------------------------ |
-| GetInfo                 | HubInfoRequest    | HubInfoResponse          | Returns metadata about the hub's state.                |
-| GetSyncStatus           | SyncStatusRequest | SyncStatusResponse       | Returns the hub's sync status.  |
-| GetAllSyncIdsByPrefix   | TrieNodePrefix    | SyncIds                  | TBD |
-| GetAllMessagesBySyncIds | SyncIds           | MessagesResponse         | TBD |
-| GetSyncMetadataByPrefix | TrieNodePrefix    | TrieNodeMetadataResponse | TBD |
-| GetSyncSnapshotByPrefix | TrieNodePrefix    | TrieNodeSnapshotResponse | TBD |
+| Method Name             | Request Type              | Response Type              | Description                                                     |
+| ----------------------- | ------------------------- | -------------------------- | --------------------------------------------------------------- |
+| GetInfo                 | HubInfoRequest            | HubInfoResponse            | Returns metadata about the hub's state.                         |
+| GetSyncStatus           | SyncStatusRequest         | SyncStatusResponse         | Returns the hub's sync status.                                  |
+| GetAllSyncIdsByPrefix   | TrieNodePrefix            | SyncIds                    | TBD                                                             |
+| GetAllMessagesBySyncIds | SyncIds                   | MessagesResponse           | TBD                                                             |
+| GetSyncMetadataByPrefix | TrieNodePrefix            | TrieNodeMetadataResponse   | TBD                                                             |
+| GetSyncSnapshotByPrefix | TrieNodePrefix            | TrieNodeSnapshotResponse   | TBD                                                             |
+| StreamSync              | stream StreamSyncRequest  | stream StreamSyncResponse  | Enables sync related operations over a constant stream.         |
+| StreamFetch             | stream StreamFetchRequest | stream StreamFetchResponse | Enables reconciliation fetch operations over a constant stream. |
 
 ### HubInfoRequest
 
@@ -405,6 +407,67 @@ Response Types for the Sync RPC Methods
 | num_messages | [uint64](#uint64) |  |  |
 | num_fid_events | [uint64](#uint64) |  |  |
 | num_fname_events | [uint64](#uint64) |  |  |
+
+### StreamError
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| errCode | [string](#string) |  |  |
+| message | [string](#string) |  |  |
+| request | [string](#string) |  |  |
+
+### StreamFetchRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| idempotency_key | [string](#string) |  |  |
+| cast_messages_by_fid | [FidTimestampRequest](#FidTimestampRequest) |  |  |
+| reaction_messages_by_fid | [FidTimestampRequest](#FidTimestampRequest) |  |  |
+| verification_messages_by_fid | [FidTimestampRequest](#FidTimestampRequest) |  |  |
+| user_data_messages_by_fid | [FidTimestampRequest](#FidTimestampRequest) |  |  |
+| link_messages_by_fid | [FidTimestampRequest](#FidTimestampRequest) |  |  |
+
+### StreamFetchResponse
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| idempotency_key | [string](#string) |  |  |
+| messages | [MessagesResponse](#MessagesResponse) |  |  |
+| error | [StreamError](#StreamError) |  |  |
+
+### StreamSyncRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| get_info | [HubInfoRequest](#HubInfoRequest) |  |  |
+| get_current_peers | [Empty](#Empty) |  |  |
+| stop_sync | [Empty](#Empty) |  |  |
+| force_sync | [SyncStatusRequest](#SyncStatusRequest) |  |  |
+| get_sync_status | [SyncStatusRequest](#SyncStatusRequest) |  |  |
+| get_all_sync_ids_by_prefix | [TrieNodePrefix](#TrieNodePrefix) |  |  |
+| get_all_messages_by_sync_ids | [SyncIds](#SyncIds) |  |  |
+| get_sync_metadata_by_prefix | [TrieNodePrefix](#TrieNodePrefix) |  |  |
+| get_sync_snapshot_by_prefix | [TrieNodePrefix](#TrieNodePrefix) |  |  |
+| get_on_chain_events | [OnChainEventRequest](#OnChainEventRequest) |  |  |
+| get_on_chain_signers_by_fid | [FidRequest](#FidRequest) |  |  |
+
+### StreamSyncResponse
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| get_info | [HubInfoResponse](#HubInfoResponse) |  |  |
+| get_current_peers | [ContactInfoResponse](#ContactInfoResponse) |  |  |
+| stop_sync | [SyncStatusResponse](#SyncStatusResponse) |  |  |
+| force_sync | [SyncStatusResponse](#SyncStatusResponse) |  |  |
+| get_sync_status | [SyncStatusResponse](#SyncStatusResponse) |  |  |
+| get_all_sync_ids_by_prefix | [SyncIds](#SyncIds) |  |  |
+| get_all_messages_by_sync_ids | [MessagesResponse](#MessagesResponse) |  |  |
+| get_sync_metadata_by_prefix | [TrieNodeMetadataResponse](#TrieNodeMetadataResponse) |  |  |
+| get_sync_snapshot_by_prefix | [TrieNodeSnapshotResponse](#TrieNodeSnapshotResponse) |  |  |
+| get_on_chain_events | [OnChainEventResponse](#OnChainEventResponse) |  |  |
+| get_on_chain_signers_by_fid | [OnChainEventResponse](#OnChainEventResponse) |  |  |
+| error | [StreamError](#StreamError) |  |  |
+
 
 ## 12. Storage Service
 


### PR DESCRIPTION
## Why is this change needed?

Removing a superfluous warn log on client disconnects, also updates docs from last change

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes superfluous warn logs and adds new stream-related methods to the `hubble` app's RPC server.

### Detailed summary
- Removed unnecessary warn logs in `streamSync` and `streamFetch` methods in `Server` class.
- Added new stream-related methods `StreamSync` and `StreamFetch` to the API documentation in `api.md`.
- Defined new request and response types for stream operations: `StreamError`, `StreamFetchRequest`, `StreamFetchResponse`, `StreamSyncRequest`, and `StreamSyncResponse`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->