### PR TITLE
chore: turn sync health contact info into string before logging

### DIFF
--- a/apps/hubble/src/network/sync/syncHealthJob.ts
+++ b/apps/hubble/src/network/sync/syncHealthJob.ts
@@ -8,6 +8,8 @@ import { bytesToHexString, fromFarcasterTime, Message, UserDataType } from "@far
 import { Result } from "neverthrow";
 import { SubmitError } from "../../utils/syncHealth.js";
 import { SyncId } from "./syncId.js";
+import { addressInfoFromGossip, addressInfoToString } from "utils/p2p.js";
+import { rpc } from "viem/utils";
 
 const log = logger.child({
   component: "SyncHealth",
@@ -181,6 +183,17 @@ export class MeasureSyncHealthJobScheduler {
 
       if (!contactInfo) {
         return undefined;
+      }
+
+      const rpcAddress = contactInfo.contactInfo.rpcAddress;
+      if (rpcAddress) {
+        const addressInfo = addressInfoFromGossip(rpcAddress);
+
+        if (addressInfo.isErr()) {
+          return undefined;
+        }
+
+        return addressInfoToString(addressInfo.value);
       }
 
       return contactInfo;


### PR DESCRIPTION
Contact info appears as "Object" in the logs because it isn't translated into a string prior to logging. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
