### PR TITLE
chore: add metrics for rpc server

### DIFF
--- a/.changeset/cyan-chefs-tickle.md
+++ b/.changeset/cyan-chefs-tickle.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+chore: add metrics for grpc server

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -1713,6 +1713,7 @@ export default class Server {
 
         if (allowed.isOk() || authorized) {
           log.info({ r: request, peer }, "subscribe: starting stream");
+          statsd().decrement("rpc.open_request_count", { method: "subscribe" });
         } else {
           log.info({ r: request, peer, err: allowed.error.message }, "subscribe: rejected stream");
           destroyStream(stream, allowed.error);
@@ -1763,6 +1764,7 @@ export default class Server {
           this.subscribeIpLimiter.removeConnection(peer);
 
           log.info({ peer }, "subscribe: stream closed");
+          statsd().decrement("rpc.open_request_count", { method: "subscribe" });
         });
 
         // If the user wants to start from a specific event, we'll start from there first

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -938,7 +938,6 @@ export default class Server {
           () => call.getPeer(),
           (e) => e,
         )().unwrapOr("unavailable");
-        log.info({ method: "submitMessage", req: call.request }, `RPC call from ${peer} started`);
         statsd().increment("rpc.open_request_count", { method: "submitMessage" });
 
         const rateLimitResult = await rateLimitByIp(peer, this.submitMessageRateLimiter);
@@ -961,7 +960,6 @@ export default class Server {
         const message = call.request;
         const result = await this.hub?.submitMessage(message, "rpc");
 
-        log.info({ method: "submitMessage", req: call.request }, `RPC call from ${peer} completed`);
         statsd().decrement("rpc.open_request_count", { method: "submitMessage" });
 
         result?.match(
@@ -979,7 +977,6 @@ export default class Server {
           () => call.getPeer(),
           (e) => e,
         )().unwrapOr("unavailable");
-        log.info({ method: "submitBulkMessages", req: call.request }, `RPC call from ${peer} started`);
         statsd().increment("rpc.open_request_count", { method: "submitBulkMessages" });
 
         // Check for rate limits
@@ -1026,7 +1023,6 @@ export default class Server {
         });
         const result = await this.hub?.submitMessageBundle(submissionTime.value, messageBundle, "rpc");
 
-        log.info({ method: "submitBulkMessages", req: call.request }, `RPC call from ${peer} completed`);
         statsd().decrement("rpc.open_request_count", { method: "submitBulkMessages" });
 
         callback(
@@ -1054,14 +1050,11 @@ export default class Server {
         );
       },
       validateMessage: async (call, callback) => {
-        const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
-        log.info({ method: "validateMessage", req: call.request }, `RPC call from ${peer} started`);
         statsd().increment("rpc.open_request_count", { method: "validateMessage" });
 
         const message = call.request;
         const result = await this.hub?.validateMessage(message);
 
-        log.info({ method: "validateMessage", req: call.request }, `RPC call from ${peer} completed`);
         statsd().decrement("rpc.open_request_count", { method: "validateMessage" });
         result?.match(
           (message: Message) => {

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -1713,7 +1713,7 @@ export default class Server {
 
         if (allowed.isOk() || authorized) {
           log.info({ r: request, peer }, "subscribe: starting stream");
-          statsd().decrement("rpc.open_request_count", { method: "subscribe" });
+          statsd().increment("rpc.open_request_count", { method: "subscribe" });
         } else {
           log.info({ r: request, peer, err: allowed.error.message }, "subscribe: rejected stream");
           destroyStream(stream, allowed.error);

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -533,9 +533,11 @@ export default class Server {
     (async () => {
       const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
       log.debug({ method: "getInfo", req: call?.request || { dbStats: false } }, `RPC call from ${peer}`);
+      statsd().increment("rpc.open_request_count", { method: "getInfo" });
 
       const info = await this.getInfo(call?.request || { dbStats: false });
 
+      statsd().decrement("rpc.open_request_count", { method: "getInfo" });
       callback(null, info);
     })();
   }
@@ -559,8 +561,11 @@ export default class Server {
     (async () => {
       const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
       log.debug({ method: "stopSync", req: call.request }, `RPC call from ${peer}`);
+      statsd().increment("rpc.open_request_count", { method: "stopSync" });
 
       const result = await this.stopSync();
+
+      statsd().decrement("rpc.open_request_count", { method: "stopSync" });
       if (result.isErr()) {
         callback(toServiceError(result.error));
       } else {
@@ -605,8 +610,11 @@ export default class Server {
     (async () => {
       const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
       log.debug({ method: "forceSync", req: call.request }, `RPC call from ${peer}`);
+      statsd().increment("rpc.open_request_count", { method: "forceSync" });
 
       const result = await this.forceSync(call.request);
+
+      statsd().decrement("rpc.open_request_count", { method: "forceSync" });
       if (result.isErr()) {
         callback(toServiceError(result.error));
       } else {
@@ -633,8 +641,12 @@ export default class Server {
     (async () => {
       const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
       log.debug({ method: "getCurrentPeers", req: call.request }, `RPC call from ${peer}`);
+      statsd().increment("rpc.open_request_count", { method: "getCurrentPeers" });
 
       const result = this.getCurrentPeers();
+
+      statsd().decrement("rpc.open_request_count", { method: "getCurrentPeers" });
+
       callback(null, result);
     })();
   }
@@ -689,9 +701,12 @@ export default class Server {
     (async () => {
       const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
       log.debug({ method: "getSyncStatus", req: call.request }, `RPC call from ${peer}`);
+      statsd().increment("rpc.open_request_count", { method: "getSyncStatus" });
 
       const peerId = call.request.peerId;
       const result = await this.getSyncStatus(peerId);
+
+      statsd().decrement("rpc.open_request_count", { method: "getSyncStatus" });
       if (result.isErr()) {
         callback(toServiceError(result.error));
       } else {
@@ -708,9 +723,12 @@ export default class Server {
   public getAllSyncIdsByPrefixRPC(call: ServerUnaryCall<TrieNodePrefix, SyncIds>, callback: sendUnaryData<SyncIds>) {
     const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
     log.debug({ method: "getAllSyncIdsByPrefix", req: call.request }, `RPC call from ${peer}`);
+    statsd().increment("rpc.open_request_count", { method: "getAllSyncIdsByPrefix" });
 
     (async () => {
       const result = await this.getAllSyncIdsByPrefix(call.request);
+
+      statsd().decrement("rpc.open_request_count", { method: "getAllSyncIdsByPrefix" });
       if (result.isErr()) {
         callback(toServiceError(result.error));
       } else {
@@ -760,8 +778,11 @@ export default class Server {
   ) {
     const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
     log.debug({ method: "getAllMessagesBySyncIds", req: call.request }, `RPC call from ${peer}`);
+    statsd().increment("rpc.open_request_count", { method: "getAllMessagesBySyncIds" });
 
     const result = await this.getAllMessagesBySyncIds(call.request);
+
+    statsd().decrement("rpc.open_request_count", { method: "getAllMessagesBySyncIds" });
     if (result.isErr()) {
       callback(toServiceError(result.error));
     } else {
@@ -780,9 +801,12 @@ export default class Server {
   ) {
     const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
     log.debug({ method: "getSyncMetadataByPrefix", req: call.request }, `RPC call from ${peer}`);
+    statsd().increment("rpc.open_request_count", { method: "getSyncMetadataByPrefix" });
 
     (async () => {
       const result = await this.getSyncMetadataByPrefix(call.request);
+      statsd().decrement("rpc.open_request_count", { method: "getSyncMetadataByPrefix" });
+
       if (result.isErr()) {
         callback(toServiceError(result.error));
       } else {
@@ -815,6 +839,7 @@ export default class Server {
   ) {
     const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
     log.debug({ method: "getSyncSnapshotByPrefix", req: call.request }, `RPC call from ${peer}`);
+    statsd().increment("rpc.open_request_count", { method: "getSyncSnapshotByPrefix" });
 
     // If someone is asking for our sync snapshot, that means we're getting incoming
     // connections
@@ -823,6 +848,7 @@ export default class Server {
 
     (async () => {
       const result = await this.getSyncSnapshotByPrefix(call.request);
+      statsd().decrement("rpc.open_request_count", { method: "getSyncSnapshotByPrefix" });
       if (result.isErr()) {
         callback(toServiceError(result.error));
       } else {
@@ -848,8 +874,11 @@ export default class Server {
   ) {
     const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
     log.debug({ method: "getOnChainSignersByFid", req: call.request }, `RPC call from ${peer}`);
+    statsd().increment("rpc.open_request_count", { method: "getOnChainSignersByFid" });
 
     const signersResult = await this.getOnChainSignersByFid(call.request);
+
+    statsd().decrement("rpc.open_request_count", { method: "getOnChainSignersByFid" });
     signersResult?.match(
       (page: OnChainEventResponse) => {
         callback(null, page);
@@ -873,9 +902,11 @@ export default class Server {
   ) {
     const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
     log.debug({ method: "getOnChainEvents", req: call.request }, `RPC call from ${peer}`);
+    statsd().increment("rpc.open_request_count", { method: "getOnChainEvents" });
 
     (async () => {
       const result = await this.getOnChainEvents(call.request);
+      statsd().decrement("rpc.open_request_count", { method: "getOnChainEvents" });
       if (result.isErr()) {
         callback(toServiceError(result.error));
       } else {
@@ -907,6 +938,8 @@ export default class Server {
           () => call.getPeer(),
           (e) => e,
         )().unwrapOr("unavailable");
+        log.info({ method: "submitMessage", req: call.request }, `RPC call from ${peer} started`);
+        statsd().increment("rpc.open_request_count", { method: "submitMessage" });
 
         const rateLimitResult = await rateLimitByIp(peer, this.submitMessageRateLimiter);
         if (rateLimitResult.isErr()) {
@@ -927,6 +960,10 @@ export default class Server {
 
         const message = call.request;
         const result = await this.hub?.submitMessage(message, "rpc");
+
+        log.info({ method: "submitMessage", req: call.request }, `RPC call from ${peer} completed`);
+        statsd().decrement("rpc.open_request_count", { method: "submitMessage" });
+
         result?.match(
           () => {
             callback(null, message);
@@ -942,6 +979,8 @@ export default class Server {
           () => call.getPeer(),
           (e) => e,
         )().unwrapOr("unavailable");
+        log.info({ method: "submitBulkMessages", req: call.request }, `RPC call from ${peer} started`);
+        statsd().increment("rpc.open_request_count", { method: "submitBulkMessages" });
 
         // Check for rate limits
         const rateLimitResult = await rateLimitByIp(peer, this.submitMessageRateLimiter);
@@ -986,6 +1025,10 @@ export default class Server {
           hash: bundleHash,
         });
         const result = await this.hub?.submitMessageBundle(submissionTime.value, messageBundle, "rpc");
+
+        log.info({ method: "submitBulkMessages", req: call.request }, `RPC call from ${peer} completed`);
+        statsd().decrement("rpc.open_request_count", { method: "submitBulkMessages" });
+
         callback(
           null,
           SubmitBulkMessagesResponse.create({
@@ -1011,8 +1054,15 @@ export default class Server {
         );
       },
       validateMessage: async (call, callback) => {
+        const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
+        log.info({ method: "validateMessage", req: call.request }, `RPC call from ${peer} started`);
+        statsd().increment("rpc.open_request_count", { method: "validateMessage" });
+
         const message = call.request;
         const result = await this.hub?.validateMessage(message);
+
+        log.info({ method: "validateMessage", req: call.request }, `RPC call from ${peer} completed`);
+        statsd().decrement("rpc.open_request_count", { method: "validateMessage" });
         result?.match(
           (message: Message) => {
             callback(null, ValidationResponse.create({ valid: true, message }));
@@ -1025,10 +1075,13 @@ export default class Server {
       getCast: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getCast", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getCast" });
 
         const request = call.request;
 
         const castAddResult = await this.engine?.getCast(request.fid, request.hash);
+        statsd().decrement("rpc.open_request_count", { method: "getCast" });
+
         castAddResult?.match(
           (castAdd: CastAddMessage) => {
             callback(null, castAdd);
@@ -1041,6 +1094,7 @@ export default class Server {
       getCastsByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getCastsByFid", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getCastsByFid" });
 
         const { fid, pageSize, pageToken, reverse } = call.request;
 
@@ -1049,6 +1103,8 @@ export default class Server {
           pageToken,
           reverse,
         });
+
+        statsd().decrement("rpc.open_request_count", { method: "getCastsByFid" });
         castsResult?.match(
           (page: MessagesPage<CastAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1061,6 +1117,7 @@ export default class Server {
       getCastsByParent: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getCastsByParent", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getCastsByParent" });
 
         const { parentCastId, parentUrl, pageSize, pageToken, reverse } = call.request;
 
@@ -1076,6 +1133,8 @@ export default class Server {
           pageToken,
           reverse,
         });
+
+        statsd().decrement("rpc.open_request_count", { method: "getCastsByParent" });
         castsResult?.match(
           (page: MessagesPage<CastAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1088,10 +1147,13 @@ export default class Server {
       getCastsByMention: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getCastsByMention", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getCastsByMention" });
 
         const { fid, pageSize, pageToken, reverse } = call.request;
 
         const castsResult = await this.engine?.getCastsByMention(fid, { pageSize, pageToken, reverse });
+
+        statsd().decrement("rpc.open_request_count", { method: "getCastsByMention" });
         castsResult?.match(
           (page: MessagesPage<CastAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1104,6 +1166,7 @@ export default class Server {
       getReaction: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getReaction", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getReaction" });
 
         const request = call.request;
 
@@ -1112,6 +1175,8 @@ export default class Server {
           request.reactionType,
           request.targetCastId ?? request.targetUrl ?? "",
         );
+        statsd().decrement("rpc.open_request_count", { method: "getReaction" });
+
         reactionResult?.match(
           (reaction: ReactionAddMessage) => {
             callback(null, reaction);
@@ -1124,6 +1189,7 @@ export default class Server {
       getReactionsByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getReactionsByFid", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getReactionsByFid" });
 
         const { fid, reactionType, pageSize, pageToken, reverse } = call.request;
         const reactionsResult = await this.engine?.getReactionsByFid(fid, reactionType, {
@@ -1131,6 +1197,8 @@ export default class Server {
           pageToken,
           reverse,
         });
+
+        statsd().decrement("rpc.open_request_count", { method: "getReactionsByFid" });
         reactionsResult?.match(
           (page: MessagesPage<ReactionAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1143,6 +1211,7 @@ export default class Server {
       getReactionsByCast: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getReactionsByCast", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getReactionsByCast" });
 
         const { targetCastId, reactionType, pageSize, pageToken, reverse } = call.request;
         const reactionsResult = await this.engine?.getReactionsByTarget(targetCastId ?? CastId.create(), reactionType, {
@@ -1150,6 +1219,8 @@ export default class Server {
           pageToken,
           reverse,
         });
+        statsd().decrement("rpc.open_request_count", { method: "getReactionsByCast" });
+
         reactionsResult?.match(
           (page: MessagesPage<ReactionAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1162,6 +1233,7 @@ export default class Server {
       getReactionsByTarget: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getReactionsByTarget", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getReactionsByTarget" });
 
         const { targetCastId, targetUrl, reactionType, pageSize, pageToken, reverse } = call.request;
         const reactionsResult = await this.engine?.getReactionsByTarget(targetCastId ?? targetUrl ?? "", reactionType, {
@@ -1169,6 +1241,8 @@ export default class Server {
           pageToken,
           reverse,
         });
+
+        statsd().decrement("rpc.open_request_count", { method: "getReactionsByTarget" });
         reactionsResult?.match(
           (page: MessagesPage<ReactionAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1181,10 +1255,13 @@ export default class Server {
       getUserData: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getUserData", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getUserData" });
 
         const request = call.request;
 
         const userDataResult = await this.engine?.getUserData(request.fid, request.userDataType);
+
+        statsd().decrement("rpc.open_request_count", { method: "getUserData" });
         userDataResult?.match(
           (userData: UserDataAddMessage) => {
             callback(null, userData);
@@ -1197,6 +1274,7 @@ export default class Server {
       getUserDataByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getUserDataByFid", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getUserDataByFid" });
 
         const { fid, pageSize, pageToken, reverse } = call.request;
 
@@ -1205,6 +1283,8 @@ export default class Server {
           pageToken,
           reverse,
         });
+
+        statsd().decrement("rpc.open_request_count", { method: "getUserDataByFid" });
         userDataResult?.match(
           (page: MessagesPage<UserDataAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1217,10 +1297,13 @@ export default class Server {
       getUsernameProof: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getUsernameProof", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getUsernameProof" });
 
         const request = call.request;
 
         const usernameProofResult = await this.engine?.getUserNameProof(request.name);
+
+        statsd().decrement("rpc.open_request_count", { method: "getUsernameProof" });
         usernameProofResult?.match(
           (usernameProof: UserNameProof) => {
             callback(null, usernameProof);
@@ -1233,10 +1316,13 @@ export default class Server {
       getUserNameProofsByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getUserNameProofsByFid", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getUserNameProofsByFid" });
 
         const request = call.request;
 
         const usernameProofResult = await this.engine?.getUserNameProofsByFid(request.fid);
+
+        statsd().decrement("rpc.open_request_count", { method: "getUserNameProofsByFid" });
         usernameProofResult?.match(
           (usernameProofs: UserNameProof[]) => {
             callback(null, UsernameProofsResponse.create({ proofs: usernameProofs }));
@@ -1249,10 +1335,13 @@ export default class Server {
       getVerification: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getVerification", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getVerification" });
 
         const request = call.request;
 
         const verificationResult = await this.engine?.getVerification(request.fid, request.address);
+
+        statsd().decrement("rpc.open_request_count", { method: "getVerification" });
         verificationResult?.match(
           (verification: VerificationAddAddressMessage) => {
             callback(null, verification);
@@ -1265,6 +1354,7 @@ export default class Server {
       getVerificationsByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getVerificationsByFid", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getVerificationsByFid" });
 
         const { fid, pageSize, pageToken, reverse } = call.request;
 
@@ -1273,6 +1363,8 @@ export default class Server {
           pageToken,
           reverse,
         });
+
+        statsd().decrement("rpc.open_request_count", { method: "getVerificationsByFid" });
         verificationsResult?.match(
           (page: MessagesPage<VerificationAddAddressMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1285,10 +1377,13 @@ export default class Server {
       getOnChainSigner: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getOnChainSigner", req: call.request }, `RPC call from ${peer}`);
+        statsd().decrement("rpc.open_request_count", { method: "getVerificationsByFid" });
 
         const request = call.request;
 
         const signerResult = await this.engine?.getActiveSigner(request.fid, request.signer);
+
+        statsd().decrement("rpc.open_request_count", { method: "getOnChainSigner" });
         signerResult?.match(
           (signer: SignerOnChainEvent) => {
             callback(null, signer);
@@ -1301,10 +1396,13 @@ export default class Server {
       getLink: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getLink", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getLink" });
 
         const request = call.request;
 
         const linkResult = await this.engine?.getLink(request.fid, request.linkType, request.targetFid ?? 0);
+
+        statsd().decrement("rpc.open_request_count", { method: "getLink" });
         linkResult?.match(
           (link: LinkAddMessage) => {
             callback(null, link);
@@ -1317,6 +1415,7 @@ export default class Server {
       getLinksByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getLinksByFid", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getLinksByFid" });
 
         const { fid, linkType, pageSize, pageToken, reverse } = call.request;
         const linksResult = await this.engine?.getLinksByFid(fid, linkType, {
@@ -1324,6 +1423,8 @@ export default class Server {
           pageToken,
           reverse,
         });
+
+        statsd().decrement("rpc.open_request_count", { method: "getLinksByFid" });
         linksResult?.match(
           (page: MessagesPage<LinkAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1336,6 +1437,7 @@ export default class Server {
       getLinksByTarget: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getLinksByTarget", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getLinksByTarget" });
 
         const { targetFid, linkType, pageSize, pageToken, reverse } = call.request;
         const linksResult = await this.engine?.getLinksByTarget(targetFid ?? 0, linkType, {
@@ -1343,6 +1445,8 @@ export default class Server {
           pageToken,
           reverse,
         });
+
+        statsd().decrement("rpc.open_request_count", { method: "getLinksByTarget" });
         linksResult?.match(
           (page: MessagesPage<LinkAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1355,9 +1459,12 @@ export default class Server {
       getIdRegistryOnChainEvent: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getIdRegistryOnChainEvent", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getIdRegistryOnChainEvent" });
 
         const request = call.request;
         const idRegistryEventResult = await this.engine?.getIdRegistryOnChainEvent(request.fid);
+
+        statsd().decrement("rpc.open_request_count", { method: "getIdRegistryOnChainEvent" });
         idRegistryEventResult?.match(
           (idRegistryEvent: OnChainEvent) => {
             callback(null, idRegistryEvent);
@@ -1370,9 +1477,12 @@ export default class Server {
       getIdRegistryOnChainEventByAddress: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getIdRegistryOnChainEventByAddress", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getIdRegistryOnChainEventByAddress" });
 
         const request = call.request;
         const idRegistryEventResult = await this.engine?.getIdRegistryOnChainEventByAddress(request.address);
+
+        statsd().decrement("rpc.open_request_count", { method: "getIdRegistryOnChainEventByAddress" });
         idRegistryEventResult?.match(
           (idRegistryEvent: OnChainEvent) => {
             callback(null, idRegistryEvent);
@@ -1383,8 +1493,12 @@ export default class Server {
         );
       },
       getCurrentStorageLimitsByFid: async (call, callback) => {
+        statsd().increment("rpc.open_request_count", { method: "getCurrentStorageLimitsByFid" });
+
         const request = call.request;
         const storageLimitsResult = await this.engine?.getCurrentStorageLimitsByFid(request.fid);
+
+        statsd().decrement("rpc.open_request_count", { method: "getCurrentStorageLimitsByFid" });
         storageLimitsResult?.match(
           (storageLimits: StorageLimitsResponse) => {
             callback(null, storageLimits);
@@ -1397,6 +1511,7 @@ export default class Server {
       getFids: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getFids", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getFids" });
 
         const { pageSize, pageToken, reverse } = call.request;
 
@@ -1405,6 +1520,8 @@ export default class Server {
           pageToken,
           reverse,
         });
+
+        statsd().decrement("rpc.open_request_count", { method: "getFids" });
         result?.match(
           (page: { fids: number[]; nextPageToken: Uint8Array | undefined }) => {
             callback(null, FidsResponse.create(page));
@@ -1417,6 +1534,7 @@ export default class Server {
       getAllCastMessagesByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getAllCastMessagesByFid", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getAllCastMessagesByFid" });
 
         const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
         const result = await this.engine?.getAllCastMessagesByFid(
@@ -1429,6 +1547,8 @@ export default class Server {
           startTimestamp,
           stopTimestamp,
         );
+
+        statsd().decrement("rpc.open_request_count", { method: "getAllCastMessagesByFid" });
         result?.match(
           (page: MessagesPage<CastAddMessage | CastRemoveMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1441,6 +1561,7 @@ export default class Server {
       getAllReactionMessagesByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getAllReactionMessagesByFid", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getAllReactionMessagesByFid" });
 
         const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
         const result = await this.engine?.getAllReactionMessagesByFid(
@@ -1453,6 +1574,8 @@ export default class Server {
           startTimestamp,
           stopTimestamp,
         );
+
+        statsd().decrement("rpc.open_request_count", { method: "getAllReactionMessagesByFid" });
         result?.match(
           (page: MessagesPage<ReactionAddMessage | ReactionRemoveMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1465,6 +1588,7 @@ export default class Server {
       getAllVerificationMessagesByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getAllVerificationMessagesByFid", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getAllVerificationMessagesByFid" });
 
         const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
         const result = await this.engine?.getAllVerificationMessagesByFid(
@@ -1477,6 +1601,8 @@ export default class Server {
           startTimestamp,
           stopTimestamp,
         );
+
+        statsd().decrement("rpc.open_request_count", { method: "getAllVerificationMessagesByFid" });
         result?.match(
           (page: MessagesPage<VerificationAddAddressMessage | VerificationRemoveMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1489,6 +1615,7 @@ export default class Server {
       getAllUserDataMessagesByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getAllUserDataMessagesByFid", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getAllUserDataMessagesByFid" });
 
         const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
         const result = await this.engine?.getUserDataByFid(
@@ -1501,6 +1628,8 @@ export default class Server {
           startTimestamp,
           stopTimestamp,
         );
+
+        statsd().decrement("rpc.open_request_count", { method: "getAllUserDataMessagesByFid" });
         result?.match(
           (page: MessagesPage<UserDataAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1513,6 +1642,7 @@ export default class Server {
       getAllLinkMessagesByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getAllLinkMessagesByFid", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getAllLinkMessagesByFid" });
 
         const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
         const result = await this.engine?.getAllLinkMessagesByFid(
@@ -1525,6 +1655,8 @@ export default class Server {
           startTimestamp,
           stopTimestamp,
         );
+
+        statsd().decrement("rpc.open_request_count", { method: "getAllLinkMessagesByFid" });
         result?.match(
           (page: MessagesPage<LinkAddMessage | LinkRemoveMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1537,6 +1669,7 @@ export default class Server {
       getLinkCompactStateMessageByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getLinkCompactStateMessageByFid", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getLinkCompactStateMessageByFid" });
 
         const { fid, pageSize, pageToken, reverse } = call.request;
         const result = await this.engine?.getLinkCompactStateMessageByFid(fid, {
@@ -1544,6 +1677,8 @@ export default class Server {
           pageToken,
           reverse,
         });
+
+        statsd().decrement("rpc.open_request_count", { method: "getLinkCompactStateMessageByFid" });
         result?.match(
           (page: MessagesPage<LinkCompactStateMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1556,8 +1691,11 @@ export default class Server {
       getEvent: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getEvent", req: call.request }, `RPC call from ${peer}`);
+        statsd().increment("rpc.open_request_count", { method: "getevent" });
 
         const result = await this.engine?.getEvent(call.request.id);
+
+        statsd().decrement("rpc.open_request_count", { method: "getevent" });
         result?.match(
           (event: HubEvent) => callback(null, event),
           (err: HubError) => callback(toServiceError(err)),
@@ -1745,6 +1883,7 @@ export default class Server {
             resolve();
           });
           stream.on("data", async (request) => {
+            statsd().increment("rpc.open_request_count", { method: "streamSync" });
             if (request.forceSync) {
               const result = await this.forceSync(request.forceSync);
               if (result.isErr()) {
@@ -1933,6 +2072,7 @@ export default class Server {
                 timeout.refresh();
               }
             }
+            statsd().decrement("rpc.open_request_count", { method: "streamSync" });
           });
         });
       },
@@ -1947,6 +2087,7 @@ export default class Server {
             resolve();
           });
           stream.on("data", async (request) => {
+            statsd().increment("rpc.open_request_count", { method: "streamFetch" });
             const requestPayload =
               request.castMessagesByFid ||
               request.linkMessagesByFid ||
@@ -2045,6 +2186,7 @@ export default class Server {
               },
             );
             timeout.refresh();
+            statsd().decrement("rpc.open_request_count", { method: "streamFetch" });
           });
         });
       },


### PR DESCRIPTION
It would be useful to know when there are spikes in certain kinds of rpcs for debugging purposes. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the monitoring of RPC calls in the `Server` class by integrating `statsd` metrics to track the count of open RPC requests for various methods.

### Detailed summary
- Added `statsd().increment` for tracking open request count at the start of multiple RPC methods.
- Added `statsd().decrement` for tracking open request count at the end of the same methods.
- Methods updated include `getInfo`, `stopSync`, `forceSync`, `getCurrentPeers`, `getSyncStatus`, and many others.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->