### PR TITLE
chore: add more metrics to hub stream reader

### DIFF
--- a/.changeset/rude-dogs-whisper.md
+++ b/.changeset/rude-dogs-whisper.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+chore: add more metrics to HubSubscriber


### PR DESCRIPTION
We need some more instrumentation to understand how much of a time to read delay is accounted for by the hub stream -> redis step vs the redis -> postgres step. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds more metrics to `HubSubscriber`.

### Detailed summary
- Added `shardKey` property to `EventStreamHubSubscriber`
- Added metrics for batch size and process time per event and per batch

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->