### PR TITLE
fix: make the contact info logs for the sync health job richer

### DIFF
--- a/apps/hubble/src/network/sync/syncHealthJob.ts
+++ b/apps/hubble/src/network/sync/syncHealthJob.ts
@@ -181,7 +181,7 @@ export class MeasureSyncHealthJobScheduler {
       const contactInfo = this._metadataRetriever._syncEngine.getContactInfoForPeerId(peer.identifier);
 
       if (!contactInfo) {
-        return undefined;
+        return "Missing contact info";
       }
 
       const rpcAddress = contactInfo.contactInfo.rpcAddress;
@@ -193,11 +193,11 @@ export class MeasureSyncHealthJobScheduler {
         }
 
         return addressInfoToString(addressInfo.value);
+      } else {
+        return "No rpc address on contact info";
       }
-
-      return contactInfo;
     } else {
-      return undefined;
+      return peer.identifier;
     }
   }
 

--- a/apps/hubble/src/network/sync/syncHealthJob.ts
+++ b/apps/hubble/src/network/sync/syncHealthJob.ts
@@ -184,7 +184,7 @@ export class MeasureSyncHealthJobScheduler {
         return "Missing contact info";
       }
 
-      return contactInfo;
+      return contactInfo.contactInfo;
     } else {
       return peer.identifier;
     }

--- a/apps/hubble/src/network/sync/syncHealthJob.ts
+++ b/apps/hubble/src/network/sync/syncHealthJob.ts
@@ -184,18 +184,7 @@ export class MeasureSyncHealthJobScheduler {
         return "Missing contact info";
       }
 
-      const rpcAddress = contactInfo.contactInfo.rpcAddress;
-      if (rpcAddress) {
-        const addressInfo = addressInfoFromGossip(rpcAddress);
-
-        if (addressInfo.isErr()) {
-          return undefined;
-        }
-
-        return addressInfoToString(addressInfo.value);
-      } else {
-        return "No rpc address on contact info";
-      }
+      return contactInfo;
     } else {
       return peer.identifier;
     }
@@ -235,8 +224,9 @@ export class MeasureSyncHealthJobScheduler {
           {
             peerId: peer.identifier,
             err: syncHealthMessageStats.error,
+            contactInfo,
           },
-          `Error computing SyncHealth: ${syncHealthMessageStats.error}. Contact info: ${contactInfo}`,
+          `Error computing SyncHealth: ${syncHealthMessageStats.error}.`,
         );
         continue;
       }


### PR DESCRIPTION
It's currently hard to tell what state the contact info is in if the rpc address is not present. Differentiate the error states better in the logging. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error handling and simplifying the return values related to `contactInfo` in the `syncHealthJob.ts` file.

### Detailed summary
- Replaced returning `undefined` when `contactInfo` is missing with returning the string `"Missing contact info"`.
- Changed the return value for `contactInfo` to directly return `contactInfo.contactInfo`.
- Updated the error message to exclude `contactInfo` details in the logging.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->