### PR TITLE
chore: increase sync health span

### DIFF
--- a/apps/hubble/src/network/sync/syncHealthJob.ts
+++ b/apps/hubble/src/network/sync/syncHealthJob.ts
@@ -15,9 +15,9 @@ type SchedulerStatus = "started" | "stopped";
 export class MeasureSyncHealthJobScheduler {
   private _cronTask?: cron.ScheduledTask;
   private _metadataRetriever: SyncEngineMetadataRetriever;
-  // Start at 35 minutes ago and take a 30 minute span
-  private _startSecondsAgo = 60 * 35;
-  private _spanSeconds = 60 * 30;
+  // Start at 65 minutes ago and take a 60 minute span
+  private _startSecondsAgo = 60 * 65;
+  private _spanSeconds = 60 * 60;
   private _hub: HubInterface;
   private _peersInScope: string[];
 


### PR DESCRIPTION
The 30 minute time period does not cover the full amount of time it takes a hub to run sync health successfully after a restart. Increase the span to an hour to catch more messages around a restart. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to adjust the time span for syncing health data in `syncHealthJob.ts`.

### Detailed summary
- Updated start time to 65 minutes ago and span to 60 minutes
- Improved accuracy and coverage for health data synchronization

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->