### PR TITLE
chore: increase max stream reader shards

### DIFF
--- a/.changeset/dull-carrots-try.md
+++ b/.changeset/dull-carrots-try.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+chore: bump MAX_EVENT_STREAM_SHARDS from 10 to 50

--- a/.changeset/dull-carrots-try.md
+++ b/.changeset/dull-carrots-try.md
@@ -2,4 +2,4 @@
 "@farcaster/hubble": patch
 ---
 
-chore: bump MAX_EVENT_STREAM_SHARDS from 10 to 50
+chore: bump MAX_EVENT_STREAM_SHARDS from 10 to 20

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -87,7 +87,7 @@ const STREAM_METHODS_TIMEOUT = 8 * 1000; // 2 seconds
 
 export const DEFAULT_SUBSCRIBE_PERIP_LIMIT = 4; // Max 4 subscriptions per IP
 export const DEFAULT_SUBSCRIBE_GLOBAL_LIMIT = 4096; // Max 4096 subscriptions globally
-const MAX_EVENT_STREAM_SHARDS = 10;
+const MAX_EVENT_STREAM_SHARDS = 50;
 export const DEFAULT_SERVER_INTERNET_ADDRESS_IPV4 = "0.0.0.0";
 export const MAX_VALUES_RETURNED_PER_SYNC_ID_REQUEST = 1024; // getAllSyncIdsByPrefix returns a max of 1024 sync ids in one response. This value is mirrored in [addon/src/trie/trie_node.rs], make sure to change it in both places.
 

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -87,7 +87,7 @@ const STREAM_METHODS_TIMEOUT = 8 * 1000; // 2 seconds
 
 export const DEFAULT_SUBSCRIBE_PERIP_LIMIT = 4; // Max 4 subscriptions per IP
 export const DEFAULT_SUBSCRIBE_GLOBAL_LIMIT = 4096; // Max 4096 subscriptions globally
-const MAX_EVENT_STREAM_SHARDS = 50;
+const MAX_EVENT_STREAM_SHARDS = 20;
 export const DEFAULT_SERVER_INTERNET_ADDRESS_IPV4 = "0.0.0.0";
 export const MAX_VALUES_RETURNED_PER_SYNC_ID_REQUEST = 1024; // getAllSyncIdsByPrefix returns a max of 1024 sync ids in one response. This value is mirrored in [addon/src/trie/trie_node.rs], make sure to change it in both places.
 


### PR DESCRIPTION
The backend is experiencing inbound message processing delays. In order to increase sharding and see if it helps resolve the issue, we need to bump this parameter on the hub side. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR increases the `MAX_EVENT_STREAM_SHARDS` from 10 to 20 in the `@farcaster/hubble` package and updates related constants in `apps/hubble/src/rpc/server.ts`.

### Detailed summary
- Bumps `MAX_EVENT_STREAM_SHARDS` from 10 to 20
- Updates `DEFAULT_SUBSCRIBE_PERIP_LIMIT` and `DEFAULT_SUBSCRIBE_GLOBAL_LIMIT` constants

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->