### PR TITLE
move to hoyt from nemes and add idenitity env variable comment

### DIFF
--- a/apps/hubble/docker-compose.yml
+++ b/apps/hubble/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       timeout: 5s
       retries: 3
       start_period: 1m
+      # in case you have an identity file already you may want to use IDENTITY_B64 to pass it as base64 encoded string to Hubble as env variable
     environment:
       CATCHUP_SYNC_WITH_SNAPSHOT: "${CATCHUP_SYNC_WITH_SNAPSHOT:-true}"
       NODE_OPTIONS: "--no-warnings --max-old-space-size=8192"
@@ -34,7 +35,7 @@ services:
         --network ${FC_NETWORK_ID:-1}
         --hub-operator-fid ${HUB_OPERATOR_FID:-0}
         --rpc-subscribe-per-ip-limit ${RPC_SUBSCRIBE_PER_IP_LIMIT:-4}
-        -b ${BOOTSTRAP_NODE:-/dns/nemes.farcaster.xyz/tcp/2282}
+        -b ${BOOTSTRAP_NODE:-/dns/hoyt.farcaster.xyz/tcp/2282}
         --statsd-metrics-server $STATSD_METRICS_SERVER
         --opt-out-diagnostics ${HUB_OPT_OUT_DIAGNOSTICS:-false}
         ${HUB_OPTIONS:-}


### PR DESCRIPTION
## Why is this change needed?

Documents: https://warpcast.com/sds/0x4a4bedb1
and implements https://warpcast.com/sanjay/0x498eb749

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the bootstrap node in the `docker-compose.yml` file for the Hubble app.

### Detailed summary
- Updated the bootstrap node from `/dns/nemes.farcaster.xyz/tcp/2282` to `/dns/hoyt.farcaster.xyz/tcp/2282` in the Hubble `docker-compose.yml` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->