### PR TITLE
chore: add more tags to event stream metrics

### DIFF
--- a/.changeset/shiny-jobs-deliver.md
+++ b/.changeset/shiny-jobs-deliver.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+chore: add event kind and stale/not stale tags to event processing metrics


### PR DESCRIPTION
In order to better understand how the stale event processing and the event-specific codepaths impact the message read latency, add tags to identify these attributes. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds event kind and stale/not stale tags to event processing metrics in the `HubEventStreamConsumer` class.

### Detailed summary
- Added `whenReceived` tag to event processing metrics
- Updated metrics for different stages of event processing
- Introduced distinction between current and stale events

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->