### PR TITLE
chore: Release 1.15.5

### DIFF
--- a/.changeset/gentle-cobras-jam.md
+++ b/.changeset/gentle-cobras-jam.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Split sync health job into 10 min chunks to limit memory usage

--- a/.changeset/gentle-turtles-accept.md
+++ b/.changeset/gentle-turtles-accept.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-Ignore local/loopback IP traffic in connection limiter

--- a/.changeset/giant-jokes-end.md
+++ b/.changeset/giant-jokes-end.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-feat: Add `--announce-rpc-port` flag

--- a/.changeset/grumpy-lions-brush.md
+++ b/.changeset/grumpy-lions-brush.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-feat(shuttle): Support deleting messages on DB that are missing on hub

--- a/.changeset/honest-students-relax.md
+++ b/.changeset/honest-students-relax.md
@@ -1,5 +1,0 @@
----
-"@farcaster/core": minor
----
-
-re-introducing faker dependency

--- a/.changeset/long-mayflies-march.md
+++ b/.changeset/long-mayflies-march.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-Ignore rate limits for local loopback traffic

--- a/.changeset/many-laws-sing.md
+++ b/.changeset/many-laws-sing.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: serialize contact info into a string before logging in sync health job

--- a/.changeset/seven-cats-beg.md
+++ b/.changeset/seven-cats-beg.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-chore: add contact info to sync health logs

--- a/.changeset/three-zoos-mix.md
+++ b/.changeset/three-zoos-mix.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: add request length limit for getAllMessagesBySyncIds

--- a/.changeset/unlucky-pots-retire.md
+++ b/.changeset/unlucky-pots-retire.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-fix: restore start/stop times for reconcileMessagesForFid

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @farcaster/hubble
 
+## 1.15.5
+
+### Patch Changes
+
+- dbf1f155: fix: Split sync health job into 10 min chunks to limit memory usage
+- fff8d7bf: Ignore local/loopback IP traffic in connection limiter
+- 44126c2f: feat: Add `--announce-rpc-port` flag
+- 8923cb71: Ignore rate limits for local loopback traffic
+- 8ce6169a: fix: serialize contact info into a string before logging in sync health job
+- 2717d44d: chore: add contact info to sync health logs
+- cda909b0: fix: add request length limit for getAllMessagesBySyncIds
+  - @farcaster/hub-nodejs@0.12.4
+
 ## 1.15.4
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -75,7 +75,7 @@
     "@chainsafe/libp2p-noise": "15.1.0",
     "@datastructures-js/priority-queue": "^6.3.1",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.12.3",
+    "@farcaster/hub-nodejs": "^0.12.4",
     "@fastify/cors": "^8.4.0",
     "@figma/hot-shots": "^9.0.0-figma.1",
     "@grpc/grpc-js": "~1.11.1",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/core
 
+## 0.15.4
+
+### Patch Changes
+
+- a8736e1d: re-introducing faker dependency
+
 ## 0.15.3
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -26,7 +26,6 @@
     "neverthrow": "^6.0.0",
     "@faker-js/faker": "^7.6.0",
     "viem": "^2.17.4"
-
   },
   "scripts": {
     "build": "tsup --config tsup.config.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/hub-nodejs
 
+## 0.12.4
+
+### Patch Changes
+
+- Updated dependencies [a8736e1d]
+  - @farcaster/core@0.15.4
+
 ## 0.12.3
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -20,7 +20,7 @@
     "url": "https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/hub-nodejs"
   },
   "dependencies": {
-    "@farcaster/core": "0.15.3",
+    "@farcaster/core": "0.15.4",
     "@grpc/grpc-js": "~1.11.1",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hub-shuttle
 
+## 0.6.5
+
+### Patch Changes
+
+- 64084968: feat(shuttle): Support deleting messages on DB that are missing on hub
+- 8dfe9843: fix: restore start/stop times for reconcileMessagesForFid
+  - @farcaster/hub-nodejs@0.12.4
+
 ## 0.6.4
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@farcaster/hot-shots": "^10.0.0",
-    "@farcaster/hub-nodejs": "^0.12.3",
+    "@farcaster/hub-nodejs": "^0.12.4",
     "commander": "11.0.0",
     "dotenv": "16.4.5",
     "ioredis": "^5.3.2",


### PR DESCRIPTION
## Why is this change needed?

Release 1.15.5

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating package versions and changelogs across multiple packages within the Farcaster project, including reintroducing a dependency and fixing various issues in the `shuttle` and `hubble` packages.

### Detailed summary
- Deleted multiple `.changeset` markdown files.
- Updated `@farcaster/core` version from `0.15.3` to `0.15.4`.
- Updated `@farcaster/hub-nodejs` version from `0.12.3` to `0.12.4`.
- Updated `@farcaster/shuttle` version from `0.6.4` to `0.6.5`.
- Updated `@farcaster/hubble` version from `1.15.4` to `1.15.5`.
- Added notable changes to changelogs for `core`, `hub-nodejs`, `shuttle`, and `hubble` packages, including bug fixes and new features.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->