### PR TITLE
chore: release shuttle v0.6.2

### DIFF
--- a/.changeset/rude-dogs-whisper.md
+++ b/.changeset/rude-dogs-whisper.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-chore: add more metrics to HubSubscriber

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.6.2
+
+### Patch Changes
+
+- 4e897e9a: chore: add more metrics to HubSubscriber
+
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Releases shuttle v0.6.3 patch update. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `@farcaster/shuttle` package to `0.6.2` and adds more metrics to `HubSubscriber`.

### Detailed summary
- Updated `@farcaster/shuttle` package version to `0.6.2`
- Added more metrics to `HubSubscriber`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->