### PR TITLE
chore: increase contact announcement interval

### DIFF
--- a/.changeset/angry-fans-search.md
+++ b/.changeset/angry-fans-search.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+chore: adjust announcement interval for contact info

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -822,7 +822,7 @@ export class Hub implements HubInterface {
     this.validateOrRevokeMessagesJobScheduler.start();
 
     const randomMinute = Math.floor(Math.random() * 15);
-    this.gossipContactInfoJobScheduler.start(`${randomMinute}/15 * * * *`); // Random minute every 30 minutes
+    this.gossipContactInfoJobScheduler.start(`${randomMinute}-59/15 * * * *`); // Weird syntax but required by cron, random minute every 15 minutes
     this.checkIncomingPortsJobScheduler.start();
     this.measureSyncHealthJobScheduler.start();
 

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -821,8 +821,8 @@ export class Hub implements HubInterface {
     this.checkFarcasterVersionJobScheduler.start();
     this.validateOrRevokeMessagesJobScheduler.start();
 
-    const randomMinute = Math.floor(Math.random() * 30);
-    this.gossipContactInfoJobScheduler.start(`${randomMinute} */30 * * * *`); // Random minute every 30 minutes
+    const randomMinute = Math.floor(Math.random() * 15);
+    this.gossipContactInfoJobScheduler.start(`${randomMinute}/15 * * * *`); // Random minute every 30 minutes
     this.checkIncomingPortsJobScheduler.start();
     this.measureSyncHealthJobScheduler.start();
 


### PR DESCRIPTION
## Why is this change needed?

Reduces the interval from every 30 to every 15 minutes for announcement, with randomized start minute

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adjusts the announcement interval for contact info in the `@farcaster/hubble` package.

### Detailed summary
- Changed the random minute calculation from every 30 minutes to every 15 minutes in `hubble.ts`
- Updated the cron syntax for `gossipContactInfoJobScheduler` to reflect the new interval

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->