### PR TITLE
fix: Fix flaky test

### DIFF
--- a/apps/hubble/src/storage/stores/storageCache.test.ts
+++ b/apps/hubble/src/storage/stores/storageCache.test.ts
@@ -58,8 +58,8 @@ describe("syncFromDb", () => {
       for (let i = 0; i < fidUsage.usage.storage; i++) {
         const storageRentEvent = Factories.StorageRentOnChainEvent.build({
           fid: fidUsage.fid,
+          blockTimestamp: Date.now() / 1000,
           storageRentEventBody: Factories.StorageRentEventBody.build({
-            expiry: getFarcasterTime()._unsafeUnwrap() + 365 * 24 * 60 * 60 - i,
             units: 2,
           }),
         });
@@ -81,8 +81,8 @@ describe("syncFromDb", () => {
         ok(fidUsage.usage.userData),
       );
       const slot = (await cache.getCurrentStorageSlotForFid(fidUsage.fid))._unsafeUnwrap();
-      expect(slot.legacy_units).toEqual(4);
-      expect(slot.units).toEqual(0);
+      expect(slot.units).toEqual(4);
+      expect(slot.legacy_units).toEqual(0);
     }
   });
 });


### PR DESCRIPTION
## Why is this change needed?

Fix flaky timestamp test that was relying `expiry` instead of `blockTimestamp` for storage rent.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the storage cache test by adjusting the values of `units` and `legacy_units`.

### Detailed summary
- Updated `units` and `legacy_units` values in the storage cache test
- Added `blockTimestamp` to `storageRentEvent`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->