### PR TITLE
chore: release hubble v1.15.3

### DIFF
--- a/.changeset/fast-icons-admire.md
+++ b/.changeset/fast-icons-admire.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: add missing messages to sync trie via sync health job

--- a/.changeset/fifty-news-rest.md
+++ b/.changeset/fifty-news-rest.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-chore: add more log tags to sync health job

--- a/.changeset/short-squids-sparkle.md
+++ b/.changeset/short-squids-sparkle.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-chore: add more log tags to sync health errors with message details

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hubble
 
+## 1.15.3
+
+### Patch Changes
+
+- 5504e057: feat: add missing messages to sync trie via sync health job
+- 7206e8c5: chore: add more log tags to sync health job
+- 3b1d12ff: chore: add more log tags to sync health errors with message details
+
 ## 1.15.2
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",


### PR DESCRIPTION
Releasing hubble v1.15.3. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `@farcaster/hubble` to `1.15.3` and includes enhancements related to syncing trie and log tags in the sync health job.

### Detailed summary
- Updated version to `1.15.3`
- Added missing messages to sync trie
- Enhanced log tags in sync health job and errors

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->