### PR TITLE
feat: Add `--announce-rpc-port` flag

### DIFF
--- a/.changeset/giant-jokes-end.md
+++ b/.changeset/giant-jokes-end.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+feat: Add `--announce-rpc-port` flag

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -125,6 +125,7 @@ app
   .option("-g, --gossip-port <port>", `Port to use for gossip (default: ${DEFAULT_GOSSIP_PORT})`)
   .option("-r, --rpc-port <port>", `Port to use for gRPC  (default: ${DEFAULT_RPC_PORT})`)
   .option("-h, --http-api-port <port>", `Port to use for HTTP API (default: ${DEFAULT_HTTP_API_PORT})`)
+  .option("--announce-rpc-port <port>", `Port to announce the gRPC API is reachable via (default: ${DEFAULT_RPC_PORT})`)
   .option("--http-cors-origin <origin>", "CORS origin for HTTP API (default: *)")
   .option("--ip <ip-address>", 'IP address to listen on (default: "127.0.0.1")')
   .option("--announce-ip <ip-address>", "Public IP address announced to peers (default: fetched with external service)")
@@ -527,6 +528,12 @@ app
       allowedPeers: cliOptions.allowedPeers ?? hubConfig.allowedPeers,
       deniedPeers: cliOptions.deniedPeers ?? hubConfig.deniedPeers,
       rpcPort: cliOptions.rpcPort ?? hubConfig.rpcPort ?? DEFAULT_RPC_PORT,
+      announceRpcPort:
+        cliOptions.announceRpcPort ??
+        hubConfig.announceRpcPort ??
+        cliOptions.rpcPort ??
+        hubConfig.rpcPort ??
+        DEFAULT_RPC_PORT,
       httpApiPort: cliOptions.httpApiPort ?? hubConfig.httpApiPort ?? DEFAULT_HTTP_API_PORT,
       httpCorsOrigin: cliOptions.httpCorsOrigin ?? hubConfig.httpCorsOrigin ?? "*",
       rpcAuth,

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -201,8 +201,11 @@ export interface HubOptions {
   /** Port for libp2p to listen for gossip */
   gossipPort?: number;
 
-  /** Port for the RPC Client */
+  /** Port for the RPC Server */
   rpcPort?: number;
+
+  /** Announced port for the RPC Server. Useful if using a reverse proxy */
+  announceRpcPort?: number;
 
   /** Port for the HTTP API Server */
   httpApiPort?: number;
@@ -1248,7 +1251,7 @@ export class Hub implements HubInterface {
     const family = nodeMultiAddr?.nodeAddress().family;
     const announceIp = this.options.announceIp ?? nodeMultiAddr?.nodeAddress().address;
     const gossipPort = nodeMultiAddr?.nodeAddress().port;
-    const rpcPort = this.rpcServer.address?.map((addr: AddressInfo) => addr.port).unwrapOr(0);
+    const rpcPort = this.options.announceRpcPort;
 
     const gossipAddressContactInfo = GossipAddressInfo.create({
       address: announceIp,

--- a/apps/hubble/www/docs/docs/cli.md
+++ b/apps/hubble/www/docs/docs/cli.md
@@ -1,22 +1,22 @@
 # CLI
 
-Documentation for the Hubble CLI. 
+Documentation for the Hubble CLI.
 
 1. `start` - start hubble and configure how it should run
 2. `identity` - generate or validate hub identities
 3. `status` - status reports on sync, storage and other systems.
-4. `dbreset` - clear the database. 
+4. `dbreset` - clear the database.
 5. `profile` - profile the storage usage of the db.
 6. `console` - start an interactive repl console for debugging.
 
-Commands must invoked with yarn by running: 
+Commands must invoked with yarn by running:
 
 ```
 # if using docker
-docker compose exec hubble yarn <command> 
+docker compose exec hubble yarn <command>
 
 # if not using docker
-yarn <command> 
+yarn <command>
 ```
 
 ### start
@@ -61,12 +61,12 @@ Snapshots Options:
 
 Metrics:
   --statsd-metrics-server <host>        The host to send statsd metrics to, eg "127.0.0.1:8125". (default: disabled)
-  
+
 Diagnostics:
   --opt-out-diagnostics [boolean]       Opt-out of sending diagnostics data to the Farcaster Foundation.
                                         Diagnostics are used to troubleshoot user issues and
                                         improve health of the network. (default: disabled)
- --diagnostic-report-url <url>          The URL to send diagnostic reports to. (default: https://report.farcaster.xyz)                                        
+ --diagnostic-report-url <url>          The URL to send diagnostic reports to. (default: https://report.farcaster.xyz)
 
 Networking Options:
   -a, --allowed-peers <peerIds...>      Only peer with specific peer ids. (default: all peers allowed)
@@ -77,6 +77,7 @@ Networking Options:
   --http-cors-origin                    CORS origin for HTTP API (default: *)
   --ip <ip-address>                     IP address to listen on (default: "127.0.0.1")
   --announce-ip <ip-address>            Public IP address announced to peers (default: fetched with external service)
+  --announce-rpc-port <port>            RPC port announced to peers. Useful if using a reverse proxy (default: gRPC port)
   --announce-server-name <name>         Server name announced to peers, useful if SSL/TLS enabled. (default: "none")
   --admin-server-enabled                Enable the admin server. (default: disabled)
   --admin-server-host <host>            The host the admin server should listen on. (default: '127.0.0.1')
@@ -94,16 +95,16 @@ Snapshots Options:
 Metrics:
   --statsd-metrics-server <host>        The host to send statsd metrics to, eg "127.0.0.1:8125". (default: disabled)
 
-Debugging Options:  
+Debugging Options:
   --profile-sync                        Profile a full hub sync and exit. (default: disabled)
-  --rebuild-sync-trie                   Rebuild the sync trie before starting (default: disabled)  
+  --rebuild-sync-trie                   Rebuild the sync trie before starting (default: disabled)
   --resync-name-events                  Resync events from the Fname server before starting (default: disabled)
   --chunk-size <number>                 The number of blocks to batch when syncing historical events from Farcaster contracts. (default: 10000)
   --commit-lock-timeout <number>        Rocks DB commit lock timeout in milliseconds (default: 500)
   --commit-lock-max-pending <number>    Rocks DB commit lock max pending jobs (default: 1000)
   --rpc-auth <username:password,...>    Require username-password auth for RPC submit. (default: disabled)
   --disable-console-status              Immediately log to STDOUT, and disable console status and progressbars. (default: disabled)
-  
+
   -h, --help                            display help for command
   ```
 


### PR DESCRIPTION
## Why is this change needed?

When using a reverse proxy with hubs, the RPC port the hub itself binds to might be different than the port needed to communicate with the hub on the public internet. Allow overriding via the `--announce-rpc-port` flag.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new flag `--announce-rpc-port` for the `Hubble` application, updates documentation, and modifies the handling of RPC port configurations to enhance functionality and improve usability with reverse proxies.

### Detailed summary
- Added `announceRpcPort` property to the `Hub` class.
- Updated comments for `rpcPort` to clarify its role as the RPC Server port.
- Introduced `--announce-rpc-port` flag in the CLI options.
- Updated the handling of `announceRpcPort` in the application configuration.
- Enhanced documentation for CLI commands and options.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->