### PR TITLE
chore: Release 1.15

### DIFF
--- a/.changeset/fluffy-fans-sell.md
+++ b/.changeset/fluffy-fans-sell.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-remove superfluous warn log

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @farcaster/hubble
 
+## 1.15.0
+
+### Minor Changes
+
+- feat: Release protocol version 2024.9.4
+
+### Patch Changes
+
+- 8aaae2aa: remove superfluous warn log
+
 ## 1.14.5
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.14.5",
+  "version": "1.15.0",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -117,7 +117,7 @@ export const SNAPSHOT_S3_UPLOAD_BUCKET = "farcaster-snapshots";
 export const SNAPSHOT_S3_DOWNLOAD_BUCKET = "download.farcaster.xyz";
 export const S3_REGION = "auto";
 
-export const FARCASTER_VERSION = "2024.7.24";
+export const FARCASTER_VERSION = "2024.9.4";
 export const FARCASTER_VERSIONS_SCHEDULE: VersionSchedule[] = [
   { version: "2023.3.1", expiresAt: 1682553600000 }, // expires at 4/27/23 00:00 UTC
   { version: "2023.4.19", expiresAt: 1686700800000 }, // expires at 6/14/23 00:00 UTC
@@ -132,6 +132,7 @@ export const FARCASTER_VERSIONS_SCHEDULE: VersionSchedule[] = [
   { version: "2024.5.1", expiresAt: 1719360000000 }, // expires at 6/26/24 00:00 UTC
   { version: "2024.6.12", expiresAt: 1722988800000 }, // expires at 8/7/24 00:00 UTC
   { version: "2024.7.24", expiresAt: 1726617600000 }, // expires at 9/18/24 00:00 UTC
+  { version: "2024.9.4", expiresAt: 1730246400000 }, // expires at 10/30/24 00:00 UTC
 ];
 
 const MAX_CONTACT_INFO_AGE_MS = 1000 * 60 * 60; // 60 minutes


### PR DESCRIPTION
## Why is this change needed?

Release 1.15

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `@farcaster/hubble` to `1.15.0`, introduces a new feature, and modifies the `FARCASTER_VERSION` constant in `hubble.ts`.

### Detailed summary
- Bumped version to `1.15.0`
- Added feature: Release protocol version 2024.9.4
- Updated `FARCASTER_VERSION` to `2024.9.4` in `hubble.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->