### PR TITLE
chore: add metric to track events received by kind

### DIFF
--- a/.changeset/giant-maps-remain.md
+++ b/.changeset/giant-maps-remain.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+chore: add metric for events processed with event type tag


### PR DESCRIPTION
There are regular spikes in events received that aren't reflected in the hub metrics. This metric should be useful for understanding what kind of events are causing the spikes. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a metric for events processed with event type tag in the `shuttle` package.

### Detailed summary
- Added metric for events processed with event type tag in `shuttle/eventStream.ts`
- Incremented attempt count for current and stale events
- Added hubEventType tag to metrics
- Calculated dequeue delay for events

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->