### PR TITLE
chore: add metrics for http/rpc/streaming requests for grafana

### DIFF
--- a/.changeset/strong-teachers-cover.md
+++ b/.changeset/strong-teachers-cover.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+chore: add metrics for http/rpc/streaming requests for grafana

--- a/apps/hubble/grafana/grafana-dashboard.json
+++ b/apps/hubble/grafana/grafana-dashboard.json
@@ -2064,10 +2064,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "graphite",
-        "uid": "bac321a6-733a-4486-8028-994878266191"
-      },
+      "datasource": "Graphite",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2141,10 +2138,7 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "graphite",
-            "uid": "bac321a6-733a-4486-8028-994878266191"
-          },
+          "datasource": "Graphite",
           "refId": "A",
           "target": "stats.hubble.httpapi.*"
         }
@@ -2153,10 +2147,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "graphite",
-        "uid": "bac321a6-733a-4486-8028-994878266191"
-      },
+      "datasource": "Graphite",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2230,10 +2221,7 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "graphite",
-            "uid": "bac321a6-733a-4486-8028-994878266191"
-          },
+          "datasource": "Graphite",
           "refId": "A",
           "target": "stats.hubble.rpc.open_request_count"
         }
@@ -2242,10 +2230,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "graphite",
-        "uid": "bac321a6-733a-4486-8028-994878266191"
-      },
+      "datasource": "Graphite",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2319,10 +2304,7 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "graphite",
-            "uid": "bac321a6-733a-4486-8028-994878266191"
-          },
+          "datasource": "Graphite",
           "refId": "A",
           "target": "stats.hubble.rpc.open_stream_count",
           "textEditor": true

--- a/apps/hubble/grafana/grafana-dashboard.json
+++ b/apps/hubble/grafana/grafana-dashboard.json
@@ -2049,6 +2049,287 @@
         }
       ],
       "type": "table"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 80
+      },
+      "id": 34,
+      "panels": [],
+      "title": "Request Details",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "graphite",
+        "uid": "bac321a6-733a-4486-8028-994878266191"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 7,
+        "x": 0,
+        "y": 81
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "graphite",
+            "uid": "bac321a6-733a-4486-8028-994878266191"
+          },
+          "refId": "A",
+          "target": "stats.hubble.httpapi.*"
+        }
+      ],
+      "title": "HTTP Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "graphite",
+        "uid": "bac321a6-733a-4486-8028-994878266191"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 7,
+        "y": 81
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "graphite",
+            "uid": "bac321a6-733a-4486-8028-994878266191"
+          },
+          "refId": "A",
+          "target": "stats.hubble.rpc.open_request_count"
+        }
+      ],
+      "title": "RPC Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "graphite",
+        "uid": "bac321a6-733a-4486-8028-994878266191"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 15,
+        "y": 81
+      },
+      "id": 37,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "graphite",
+            "uid": "bac321a6-733a-4486-8028-994878266191"
+          },
+          "refId": "A",
+          "target": "stats.hubble.rpc.open_stream_count",
+          "textEditor": true
+        }
+      ],
+      "title": "Streaming RPC Requests",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",

