### PR TITLE
fix: restore start/stop time for reconcileMessagesForFid

### DIFF
--- a/.changeset/unlucky-pots-retire.md
+++ b/.changeset/unlucky-pots-retire.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+fix: restore start/stop times for reconcileMessagesForFid

--- a/packages/shuttle/src/shuttle/messageReconciliation.ts
+++ b/packages/shuttle/src/shuttle/messageReconciliation.ts
@@ -90,7 +90,7 @@ export class MessageReconciliation {
 
     const hubMessagesByHash: Record<string, Message> = {};
     // First, reconcile messages that are in the hub but not in the database
-    for await (const messages of this.allHubMessagesOfTypeForFid(fid, type)) {
+    for await (const messages of this.allHubMessagesOfTypeForFid(fid, type, startTimestamp, stopTimestamp)) {
       const messageHashes = messages.map((msg) => msg.hash);
 
       if (messageHashes.length === 0) {


### PR DESCRIPTION
## Why is this change needed?

Restores start/stop time to reconcileMessagesForFid, possibly related to #2346.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on restoring the `start` and `stop` timestamps in the `reconcileMessagesForFid` function to improve message reconciliation functionality.

### Detailed summary
- Updated the function call in `packages/shuttle/src/shuttle/messageReconciliation.ts` to include `startTimestamp` and `stopTimestamp` parameters in `allHubMessagesOfTypeForFid`.
- Added a fix note in the changelog for restoring the functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->