### PR TITLE
chore: add peer id to submit messages logs

### DIFF
--- a/.changeset/sour-candles-approve.md
+++ b/.changeset/sour-candles-approve.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+chore: add peer id to submit messages logs

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1971,10 +1971,10 @@ export class Hub implements HubInterface {
       );
     }
     if (infoLogs.length > 0) {
-      log.info(infoLogs, "successful submit messages");
+      log.info({ peerId, messages: infoLogs }, "successful submit messages");
     }
     if (errorLogs.length > 0) {
-      log.error(errorLogs, "failed submit messages");
+      log.error({ peerId, messages: errorLogs }, "failed submit messages");
     }
 
     // Convert the merge results to an Array of HubResults with the key


### PR DESCRIPTION
When there are gossip issues, it would be useful to have peer ids in the submit messages logs to identify whether the issues are isolated to certain pairs of peer ids or not. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing logging functionality by including the `peerId` in the logs when submitting messages, allowing for better traceability of operations.

### Detailed summary
- Updated logging for successful message submissions to include `peerId` and `infoLogs`.
- Updated logging for failed message submissions to include `peerId` and `errorLogs`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->