### PR TITLE
fix: Ignore rate limits for local/loopback IP traffic

### DIFF
--- a/.changeset/long-mayflies-march.md
+++ b/.changeset/long-mayflies-march.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+Ignore rate limits for local loopback traffic

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -903,7 +903,6 @@ export default class Server {
           (e) => e,
         )().unwrapOr("unavailable");
 
-        // Check for rate limits
         const rateLimitResult = await rateLimitByIp(peer, this.submitMessageRateLimiter);
         if (rateLimitResult.isErr()) {
           logger.warn({ peer }, "submitMessage rate limited");

--- a/apps/hubble/src/utils/rateLimits.test.ts
+++ b/apps/hubble/src/utils/rateLimits.test.ts
@@ -35,6 +35,13 @@ describe("test rate limits", () => {
     }
   });
 
+  test("don't rate limit local requests", async () => {
+    for (let i = 0; i < 100; i++) {
+      const result = await rateLimitByIp("127.0.0.1:3000", Limit10PerSecond);
+      expect(result.isOk()).toBeTruthy();
+    }
+  });
+
   test("test rate limiting via consumeRateLimit/isRateLimited", async () => {
     // 10 Requests should be fine
     for (let i = 0; i < 10; i++) {

--- a/apps/hubble/src/utils/rateLimits.ts
+++ b/apps/hubble/src/utils/rateLimits.ts
@@ -30,6 +30,11 @@ export const rateLimitByIp = async (ip: string, limiter: RateLimiterAbstract): H
   // Get the IP part of the address
   const ipPart = ip.split(":")[0] ?? "";
 
+  // Ignore local loopback traffic
+  if (ipPart === "127.0.0.1") {
+    return ok(true);
+  }
+
   return rateLimitByKey(ipPart, limiter);
 };
 


### PR DESCRIPTION
## Why is this change needed?

When using a proxy in front of the hub you'll get rate limit errors even though the traffic is coming from different IPs.

Until we support the `X-Forwarded-For`, this is a quick way to unblock the use of reverse proxies like nginx or Caddy.


## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the rate limiting functionality to ignore rate limits for local loopback traffic, specifically allowing requests from `127.0.0.1` without restrictions.

### Detailed summary
- Updated `rateLimits.ts` to bypass rate limits for local loopback IP `127.0.0.1`.
- Removed rate limit check in `server.ts` for local requests.
- Added a test in `rateLimits.test.ts` to ensure local requests are not rate limited.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->