### PR TITLE
fix: gracefully handle streaming hangups when the server dies unexpected

### DIFF
--- a/.changeset/fast-peaches-retire.md
+++ b/.changeset/fast-peaches-retire.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+fix: gracefully handle streaming hangups when the server dies unexpected

--- a/packages/shuttle/src/shuttle/messageReconciliation.ts
+++ b/packages/shuttle/src/shuttle/messageReconciliation.ts
@@ -181,26 +181,36 @@ export class MessageReconciliation {
   ) {
     const id = randomUUID();
     const result = new Promise<HubResult<MessagesResponse>>((resolve) => {
+      // Do not allow hanging unresponsive connections to linger:
+      const cancel = setTimeout(() => resolve(err(new HubError("unavailable", "server timeout"))), 5000);
+
       if (!this.stream) {
-        resolve(fallback());
+        fallback()
+          .then((result) => resolve(result))
+          .finally(() => clearTimeout(cancel));
         return;
       }
       const process = async (response: StreamFetchResponse) => {
         if (!this.stream) {
+          clearTimeout(cancel);
           resolve(err(new HubError("unavailable", "unexpected stream termination")));
           return;
         }
         this.stream.off("data", process);
         if (response.idempotencyKey !== id || !response.messages) {
           if (response?.error) {
+            clearTimeout(cancel);
             resolve(err(new HubError(response.error.errCode as HubErrorCode, { message: response.error.message })));
             return;
           }
 
           this.stream.cancel();
           this.stream = undefined;
-          resolve(fallback());
+          fallback()
+            .then((result) => resolve(result))
+            .finally(() => clearTimeout(cancel));
         } else {
+          clearTimeout(cancel);
           resolve(ok(response.messages));
         }
       };


### PR DESCRIPTION
## Why is this change needed?

Fixes #2346. Under certain conditions, like a hub failure or odd connectivity quirks, the fetch can hang indefinitely, leading to a need for consumers to restart if they aren't timeout driven. This avoids the issue by setting a sensible timeout and returning failure in the event it can't complete the request.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of server streaming timeouts and errors in the `shuttle` package, ensuring graceful termination of unresponsive connections and adding corresponding tests.

### Detailed summary
- Added timeout handling to prevent hanging connections in `packages/shuttle/src/shuttle/messageReconciliation.ts`.
- Updated promise resolution logic to handle server timeout errors.
- Implemented a test case in `packages/shuttle/src/shuttle.integration.test.ts` for unresponsive server requests.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->