### PR TITLE
Removed the hyphen in onchain and offchain to maintain a consistent style

### DIFF
--- a/apps/hubble/src/eth/l2EventsProvider.ts
+++ b/apps/hubble/src/eth/l2EventsProvider.ts
@@ -78,7 +78,7 @@ type EventSpecificArgs = {
 };
 
 /**
- * Class that follows the Optimism chain to handle on-chain events from the Storage Registry contract.
+ * Class that follows the Optimism chain to handle onchain events from the Storage Registry contract.
  */
 export class L2EventsProvider<chain extends Chain = Chain, transport extends Transport = Transport> {
   private _hub: HubInterface;

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -683,7 +683,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
       statsd().gauge("merkle_trie.merge_q", this._syncTrieQ);
       const result = await ResultAsync.fromPromise(this.addOnChainEvent(onChainEvent), (e) => e);
       if (result.isErr()) {
-        log.error({ err: result.error }, "Failed to add on-chain event to sync trie");
+        log.error({ err: result.error }, "Failed to add onchain event to sync trie");
       }
       this._syncTrieQ -= 1;
 
@@ -798,7 +798,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
       if (!(await this.trie.exists(syncId))) {
         const result = await ResultAsync.fromPromise(this._trie.insert(syncId), (e) => e);
         if (result.isErr()) {
-          log.error({ err: result.error }, "Failed to add on-chain event to sync trie");
+          log.error({ err: result.error }, "Failed to add onchain event to sync trie");
         }
       }
     });

