### PR TITLE
chore: add start time and stop time to sync health logs

### DIFF
--- a/.changeset/fifty-news-rest.md
+++ b/.changeset/fifty-news-rest.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+chore: add more log tags to sync health job

--- a/apps/hubble/src/network/sync/syncHealthJob.ts
+++ b/apps/hubble/src/network/sync/syncHealthJob.ts
@@ -62,7 +62,7 @@ export class MeasureSyncHealthJobScheduler {
     return peers;
   }
 
-  processSumbitResults(results: Result<Message, SubmitError>[], peerId: string) {
+  processSumbitResults(results: Result<Message, SubmitError>[], peerId: string, startTime: number, stopTime: number) {
     let numSuccesses = 0;
     let numErrors = 0;
     for (const result of results) {
@@ -75,7 +75,15 @@ export class MeasureSyncHealthJobScheduler {
 
         log.info(
           {
-            msgDetails: { type, fid: result.value.data?.fid, timestamp: result.value.data?.timestamp, hash, peerId },
+            msgDetails: {
+              type,
+              fid: result.value.data?.fid,
+              timestamp: result.value.data?.timestamp,
+              hash,
+              peerId,
+            },
+            startTime,
+            stopTime,
           },
           "Successfully submitted message via SyncHealth",
         );
@@ -85,7 +93,7 @@ export class MeasureSyncHealthJobScheduler {
         const hashString = bytesToHexString(result.error.originalMessage.hash);
         const hash = hashString.isOk() ? hashString.value : "unable to show hash";
         log.info(
-          { errMessage: result.error.hubError.message, peerId, hash },
+          { errMessage: result.error.hubError.message, peerId, hash, startTime, stopTime },
           "Failed to submit message via SyncHealth",
         );
 
@@ -153,8 +161,10 @@ export class MeasureSyncHealthJobScheduler {
           theirNumMessages: syncHealthMessageStats.value.peerNumMessages,
           syncHealth: syncHealthMessageStats.value.computeDiff(),
           syncHealthPercentage: syncHealthMessageStats.value.computeDiffPercentage(),
-          resultsPushingToUs: this.processSumbitResults(resultsPushingToUs.value, peerId),
+          resultsPushingToUs: this.processSumbitResults(resultsPushingToUs.value, peerId, startTime, stopTime),
           peerId,
+          startTime,
+          stopTime,
         },
         "Computed SyncHealth stats for peer",
       );


### PR DESCRIPTION
## Why is this change needed?

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the sync health job in `hubble` by adding more log tags and capturing start and stop times.

### Detailed summary
- Added start and stop time parameters to `processSumbitResults` function
- Enhanced log details with `startTime` and `stopTime` in `MeasureSyncHealthJobScheduler`
- Updated `resultsPushingToUs` with `startTime` and `stopTime` parameters

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->