### PR TITLE
chore: bump version

### DIFF
--- a/.changeset/gold-geckos-remain.md
+++ b/.changeset/gold-geckos-remain.md
@@ -1,6 +1,0 @@
----
-"@farcaster/core": patch
-"@farcaster/hubble": patch
----
-
-feat: request missing on chain events on related submit message errors

--- a/.changeset/pink-drinks-brush.md
+++ b/.changeset/pink-drinks-brush.md
@@ -1,8 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
-"@farcaster/hub-web": patch
-"@farcaster/core": patch
-"@farcaster/hubble": patch
----
-
-feat: support bulk message writing rpcs

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @farcaster/hubble
 
+## 1.15.2
+
+### Patch Changes
+
+- f084daa1: feat: request missing on chain events on related submit message errors
+- e5a86114: feat: support bulk message writing rpcs
+- Updated dependencies [e5a86114]
+  - @farcaster/hub-nodejs@0.12.3
+
 ## 1.15.1
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -75,7 +75,7 @@
     "@chainsafe/libp2p-noise": "15.1.0",
     "@datastructures-js/priority-queue": "^6.3.1",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.12.1",
+    "@farcaster/hub-nodejs": "^0.12.3",
     "@fastify/cors": "^8.4.0",
     "@figma/hot-shots": "^9.0.0-figma.1",
     "@grpc/grpc-js": "~1.11.1",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/core
 
+## 0.15.3
+
+### Patch Changes
+
+- f084daa1: feat: request missing on chain events on related submit message errors
+- e5a86114: feat: support bulk message writing rpcs
+
 ## 0.15.2
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @farcaster/hub-nodejs
 
+## 0.12.3
+
+### Patch Changes
+
+- e5a86114: feat: support bulk message writing rpcs
+- Updated dependencies [f084daa1]
+- Updated dependencies [e5a86114]
+  - @farcaster/core@0.15.3
+
 ## 0.12.2
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -20,7 +20,7 @@
     "url": "https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/hub-nodejs"
   },
   "dependencies": {
-    "@farcaster/core": "0.15.2",
+    "@farcaster/core": "0.15.3",
     "@grpc/grpc-js": "~1.11.1",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"

--- a/packages/hub-web/CHANGELOG.md
+++ b/packages/hub-web/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @farcaster/hub-web
 
+## 0.9.3
+
+### Patch Changes
+
+- e5a86114: feat: support bulk message writing rpcs
+- Updated dependencies [f084daa1]
+- Updated dependencies [e5a86114]
+  - @farcaster/core@0.15.3
+
 ## 0.9.2
 
 ### Patch Changes

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-web",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -32,7 +32,7 @@
     "ts-proto": "^1.146.0"
   },
   "dependencies": {
-    "@farcaster/core": "^0.15.2",
+    "@farcaster/core": "^0.15.3",
     "@improbable-eng/grpc-web": "^0.15.0",
     "rxjs": "^7.8.0"
   }


### PR DESCRIPTION
## Why is this change needed?

bumps version of hubble and libraries

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates version numbers and dependencies across different packages. 

### Detailed summary
- Bumped version to `0.15.3` in `@farcaster/core`
- Bumped version to `0.9.3` in `@farcaster/hub-web`
- Bumped version to `0.12.3` in `@farcaster/hub-nodejs`
- Bumped version to `1.15.2` in `@farcaster/hubble`
- Updated dependencies and added new features in various packages

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->