### PR TITLE
fix: handle timed out connections from hub event subscriber

### DIFF
--- a/.changeset/blue-windows-travel.md
+++ b/.changeset/blue-windows-travel.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+fix: handle timed out connections from hub event subscriber


### PR DESCRIPTION
## Why is this change needed?

Similar to #2358, this resolves unexpected hanging gRPC connections by timing them out at the call level. While gRPC configurations exist to perform keepalives and theoretically would be preferable, some deployment environments cannot alter them, and some consumers aren't always able to be aligned with the stream source.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of timed-out connections in the `BaseHubSubscriber` class within the `hubSubscriber.ts` file. It implements a mechanism to ensure that unresponsive connections are properly terminated after a specified timeout.

### Detailed summary
- Added a timeout mechanism to prevent unresponsive connections from lingering.
- Introduced a `setTimeout` to call `this.destroy()` after 30 seconds of inactivity.
- Cleared the timeout after processing each `HubEvent` to reset the timer.
- Ensured proper error handling by emitting an error event if an exception occurs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->