### PR TITLE
feat: request missing on chain events on error

### DIFF
--- a/.changeset/gold-geckos-remain.md
+++ b/.changeset/gold-geckos-remain.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+feat: request missing on chain events on related submit message errors

--- a/apps/hubble/src/eth/l2EventsProvider.test.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.test.ts
@@ -200,7 +200,6 @@ describe("process events", () => {
     TEST_TIMEOUT_LONG,
   );
 
-  // TODO(aditi): It's pretty high overhead to set up tests with the id registry and key registry -- need to deploy contracts (need bytecode). Testing via the storage contract tests most of the meaningful logic.
   test(
     "retry by fid",
     async () => {

--- a/apps/hubble/src/eth/l2EventsProvider.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.ts
@@ -313,6 +313,7 @@ export class L2EventsProvider<chain extends Chain = Chain, transport extends Tra
       // Handling: use try-catch + log since errors are expected and not important to surface
       try {
         if (event.eventName === "Rent") {
+          statsd().increment("l2events.events_processed", { kind: "storage:rent" });
           // Fix when viem fixes https://github.com/wagmi-dev/viem/issues/938
           const rentEvent = event as Log<
             bigint,
@@ -379,6 +380,7 @@ export class L2EventsProvider<chain extends Chain = Chain, transport extends Tra
       // Handling: use try-catch + log since errors are expected and not important to surface
       try {
         if (event.eventName === "Add") {
+          statsd().increment("l2events.events_processed", { kind: "key-registry:add" });
           const addEvent = event as Log<
             bigint,
             number,
@@ -406,6 +408,7 @@ export class L2EventsProvider<chain extends Chain = Chain, transport extends Tra
             signerEventBody,
           );
         } else if (event.eventName === "Remove") {
+          statsd().increment("l2events.events_processed", { kind: "key-registry:remove" });
           const removeEvent = event as Log<
             bigint,
             number,
@@ -430,6 +433,7 @@ export class L2EventsProvider<chain extends Chain = Chain, transport extends Tra
             signerEventBody,
           );
         } else if (event.eventName === "AdminReset") {
+          statsd().increment("l2events.events_processed", { kind: "key-registry:admin-reset" });
           const resetEvent = event as Log<
             bigint,
             number,
@@ -454,6 +458,7 @@ export class L2EventsProvider<chain extends Chain = Chain, transport extends Tra
             signerEventBody,
           );
         } else if (event.eventName === "Migrated") {
+          statsd().increment("l2events.events_processed", { kind: "key-registry:migrated" });
           const migratedEvent = event as Log<
             bigint,
             number,
@@ -506,6 +511,7 @@ export class L2EventsProvider<chain extends Chain = Chain, transport extends Tra
       // Handling: use try-catch + log since errors are expected and not important to surface
       try {
         if (event.eventName === "Register") {
+          statsd().increment("l2events.events_processed", { kind: "id-registry:register" });
           const registerEvent = event as Log<
             bigint,
             number,
@@ -533,6 +539,7 @@ export class L2EventsProvider<chain extends Chain = Chain, transport extends Tra
             idRegisterEventBody,
           );
         } else if (event.eventName === "Transfer") {
+          statsd().increment("l2events.events_processed", { kind: "id-registry:transfer" });
           const transferEvent = event as Log<
             bigint,
             number,
@@ -560,6 +567,7 @@ export class L2EventsProvider<chain extends Chain = Chain, transport extends Tra
             idRegisterEventBody,
           );
         } else if (event.eventName === "ChangeRecoveryAddress") {
+          statsd().increment("l2events.events_processed", { kind: "id-registry:change-recovery-address" });
           const transferEvent = event as Log<
             bigint,
             number,
@@ -928,9 +936,9 @@ export class L2EventsProvider<chain extends Chain = Chain, transport extends Tra
         `syncing events (${formatPercentage((nextFromBlock - fromBlock) / totalBlocks)})`,
       );
       progressBar?.update(Math.max(nextFromBlock - fromBlock - 1, 0));
-      statsd().increment("l2events.blocks", Math.min(toBlock, nextToBlock - nextFromBlock));
 
       if (byEventKind) {
+        // If there are event-specific filters, we don't count the blocks here. The filters mean we don't necessarily consume all the blocks in the provided range. Instead, look at "l2events.events_processed" for an accurate metric.
         for (const storageEventSpecific of byEventKind.StorageRegistry) {
           await this.getStorageEvents(nextFromBlock, nextToBlock, storageEventSpecific);
         }
@@ -943,6 +951,7 @@ export class L2EventsProvider<chain extends Chain = Chain, transport extends Tra
           await this.getKeyRegistryEvents(nextFromBlock, nextToBlock, keyRegistryEventSpecific);
         }
       } else {
+        statsd().increment("l2events.blocks", Math.min(toBlock, nextToBlock - nextFromBlock));
         await this.getStorageEvents(nextFromBlock, nextToBlock);
         await this.getIdRegistryEvents(nextFromBlock, nextToBlock);
         await this.getKeyRegistryEvents(nextFromBlock, nextToBlock);

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -471,6 +471,7 @@ export class Hub implements HubInterface {
       mainnetClient,
       opClient as PublicClient,
       this.fNameRegistryEventsProvider,
+      this.l2RegistryProvider,
     );
 
     const profileSync = options.profileSync ?? false;

--- a/apps/hubble/src/rpc/test/httpServer.test.ts
+++ b/apps/hubble/src/rpc/test/httpServer.test.ts
@@ -273,7 +273,7 @@ describe("httpServer", () => {
         const response = (e as any).response;
 
         expect(response.status).toBe(400);
-        expect(response.data.errCode).toEqual("bad_request.validation_failure");
+        expect(response.data.errCode).toEqual("bad_request.unknown_fid");
         expect(response.data.details).toMatch("unknown fid");
       }
       expect(errored).toBeTruthy();

--- a/apps/hubble/src/rpc/test/messageService.test.ts
+++ b/apps/hubble/src/rpc/test/messageService.test.ts
@@ -105,7 +105,7 @@ describe("submitMessage", () => {
   test("fails without signer", async () => {
     const result = await client.submitMessage(castAdd);
     const err = result._unsafeUnwrapErr();
-    expect(err.errCode).toEqual("bad_request.validation_failure");
+    expect(err.errCode).toEqual("bad_request.unknown_fid");
     expect(err.message).toMatch("unknown fid");
   });
 });
@@ -134,12 +134,12 @@ describe("validateMessage", () => {
   test("fails without signer", async () => {
     const castResult = await client.submitMessage(castAdd);
     const castErr = castResult._unsafeUnwrapErr();
-    expect(castErr.errCode).toEqual("bad_request.validation_failure");
+    expect(castErr.errCode).toEqual("bad_request.unknown_fid");
     expect(castErr.message).toMatch("unknown fid");
 
     const frameResult = await client.submitMessage(frameAction);
     const frameErr = frameResult._unsafeUnwrapErr();
-    expect(frameErr.errCode).toEqual("bad_request.validation_failure");
+    expect(frameErr.errCode).toEqual("bad_request.unknown_fid");
     expect(frameErr.message).toMatch("unknown fid");
   });
 });

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -338,14 +338,13 @@ class Engine extends TypedEmitter<EngineEvents> {
       }
       if (result.isErr()) {
         // Try to request on chain event if it's missing
-        // TODO(aditi): Do we just want to request all? If missing one likely to be missing all?
         if (
           result.error.errCode === "bad_request.no_storage" ||
           "bad_request.missing_signer" ||
           "bad_request.missing_fid"
         ) {
           // TODO(aditi): Add timeout
-          // TODO(aditi): Do we want a start and stop?
+          // TODO(aditi): Do we just want to request all or only the appropriate event for the error message. Seems worth just requesting all. Simplifies the dedup logic too.
           await this._l2EventsProvider?.retryEventsForFid(fid);
         }
       }

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -339,16 +339,14 @@ class Engine extends TypedEmitter<EngineEvents> {
       if (result.isErr()) {
         // Try to request on chain event if it's missing
         // TODO(aditi): Do we just want to request all? If missing one likely to be missing all?
-        if (result.error.errCode === "bad_request.no_storage") {
+        if (
+          result.error.errCode === "bad_request.no_storage" ||
+          "bad_request.missing_signer" ||
+          "bad_request.missing_fid"
+        ) {
           // TODO(aditi): Add timeout
           // TODO(aditi): Do we want a start and stop?
-          await this._l2EventsProvider?.getStorageEvents(undefined, undefined, fid);
-        }
-        if (result.error.errCode === "bad_request.missing_signer") {
-          await this._l2EventsProvider?.getKeyRegistryEvents(undefined, undefined, fid);
-        }
-        if (result.error.errCode === "bad_request.missing_fid") {
-          await this._l2EventsProvider?.getIdRegistryEvents(undefined, undefined, fid);
+          await this._l2EventsProvider?.retryEventsForFid(fid);
         }
       }
       mergeResults.set(validatedMessages[j]?.i as number, result);

--- a/apps/hubble/src/storage/stores/onChainEventStore.ts
+++ b/apps/hubble/src/storage/stores/onChainEventStore.ts
@@ -185,6 +185,7 @@ class OnChainEventStore {
     if (result.isErr()) {
       throw result.error;
     }
+
     return result.value;
   }
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -69,12 +69,12 @@ export type HubErrorCode =
   | "bad_request.parse_failure"
   | "bad_request.invalid_param"
   | "bad_request.validation_failure"
-  | "bad_request.missing_signer"
+  | "bad_request.unknown_signer"
   | "bad_request.duplicate"
   | "bad_request.conflict"
   | "bad_request.prunable"
   | "bad_request.no_storage"
-  | "bad_request.missing_fid"
+  | "bad_request.unknown_fid"
   /* The requested resource could not be found */
   | "not_found"
   /* The request could not be completed because the operation is not executable */

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -69,9 +69,12 @@ export type HubErrorCode =
   | "bad_request.parse_failure"
   | "bad_request.invalid_param"
   | "bad_request.validation_failure"
+  | "bad_request.missing_signer"
   | "bad_request.duplicate"
   | "bad_request.conflict"
   | "bad_request.prunable"
+  | "bad_request.no_storage"
+  | "bad_request.missing_fid"
   /* The requested resource could not be found */
   | "not_found"
   /* The request could not be completed because the operation is not executable */


### PR DESCRIPTION
## Why is this change needed?

Our hubs regularly fail to get into sync because some of them are missing onchain events. This feature will have us request missing onchain events if there are errors related to missing on chain events when messages are submitted. 

Deployed to hoyt for testing: [Logs](https://app.datadoghq.com/logs?query=%22Attempting%20to%20retryEventsForFid%22%20OR%20%22Finished%20retryEventsForFid%22%20OR%20%22cacheOnChainEvent%22%20&agg_m=count&agg_m_source=base&agg_q=%40fid&agg_q_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&top_n=30&top_o=top&viz=stream&x_missing=true&from_ts=1726433975166&to_ts=1726433977504&live=false)
## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance error handling and retry mechanisms for on-chain events in the Hubble application.

### Detailed summary
- Added feature to request missing on-chain events on related submit message errors
- Improved error code handling for validation failures and unknown signers
- Implemented retry mechanism for on-chain events by fid
- Enhanced error messages and error handling logic

> The following files were skipped due to too many changes: `apps/hubble/src/storage/engine/index.ts`, `apps/hubble/src/eth/l2EventsProvider.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->