--- a/apps/hubble/src/rpc/httpServer.ts
+++ b/apps/hubble/src/rpc/httpServer.ts
@@ -66,7 +66,7 @@ function getCallObject<M extends keyof HubServiceServer>(
   request: fastify.FastifyRequest,
   metadata?: Metadata,
 ): CallTypeForMethod<M> {
-  statsd().increment(`httpapi.${method}`, { peer: request.ip });
+  statsd().increment(`httpapi.${method}`);
 
   return {
     request: params,

--- a/apps/hubble/src/rpc/httpServer.ts
+++ b/apps/hubble/src/rpc/httpServer.ts
@@ -66,7 +66,7 @@ function getCallObject<M extends keyof HubServiceServer>(
   request: fastify.FastifyRequest,
   metadata?: Metadata,
 ): CallTypeForMethod<M> {
-  statsd().increment(`httpapi.${method}`);
+  statsd().increment(`httpapi.${method}`, { peer: request.ip });
 
   return {
     request: params,

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -533,11 +533,11 @@ export default class Server {
     (async () => {
       const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
       log.debug({ method: "getInfo", req: call?.request || { dbStats: false } }, `RPC call from ${peer}`);
-      statsd().increment("rpc.open_request_count", { method: "getInfo", peer: call.getPeer() });
+      statsd().increment("rpc.open_request_count", { method: "getInfo" });
 
       const info = await this.getInfo(call?.request || { dbStats: false });
 
-      statsd().decrement("rpc.open_request_count", { method: "getInfo", peer: call.getPeer() });
+      statsd().decrement("rpc.open_request_count", { method: "getInfo" });
       callback(null, info);
     })();
   }
@@ -561,11 +561,11 @@ export default class Server {
     (async () => {
       const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
       log.debug({ method: "stopSync", req: call.request }, `RPC call from ${peer}`);
-      statsd().increment("rpc.open_request_count", { method: "stopSync", peer: call.getPeer() });
+      statsd().increment("rpc.open_request_count", { method: "stopSync" });
 
       const result = await this.stopSync();
 
-      statsd().decrement("rpc.open_request_count", { method: "stopSync", peer: call.getPeer() });
+      statsd().decrement("rpc.open_request_count", { method: "stopSync" });
       if (result.isErr()) {
         callback(toServiceError(result.error));
       } else {
@@ -610,11 +610,11 @@ export default class Server {
     (async () => {
       const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
       log.debug({ method: "forceSync", req: call.request }, `RPC call from ${peer}`);
-      statsd().increment("rpc.open_request_count", { method: "forceSync", peer: call.getPeer() });
+      statsd().increment("rpc.open_request_count", { method: "forceSync" });
 
       const result = await this.forceSync(call.request);
 
-      statsd().decrement("rpc.open_request_count", { method: "forceSync", peer: call.getPeer() });
+      statsd().decrement("rpc.open_request_count", { method: "forceSync" });
       if (result.isErr()) {
         callback(toServiceError(result.error));
       } else {
@@ -641,11 +641,11 @@ export default class Server {
     (async () => {
       const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
       log.debug({ method: "getCurrentPeers", req: call.request }, `RPC call from ${peer}`);
-      statsd().increment("rpc.open_request_count", { method: "getCurrentPeers", peer: call.getPeer() });
+      statsd().increment("rpc.open_request_count", { method: "getCurrentPeers" });
 
       const result = this.getCurrentPeers();
 
-      statsd().decrement("rpc.open_request_count", { method: "getCurrentPeers", peer: call.getPeer() });
+      statsd().decrement("rpc.open_request_count", { method: "getCurrentPeers" });
 
       callback(null, result);
     })();
@@ -701,12 +701,12 @@ export default class Server {
     (async () => {
       const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
       log.debug({ method: "getSyncStatus", req: call.request }, `RPC call from ${peer}`);
-      statsd().increment("rpc.open_request_count", { method: "getSyncStatus", peer: call.getPeer() });
+      statsd().increment("rpc.open_request_count", { method: "getSyncStatus" });
 
       const peerId = call.request.peerId;
       const result = await this.getSyncStatus(peerId);
 
-      statsd().decrement("rpc.open_request_count", { method: "getSyncStatus", peer: call.getPeer() });
+      statsd().decrement("rpc.open_request_count", { method: "getSyncStatus" });
       if (result.isErr()) {
         callback(toServiceError(result.error));
       } else {
@@ -723,12 +723,12 @@ export default class Server {
   public getAllSyncIdsByPrefixRPC(call: ServerUnaryCall<TrieNodePrefix, SyncIds>, callback: sendUnaryData<SyncIds>) {
     const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
     log.debug({ method: "getAllSyncIdsByPrefix", req: call.request }, `RPC call from ${peer}`);
-    statsd().increment("rpc.open_request_count", { method: "getAllSyncIdsByPrefix", peer: call.getPeer() });
+    statsd().increment("rpc.open_request_count", { method: "getAllSyncIdsByPrefix" });
 
     (async () => {
       const result = await this.getAllSyncIdsByPrefix(call.request);
 
-      statsd().decrement("rpc.open_request_count", { method: "getAllSyncIdsByPrefix", peer: call.getPeer() });
+      statsd().decrement("rpc.open_request_count", { method: "getAllSyncIdsByPrefix" });
       if (result.isErr()) {
         callback(toServiceError(result.error));
       } else {
@@ -778,11 +778,11 @@ export default class Server {
   ) {
     const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
     log.debug({ method: "getAllMessagesBySyncIds", req: call.request }, `RPC call from ${peer}`);
-    statsd().increment("rpc.open_request_count", { method: "getAllMessagesBySyncIds", peer: call.getPeer() });
+    statsd().increment("rpc.open_request_count", { method: "getAllMessagesBySyncIds" });
 
     const result = await this.getAllMessagesBySyncIds(call.request);
 
-    statsd().decrement("rpc.open_request_count", { method: "getAllMessagesBySyncIds", peer: call.getPeer() });
+    statsd().decrement("rpc.open_request_count", { method: "getAllMessagesBySyncIds" });
     if (result.isErr()) {
       callback(toServiceError(result.error));
     } else {
@@ -801,11 +801,11 @@ export default class Server {
   ) {
     const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
     log.debug({ method: "getSyncMetadataByPrefix", req: call.request }, `RPC call from ${peer}`);
-    statsd().increment("rpc.open_request_count", { method: "getSyncMetadataByPrefix", peer: call.getPeer() });
+    statsd().increment("rpc.open_request_count", { method: "getSyncMetadataByPrefix" });
 
     (async () => {
       const result = await this.getSyncMetadataByPrefix(call.request);
-      statsd().decrement("rpc.open_request_count", { method: "getSyncMetadataByPrefix", peer: call.getPeer() });
+      statsd().decrement("rpc.open_request_count", { method: "getSyncMetadataByPrefix" });
 
       if (result.isErr()) {
         callback(toServiceError(result.error));
@@ -839,7 +839,7 @@ export default class Server {
   ) {
     const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
     log.debug({ method: "getSyncSnapshotByPrefix", req: call.request }, `RPC call from ${peer}`);
-    statsd().increment("rpc.open_request_count", { method: "getSyncSnapshotByPrefix", peer: call.getPeer() });
+    statsd().increment("rpc.open_request_count", { method: "getSyncSnapshotByPrefix" });
 
     // If someone is asking for our sync snapshot, that means we're getting incoming
     // connections
@@ -848,7 +848,7 @@ export default class Server {
 
     (async () => {
       const result = await this.getSyncSnapshotByPrefix(call.request);
-      statsd().decrement("rpc.open_request_count", { method: "getSyncSnapshotByPrefix", peer: call.getPeer() });
+      statsd().decrement("rpc.open_request_count", { method: "getSyncSnapshotByPrefix" });
       if (result.isErr()) {
         callback(toServiceError(result.error));
       } else {
@@ -874,11 +874,11 @@ export default class Server {
   ) {
     const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
     log.debug({ method: "getOnChainSignersByFid", req: call.request }, `RPC call from ${peer}`);
-    statsd().increment("rpc.open_request_count", { method: "getOnChainSignersByFid", peer: call.getPeer() });
+    statsd().increment("rpc.open_request_count", { method: "getOnChainSignersByFid" });
 
     const signersResult = await this.getOnChainSignersByFid(call.request);
 
-    statsd().decrement("rpc.open_request_count", { method: "getOnChainSignersByFid", peer: call.getPeer() });
+    statsd().decrement("rpc.open_request_count", { method: "getOnChainSignersByFid" });
     signersResult?.match(
       (page: OnChainEventResponse) => {
         callback(null, page);
@@ -902,11 +902,11 @@ export default class Server {
   ) {
     const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
     log.debug({ method: "getOnChainEvents", req: call.request }, `RPC call from ${peer}`);
-    statsd().increment("rpc.open_request_count", { method: "getOnChainEvents", peer: call.getPeer() });
+    statsd().increment("rpc.open_request_count", { method: "getOnChainEvents" });
 
     (async () => {
       const result = await this.getOnChainEvents(call.request);
-      statsd().decrement("rpc.open_request_count", { method: "getOnChainEvents", peer: call.getPeer() });
+      statsd().decrement("rpc.open_request_count", { method: "getOnChainEvents" });
       if (result.isErr()) {
         callback(toServiceError(result.error));
       } else {
@@ -938,7 +938,7 @@ export default class Server {
           () => call.getPeer(),
           (e) => e,
         )().unwrapOr("unavailable");
-        statsd().increment("rpc.open_request_count", { method: "submitMessage", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "submitMessage" });
 
         const rateLimitResult = await rateLimitByIp(peer, this.submitMessageRateLimiter);
         if (rateLimitResult.isErr()) {
@@ -960,7 +960,7 @@ export default class Server {
         const message = call.request;
         const result = await this.hub?.submitMessage(message, "rpc");
 
-        statsd().decrement("rpc.open_request_count", { method: "submitMessage", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "submitMessage" });
 
         result?.match(
           () => {
@@ -977,7 +977,7 @@ export default class Server {
           () => call.getPeer(),
           (e) => e,
         )().unwrapOr("unavailable");
-        statsd().increment("rpc.open_request_count", { method: "submitBulkMessages", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "submitBulkMessages" });
 
         // Check for rate limits
         const rateLimitResult = await rateLimitByIp(peer, this.submitMessageRateLimiter);
@@ -1023,7 +1023,7 @@ export default class Server {
         });
         const result = await this.hub?.submitMessageBundle(submissionTime.value, messageBundle, "rpc");
 
-        statsd().decrement("rpc.open_request_count", { method: "submitBulkMessages", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "submitBulkMessages" });
 
         callback(
           null,
@@ -1050,12 +1050,12 @@ export default class Server {
         );
       },
       validateMessage: async (call, callback) => {
-        statsd().increment("rpc.open_request_count", { method: "validateMessage", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "validateMessage" });
 
         const message = call.request;
         const result = await this.hub?.validateMessage(message);
 
-        statsd().decrement("rpc.open_request_count", { method: "validateMessage", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "validateMessage" });
         result?.match(
           (message: Message) => {
             callback(null, ValidationResponse.create({ valid: true, message }));
@@ -1068,12 +1068,12 @@ export default class Server {
       getCast: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getCast", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getCast", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getCast" });
 
         const request = call.request;
 
         const castAddResult = await this.engine?.getCast(request.fid, request.hash);
-        statsd().decrement("rpc.open_request_count", { method: "getCast", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getCast" });
 
         castAddResult?.match(
           (castAdd: CastAddMessage) => {
@@ -1087,7 +1087,7 @@ export default class Server {
       getCastsByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getCastsByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getCastsByFid", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getCastsByFid" });
 
         const { fid, pageSize, pageToken, reverse } = call.request;
 
@@ -1097,7 +1097,7 @@ export default class Server {
           reverse,
         });
 
-        statsd().decrement("rpc.open_request_count", { method: "getCastsByFid", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getCastsByFid" });
         castsResult?.match(
           (page: MessagesPage<CastAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1110,7 +1110,7 @@ export default class Server {
       getCastsByParent: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getCastsByParent", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getCastsByParent", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getCastsByParent" });
 
         const { parentCastId, parentUrl, pageSize, pageToken, reverse } = call.request;
 
@@ -1127,7 +1127,7 @@ export default class Server {
           reverse,
         });
 
-        statsd().decrement("rpc.open_request_count", { method: "getCastsByParent", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getCastsByParent" });
         castsResult?.match(
           (page: MessagesPage<CastAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1140,13 +1140,13 @@ export default class Server {
       getCastsByMention: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getCastsByMention", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getCastsByMention", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getCastsByMention" });
 
         const { fid, pageSize, pageToken, reverse } = call.request;
 
         const castsResult = await this.engine?.getCastsByMention(fid, { pageSize, pageToken, reverse });
 
-        statsd().decrement("rpc.open_request_count", { method: "getCastsByMention", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getCastsByMention" });
         castsResult?.match(
           (page: MessagesPage<CastAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1159,7 +1159,7 @@ export default class Server {
       getReaction: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getReaction", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getReaction", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getReaction" });
 
         const request = call.request;
 
@@ -1168,7 +1168,7 @@ export default class Server {
           request.reactionType,
           request.targetCastId ?? request.targetUrl ?? "",
         );
-        statsd().decrement("rpc.open_request_count", { method: "getReaction", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getReaction" });
 
         reactionResult?.match(
           (reaction: ReactionAddMessage) => {
@@ -1182,7 +1182,7 @@ export default class Server {
       getReactionsByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getReactionsByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getReactionsByFid", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getReactionsByFid" });
 
         const { fid, reactionType, pageSize, pageToken, reverse } = call.request;
         const reactionsResult = await this.engine?.getReactionsByFid(fid, reactionType, {
@@ -1191,7 +1191,7 @@ export default class Server {
           reverse,
         });
 
-        statsd().decrement("rpc.open_request_count", { method: "getReactionsByFid", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getReactionsByFid" });
         reactionsResult?.match(
           (page: MessagesPage<ReactionAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1204,7 +1204,7 @@ export default class Server {
       getReactionsByCast: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getReactionsByCast", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getReactionsByCast", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getReactionsByCast" });
 
         const { targetCastId, reactionType, pageSize, pageToken, reverse } = call.request;
         const reactionsResult = await this.engine?.getReactionsByTarget(targetCastId ?? CastId.create(), reactionType, {
@@ -1212,7 +1212,7 @@ export default class Server {
           pageToken,
           reverse,
         });
-        statsd().decrement("rpc.open_request_count", { method: "getReactionsByCast", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getReactionsByCast" });
 
         reactionsResult?.match(
           (page: MessagesPage<ReactionAddMessage>) => {
@@ -1226,7 +1226,7 @@ export default class Server {
       getReactionsByTarget: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getReactionsByTarget", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getReactionsByTarget", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getReactionsByTarget" });
 
         const { targetCastId, targetUrl, reactionType, pageSize, pageToken, reverse } = call.request;
         const reactionsResult = await this.engine?.getReactionsByTarget(targetCastId ?? targetUrl ?? "", reactionType, {
@@ -1235,7 +1235,7 @@ export default class Server {
           reverse,
         });
 
-        statsd().decrement("rpc.open_request_count", { method: "getReactionsByTarget", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getReactionsByTarget" });
         reactionsResult?.match(
           (page: MessagesPage<ReactionAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1248,13 +1248,13 @@ export default class Server {
       getUserData: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getUserData", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getUserData", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getUserData" });
 
         const request = call.request;
 
         const userDataResult = await this.engine?.getUserData(request.fid, request.userDataType);
 
-        statsd().decrement("rpc.open_request_count", { method: "getUserData", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getUserData" });
         userDataResult?.match(
           (userData: UserDataAddMessage) => {
             callback(null, userData);
@@ -1267,7 +1267,7 @@ export default class Server {
       getUserDataByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getUserDataByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getUserDataByFid", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getUserDataByFid" });
 
         const { fid, pageSize, pageToken, reverse } = call.request;
 
@@ -1277,7 +1277,7 @@ export default class Server {
           reverse,
         });
 
-        statsd().decrement("rpc.open_request_count", { method: "getUserDataByFid", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getUserDataByFid" });
         userDataResult?.match(
           (page: MessagesPage<UserDataAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1290,13 +1290,13 @@ export default class Server {
       getUsernameProof: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getUsernameProof", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getUsernameProof", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getUsernameProof" });
 
         const request = call.request;
 
         const usernameProofResult = await this.engine?.getUserNameProof(request.name);
 
-        statsd().decrement("rpc.open_request_count", { method: "getUsernameProof", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getUsernameProof" });
         usernameProofResult?.match(
           (usernameProof: UserNameProof) => {
             callback(null, usernameProof);
@@ -1309,13 +1309,13 @@ export default class Server {
       getUserNameProofsByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getUserNameProofsByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getUserNameProofsByFid", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getUserNameProofsByFid" });
 
         const request = call.request;
 
         const usernameProofResult = await this.engine?.getUserNameProofsByFid(request.fid);
 
-        statsd().decrement("rpc.open_request_count", { method: "getUserNameProofsByFid", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getUserNameProofsByFid" });
         usernameProofResult?.match(
           (usernameProofs: UserNameProof[]) => {
             callback(null, UsernameProofsResponse.create({ proofs: usernameProofs }));
@@ -1328,13 +1328,13 @@ export default class Server {
       getVerification: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getVerification", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getVerification", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getVerification" });
 
         const request = call.request;
 
         const verificationResult = await this.engine?.getVerification(request.fid, request.address);
 
-        statsd().decrement("rpc.open_request_count", { method: "getVerification", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getVerification" });
         verificationResult?.match(
           (verification: VerificationAddAddressMessage) => {
             callback(null, verification);
@@ -1347,7 +1347,7 @@ export default class Server {
       getVerificationsByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getVerificationsByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getVerificationsByFid", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getVerificationsByFid" });
 
         const { fid, pageSize, pageToken, reverse } = call.request;
 
@@ -1357,7 +1357,7 @@ export default class Server {
           reverse,
         });
 
-        statsd().decrement("rpc.open_request_count", { method: "getVerificationsByFid", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getVerificationsByFid" });
         verificationsResult?.match(
           (page: MessagesPage<VerificationAddAddressMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1370,13 +1370,13 @@ export default class Server {
       getOnChainSigner: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getOnChainSigner", req: call.request }, `RPC call from ${peer}`);
-        statsd().decrement("rpc.open_request_count", { method: "getOnChainSigner", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getOnChainSigner" });
 
         const request = call.request;
 
         const signerResult = await this.engine?.getActiveSigner(request.fid, request.signer);
 
-        statsd().decrement("rpc.open_request_count", { method: "getOnChainSigner", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getOnChainSigner" });
         signerResult?.match(
           (signer: SignerOnChainEvent) => {
             callback(null, signer);
@@ -1389,13 +1389,13 @@ export default class Server {
       getLink: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getLink", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getLink", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getLink" });
 
         const request = call.request;
 
         const linkResult = await this.engine?.getLink(request.fid, request.linkType, request.targetFid ?? 0);
 
-        statsd().decrement("rpc.open_request_count", { method: "getLink", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getLink" });
         linkResult?.match(
           (link: LinkAddMessage) => {
             callback(null, link);
@@ -1408,7 +1408,7 @@ export default class Server {
       getLinksByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getLinksByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getLinksByFid", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getLinksByFid" });
 
         const { fid, linkType, pageSize, pageToken, reverse } = call.request;
         const linksResult = await this.engine?.getLinksByFid(fid, linkType, {
@@ -1417,7 +1417,7 @@ export default class Server {
           reverse,
         });
 
-        statsd().decrement("rpc.open_request_count", { method: "getLinksByFid", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getLinksByFid" });
         linksResult?.match(
           (page: MessagesPage<LinkAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1430,7 +1430,7 @@ export default class Server {
       getLinksByTarget: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getLinksByTarget", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getLinksByTarget", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getLinksByTarget" });
 
         const { targetFid, linkType, pageSize, pageToken, reverse } = call.request;
         const linksResult = await this.engine?.getLinksByTarget(targetFid ?? 0, linkType, {
@@ -1439,7 +1439,7 @@ export default class Server {
           reverse,
         });
 
-        statsd().decrement("rpc.open_request_count", { method: "getLinksByTarget", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getLinksByTarget" });
         linksResult?.match(
           (page: MessagesPage<LinkAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1452,12 +1452,12 @@ export default class Server {
       getIdRegistryOnChainEvent: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getIdRegistryOnChainEvent", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getIdRegistryOnChainEvent", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getIdRegistryOnChainEvent" });
 
         const request = call.request;
         const idRegistryEventResult = await this.engine?.getIdRegistryOnChainEvent(request.fid);
 
-        statsd().decrement("rpc.open_request_count", { method: "getIdRegistryOnChainEvent", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getIdRegistryOnChainEvent" });
         idRegistryEventResult?.match(
           (idRegistryEvent: OnChainEvent) => {
             callback(null, idRegistryEvent);
@@ -1470,18 +1470,12 @@ export default class Server {
       getIdRegistryOnChainEventByAddress: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getIdRegistryOnChainEventByAddress", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", {
-          method: "getIdRegistryOnChainEventByAddress",
-          peer: call.getPeer(),
-        });
+        statsd().increment("rpc.open_request_count", { method: "getIdRegistryOnChainEventByAddress" });
 
         const request = call.request;
         const idRegistryEventResult = await this.engine?.getIdRegistryOnChainEventByAddress(request.address);
 
-        statsd().decrement("rpc.open_request_count", {
-          method: "getIdRegistryOnChainEventByAddress",
-          peer: call.getPeer(),
-        });
+        statsd().decrement("rpc.open_request_count", { method: "getIdRegistryOnChainEventByAddress" });
         idRegistryEventResult?.match(
           (idRegistryEvent: OnChainEvent) => {
             callback(null, idRegistryEvent);
@@ -1492,12 +1486,12 @@ export default class Server {
         );
       },
       getCurrentStorageLimitsByFid: async (call, callback) => {
-        statsd().increment("rpc.open_request_count", { method: "getCurrentStorageLimitsByFid", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getCurrentStorageLimitsByFid" });
 
         const request = call.request;
         const storageLimitsResult = await this.engine?.getCurrentStorageLimitsByFid(request.fid);
 
-        statsd().decrement("rpc.open_request_count", { method: "getCurrentStorageLimitsByFid", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getCurrentStorageLimitsByFid" });
         storageLimitsResult?.match(
           (storageLimits: StorageLimitsResponse) => {
             callback(null, storageLimits);
@@ -1510,7 +1504,7 @@ export default class Server {
       getFids: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getFids", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getFids", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getFids" });
 
         const { pageSize, pageToken, reverse } = call.request;
 
@@ -1520,7 +1514,7 @@ export default class Server {
           reverse,
         });
 
-        statsd().decrement("rpc.open_request_count", { method: "getFids", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getFids" });
         result?.match(
           (page: { fids: number[]; nextPageToken: Uint8Array | undefined }) => {
             callback(null, FidsResponse.create(page));
@@ -1533,7 +1527,7 @@ export default class Server {
       getAllCastMessagesByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getAllCastMessagesByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getAllCastMessagesByFid", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getAllCastMessagesByFid" });
 
         const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
         const result = await this.engine?.getAllCastMessagesByFid(
@@ -1547,7 +1541,7 @@ export default class Server {
           stopTimestamp,
         );
 
-        statsd().decrement("rpc.open_request_count", { method: "getAllCastMessagesByFid", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getAllCastMessagesByFid" });
         result?.match(
           (page: MessagesPage<CastAddMessage | CastRemoveMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1560,7 +1554,7 @@ export default class Server {
       getAllReactionMessagesByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getAllReactionMessagesByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getAllReactionMessagesByFid", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getAllReactionMessagesByFid" });
 
         const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
         const result = await this.engine?.getAllReactionMessagesByFid(
@@ -1574,7 +1568,7 @@ export default class Server {
           stopTimestamp,
         );
 
-        statsd().decrement("rpc.open_request_count", { method: "getAllReactionMessagesByFid", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getAllReactionMessagesByFid" });
         result?.match(
           (page: MessagesPage<ReactionAddMessage | ReactionRemoveMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1587,10 +1581,7 @@ export default class Server {
       getAllVerificationMessagesByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getAllVerificationMessagesByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", {
-          method: "getAllVerificationMessagesByFid",
-          peer: call.getPeer(),
-        });
+        statsd().increment("rpc.open_request_count", { method: "getAllVerificationMessagesByFid" });
 
         const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
         const result = await this.engine?.getAllVerificationMessagesByFid(
@@ -1604,10 +1595,7 @@ export default class Server {
           stopTimestamp,
         );
 
-        statsd().decrement("rpc.open_request_count", {
-          method: "getAllVerificationMessagesByFid",
-          peer: call.getPeer(),
-        });
+        statsd().decrement("rpc.open_request_count", { method: "getAllVerificationMessagesByFid" });
         result?.match(
           (page: MessagesPage<VerificationAddAddressMessage | VerificationRemoveMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1620,7 +1608,7 @@ export default class Server {
       getAllUserDataMessagesByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getAllUserDataMessagesByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getAllUserDataMessagesByFid", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getAllUserDataMessagesByFid" });
 
         const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
         const result = await this.engine?.getUserDataByFid(
@@ -1634,7 +1622,7 @@ export default class Server {
           stopTimestamp,
         );
 
-        statsd().decrement("rpc.open_request_count", { method: "getAllUserDataMessagesByFid", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getAllUserDataMessagesByFid" });
         result?.match(
           (page: MessagesPage<UserDataAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1647,7 +1635,7 @@ export default class Server {
       getAllLinkMessagesByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getAllLinkMessagesByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getAllLinkMessagesByFid", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getAllLinkMessagesByFid" });
 
         const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
         const result = await this.engine?.getAllLinkMessagesByFid(
@@ -1661,7 +1649,7 @@ export default class Server {
           stopTimestamp,
         );
 
-        statsd().decrement("rpc.open_request_count", { method: "getAllLinkMessagesByFid", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getAllLinkMessagesByFid" });
         result?.match(
           (page: MessagesPage<LinkAddMessage | LinkRemoveMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1674,10 +1662,7 @@ export default class Server {
       getLinkCompactStateMessageByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getLinkCompactStateMessageByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", {
-          method: "getLinkCompactStateMessageByFid",
-          peer: call.getPeer(),
-        });
+        statsd().increment("rpc.open_request_count", { method: "getLinkCompactStateMessageByFid" });
 
         const { fid, pageSize, pageToken, reverse } = call.request;
         const result = await this.engine?.getLinkCompactStateMessageByFid(fid, {
@@ -1686,10 +1671,7 @@ export default class Server {
           reverse,
         });
 
-        statsd().decrement("rpc.open_request_count", {
-          method: "getLinkCompactStateMessageByFid",
-          peer: call.getPeer(),
-        });
+        statsd().decrement("rpc.open_request_count", { method: "getLinkCompactStateMessageByFid" });
         result?.match(
           (page: MessagesPage<LinkCompactStateMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1702,11 +1684,11 @@ export default class Server {
       getEvent: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getEvent", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getevent", peer: call.getPeer() });
+        statsd().increment("rpc.open_request_count", { method: "getevent" });
 
         const result = await this.engine?.getEvent(call.request.id);
 
-        statsd().decrement("rpc.open_request_count", { method: "getevent", peer: call.getPeer() });
+        statsd().decrement("rpc.open_request_count", { method: "getevent" });
         result?.match(
           (event: HubEvent) => callback(null, event),
           (err: HubError) => callback(toServiceError(err)),
@@ -1731,8 +1713,8 @@ export default class Server {
 
         if (allowed.isOk() || authorized) {
           log.info({ r: request, peer }, "subscribe: starting stream");
-          statsd().increment("rpc.open_stream_count", { method: "subscribe", peer: stream.getPeer() });
-          statsd().increment("rpc.open_request_count", { method: "subscribe", peer: stream.getPeer() });
+          statsd().increment("rpc.open_stream_count", { method: "subscribe" });
+          statsd().increment("rpc.open_request_count", { method: "subscribe" });
         } else {
           log.info({ r: request, peer, err: allowed.error.message }, "subscribe: rejected stream");
           destroyStream(stream, allowed.error);
@@ -1783,8 +1765,8 @@ export default class Server {
           this.subscribeIpLimiter.removeConnection(peer);
 
           log.info({ peer }, "subscribe: stream closed");
-          statsd().decrement("rpc.open_stream_count", { method: "subscribe", peer: stream.getPeer() });
-          statsd().decrement("rpc.open_request_count", { method: "subscribe", peer: stream.getPeer() });
+          statsd().decrement("rpc.open_stream_count", { method: "subscribe" });
+          statsd().decrement("rpc.open_request_count", { method: "subscribe" });
         });
 
         // If the user wants to start from a specific event, we'll start from there first
@@ -1898,8 +1880,8 @@ export default class Server {
             resolve();
           });
           stream.on("data", async (request) => {
-            statsd().increment("rpc.open_stream_count", { method: "streamSync", peer: stream.getPeer() });
-            statsd().increment("rpc.open_request_count", { method: "streamSync", peer: stream.getPeer() });
+            statsd().increment("rpc.open_stream_count", { method: "streamSync" });
+            statsd().increment("rpc.open_request_count", { method: "streamSync" });
             if (request.forceSync) {
               const result = await this.forceSync(request.forceSync);
               if (result.isErr()) {
@@ -2088,8 +2070,8 @@ export default class Server {
                 timeout.refresh();
               }
             }
-            statsd().decrement("rpc.open_stream_count", { method: "streamSync", peer: stream.getPeer() });
-            statsd().decrement("rpc.open_request_count", { method: "streamSync", peer: stream.getPeer() });
+            statsd().decrement("rpc.open_stream_count", { method: "streamSync" });
+            statsd().decrement("rpc.open_request_count", { method: "streamSync" });
           });
         });
       },
@@ -2104,8 +2086,8 @@ export default class Server {
             resolve();
           });
           stream.on("data", async (request) => {
-            statsd().increment("rpc.open_stream_count", { method: "streamFetch", peer: stream.getPeer() });
-            statsd().increment("rpc.open_request_count", { method: "streamFetch", peer: stream.getPeer() });
+            statsd().increment("rpc.open_stream_count", { method: "streamFetch" });
+            statsd().increment("rpc.open_request_count", { method: "streamFetch" });
             const requestPayload =
               request.castMessagesByFid ||
               request.linkMessagesByFid ||
@@ -2204,8 +2186,8 @@ export default class Server {
               },
             );
             timeout.refresh();
-            statsd().decrement("rpc.open_stream_count", { method: "streamFetch", peer: stream.getPeer() });
-            statsd().decrement("rpc.open_request_count", { method: "streamFetch", peer: stream.getPeer() });
+            statsd().decrement("rpc.open_stream_count", { method: "streamFetch" });
+            statsd().decrement("rpc.open_request_count", { method: "streamFetch" });
           });
         });
       },

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -533,11 +533,11 @@ export default class Server {
     (async () => {
       const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
       log.debug({ method: "getInfo", req: call?.request || { dbStats: false } }, `RPC call from ${peer}`);
-      statsd().increment("rpc.open_request_count", { method: "getInfo" });
+      statsd().increment("rpc.open_request_count", { method: "getInfo", peer: call.getPeer() });
 
       const info = await this.getInfo(call?.request || { dbStats: false });
 
-      statsd().decrement("rpc.open_request_count", { method: "getInfo" });
+      statsd().decrement("rpc.open_request_count", { method: "getInfo", peer: call.getPeer() });
       callback(null, info);
     })();
   }
@@ -561,11 +561,11 @@ export default class Server {
     (async () => {
       const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
       log.debug({ method: "stopSync", req: call.request }, `RPC call from ${peer}`);
-      statsd().increment("rpc.open_request_count", { method: "stopSync" });
+      statsd().increment("rpc.open_request_count", { method: "stopSync", peer: call.getPeer() });
 
       const result = await this.stopSync();
 
-      statsd().decrement("rpc.open_request_count", { method: "stopSync" });
+      statsd().decrement("rpc.open_request_count", { method: "stopSync", peer: call.getPeer() });
       if (result.isErr()) {
         callback(toServiceError(result.error));
       } else {
@@ -610,11 +610,11 @@ export default class Server {
     (async () => {
       const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
       log.debug({ method: "forceSync", req: call.request }, `RPC call from ${peer}`);
-      statsd().increment("rpc.open_request_count", { method: "forceSync" });
+      statsd().increment("rpc.open_request_count", { method: "forceSync", peer: call.getPeer() });
 
       const result = await this.forceSync(call.request);
 
-      statsd().decrement("rpc.open_request_count", { method: "forceSync" });
+      statsd().decrement("rpc.open_request_count", { method: "forceSync", peer: call.getPeer() });
       if (result.isErr()) {
         callback(toServiceError(result.error));
       } else {
@@ -641,11 +641,11 @@ export default class Server {
     (async () => {
       const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
       log.debug({ method: "getCurrentPeers", req: call.request }, `RPC call from ${peer}`);
-      statsd().increment("rpc.open_request_count", { method: "getCurrentPeers" });
+      statsd().increment("rpc.open_request_count", { method: "getCurrentPeers", peer: call.getPeer() });
 
       const result = this.getCurrentPeers();
 
-      statsd().decrement("rpc.open_request_count", { method: "getCurrentPeers" });
+      statsd().decrement("rpc.open_request_count", { method: "getCurrentPeers", peer: call.getPeer() });
 
       callback(null, result);
     })();
@@ -701,12 +701,12 @@ export default class Server {
     (async () => {
       const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
       log.debug({ method: "getSyncStatus", req: call.request }, `RPC call from ${peer}`);
-      statsd().increment("rpc.open_request_count", { method: "getSyncStatus" });
+      statsd().increment("rpc.open_request_count", { method: "getSyncStatus", peer: call.getPeer() });
 
       const peerId = call.request.peerId;
       const result = await this.getSyncStatus(peerId);
 
-      statsd().decrement("rpc.open_request_count", { method: "getSyncStatus" });
+      statsd().decrement("rpc.open_request_count", { method: "getSyncStatus", peer: call.getPeer() });
       if (result.isErr()) {
         callback(toServiceError(result.error));
       } else {
@@ -723,12 +723,12 @@ export default class Server {
   public getAllSyncIdsByPrefixRPC(call: ServerUnaryCall<TrieNodePrefix, SyncIds>, callback: sendUnaryData<SyncIds>) {
     const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
     log.debug({ method: "getAllSyncIdsByPrefix", req: call.request }, `RPC call from ${peer}`);
-    statsd().increment("rpc.open_request_count", { method: "getAllSyncIdsByPrefix" });
+    statsd().increment("rpc.open_request_count", { method: "getAllSyncIdsByPrefix", peer: call.getPeer() });
 
     (async () => {
       const result = await this.getAllSyncIdsByPrefix(call.request);
 
-      statsd().decrement("rpc.open_request_count", { method: "getAllSyncIdsByPrefix" });
+      statsd().decrement("rpc.open_request_count", { method: "getAllSyncIdsByPrefix", peer: call.getPeer() });
       if (result.isErr()) {
         callback(toServiceError(result.error));
       } else {
@@ -778,11 +778,11 @@ export default class Server {
   ) {
     const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
     log.debug({ method: "getAllMessagesBySyncIds", req: call.request }, `RPC call from ${peer}`);
-    statsd().increment("rpc.open_request_count", { method: "getAllMessagesBySyncIds" });
+    statsd().increment("rpc.open_request_count", { method: "getAllMessagesBySyncIds", peer: call.getPeer() });
 
     const result = await this.getAllMessagesBySyncIds(call.request);
 
-    statsd().decrement("rpc.open_request_count", { method: "getAllMessagesBySyncIds" });
+    statsd().decrement("rpc.open_request_count", { method: "getAllMessagesBySyncIds", peer: call.getPeer() });
     if (result.isErr()) {
       callback(toServiceError(result.error));
     } else {
@@ -801,11 +801,11 @@ export default class Server {
   ) {
     const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
     log.debug({ method: "getSyncMetadataByPrefix", req: call.request }, `RPC call from ${peer}`);
-    statsd().increment("rpc.open_request_count", { method: "getSyncMetadataByPrefix" });
+    statsd().increment("rpc.open_request_count", { method: "getSyncMetadataByPrefix", peer: call.getPeer() });
 
     (async () => {
       const result = await this.getSyncMetadataByPrefix(call.request);
-      statsd().decrement("rpc.open_request_count", { method: "getSyncMetadataByPrefix" });
+      statsd().decrement("rpc.open_request_count", { method: "getSyncMetadataByPrefix", peer: call.getPeer() });
 
       if (result.isErr()) {
         callback(toServiceError(result.error));
@@ -839,7 +839,7 @@ export default class Server {
   ) {
     const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
     log.debug({ method: "getSyncSnapshotByPrefix", req: call.request }, `RPC call from ${peer}`);
-    statsd().increment("rpc.open_request_count", { method: "getSyncSnapshotByPrefix" });
+    statsd().increment("rpc.open_request_count", { method: "getSyncSnapshotByPrefix", peer: call.getPeer() });
 
     // If someone is asking for our sync snapshot, that means we're getting incoming
     // connections
@@ -848,7 +848,7 @@ export default class Server {
 
     (async () => {
       const result = await this.getSyncSnapshotByPrefix(call.request);
-      statsd().decrement("rpc.open_request_count", { method: "getSyncSnapshotByPrefix" });
+      statsd().decrement("rpc.open_request_count", { method: "getSyncSnapshotByPrefix", peer: call.getPeer() });
       if (result.isErr()) {
         callback(toServiceError(result.error));
       } else {
@@ -874,11 +874,11 @@ export default class Server {
   ) {
     const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
     log.debug({ method: "getOnChainSignersByFid", req: call.request }, `RPC call from ${peer}`);
-    statsd().increment("rpc.open_request_count", { method: "getOnChainSignersByFid" });
+    statsd().increment("rpc.open_request_count", { method: "getOnChainSignersByFid", peer: call.getPeer() });
 
     const signersResult = await this.getOnChainSignersByFid(call.request);
 
-    statsd().decrement("rpc.open_request_count", { method: "getOnChainSignersByFid" });
+    statsd().decrement("rpc.open_request_count", { method: "getOnChainSignersByFid", peer: call.getPeer() });
     signersResult?.match(
       (page: OnChainEventResponse) => {
         callback(null, page);
@@ -902,11 +902,11 @@ export default class Server {
   ) {
     const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
     log.debug({ method: "getOnChainEvents", req: call.request }, `RPC call from ${peer}`);
-    statsd().increment("rpc.open_request_count", { method: "getOnChainEvents" });
+    statsd().increment("rpc.open_request_count", { method: "getOnChainEvents", peer: call.getPeer() });
 
     (async () => {
       const result = await this.getOnChainEvents(call.request);
-      statsd().decrement("rpc.open_request_count", { method: "getOnChainEvents" });
+      statsd().decrement("rpc.open_request_count", { method: "getOnChainEvents", peer: call.getPeer() });
       if (result.isErr()) {
         callback(toServiceError(result.error));
       } else {
@@ -938,7 +938,7 @@ export default class Server {
           () => call.getPeer(),
           (e) => e,
         )().unwrapOr("unavailable");
-        statsd().increment("rpc.open_request_count", { method: "submitMessage" });
+        statsd().increment("rpc.open_request_count", { method: "submitMessage", peer: call.getPeer() });
 
         const rateLimitResult = await rateLimitByIp(peer, this.submitMessageRateLimiter);
         if (rateLimitResult.isErr()) {
@@ -960,7 +960,7 @@ export default class Server {
         const message = call.request;
         const result = await this.hub?.submitMessage(message, "rpc");
 
-        statsd().decrement("rpc.open_request_count", { method: "submitMessage" });
+        statsd().decrement("rpc.open_request_count", { method: "submitMessage", peer: call.getPeer() });
 
         result?.match(
           () => {
@@ -977,7 +977,7 @@ export default class Server {
           () => call.getPeer(),
           (e) => e,
         )().unwrapOr("unavailable");
-        statsd().increment("rpc.open_request_count", { method: "submitBulkMessages" });
+        statsd().increment("rpc.open_request_count", { method: "submitBulkMessages", peer: call.getPeer() });
 
         // Check for rate limits
         const rateLimitResult = await rateLimitByIp(peer, this.submitMessageRateLimiter);
@@ -1023,7 +1023,7 @@ export default class Server {
         });
         const result = await this.hub?.submitMessageBundle(submissionTime.value, messageBundle, "rpc");
 
-        statsd().decrement("rpc.open_request_count", { method: "submitBulkMessages" });
+        statsd().decrement("rpc.open_request_count", { method: "submitBulkMessages", peer: call.getPeer() });
 
         callback(
           null,
@@ -1050,12 +1050,12 @@ export default class Server {
         );
       },
       validateMessage: async (call, callback) => {
-        statsd().increment("rpc.open_request_count", { method: "validateMessage" });
+        statsd().increment("rpc.open_request_count", { method: "validateMessage", peer: call.getPeer() });
 
         const message = call.request;
         const result = await this.hub?.validateMessage(message);
 
-        statsd().decrement("rpc.open_request_count", { method: "validateMessage" });
+        statsd().decrement("rpc.open_request_count", { method: "validateMessage", peer: call.getPeer() });
         result?.match(
           (message: Message) => {
             callback(null, ValidationResponse.create({ valid: true, message }));
@@ -1068,12 +1068,12 @@ export default class Server {
       getCast: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getCast", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getCast" });
+        statsd().increment("rpc.open_request_count", { method: "getCast", peer: call.getPeer() });
 
         const request = call.request;
 
         const castAddResult = await this.engine?.getCast(request.fid, request.hash);
-        statsd().decrement("rpc.open_request_count", { method: "getCast" });
+        statsd().decrement("rpc.open_request_count", { method: "getCast", peer: call.getPeer() });
 
         castAddResult?.match(
           (castAdd: CastAddMessage) => {
@@ -1087,7 +1087,7 @@ export default class Server {
       getCastsByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getCastsByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getCastsByFid" });
+        statsd().increment("rpc.open_request_count", { method: "getCastsByFid", peer: call.getPeer() });
 
         const { fid, pageSize, pageToken, reverse } = call.request;
 
@@ -1097,7 +1097,7 @@ export default class Server {
           reverse,
         });
 
-        statsd().decrement("rpc.open_request_count", { method: "getCastsByFid" });
+        statsd().decrement("rpc.open_request_count", { method: "getCastsByFid", peer: call.getPeer() });
         castsResult?.match(
           (page: MessagesPage<CastAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1110,7 +1110,7 @@ export default class Server {
       getCastsByParent: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getCastsByParent", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getCastsByParent" });
+        statsd().increment("rpc.open_request_count", { method: "getCastsByParent", peer: call.getPeer() });
 
         const { parentCastId, parentUrl, pageSize, pageToken, reverse } = call.request;
 
@@ -1127,7 +1127,7 @@ export default class Server {
           reverse,
         });
 
-        statsd().decrement("rpc.open_request_count", { method: "getCastsByParent" });
+        statsd().decrement("rpc.open_request_count", { method: "getCastsByParent", peer: call.getPeer() });
         castsResult?.match(
           (page: MessagesPage<CastAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1140,13 +1140,13 @@ export default class Server {
       getCastsByMention: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getCastsByMention", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getCastsByMention" });
+        statsd().increment("rpc.open_request_count", { method: "getCastsByMention", peer: call.getPeer() });
 
         const { fid, pageSize, pageToken, reverse } = call.request;
 
         const castsResult = await this.engine?.getCastsByMention(fid, { pageSize, pageToken, reverse });
 
-        statsd().decrement("rpc.open_request_count", { method: "getCastsByMention" });
+        statsd().decrement("rpc.open_request_count", { method: "getCastsByMention", peer: call.getPeer() });
         castsResult?.match(
           (page: MessagesPage<CastAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1159,7 +1159,7 @@ export default class Server {
       getReaction: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getReaction", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getReaction" });
+        statsd().increment("rpc.open_request_count", { method: "getReaction", peer: call.getPeer() });
 
         const request = call.request;
 
@@ -1168,7 +1168,7 @@ export default class Server {
           request.reactionType,
           request.targetCastId ?? request.targetUrl ?? "",
         );
-        statsd().decrement("rpc.open_request_count", { method: "getReaction" });
+        statsd().decrement("rpc.open_request_count", { method: "getReaction", peer: call.getPeer() });
 
         reactionResult?.match(
           (reaction: ReactionAddMessage) => {
@@ -1182,7 +1182,7 @@ export default class Server {
       getReactionsByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getReactionsByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getReactionsByFid" });
+        statsd().increment("rpc.open_request_count", { method: "getReactionsByFid", peer: call.getPeer() });
 
         const { fid, reactionType, pageSize, pageToken, reverse } = call.request;
         const reactionsResult = await this.engine?.getReactionsByFid(fid, reactionType, {
@@ -1191,7 +1191,7 @@ export default class Server {
           reverse,
         });
 
-        statsd().decrement("rpc.open_request_count", { method: "getReactionsByFid" });
+        statsd().decrement("rpc.open_request_count", { method: "getReactionsByFid", peer: call.getPeer() });
         reactionsResult?.match(
           (page: MessagesPage<ReactionAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1204,7 +1204,7 @@ export default class Server {
       getReactionsByCast: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getReactionsByCast", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getReactionsByCast" });
+        statsd().increment("rpc.open_request_count", { method: "getReactionsByCast", peer: call.getPeer() });
 
         const { targetCastId, reactionType, pageSize, pageToken, reverse } = call.request;
         const reactionsResult = await this.engine?.getReactionsByTarget(targetCastId ?? CastId.create(), reactionType, {
@@ -1212,7 +1212,7 @@ export default class Server {
           pageToken,
           reverse,
         });
-        statsd().decrement("rpc.open_request_count", { method: "getReactionsByCast" });
+        statsd().decrement("rpc.open_request_count", { method: "getReactionsByCast", peer: call.getPeer() });
 
         reactionsResult?.match(
           (page: MessagesPage<ReactionAddMessage>) => {
@@ -1226,7 +1226,7 @@ export default class Server {
       getReactionsByTarget: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getReactionsByTarget", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getReactionsByTarget" });
+        statsd().increment("rpc.open_request_count", { method: "getReactionsByTarget", peer: call.getPeer() });
 
         const { targetCastId, targetUrl, reactionType, pageSize, pageToken, reverse } = call.request;
         const reactionsResult = await this.engine?.getReactionsByTarget(targetCastId ?? targetUrl ?? "", reactionType, {
@@ -1235,7 +1235,7 @@ export default class Server {
           reverse,
         });
 
-        statsd().decrement("rpc.open_request_count", { method: "getReactionsByTarget" });
+        statsd().decrement("rpc.open_request_count", { method: "getReactionsByTarget", peer: call.getPeer() });
         reactionsResult?.match(
           (page: MessagesPage<ReactionAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1248,13 +1248,13 @@ export default class Server {
       getUserData: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getUserData", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getUserData" });
+        statsd().increment("rpc.open_request_count", { method: "getUserData", peer: call.getPeer() });
 
         const request = call.request;
 
         const userDataResult = await this.engine?.getUserData(request.fid, request.userDataType);
 
-        statsd().decrement("rpc.open_request_count", { method: "getUserData" });
+        statsd().decrement("rpc.open_request_count", { method: "getUserData", peer: call.getPeer() });
         userDataResult?.match(
           (userData: UserDataAddMessage) => {
             callback(null, userData);
@@ -1267,7 +1267,7 @@ export default class Server {
       getUserDataByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getUserDataByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getUserDataByFid" });
+        statsd().increment("rpc.open_request_count", { method: "getUserDataByFid", peer: call.getPeer() });
 
         const { fid, pageSize, pageToken, reverse } = call.request;
 
@@ -1277,7 +1277,7 @@ export default class Server {
           reverse,
         });
 
-        statsd().decrement("rpc.open_request_count", { method: "getUserDataByFid" });
+        statsd().decrement("rpc.open_request_count", { method: "getUserDataByFid", peer: call.getPeer() });
         userDataResult?.match(
           (page: MessagesPage<UserDataAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1290,13 +1290,13 @@ export default class Server {
       getUsernameProof: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getUsernameProof", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getUsernameProof" });
+        statsd().increment("rpc.open_request_count", { method: "getUsernameProof", peer: call.getPeer() });
 
         const request = call.request;
 
         const usernameProofResult = await this.engine?.getUserNameProof(request.name);
 
-        statsd().decrement("rpc.open_request_count", { method: "getUsernameProof" });
+        statsd().decrement("rpc.open_request_count", { method: "getUsernameProof", peer: call.getPeer() });
         usernameProofResult?.match(
           (usernameProof: UserNameProof) => {
             callback(null, usernameProof);
@@ -1309,13 +1309,13 @@ export default class Server {
       getUserNameProofsByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getUserNameProofsByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getUserNameProofsByFid" });
+        statsd().increment("rpc.open_request_count", { method: "getUserNameProofsByFid", peer: call.getPeer() });
 
         const request = call.request;
 
         const usernameProofResult = await this.engine?.getUserNameProofsByFid(request.fid);
 
-        statsd().decrement("rpc.open_request_count", { method: "getUserNameProofsByFid" });
+        statsd().decrement("rpc.open_request_count", { method: "getUserNameProofsByFid", peer: call.getPeer() });
         usernameProofResult?.match(
           (usernameProofs: UserNameProof[]) => {
             callback(null, UsernameProofsResponse.create({ proofs: usernameProofs }));
@@ -1328,13 +1328,13 @@ export default class Server {
       getVerification: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getVerification", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getVerification" });
+        statsd().increment("rpc.open_request_count", { method: "getVerification", peer: call.getPeer() });
 
         const request = call.request;
 
         const verificationResult = await this.engine?.getVerification(request.fid, request.address);
 
-        statsd().decrement("rpc.open_request_count", { method: "getVerification" });
+        statsd().decrement("rpc.open_request_count", { method: "getVerification", peer: call.getPeer() });
         verificationResult?.match(
           (verification: VerificationAddAddressMessage) => {
             callback(null, verification);
@@ -1347,7 +1347,7 @@ export default class Server {
       getVerificationsByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getVerificationsByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getVerificationsByFid" });
+        statsd().increment("rpc.open_request_count", { method: "getVerificationsByFid", peer: call.getPeer() });
 
         const { fid, pageSize, pageToken, reverse } = call.request;
 
@@ -1357,7 +1357,7 @@ export default class Server {
           reverse,
         });
 
-        statsd().decrement("rpc.open_request_count", { method: "getVerificationsByFid" });
+        statsd().decrement("rpc.open_request_count", { method: "getVerificationsByFid", peer: call.getPeer() });
         verificationsResult?.match(
           (page: MessagesPage<VerificationAddAddressMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1370,13 +1370,13 @@ export default class Server {
       getOnChainSigner: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getOnChainSigner", req: call.request }, `RPC call from ${peer}`);
-        statsd().decrement("rpc.open_request_count", { method: "getVerificationsByFid" });
+        statsd().decrement("rpc.open_request_count", { method: "getOnChainSigner", peer: call.getPeer() });
 
         const request = call.request;
 
         const signerResult = await this.engine?.getActiveSigner(request.fid, request.signer);
 
-        statsd().decrement("rpc.open_request_count", { method: "getOnChainSigner" });
+        statsd().decrement("rpc.open_request_count", { method: "getOnChainSigner", peer: call.getPeer() });
         signerResult?.match(
           (signer: SignerOnChainEvent) => {
             callback(null, signer);
@@ -1389,13 +1389,13 @@ export default class Server {
       getLink: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getLink", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getLink" });
+        statsd().increment("rpc.open_request_count", { method: "getLink", peer: call.getPeer() });
 
         const request = call.request;
 
         const linkResult = await this.engine?.getLink(request.fid, request.linkType, request.targetFid ?? 0);
 
-        statsd().decrement("rpc.open_request_count", { method: "getLink" });
+        statsd().decrement("rpc.open_request_count", { method: "getLink", peer: call.getPeer() });
         linkResult?.match(
           (link: LinkAddMessage) => {
             callback(null, link);
@@ -1408,7 +1408,7 @@ export default class Server {
       getLinksByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getLinksByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getLinksByFid" });
+        statsd().increment("rpc.open_request_count", { method: "getLinksByFid", peer: call.getPeer() });
 
         const { fid, linkType, pageSize, pageToken, reverse } = call.request;
         const linksResult = await this.engine?.getLinksByFid(fid, linkType, {
@@ -1417,7 +1417,7 @@ export default class Server {
           reverse,
         });
 
-        statsd().decrement("rpc.open_request_count", { method: "getLinksByFid" });
+        statsd().decrement("rpc.open_request_count", { method: "getLinksByFid", peer: call.getPeer() });
         linksResult?.match(
           (page: MessagesPage<LinkAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1430,7 +1430,7 @@ export default class Server {
       getLinksByTarget: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getLinksByTarget", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getLinksByTarget" });
+        statsd().increment("rpc.open_request_count", { method: "getLinksByTarget", peer: call.getPeer() });
 
         const { targetFid, linkType, pageSize, pageToken, reverse } = call.request;
         const linksResult = await this.engine?.getLinksByTarget(targetFid ?? 0, linkType, {
@@ -1439,7 +1439,7 @@ export default class Server {
           reverse,
         });
 
-        statsd().decrement("rpc.open_request_count", { method: "getLinksByTarget" });
+        statsd().decrement("rpc.open_request_count", { method: "getLinksByTarget", peer: call.getPeer() });
         linksResult?.match(
           (page: MessagesPage<LinkAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1452,12 +1452,12 @@ export default class Server {
       getIdRegistryOnChainEvent: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getIdRegistryOnChainEvent", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getIdRegistryOnChainEvent" });
+        statsd().increment("rpc.open_request_count", { method: "getIdRegistryOnChainEvent", peer: call.getPeer() });
 
         const request = call.request;
         const idRegistryEventResult = await this.engine?.getIdRegistryOnChainEvent(request.fid);
 
-        statsd().decrement("rpc.open_request_count", { method: "getIdRegistryOnChainEvent" });
+        statsd().decrement("rpc.open_request_count", { method: "getIdRegistryOnChainEvent", peer: call.getPeer() });
         idRegistryEventResult?.match(
           (idRegistryEvent: OnChainEvent) => {
             callback(null, idRegistryEvent);
@@ -1470,12 +1470,18 @@ export default class Server {
       getIdRegistryOnChainEventByAddress: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getIdRegistryOnChainEventByAddress", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getIdRegistryOnChainEventByAddress" });
+        statsd().increment("rpc.open_request_count", {
+          method: "getIdRegistryOnChainEventByAddress",
+          peer: call.getPeer(),
+        });
 
         const request = call.request;
         const idRegistryEventResult = await this.engine?.getIdRegistryOnChainEventByAddress(request.address);
 
-        statsd().decrement("rpc.open_request_count", { method: "getIdRegistryOnChainEventByAddress" });
+        statsd().decrement("rpc.open_request_count", {
+          method: "getIdRegistryOnChainEventByAddress",
+          peer: call.getPeer(),
+        });
         idRegistryEventResult?.match(
           (idRegistryEvent: OnChainEvent) => {
             callback(null, idRegistryEvent);
@@ -1486,12 +1492,12 @@ export default class Server {
         );
       },
       getCurrentStorageLimitsByFid: async (call, callback) => {
-        statsd().increment("rpc.open_request_count", { method: "getCurrentStorageLimitsByFid" });
+        statsd().increment("rpc.open_request_count", { method: "getCurrentStorageLimitsByFid", peer: call.getPeer() });
 
         const request = call.request;
         const storageLimitsResult = await this.engine?.getCurrentStorageLimitsByFid(request.fid);
 
-        statsd().decrement("rpc.open_request_count", { method: "getCurrentStorageLimitsByFid" });
+        statsd().decrement("rpc.open_request_count", { method: "getCurrentStorageLimitsByFid", peer: call.getPeer() });
         storageLimitsResult?.match(
           (storageLimits: StorageLimitsResponse) => {
             callback(null, storageLimits);
@@ -1504,7 +1510,7 @@ export default class Server {
       getFids: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getFids", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getFids" });
+        statsd().increment("rpc.open_request_count", { method: "getFids", peer: call.getPeer() });
 
         const { pageSize, pageToken, reverse } = call.request;
 
@@ -1514,7 +1520,7 @@ export default class Server {
           reverse,
         });
 
-        statsd().decrement("rpc.open_request_count", { method: "getFids" });
+        statsd().decrement("rpc.open_request_count", { method: "getFids", peer: call.getPeer() });
         result?.match(
           (page: { fids: number[]; nextPageToken: Uint8Array | undefined }) => {
             callback(null, FidsResponse.create(page));
@@ -1527,7 +1533,7 @@ export default class Server {
       getAllCastMessagesByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getAllCastMessagesByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getAllCastMessagesByFid" });
+        statsd().increment("rpc.open_request_count", { method: "getAllCastMessagesByFid", peer: call.getPeer() });
 
         const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
         const result = await this.engine?.getAllCastMessagesByFid(
@@ -1541,7 +1547,7 @@ export default class Server {
           stopTimestamp,
         );
 
-        statsd().decrement("rpc.open_request_count", { method: "getAllCastMessagesByFid" });
+        statsd().decrement("rpc.open_request_count", { method: "getAllCastMessagesByFid", peer: call.getPeer() });
         result?.match(
           (page: MessagesPage<CastAddMessage | CastRemoveMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1554,7 +1560,7 @@ export default class Server {
       getAllReactionMessagesByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getAllReactionMessagesByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getAllReactionMessagesByFid" });
+        statsd().increment("rpc.open_request_count", { method: "getAllReactionMessagesByFid", peer: call.getPeer() });
 
         const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
         const result = await this.engine?.getAllReactionMessagesByFid(
@@ -1568,7 +1574,7 @@ export default class Server {
           stopTimestamp,
         );
 
-        statsd().decrement("rpc.open_request_count", { method: "getAllReactionMessagesByFid" });
+        statsd().decrement("rpc.open_request_count", { method: "getAllReactionMessagesByFid", peer: call.getPeer() });
         result?.match(
           (page: MessagesPage<ReactionAddMessage | ReactionRemoveMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1581,7 +1587,10 @@ export default class Server {
       getAllVerificationMessagesByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getAllVerificationMessagesByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getAllVerificationMessagesByFid" });
+        statsd().increment("rpc.open_request_count", {
+          method: "getAllVerificationMessagesByFid",
+          peer: call.getPeer(),
+        });
 
         const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
         const result = await this.engine?.getAllVerificationMessagesByFid(
@@ -1595,7 +1604,10 @@ export default class Server {
           stopTimestamp,
         );
 
-        statsd().decrement("rpc.open_request_count", { method: "getAllVerificationMessagesByFid" });
+        statsd().decrement("rpc.open_request_count", {
+          method: "getAllVerificationMessagesByFid",
+          peer: call.getPeer(),
+        });
         result?.match(
           (page: MessagesPage<VerificationAddAddressMessage | VerificationRemoveMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1608,7 +1620,7 @@ export default class Server {
       getAllUserDataMessagesByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getAllUserDataMessagesByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getAllUserDataMessagesByFid" });
+        statsd().increment("rpc.open_request_count", { method: "getAllUserDataMessagesByFid", peer: call.getPeer() });
 
         const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
         const result = await this.engine?.getUserDataByFid(
@@ -1622,7 +1634,7 @@ export default class Server {
           stopTimestamp,
         );
 
-        statsd().decrement("rpc.open_request_count", { method: "getAllUserDataMessagesByFid" });
+        statsd().decrement("rpc.open_request_count", { method: "getAllUserDataMessagesByFid", peer: call.getPeer() });
         result?.match(
           (page: MessagesPage<UserDataAddMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1635,7 +1647,7 @@ export default class Server {
       getAllLinkMessagesByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getAllLinkMessagesByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getAllLinkMessagesByFid" });
+        statsd().increment("rpc.open_request_count", { method: "getAllLinkMessagesByFid", peer: call.getPeer() });
 
         const { fid, pageSize, pageToken, reverse, startTimestamp, stopTimestamp } = call.request;
         const result = await this.engine?.getAllLinkMessagesByFid(
@@ -1649,7 +1661,7 @@ export default class Server {
           stopTimestamp,
         );
 
-        statsd().decrement("rpc.open_request_count", { method: "getAllLinkMessagesByFid" });
+        statsd().decrement("rpc.open_request_count", { method: "getAllLinkMessagesByFid", peer: call.getPeer() });
         result?.match(
           (page: MessagesPage<LinkAddMessage | LinkRemoveMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1662,7 +1674,10 @@ export default class Server {
       getLinkCompactStateMessageByFid: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getLinkCompactStateMessageByFid", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getLinkCompactStateMessageByFid" });
+        statsd().increment("rpc.open_request_count", {
+          method: "getLinkCompactStateMessageByFid",
+          peer: call.getPeer(),
+        });
 
         const { fid, pageSize, pageToken, reverse } = call.request;
         const result = await this.engine?.getLinkCompactStateMessageByFid(fid, {
@@ -1671,7 +1686,10 @@ export default class Server {
           reverse,
         });
 
-        statsd().decrement("rpc.open_request_count", { method: "getLinkCompactStateMessageByFid" });
+        statsd().decrement("rpc.open_request_count", {
+          method: "getLinkCompactStateMessageByFid",
+          peer: call.getPeer(),
+        });
         result?.match(
           (page: MessagesPage<LinkCompactStateMessage>) => {
             callback(null, messagesPageToResponse(page));
@@ -1684,11 +1702,11 @@ export default class Server {
       getEvent: async (call, callback) => {
         const peer = Result.fromThrowable(() => call.getPeer())().unwrapOr("unknown");
         log.debug({ method: "getEvent", req: call.request }, `RPC call from ${peer}`);
-        statsd().increment("rpc.open_request_count", { method: "getevent" });
+        statsd().increment("rpc.open_request_count", { method: "getevent", peer: call.getPeer() });
 
         const result = await this.engine?.getEvent(call.request.id);
 
-        statsd().decrement("rpc.open_request_count", { method: "getevent" });
+        statsd().decrement("rpc.open_request_count", { method: "getevent", peer: call.getPeer() });
         result?.match(
           (event: HubEvent) => callback(null, event),
           (err: HubError) => callback(toServiceError(err)),
@@ -1713,7 +1731,8 @@ export default class Server {
 
         if (allowed.isOk() || authorized) {
           log.info({ r: request, peer }, "subscribe: starting stream");
-          statsd().increment("rpc.open_request_count", { method: "subscribe" });
+          statsd().increment("rpc.open_stream_count", { method: "subscribe", peer: stream.getPeer() });
+          statsd().increment("rpc.open_request_count", { method: "subscribe", peer: stream.getPeer() });
         } else {
           log.info({ r: request, peer, err: allowed.error.message }, "subscribe: rejected stream");
           destroyStream(stream, allowed.error);
@@ -1764,7 +1783,8 @@ export default class Server {
           this.subscribeIpLimiter.removeConnection(peer);
 
           log.info({ peer }, "subscribe: stream closed");
-          statsd().decrement("rpc.open_request_count", { method: "subscribe" });
+          statsd().decrement("rpc.open_stream_count", { method: "subscribe", peer: stream.getPeer() });
+          statsd().decrement("rpc.open_request_count", { method: "subscribe", peer: stream.getPeer() });
         });
 
         // If the user wants to start from a specific event, we'll start from there first
@@ -1878,7 +1898,8 @@ export default class Server {
             resolve();
           });
           stream.on("data", async (request) => {
-            statsd().increment("rpc.open_request_count", { method: "streamSync" });
+            statsd().increment("rpc.open_stream_count", { method: "streamSync", peer: stream.getPeer() });
+            statsd().increment("rpc.open_request_count", { method: "streamSync", peer: stream.getPeer() });
             if (request.forceSync) {
               const result = await this.forceSync(request.forceSync);
               if (result.isErr()) {
@@ -2067,7 +2088,8 @@ export default class Server {
                 timeout.refresh();
               }
             }
-            statsd().decrement("rpc.open_request_count", { method: "streamSync" });
+            statsd().decrement("rpc.open_stream_count", { method: "streamSync", peer: stream.getPeer() });
+            statsd().decrement("rpc.open_request_count", { method: "streamSync", peer: stream.getPeer() });
           });
         });
       },
@@ -2082,7 +2104,8 @@ export default class Server {
             resolve();
           });
           stream.on("data", async (request) => {
-            statsd().increment("rpc.open_request_count", { method: "streamFetch" });
+            statsd().increment("rpc.open_stream_count", { method: "streamFetch", peer: stream.getPeer() });
+            statsd().increment("rpc.open_request_count", { method: "streamFetch", peer: stream.getPeer() });
             const requestPayload =
               request.castMessagesByFid ||
               request.linkMessagesByFid ||
@@ -2181,7 +2204,8 @@ export default class Server {
               },
             );
             timeout.refresh();
-            statsd().decrement("rpc.open_request_count", { method: "streamFetch" });
+            statsd().decrement("rpc.open_stream_count", { method: "streamFetch", peer: stream.getPeer() });
+            statsd().decrement("rpc.open_request_count", { method: "streamFetch", peer: stream.getPeer() });
           });
         });
       },


### PR DESCRIPTION
## Why is this change needed?

The metrics collected for statsd were not integrated into grafana, and needed a few extra details for advanced configurations. This adds a new metric for streaming, more tags on all three (http/rpc/streaming), and incorporates them into grafana. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing metrics tracking for HTTP and RPC requests in the `hubble` application, particularly for Grafana monitoring, by adding new metrics and adjusting existing ones.

### Detailed summary
- Updated the method for decrementing `rpc.open_request_count` to use `getOnChainSigner`.
- Introduced new metrics for `rpc.open_stream_count` in `subscribe`, `streamSync`, `streamFetch`.
- Added new Grafana dashboard panels for tracking HTTP and RPC requests.
- Configured `Graphite` as the data source for the new metrics in Grafana.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->