### PR TITLE
chore: upgrade hub-nodejs dependency so interfaces align

### DIFF
--- a/.changeset/fast-bugs-fetch.md
+++ b/.changeset/fast-bugs-fetch.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+chore: upgrade hub-nodejs dependency so interfaces align

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@farcaster/hot-shots": "^10.0.0",
-    "@farcaster/hub-nodejs": "^0.12.2",
+    "@farcaster/hub-nodejs": "^0.12.3",
     "commander": "11.0.0",
     "dotenv": "16.4.5",
     "ioredis": "^5.3.2",


### PR DESCRIPTION
## Why is this change needed?

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `@farcaster/hub-nodejs` dependency in the `shuttle` package to version `0.12.3` to align with interfaces.

### Detailed summary
- Updated `@farcaster/hub-nodejs` dependency in `shuttle` package to `0.12.3`
- Ensured alignment with interfaces by upgrading hub-nodejs dependency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->