--- a/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
@@ -179,7 +179,7 @@ export class ValidateOrRevokeMessagesJobScheduler {
       if (signers.isErr()) {
         log.error(
           { errCode: signers.error.errCode },
-          `error getting on-chain signers for FID ${fid}: ${signers.error.message}`,
+          `error getting onchain signers for FID ${fid}: ${signers.error.message}`,
         );
         return err(signers.error);
       }

--- a/packages/core/src/verifications.ts
+++ b/packages/core/src/verifications.ts
@@ -83,7 +83,7 @@ export const makeVerificationAddressClaim = (
 };
 
 export const recreateSolanaClaimMessage = (claim: VerificationAddressClaimSolana, pubkey: Uint8Array): Buffer => {
-  // We're using a simple ascii string instead of the full off-chain signing spec because this provides better compatibility with wallet libraries
+  // We're using a simple ascii string instead of the full offchain signing spec because this provides better compatibility with wallet libraries
   const messageContent = `fid: ${claim.fid} address: ${claim.address} network: ${claim.network} blockHash: ${claim.blockHash} protocol: ${claim.protocol}`;
   return Buffer.from(utf8StringToBytes(messageContent)._unsafeUnwrap());
 };

--- a/packages/hub-nodejs/docs/Client.md
+++ b/packages/hub-nodejs/docs/Client.md
@@ -4,7 +4,7 @@ A Client established a connection with a Farcaster Hub which can be used to send
 with the IP address and gRPC port of the Hub. Once connected, a Client instance can:
 
 - Query for messages by user or type.
-- Query for on-chain Farcaster Contracts state.
+- Query for onchain Farcaster Contracts state.
 - Subscribe to changes by type.
 - Upload new messages.
 
@@ -1093,7 +1093,7 @@ client.$.waitForReady(Date.now() + 5000, async (e) => {
 
 ### getNameRegistryEvent
 
-Returns the on-chain event most recently associated with changing an fname's ownership.
+Returns the onchain event most recently associated with changing an fname's ownership.
 
 #### Usage
 

--- a/packages/hub-nodejs/docs/Events.md
+++ b/packages/hub-nodejs/docs/Events.md
@@ -1,7 +1,7 @@
 # Events
 
 - [Hub Events](#hub-events)
-- [On-Chain Events](#on-chain-events)
+- [Onchain Events](#onchain-events)
 
 ## Hub Events
 
@@ -58,13 +58,13 @@ Emit when an NameRegistryEvent is merged into the Hub.
 | type              | [`HubEventType`](#hubeventtype) | Always set to `MERGE_NAME_REGISTRY_EVENT` |
 | nameRegistryEvent | `NameRegistryEvent`             | The message that was merged               |
 
-## On-Chain Events
+## Onchain Events
 
 Emitted by contracts whenever the ownership of fids or fnames changes.
 
 ### IdRegistryEvent
 
-Emit when an on-chain event occurs in the IdRegistry which registers or transfers an fid.
+Emit when an onchain event occurs in the IdRegistry which registers or transfers an fid.
 
 | Name            | Type                        | Description                                              |
 | --------------- | --------------------------- | -------------------------------------------------------- |
@@ -79,7 +79,7 @@ Emit when an on-chain event occurs in the IdRegistry which registers or transfer
 
 ### NameRegistryEvent
 
-Emit when an on-chain event occurs in the NameRegistry which registers, transfers or renews an fname.
+Emit when an onchain event occurs in the NameRegistry which registers, transfers or renews an fname.
 
 | Name            | Type                                              | Description                                              |
 | --------------- | ------------------------------------------------- | -------------------------------------------------------- |

--- a/packages/hub-nodejs/docs/Messages.md
+++ b/packages/hub-nodejs/docs/Messages.md
@@ -4,7 +4,7 @@ A Farcaster Message represents an action taken by a user.
 
 Messages are atomic updates that add or remove content from the network. For example, a user can make a new cast by generating a `CastAdd` message and remove it with a `CastRemove` message. See the [protocol spec](https://github.com/farcasterxyz/protocol#3-delta-graph) for more information on how messages work.
 
-Messages are [protobufs](https://protobuf.dev/) which are converted by @farcaster/hub-nodejs into the Typescript types documented below. Each message is signed by a key pair that is provably controlled by the user. Some messages must be signed by the Ethereum address that controls the user's fid on-chain while other messages must be signed by an EdDSA key pair known as a Signer, which is authorized to act on behalf of the Ethereum address. The protocol specification defines the message types as:
+Messages are [protobufs](https://protobuf.dev/) which are converted by @farcaster/hub-nodejs into the Typescript types documented below. Each message is signed by a key pair that is provably controlled by the user. Some messages must be signed by the Ethereum address that controls the user's fid onchain while other messages must be signed by an EdDSA key pair known as a Signer, which is authorized to act on behalf of the Ethereum address. The protocol specification defines the message types as:
 
 | Message                   | Action                                                              |
 | ------------------------- | ------------------------------------------------------------------- |

--- a/packages/hub-nodejs/spec.yaml
+++ b/packages/hub-nodejs/spec.yaml
@@ -672,7 +672,7 @@ paths:
     get:
       tags:
         - OnChainEvents
-      summary: Get an on chain ID Registry Event for a given Address
+      summary: Get an onchain ID Registry Event for a given Address
       operationId: GetOnChainIdRegistrationByAddress
       parameters:
         - name: address
@@ -695,7 +695,7 @@ paths:
     get:
       tags:
         - OnChainEvents
-      summary: Get a list of on-chain events provided by an FID
+      summary: Get a list of onchain events provided by an FID
       operationId: ListOnChainEventsByFid
       parameters:
         - name: fid

--- a/packages/hub-web/examples/submit-message/index.ts
+++ b/packages/hub-web/examples/submit-message/index.ts
@@ -12,7 +12,7 @@ async function submitMessage() {
   const fid = 2;
 
   // The signer of the message. This is used to sign the message, and can be obtained by creating
-  // an on-chain signer on behalf of the user.
+  // an onchain signer on behalf of the user.
   // TODO: Replace with your own signer
   const signer = Factories.Ed25519Signer.build();
 


### PR DESCRIPTION
## Why is this change needed?

"The community has generally settled on onchain and offchain as individual words, rather than hyphenated." - @sds
https://github.com/farcasterxyz/docs/pull/296#discussion_r1744299916

Removed the hyphen in onchain and offchain to maintain a consistent style

<!-- start pr-codex -->

---

## PR-Codex overview
This PR standardizes the term "on-chain" to "onchain" across various files and documentation.

### Detailed summary
- Replaced "on-chain" with "onchain" for consistency
- Updated terminology in code comments, classes, and documentation

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->