### PR TITLE
feat(shuttle): Support deleting messages on DB that are missing on hub

### DIFF
--- a/.changeset/grumpy-lions-brush.md
+++ b/.changeset/grumpy-lions-brush.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+feat(shuttle): Support deleting messages on DB that are missing on hub

--- a/packages/shuttle/src/example-app/app.ts
+++ b/packages/shuttle/src/example-app/app.ts
@@ -220,7 +220,7 @@ export class App implements MessageHandler {
         fid,
         async (message, missingInDb, prunedInDb, revokedInDb) => {
           if (missingInDb) {
-            await HubEventProcessor.handleMissingMessage(this.db, message, this);
+            await HubEventProcessor.handleMissingMessage(this.db, message, this, !missingInDb);
           } else if (prunedInDb || revokedInDb) {
             const messageDesc = prunedInDb ? "pruned" : revokedInDb ? "revoked" : "existing";
             log.info(`Reconciled ${messageDesc} message ${bytesToHexString(message.hash)._unsafeUnwrap()}`);
@@ -228,7 +228,7 @@ export class App implements MessageHandler {
         },
         async (message, missingInHub) => {
           if (missingInHub) {
-            log.info(`Message ${bytesToHexString(message.hash)._unsafeUnwrap()} is missing in the hub`);
+            await HubEventProcessor.handleMissingMessage(this.db, Message.decode(message.raw), this, missingInHub);
           }
         },
       );

--- a/packages/shuttle/src/example-app/app.ts
+++ b/packages/shuttle/src/example-app/app.ts
@@ -220,7 +220,7 @@ export class App implements MessageHandler {
         fid,
         async (message, missingInDb, prunedInDb, revokedInDb) => {
           if (missingInDb) {
-            await HubEventProcessor.handleMissingMessage(this.db, message, this, !missingInDb);
+            await HubEventProcessor.handleMissingMessage(this.db, message, this, false);
           } else if (prunedInDb || revokedInDb) {
             const messageDesc = prunedInDb ? "pruned" : revokedInDb ? "revoked" : "existing";
             log.info(`Reconciled ${messageDesc} message ${bytesToHexString(message.hash)._unsafeUnwrap()}`);

--- a/packages/shuttle/src/shuttle/hubEventProcessor.ts
+++ b/packages/shuttle/src/shuttle/hubEventProcessor.ts
@@ -42,9 +42,13 @@ export class HubEventProcessor {
     });
   }
 
-  static async handleMissingMessage(db: DB, message: Message, handler: MessageHandler) {
+  static async handleMissingMessage(db: DB, message: Message, handler: MessageHandler, missingInHub?: boolean) {
     await db.transaction().execute(async (trx) => {
-      await this.processMessage(trx, message, handler, "merge", [], true);
+      if (missingInHub) {
+        await this.processMessage(trx, message, handler, "delete", [], true);
+      } else {
+        await this.processMessage(trx, message, handler, "merge", [], true);
+      }
     });
   }
 


### PR DESCRIPTION
There was existing support for handling messages that were present on hub and missing on DB, but not the opposite. From talking with Sanjay, it should be correct/safe to delete these messages from the DB.

## Why is this change needed?

Shuttle only reconciled in one direction, even though everything appears 95% written to support both directions. This completes that. I know from adding logging to our Shuttle-powered app that that are a significant number of messages present in our DB that are missing in the hub. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces functionality to delete messages from the database that are not present on the hub, enhancing the message handling logic in the `shuttle` package.

### Detailed summary
- Updated `handleMissingMessage` method in `HubEventProcessor` to accept an optional `missingInHub` parameter.
- Added logic to delete messages if `missingInHub` is true; otherwise, it merges them.
- Adjusted calls to `handleMissingMessage` in `app.ts` to pass the new parameter.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->