### PR TITLE
chore: add contact info to sync health logs

### DIFF
--- a/.changeset/seven-cats-beg.md
+++ b/.changeset/seven-cats-beg.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+chore: add contact info to sync health logs

--- a/apps/hubble/src/network/sync/syncHealthJob.ts
+++ b/apps/hubble/src/network/sync/syncHealthJob.ts
@@ -175,6 +175,20 @@ export class MeasureSyncHealthJobScheduler {
     }
   }
 
+  contactInfoForLogs(peer: PeerIdentifier) {
+    if (peer.kind === PeerIdentifierKind.PeerId) {
+      const contactInfo = this._metadataRetriever._syncEngine.getContactInfoForPeerId(peer.identifier);
+
+      if (!contactInfo) {
+        return undefined;
+      }
+
+      return contactInfo;
+    } else {
+      return undefined;
+    }
+  }
+
   async doJobs() {
     if (!this._hub.performedFirstSync) {
       log.info("Skipping SyncHealth job because we haven't performed our first sync yet");
@@ -204,9 +218,13 @@ export class MeasureSyncHealthJobScheduler {
       );
 
       if (syncHealthMessageStats.isErr()) {
+        const contactInfo = this.contactInfoForLogs(peer);
         log.info(
-          { peerId: peer.identifier, err: syncHealthMessageStats.error },
-          `Error computing SyncHealth: ${syncHealthMessageStats.error}`,
+          {
+            peerId: peer.identifier,
+            err: syncHealthMessageStats.error,
+          },
+          `Error computing SyncHealth: ${syncHealthMessageStats.error}. Contact info: ${contactInfo}`,
         );
         continue;
       }


### PR DESCRIPTION
Add more data to validate whether hubs are connecting to the correct IP addresses and ports. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the logging of sync health jobs by adding contact information related to peers in the logs, which aids in troubleshooting.

### Detailed summary
- Added `contactInfoForLogs` method in `syncHealthJob.ts` to retrieve contact information for peers.
- Updated the logging in `doJobs` method to include contact info when an error occurs during sync health computation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->