### PR TITLE
chore: release shuttle v0.6.7

### DIFF
--- a/.changeset/blue-windows-travel.md
+++ b/.changeset/blue-windows-travel.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-fix: handle timed out connections from hub event subscriber

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.6.7
+
+### Patch Changes
+
+- d06fbda8: fix: handle timed out connections from hub event subscriber
+
 ## 0.6.6
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Why is this change needed?

Releases shuttle v0.6.7

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of the `@farcaster/shuttle` package from `0.6.6` to `0.6.7` and includes a new changelog entry for the patch that addresses a specific issue with timed out connections.

### Detailed summary
- Updated version of `@farcaster/shuttle` in `package.json` from `0.6.6` to `0.6.7`.
- Added changelog entry for version `0.6.7`:
  - Fixed handling of timed out connections from hub event subscriber.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->