### PR TITLE
feat: support bulk message RPC

### DIFF
--- a/.changeset/pink-drinks-brush.md
+++ b/.changeset/pink-drinks-brush.md
@@ -1,0 +1,8 @@
+---
+"@farcaster/hub-nodejs": patch
+"@farcaster/hub-web": patch
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+feat: support bulk message writing rpcs

--- a/apps/hubble/www/docs/docs/api.md
+++ b/apps/hubble/www/docs/docs/api.md
@@ -270,6 +270,34 @@ Used to subscribe to real-time event updates from the Farcaster Hub
 | Method Name   | Request Type | Response Type | Description                  |
 | ------------- | ------------ | ------------- | ---------------------------- |
 | SubmitMessage | Message      | Message       | Submits a Message to the Hub |
+| SubmitBulkMessages | [SubmitBulkMessagesRequest](#SubmitBulkMessagesRequest) | [SubmitBulkMessagesResponse](#SubmitBulkMessagesResponse) | Submits several Messages to the Hub |
+
+### SubmitBulkMessagesRequest
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| messages | [Message](#Message) | repeated |  |
+
+### MessageError
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| hash | [bytes](#bytes) |  |  |
+| errCode | [string](#string) |  |  |
+| message | [string](#string) |  |  |
+
+### BulkMessageResponse
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| message | [Message](#Message) |  |  |
+| message_error | [MessageError](#MessageError) |  |  |
+
+### SubmitBulkMessagesResponse
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| messages | [BulkMessageResponse](#BulkMessageResponse) | repeated |  |
 
 ## 10. Username Proofs Service
 

--- a/packages/core/src/protobufs/generated/request_response.ts
+++ b/packages/core/src/protobufs/generated/request_response.ts
@@ -347,6 +347,25 @@ export interface ValidationResponse {
   message: Message | undefined;
 }
 
+export interface SubmitBulkMessagesRequest {
+  messages: Message[];
+}
+
+export interface MessageError {
+  hash: Uint8Array;
+  errCode: string;
+  message: string;
+}
+
+export interface BulkMessageResponse {
+  message?: Message | undefined;
+  messageError?: MessageError | undefined;
+}
+
+export interface SubmitBulkMessagesResponse {
+  messages: BulkMessageResponse[];
+}
+
 export interface StreamSyncRequest {
   getInfo?: HubInfoRequest | undefined;
   getCurrentPeers?: Empty | undefined;
@@ -3912,6 +3931,289 @@ export const ValidationResponse = {
     message.message = (object.message !== undefined && object.message !== null)
       ? Message.fromPartial(object.message)
       : undefined;
+    return message;
+  },
+};
+
+function createBaseSubmitBulkMessagesRequest(): SubmitBulkMessagesRequest {
+  return { messages: [] };
+}
+
+export const SubmitBulkMessagesRequest = {
+  encode(message: SubmitBulkMessagesRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    for (const v of message.messages) {
+      Message.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): SubmitBulkMessagesRequest {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSubmitBulkMessagesRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.messages.push(Message.decode(reader, reader.uint32()));
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SubmitBulkMessagesRequest {
+    return { messages: Array.isArray(object?.messages) ? object.messages.map((e: any) => Message.fromJSON(e)) : [] };
+  },
+
+  toJSON(message: SubmitBulkMessagesRequest): unknown {
+    const obj: any = {};
+    if (message.messages) {
+      obj.messages = message.messages.map((e) => e ? Message.toJSON(e) : undefined);
+    } else {
+      obj.messages = [];
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SubmitBulkMessagesRequest>, I>>(base?: I): SubmitBulkMessagesRequest {
+    return SubmitBulkMessagesRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SubmitBulkMessagesRequest>, I>>(object: I): SubmitBulkMessagesRequest {
+    const message = createBaseSubmitBulkMessagesRequest();
+    message.messages = object.messages?.map((e) => Message.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBaseMessageError(): MessageError {
+  return { hash: new Uint8Array(), errCode: "", message: "" };
+}
+
+export const MessageError = {
+  encode(message: MessageError, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.hash.length !== 0) {
+      writer.uint32(10).bytes(message.hash);
+    }
+    if (message.errCode !== "") {
+      writer.uint32(18).string(message.errCode);
+    }
+    if (message.message !== "") {
+      writer.uint32(26).string(message.message);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MessageError {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMessageError();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.hash = reader.bytes();
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.errCode = reader.string();
+          continue;
+        case 3:
+          if (tag != 26) {
+            break;
+          }
+
+          message.message = reader.string();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MessageError {
+    return {
+      hash: isSet(object.hash) ? bytesFromBase64(object.hash) : new Uint8Array(),
+      errCode: isSet(object.errCode) ? String(object.errCode) : "",
+      message: isSet(object.message) ? String(object.message) : "",
+    };
+  },
+
+  toJSON(message: MessageError): unknown {
+    const obj: any = {};
+    message.hash !== undefined &&
+      (obj.hash = base64FromBytes(message.hash !== undefined ? message.hash : new Uint8Array()));
+    message.errCode !== undefined && (obj.errCode = message.errCode);
+    message.message !== undefined && (obj.message = message.message);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<MessageError>, I>>(base?: I): MessageError {
+    return MessageError.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MessageError>, I>>(object: I): MessageError {
+    const message = createBaseMessageError();
+    message.hash = object.hash ?? new Uint8Array();
+    message.errCode = object.errCode ?? "";
+    message.message = object.message ?? "";
+    return message;
+  },
+};
+
+function createBaseBulkMessageResponse(): BulkMessageResponse {
+  return { message: undefined, messageError: undefined };
+}
+
+export const BulkMessageResponse = {
+  encode(message: BulkMessageResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.message !== undefined) {
+      Message.encode(message.message, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.messageError !== undefined) {
+      MessageError.encode(message.messageError, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): BulkMessageResponse {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseBulkMessageResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.message = Message.decode(reader, reader.uint32());
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.messageError = MessageError.decode(reader, reader.uint32());
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): BulkMessageResponse {
+    return {
+      message: isSet(object.message) ? Message.fromJSON(object.message) : undefined,
+      messageError: isSet(object.messageError) ? MessageError.fromJSON(object.messageError) : undefined,
+    };
+  },
+
+  toJSON(message: BulkMessageResponse): unknown {
+    const obj: any = {};
+    message.message !== undefined && (obj.message = message.message ? Message.toJSON(message.message) : undefined);
+    message.messageError !== undefined &&
+      (obj.messageError = message.messageError ? MessageError.toJSON(message.messageError) : undefined);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<BulkMessageResponse>, I>>(base?: I): BulkMessageResponse {
+    return BulkMessageResponse.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<BulkMessageResponse>, I>>(object: I): BulkMessageResponse {
+    const message = createBaseBulkMessageResponse();
+    message.message = (object.message !== undefined && object.message !== null)
+      ? Message.fromPartial(object.message)
+      : undefined;
+    message.messageError = (object.messageError !== undefined && object.messageError !== null)
+      ? MessageError.fromPartial(object.messageError)
+      : undefined;
+    return message;
+  },
+};
+
+function createBaseSubmitBulkMessagesResponse(): SubmitBulkMessagesResponse {
+  return { messages: [] };
+}
+
+export const SubmitBulkMessagesResponse = {
+  encode(message: SubmitBulkMessagesResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    for (const v of message.messages) {
+      BulkMessageResponse.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): SubmitBulkMessagesResponse {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSubmitBulkMessagesResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.messages.push(BulkMessageResponse.decode(reader, reader.uint32()));
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SubmitBulkMessagesResponse {
+    return {
+      messages: Array.isArray(object?.messages) ? object.messages.map((e: any) => BulkMessageResponse.fromJSON(e)) : [],
+    };
+  },
+
+  toJSON(message: SubmitBulkMessagesResponse): unknown {
+    const obj: any = {};
+    if (message.messages) {
+      obj.messages = message.messages.map((e) => e ? BulkMessageResponse.toJSON(e) : undefined);
+    } else {
+      obj.messages = [];
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SubmitBulkMessagesResponse>, I>>(base?: I): SubmitBulkMessagesResponse {
+    return SubmitBulkMessagesResponse.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SubmitBulkMessagesResponse>, I>>(object: I): SubmitBulkMessagesResponse {
+    const message = createBaseSubmitBulkMessagesResponse();
+    message.messages = object.messages?.map((e) => BulkMessageResponse.fromPartial(e)) || [];
     return message;
   },
 };

--- a/packages/hub-nodejs/src/generated/request_response.ts
+++ b/packages/hub-nodejs/src/generated/request_response.ts
@@ -347,6 +347,25 @@ export interface ValidationResponse {
   message: Message | undefined;
 }
 
+export interface SubmitBulkMessagesRequest {
+  messages: Message[];
+}
+
+export interface MessageError {
+  hash: Uint8Array;
+  errCode: string;
+  message: string;
+}
+
+export interface BulkMessageResponse {
+  message?: Message | undefined;
+  messageError?: MessageError | undefined;
+}
+
+export interface SubmitBulkMessagesResponse {
+  messages: BulkMessageResponse[];
+}
+
 export interface StreamSyncRequest {
   getInfo?: HubInfoRequest | undefined;
   getCurrentPeers?: Empty | undefined;
@@ -3912,6 +3931,289 @@ export const ValidationResponse = {
     message.message = (object.message !== undefined && object.message !== null)
       ? Message.fromPartial(object.message)
       : undefined;
+    return message;
+  },
+};
+
+function createBaseSubmitBulkMessagesRequest(): SubmitBulkMessagesRequest {
+  return { messages: [] };
+}
+
+export const SubmitBulkMessagesRequest = {
+  encode(message: SubmitBulkMessagesRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    for (const v of message.messages) {
+      Message.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): SubmitBulkMessagesRequest {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSubmitBulkMessagesRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.messages.push(Message.decode(reader, reader.uint32()));
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SubmitBulkMessagesRequest {
+    return { messages: Array.isArray(object?.messages) ? object.messages.map((e: any) => Message.fromJSON(e)) : [] };
+  },
+
+  toJSON(message: SubmitBulkMessagesRequest): unknown {
+    const obj: any = {};
+    if (message.messages) {
+      obj.messages = message.messages.map((e) => e ? Message.toJSON(e) : undefined);
+    } else {
+      obj.messages = [];
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SubmitBulkMessagesRequest>, I>>(base?: I): SubmitBulkMessagesRequest {
+    return SubmitBulkMessagesRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SubmitBulkMessagesRequest>, I>>(object: I): SubmitBulkMessagesRequest {
+    const message = createBaseSubmitBulkMessagesRequest();
+    message.messages = object.messages?.map((e) => Message.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBaseMessageError(): MessageError {
+  return { hash: new Uint8Array(), errCode: "", message: "" };
+}
+
+export const MessageError = {
+  encode(message: MessageError, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.hash.length !== 0) {
+      writer.uint32(10).bytes(message.hash);
+    }
+    if (message.errCode !== "") {
+      writer.uint32(18).string(message.errCode);
+    }
+    if (message.message !== "") {
+      writer.uint32(26).string(message.message);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MessageError {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMessageError();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.hash = reader.bytes();
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.errCode = reader.string();
+          continue;
+        case 3:
+          if (tag != 26) {
+            break;
+          }
+
+          message.message = reader.string();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MessageError {
+    return {
+      hash: isSet(object.hash) ? bytesFromBase64(object.hash) : new Uint8Array(),
+      errCode: isSet(object.errCode) ? String(object.errCode) : "",
+      message: isSet(object.message) ? String(object.message) : "",
+    };
+  },
+
+  toJSON(message: MessageError): unknown {
+    const obj: any = {};
+    message.hash !== undefined &&
+      (obj.hash = base64FromBytes(message.hash !== undefined ? message.hash : new Uint8Array()));
+    message.errCode !== undefined && (obj.errCode = message.errCode);
+    message.message !== undefined && (obj.message = message.message);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<MessageError>, I>>(base?: I): MessageError {
+    return MessageError.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MessageError>, I>>(object: I): MessageError {
+    const message = createBaseMessageError();
+    message.hash = object.hash ?? new Uint8Array();
+    message.errCode = object.errCode ?? "";
+    message.message = object.message ?? "";
+    return message;
+  },
+};
+
+function createBaseBulkMessageResponse(): BulkMessageResponse {
+  return { message: undefined, messageError: undefined };
+}
+
+export const BulkMessageResponse = {
+  encode(message: BulkMessageResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.message !== undefined) {
+      Message.encode(message.message, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.messageError !== undefined) {
+      MessageError.encode(message.messageError, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): BulkMessageResponse {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseBulkMessageResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.message = Message.decode(reader, reader.uint32());
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.messageError = MessageError.decode(reader, reader.uint32());
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): BulkMessageResponse {
+    return {
+      message: isSet(object.message) ? Message.fromJSON(object.message) : undefined,
+      messageError: isSet(object.messageError) ? MessageError.fromJSON(object.messageError) : undefined,
+    };
+  },
+
+  toJSON(message: BulkMessageResponse): unknown {
+    const obj: any = {};
+    message.message !== undefined && (obj.message = message.message ? Message.toJSON(message.message) : undefined);
+    message.messageError !== undefined &&
+      (obj.messageError = message.messageError ? MessageError.toJSON(message.messageError) : undefined);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<BulkMessageResponse>, I>>(base?: I): BulkMessageResponse {
+    return BulkMessageResponse.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<BulkMessageResponse>, I>>(object: I): BulkMessageResponse {
+    const message = createBaseBulkMessageResponse();
+    message.message = (object.message !== undefined && object.message !== null)
+      ? Message.fromPartial(object.message)
+      : undefined;
+    message.messageError = (object.messageError !== undefined && object.messageError !== null)
+      ? MessageError.fromPartial(object.messageError)
+      : undefined;
+    return message;
+  },
+};
+
+function createBaseSubmitBulkMessagesResponse(): SubmitBulkMessagesResponse {
+  return { messages: [] };
+}
+
+export const SubmitBulkMessagesResponse = {
+  encode(message: SubmitBulkMessagesResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    for (const v of message.messages) {
+      BulkMessageResponse.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): SubmitBulkMessagesResponse {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSubmitBulkMessagesResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.messages.push(BulkMessageResponse.decode(reader, reader.uint32()));
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SubmitBulkMessagesResponse {
+    return {
+      messages: Array.isArray(object?.messages) ? object.messages.map((e: any) => BulkMessageResponse.fromJSON(e)) : [],
+    };
+  },
+
+  toJSON(message: SubmitBulkMessagesResponse): unknown {
+    const obj: any = {};
+    if (message.messages) {
+      obj.messages = message.messages.map((e) => e ? BulkMessageResponse.toJSON(e) : undefined);
+    } else {
+      obj.messages = [];
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SubmitBulkMessagesResponse>, I>>(base?: I): SubmitBulkMessagesResponse {
+    return SubmitBulkMessagesResponse.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SubmitBulkMessagesResponse>, I>>(object: I): SubmitBulkMessagesResponse {
+    const message = createBaseSubmitBulkMessagesResponse();
+    message.messages = object.messages?.map((e) => BulkMessageResponse.fromPartial(e)) || [];
     return message;
   },
 };

--- a/packages/hub-nodejs/src/generated/rpc.ts
+++ b/packages/hub-nodejs/src/generated/rpc.ts
@@ -45,6 +45,8 @@ import {
   StreamFetchResponse,
   StreamSyncRequest,
   StreamSyncResponse,
+  SubmitBulkMessagesRequest,
+  SubmitBulkMessagesResponse,
   SubscribeRequest,
   SyncIds,
   SyncStatusRequest,
@@ -421,6 +423,18 @@ export const HubServiceService = {
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
+  /** @http-api: none */
+  submitBulkMessages: {
+    path: "/HubService/SubmitBulkMessages",
+    requestStream: false,
+    responseStream: false,
+    requestSerialize: (value: SubmitBulkMessagesRequest) =>
+      Buffer.from(SubmitBulkMessagesRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => SubmitBulkMessagesRequest.decode(value),
+    responseSerialize: (value: SubmitBulkMessagesResponse) =>
+      Buffer.from(SubmitBulkMessagesResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer) => SubmitBulkMessagesResponse.decode(value),
+  },
   /** Sync Methods */
   getInfo: {
     path: "/HubService/GetInfo",
@@ -624,6 +638,8 @@ export interface HubServiceServer extends UntypedServiceImplementation {
   getAllLinkMessagesByFid: handleUnaryCall<FidTimestampRequest, MessagesResponse>;
   /** @http-api: none */
   getLinkCompactStateMessageByFid: handleUnaryCall<FidRequest, MessagesResponse>;
+  /** @http-api: none */
+  submitBulkMessages: handleUnaryCall<SubmitBulkMessagesRequest, SubmitBulkMessagesResponse>;
   /** Sync Methods */
   getInfo: handleUnaryCall<HubInfoRequest, HubInfoResponse>;
   getCurrentPeers: handleUnaryCall<Empty, ContactInfoResponse>;
@@ -1191,6 +1207,22 @@ export interface HubServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,
+  ): ClientUnaryCall;
+  /** @http-api: none */
+  submitBulkMessages(
+    request: SubmitBulkMessagesRequest,
+    callback: (error: ServiceError | null, response: SubmitBulkMessagesResponse) => void,
+  ): ClientUnaryCall;
+  submitBulkMessages(
+    request: SubmitBulkMessagesRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: SubmitBulkMessagesResponse) => void,
+  ): ClientUnaryCall;
+  submitBulkMessages(
+    request: SubmitBulkMessagesRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: SubmitBulkMessagesResponse) => void,
   ): ClientUnaryCall;
   /** Sync Methods */
   getInfo(

--- a/packages/hub-web/src/generated/request_response.ts
+++ b/packages/hub-web/src/generated/request_response.ts
@@ -347,6 +347,25 @@ export interface ValidationResponse {
   message: Message | undefined;
 }
 
+export interface SubmitBulkMessagesRequest {
+  messages: Message[];
+}
+
+export interface MessageError {
+  hash: Uint8Array;
+  errCode: string;
+  message: string;
+}
+
+export interface BulkMessageResponse {
+  message?: Message | undefined;
+  messageError?: MessageError | undefined;
+}
+
+export interface SubmitBulkMessagesResponse {
+  messages: BulkMessageResponse[];
+}
+
 export interface StreamSyncRequest {
   getInfo?: HubInfoRequest | undefined;
   getCurrentPeers?: Empty | undefined;
@@ -3912,6 +3931,289 @@ export const ValidationResponse = {
     message.message = (object.message !== undefined && object.message !== null)
       ? Message.fromPartial(object.message)
       : undefined;
+    return message;
+  },
+};
+
+function createBaseSubmitBulkMessagesRequest(): SubmitBulkMessagesRequest {
+  return { messages: [] };
+}
+
+export const SubmitBulkMessagesRequest = {
+  encode(message: SubmitBulkMessagesRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    for (const v of message.messages) {
+      Message.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): SubmitBulkMessagesRequest {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSubmitBulkMessagesRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.messages.push(Message.decode(reader, reader.uint32()));
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SubmitBulkMessagesRequest {
+    return { messages: Array.isArray(object?.messages) ? object.messages.map((e: any) => Message.fromJSON(e)) : [] };
+  },
+
+  toJSON(message: SubmitBulkMessagesRequest): unknown {
+    const obj: any = {};
+    if (message.messages) {
+      obj.messages = message.messages.map((e) => e ? Message.toJSON(e) : undefined);
+    } else {
+      obj.messages = [];
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SubmitBulkMessagesRequest>, I>>(base?: I): SubmitBulkMessagesRequest {
+    return SubmitBulkMessagesRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SubmitBulkMessagesRequest>, I>>(object: I): SubmitBulkMessagesRequest {
+    const message = createBaseSubmitBulkMessagesRequest();
+    message.messages = object.messages?.map((e) => Message.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBaseMessageError(): MessageError {
+  return { hash: new Uint8Array(), errCode: "", message: "" };
+}
+
+export const MessageError = {
+  encode(message: MessageError, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.hash.length !== 0) {
+      writer.uint32(10).bytes(message.hash);
+    }
+    if (message.errCode !== "") {
+      writer.uint32(18).string(message.errCode);
+    }
+    if (message.message !== "") {
+      writer.uint32(26).string(message.message);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MessageError {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMessageError();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.hash = reader.bytes();
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.errCode = reader.string();
+          continue;
+        case 3:
+          if (tag != 26) {
+            break;
+          }
+
+          message.message = reader.string();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MessageError {
+    return {
+      hash: isSet(object.hash) ? bytesFromBase64(object.hash) : new Uint8Array(),
+      errCode: isSet(object.errCode) ? String(object.errCode) : "",
+      message: isSet(object.message) ? String(object.message) : "",
+    };
+  },
+
+  toJSON(message: MessageError): unknown {
+    const obj: any = {};
+    message.hash !== undefined &&
+      (obj.hash = base64FromBytes(message.hash !== undefined ? message.hash : new Uint8Array()));
+    message.errCode !== undefined && (obj.errCode = message.errCode);
+    message.message !== undefined && (obj.message = message.message);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<MessageError>, I>>(base?: I): MessageError {
+    return MessageError.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MessageError>, I>>(object: I): MessageError {
+    const message = createBaseMessageError();
+    message.hash = object.hash ?? new Uint8Array();
+    message.errCode = object.errCode ?? "";
+    message.message = object.message ?? "";
+    return message;
+  },
+};
+
+function createBaseBulkMessageResponse(): BulkMessageResponse {
+  return { message: undefined, messageError: undefined };
+}
+
+export const BulkMessageResponse = {
+  encode(message: BulkMessageResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.message !== undefined) {
+      Message.encode(message.message, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.messageError !== undefined) {
+      MessageError.encode(message.messageError, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): BulkMessageResponse {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseBulkMessageResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.message = Message.decode(reader, reader.uint32());
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.messageError = MessageError.decode(reader, reader.uint32());
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): BulkMessageResponse {
+    return {
+      message: isSet(object.message) ? Message.fromJSON(object.message) : undefined,
+      messageError: isSet(object.messageError) ? MessageError.fromJSON(object.messageError) : undefined,
+    };
+  },
+
+  toJSON(message: BulkMessageResponse): unknown {
+    const obj: any = {};
+    message.message !== undefined && (obj.message = message.message ? Message.toJSON(message.message) : undefined);
+    message.messageError !== undefined &&
+      (obj.messageError = message.messageError ? MessageError.toJSON(message.messageError) : undefined);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<BulkMessageResponse>, I>>(base?: I): BulkMessageResponse {
+    return BulkMessageResponse.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<BulkMessageResponse>, I>>(object: I): BulkMessageResponse {
+    const message = createBaseBulkMessageResponse();
+    message.message = (object.message !== undefined && object.message !== null)
+      ? Message.fromPartial(object.message)
+      : undefined;
+    message.messageError = (object.messageError !== undefined && object.messageError !== null)
+      ? MessageError.fromPartial(object.messageError)
+      : undefined;
+    return message;
+  },
+};
+
+function createBaseSubmitBulkMessagesResponse(): SubmitBulkMessagesResponse {
+  return { messages: [] };
+}
+
+export const SubmitBulkMessagesResponse = {
+  encode(message: SubmitBulkMessagesResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    for (const v of message.messages) {
+      BulkMessageResponse.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): SubmitBulkMessagesResponse {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSubmitBulkMessagesResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.messages.push(BulkMessageResponse.decode(reader, reader.uint32()));
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SubmitBulkMessagesResponse {
+    return {
+      messages: Array.isArray(object?.messages) ? object.messages.map((e: any) => BulkMessageResponse.fromJSON(e)) : [],
+    };
+  },
+
+  toJSON(message: SubmitBulkMessagesResponse): unknown {
+    const obj: any = {};
+    if (message.messages) {
+      obj.messages = message.messages.map((e) => e ? BulkMessageResponse.toJSON(e) : undefined);
+    } else {
+      obj.messages = [];
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SubmitBulkMessagesResponse>, I>>(base?: I): SubmitBulkMessagesResponse {
+    return SubmitBulkMessagesResponse.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SubmitBulkMessagesResponse>, I>>(object: I): SubmitBulkMessagesResponse {
+    const message = createBaseSubmitBulkMessagesResponse();
+    message.messages = object.messages?.map((e) => BulkMessageResponse.fromPartial(e)) || [];
     return message;
   },
 };

--- a/packages/hub-web/src/generated/rpc.ts
+++ b/packages/hub-web/src/generated/rpc.ts
@@ -33,6 +33,8 @@ import {
   StreamFetchResponse,
   StreamSyncRequest,
   StreamSyncResponse,
+  SubmitBulkMessagesRequest,
+  SubmitBulkMessagesResponse,
   SubscribeRequest,
   SyncIds,
   SyncStatusRequest,
@@ -165,6 +167,11 @@ export interface HubService {
     request: DeepPartial<FidRequest>,
     metadata?: grpcWeb.grpc.Metadata,
   ): Promise<MessagesResponse>;
+  /** @http-api: none */
+  submitBulkMessages(
+    request: DeepPartial<SubmitBulkMessagesRequest>,
+    metadata?: grpcWeb.grpc.Metadata,
+  ): Promise<SubmitBulkMessagesResponse>;
   /** Sync Methods */
   getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubInfoResponse>;
   getCurrentPeers(request: DeepPartial<Empty>, metadata?: grpcWeb.grpc.Metadata): Promise<ContactInfoResponse>;
@@ -242,6 +249,7 @@ export class HubServiceClientImpl implements HubService {
     this.getAllUserDataMessagesByFid = this.getAllUserDataMessagesByFid.bind(this);
     this.getAllLinkMessagesByFid = this.getAllLinkMessagesByFid.bind(this);
     this.getLinkCompactStateMessageByFid = this.getLinkCompactStateMessageByFid.bind(this);
+    this.submitBulkMessages = this.submitBulkMessages.bind(this);
     this.getInfo = this.getInfo.bind(this);
     this.getCurrentPeers = this.getCurrentPeers.bind(this);
     this.stopSync = this.stopSync.bind(this);
@@ -435,6 +443,13 @@ export class HubServiceClientImpl implements HubService {
     metadata?: grpcWeb.grpc.Metadata,
   ): Promise<MessagesResponse> {
     return this.rpc.unary(HubServiceGetLinkCompactStateMessageByFidDesc, FidRequest.fromPartial(request), metadata);
+  }
+
+  submitBulkMessages(
+    request: DeepPartial<SubmitBulkMessagesRequest>,
+    metadata?: grpcWeb.grpc.Metadata,
+  ): Promise<SubmitBulkMessagesResponse> {
+    return this.rpc.unary(HubServiceSubmitBulkMessagesDesc, SubmitBulkMessagesRequest.fromPartial(request), metadata);
   }
 
   getInfo(request: DeepPartial<HubInfoRequest>, metadata?: grpcWeb.grpc.Metadata): Promise<HubInfoResponse> {
@@ -1268,6 +1283,29 @@ export const HubServiceGetLinkCompactStateMessageByFidDesc: UnaryMethodDefinitio
   responseType: {
     deserializeBinary(data: Uint8Array) {
       const value = MessagesResponse.decode(data);
+      return {
+        ...value,
+        toObject() {
+          return value;
+        },
+      };
+    },
+  } as any,
+};
+
+export const HubServiceSubmitBulkMessagesDesc: UnaryMethodDefinitionish = {
+  methodName: "SubmitBulkMessages",
+  service: HubServiceDesc,
+  requestStream: false,
+  responseStream: false,
+  requestType: {
+    serializeBinary() {
+      return SubmitBulkMessagesRequest.encode(this).finish();
+    },
+  } as any,
+  responseType: {
+    deserializeBinary(data: Uint8Array) {
+      const value = SubmitBulkMessagesResponse.decode(data);
       return {
         ...value,
         toObject() {

--- a/protobufs/schemas/request_response.proto
+++ b/protobufs/schemas/request_response.proto
@@ -273,6 +273,27 @@ message ValidationResponse {
   Message message = 2;
 }
 
+message SubmitBulkMessagesRequest {
+  repeated Message messages = 1;
+}
+
+message MessageError {
+  bytes hash = 1;
+  string errCode = 2;
+  string message = 3;
+}
+
+message BulkMessageResponse {
+  oneof response {
+    Message message = 1;
+    MessageError message_error = 2;
+  }
+}
+
+message SubmitBulkMessagesResponse {
+  repeated BulkMessageResponse messages = 1;
+}
+
 message StreamSyncRequest {
   oneof request {
     HubInfoRequest get_info = 1;

--- a/protobufs/schemas/rpc.proto
+++ b/protobufs/schemas/rpc.proto
@@ -93,6 +93,8 @@ service HubService {
   rpc GetAllLinkMessagesByFid(FidTimestampRequest) returns (MessagesResponse);
   // @http-api: none
   rpc GetLinkCompactStateMessageByFid(FidRequest) returns (MessagesResponse);
+  // @http-api: none
+  rpc SubmitBulkMessages(SubmitBulkMessagesRequest) returns (SubmitBulkMessagesResponse);
 
   // Sync Methods
   rpc GetInfo(HubInfoRequest) returns (HubInfoResponse);


### PR DESCRIPTION
## Why is this change needed?

Reconciliation of messages historically from off-hub sources is achieved via `submitMessage`, which incurs a performance penalty when many of these calls are made in rapid succession. This change introduces a new `submitBulkMessages` RPC which allows many of the to-be reconciled messages to be submitted at once and handle via the more efficient rust `mergeMany` underlying call.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new gRPC method `SubmitBulkMessages` for submitting multiple messages at once and updates related proto files and service implementations.

### Detailed summary
- Added `SubmitBulkMessages` gRPC method
- Defined new message types: `SubmitBulkMessagesRequest`, `MessageError`, `BulkMessageResponse`, `SubmitBulkMessagesResponse`
- Updated service implementations and proto files
- Implemented server-side logic for `SubmitBulkMessages`
- Added encoding and decoding functions for new message types

> The following files were skipped due to too many changes: `packages/hub-web/src/generated/request_response.ts`, `packages/hub-nodejs/src/generated/request_response.ts`, `packages/core/src/protobufs/generated/request_response.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->