### PR TITLE
Release shuttle v0.6.6

### DIFF
--- a/.changeset/fast-peaches-retire.md
+++ b/.changeset/fast-peaches-retire.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-fix: gracefully handle streaming hangups when the server dies unexpected

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.6.6
+
+### Patch Changes
+
+- 386059ac: fix: gracefully handle streaming hangups when the server dies unexpected
+
 ## 0.6.5
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Why is this change needed?

Releases v0.6.6 of shuttle

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of the `@farcaster/shuttle` package from `0.6.5` to `0.6.6`, adds a new entry to the `CHANGELOG.md` for patch changes, and includes a fix for handling streaming hangups when the server unexpectedly dies.

### Detailed summary
- Updated `version` in `packages/shuttle/package.json` from `0.6.5` to `0.6.6`.
- Added a new section in `CHANGELOG.md` for version `0.6.6`.
- Documented a fix for gracefully handling streaming hangups when the server dies unexpectedly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->