### PR TITLE
fix: add request length limit for getAllMessagesBySyncIds

### DIFF
--- a/.changeset/three-zoos-mix.md
+++ b/.changeset/three-zoos-mix.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: add request length limit for getAllMessagesBySyncIds

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -719,6 +719,10 @@ export default class Server {
   }
 
   public async getAllMessagesBySyncIds(request: SyncIds) {
+    if (request.syncIds.length > MAX_VALUES_RETURNED_PER_SYNC_ID_REQUEST) {
+      return err(new HubError("bad_request.validation_failure", "Too many sync ids provided"));
+    }
+
     const syncIds = request.syncIds.map((syncId) => SyncId.fromBytes(syncId));
     const messagesResult = await this.syncEngine?.getAllMessagesBySyncIds(syncIds);
     if (messagesResult?.isErr()) {


### PR DESCRIPTION
We've observed hub memory usage and disk reads spike over the last couple days. We'd like to put a size bound on `getAllMessagesBySyncIds` because it currently accepts an unlimited number of sync ids and could end up exhausting hub resources. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a request length limit for the `getAllMessagesBySyncIds` function in the `server.ts` file and refactoring the message retrieval logic in `syncHealth.ts` to handle multiple requests efficiently.

### Detailed summary
- Added a check for the length of `syncIds` in `getAllMessagesBySyncIds` to enforce a maximum limit.
- Changed the message retrieval logic in `syncHealth.ts` to accumulate messages from multiple requests into `allMessages`.
- Updated the error handling to ensure consistent error responses.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->