### PR TITLE
fix: Limit max bundle size

### DIFF
--- a/.changeset/real-hounds-divide.md
+++ b/.changeset/real-hounds-divide.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Limit message bundle size

--- a/apps/hubble/src/network/p2p/bundleCreator.ts
+++ b/apps/hubble/src/network/p2p/bundleCreator.ts
@@ -2,7 +2,7 @@ import { Message, MessageBundle } from "@farcaster/hub-nodejs";
 import { GossipPublishResult, LibP2PNode } from "./gossipNodeWorker.js";
 import { blake3Truncate160 } from "../../utils/crypto.js";
 
-const MAX_BUNDLE_SIZE = 256;
+export const MAX_BUNDLE_SIZE = 256;
 const DEFAULT_BUNDLE_TIME_MS = 1000;
 
 export class BundleCreator {


### PR DESCRIPTION
## Why is this change needed?

`submitBulkMessages` and `submitMessageBundle` were not validating size of the bundle and allowing unbounded input.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on limiting the size of message bundles in the application to enhance performance and prevent overload.

### Detailed summary
- Added a new export `MAX_BUNDLE_SIZE` in `apps/hubble/src/network/p2p/bundleCreator.ts`.
- Implemented a check in `apps/hubble/src/hubble.ts` to reject message bundles exceeding `MAX_BUNDLE_SIZE`.
- Added a similar check in `apps/hubble/src/rpc/server.ts` for gRPC message submissions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->