### PR TITLE
chore: release hubble v1.15.6

### DIFF
--- a/.changeset/cyan-chefs-tickle.md
+++ b/.changeset/cyan-chefs-tickle.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-chore: add metrics for grpc server

--- a/.changeset/real-hounds-divide.md
+++ b/.changeset/real-hounds-divide.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: Limit message bundle size

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/hubble
 
+## 1.15.6
+
+### Patch Changes
+
+- c2c409fb: chore: add metrics for grpc server
+- 1ca66d8c: fix: Limit message bundle size
+
 ## 1.15.5
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.15.5",
+  "version": "1.15.6",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",


### PR DESCRIPTION
Releasing hubble v1.15.6

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on updating the version of the `@farcaster/hubble` package from `1.15.5` to `1.15.6`. It includes updates to the `CHANGELOG.md` to reflect the new version and its associated changes.

### Detailed summary
- Updated `version` of `@farcaster/hubble` from `1.15.5` to `1.15.6` in `package.json`.
- Added a new section for version `1.15.6` in `CHANGELOG.md`:
  - `c2c409fb`: Added metrics for gRPC server.
  - `1ca66d8c`: Fixed limit on message bundle size.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->