### PR TITLE
chore: release hubble v1.15.1

### DIFF
--- a/.changeset/angry-fans-search.md
+++ b/.changeset/angry-fans-search.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-chore: adjust announcement interval for contact info

--- a/.changeset/mean-tomatoes-beg.md
+++ b/.changeset/mean-tomatoes-beg.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: direct peering data needs to be processed by the worker due to obscure node behavior

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/hubble
 
+## 1.15.1
+
+### Patch Changes
+
+- 1943a027: chore: adjust announcement interval for contact info
+- ec80ff3b: fix: direct peering data needs to be processed by the worker due to obscure node behavior
+
 ## 1.15.0
 
 ### Minor Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",


### PR DESCRIPTION
## Why is this change needed?

Releases v1.15.1 patch update to hubble

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `@farcaster/hubble` to `1.15.1` in the package.json file. The CHANGELOG.md includes patch changes related to adjusting announcement interval and fixing direct peering data processing.

### Detailed summary
- Updated `@farcaster/hubble` version to `1.15.1`
- Patch changes:
  - Adjusted announcement interval for contact info
  - Fixed direct peering data processing due to obscure node behavior

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->