### PR TITLE
chore: release shuttle v0.6.4

### DIFF
--- a/.changeset/fast-bugs-fetch.md
+++ b/.changeset/fast-bugs-fetch.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-chore: upgrade hub-nodejs dependency so interfaces align

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.6.4
+
+### Patch Changes
+
+- 2de0697e: chore: upgrade hub-nodejs dependency so interfaces align
+
 ## 0.6.3
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Why is this change needed?

Releases shuttle v.0.6.4

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of the `@farcaster/shuttle` package to `0.6.4` and aligns hub-nodejs dependency interfaces.

### Detailed summary
- Updated `@farcaster/shuttle` package version to `0.6.4`
- Aligned hub-nodejs dependency interfaces

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->