### PR TITLE
feat: add support for user location in the protocol

### DIFF
--- a/.changeset/serious-bulldogs-sort.md
+++ b/.changeset/serious-bulldogs-sort.md
@@ -1,0 +1,8 @@
+---
+"@farcaster/hub-nodejs": patch
+"@farcaster/hub-web": patch
+"@farcaster/core": patch
+"@farcaster/hubble": patch
+---
+
+feat: add user location to the protocol

--- a/packages/core/src/protobufs/generated/message.ts
+++ b/packages/core/src/protobufs/generated/message.ts
@@ -242,6 +242,8 @@ export enum UserDataType {
   URL = 5,
   /** USERNAME - Preferred Name for the user */
   USERNAME = 6,
+  /** LOCATION - Current location for the user */
+  LOCATION = 7,
 }
 
 export function userDataTypeFromJSON(object: any): UserDataType {
@@ -264,6 +266,9 @@ export function userDataTypeFromJSON(object: any): UserDataType {
     case 6:
     case "USER_DATA_TYPE_USERNAME":
       return UserDataType.USERNAME;
+    case 7:
+    case "USER_DATA_TYPE_LOCATION":
+      return UserDataType.LOCATION;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }
@@ -283,6 +288,8 @@ export function userDataTypeToJSON(object: UserDataType): string {
       return "USER_DATA_TYPE_URL";
     case UserDataType.USERNAME:
       return "USER_DATA_TYPE_USERNAME";
+    case UserDataType.LOCATION:
+      return "USER_DATA_TYPE_LOCATION";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }

--- a/packages/core/src/validations.test.ts
+++ b/packages/core/src/validations.test.ts
@@ -1159,7 +1159,7 @@ describe("validateUserDataAddBody", () => {
     test("when longitude has insufficient precision", () => {
       body = Factories.UserDataBody.build({
         type: protobufs.UserDataType.LOCATION,
-        value: "geo:12.345,12.34",
+        value: "geo:12.34,12",
       });
       hubErrorMessage = "Wrong precision for latitude or longitude";
     });
@@ -1188,12 +1188,20 @@ describe("validateUserDataAddBody", () => {
       hubErrorMessage = "Location missing geo: prefix";
     });
 
+    test("when location is missing both coordinates", () => {
+      body = Factories.UserDataBody.build({
+        type: protobufs.UserDataType.LOCATION,
+        value: "geo:",
+      });
+      hubErrorMessage = "Location contains invalid coordinates";
+    });
+
     test("when location is missing a coordinate", () => {
       body = Factories.UserDataBody.build({
         type: protobufs.UserDataType.LOCATION,
-        value: "geo:12.34",
+        value: "geo:12.34,",
       });
-      hubErrorMessage = "Invalid coordinates in Geo URI";
+      hubErrorMessage = "Latitude or longitude is not a valid number";
     });
   });
 });

--- a/packages/core/src/validations.test.ts
+++ b/packages/core/src/validations.test.ts
@@ -1137,7 +1137,7 @@ describe("validateUserDataAddBody", () => {
         type: protobufs.UserDataType.LOCATION,
         value: "geo:12.345,12.34",
       });
-      hubErrorMessage = "Wrong precision for latitude or longitude";
+      hubErrorMessage = "Invalid location string";
     });
 
     test("when latitude has insufficient precision", () => {
@@ -1145,7 +1145,7 @@ describe("validateUserDataAddBody", () => {
         type: protobufs.UserDataType.LOCATION,
         value: "geo:12,12.34",
       });
-      hubErrorMessage = "Wrong precision for latitude or longitude";
+      hubErrorMessage = "Invalid location string";
     });
 
     test("when longitude has too much precision", () => {
@@ -1153,7 +1153,7 @@ describe("validateUserDataAddBody", () => {
         type: protobufs.UserDataType.LOCATION,
         value: "geo:12.34,12.345",
       });
-      hubErrorMessage = "Wrong precision for latitude or longitude";
+      hubErrorMessage = "Invalid location string";
     });
 
     test("when longitude has insufficient precision", () => {
@@ -1161,7 +1161,7 @@ describe("validateUserDataAddBody", () => {
         type: protobufs.UserDataType.LOCATION,
         value: "geo:12.34,12",
       });
-      hubErrorMessage = "Wrong precision for latitude or longitude";
+      hubErrorMessage = "Invalid location string";
     });
 
     test("when latitude is an invalid number", () => {
@@ -1169,7 +1169,7 @@ describe("validateUserDataAddBody", () => {
         type: protobufs.UserDataType.LOCATION,
         value: "geo:xx,12.34",
       });
-      hubErrorMessage = "Latitude or longitude is not a valid number";
+      hubErrorMessage = "Invalid location string";
     });
 
     test("when longitude is an invalid number", () => {
@@ -1177,7 +1177,7 @@ describe("validateUserDataAddBody", () => {
         type: protobufs.UserDataType.LOCATION,
         value: "geo:12.34,xx",
       });
-      hubErrorMessage = "Latitude or longitude is not a valid number";
+      hubErrorMessage = "Invalid location string";
     });
 
     test("when location is missing geo prefix", () => {
@@ -1185,7 +1185,7 @@ describe("validateUserDataAddBody", () => {
         type: protobufs.UserDataType.LOCATION,
         value: "12.34,12.34",
       });
-      hubErrorMessage = "Location missing geo: prefix";
+      hubErrorMessage = "Invalid location string";
     });
 
     test("when location is missing both coordinates", () => {
@@ -1193,7 +1193,7 @@ describe("validateUserDataAddBody", () => {
         type: protobufs.UserDataType.LOCATION,
         value: "geo:",
       });
-      hubErrorMessage = "Location contains invalid coordinates";
+      hubErrorMessage = "Invalid location string";
     });
 
     test("when location is missing a coordinate", () => {
@@ -1201,7 +1201,15 @@ describe("validateUserDataAddBody", () => {
         type: protobufs.UserDataType.LOCATION,
         value: "geo:12.34,",
       });
-      hubErrorMessage = "Latitude or longitude is not a valid number";
+      hubErrorMessage = "Invalid location string";
+    });
+
+    test("when location contains a space", () => {
+      body = Factories.UserDataBody.build({
+        type: protobufs.UserDataType.LOCATION,
+        value: "geo:12.34, 12.34",
+      });
+      hubErrorMessage = "Invalid location string";
     });
   });
 });

--- a/packages/core/src/validations.test.ts
+++ b/packages/core/src/validations.test.ts
@@ -1042,6 +1042,22 @@ describe("validateUserDataAddBody", () => {
     expect(validations.validateUserDataAddBody(body)).toEqual(ok(body));
   });
 
+  test("succeeds for empty location", async () => {
+    const body = Factories.UserDataBody.build({
+      type: UserDataType.LOCATION,
+      value: "",
+    });
+    expect(validations.validateUserDataAddBody(body)).toEqual(ok(body));
+  });
+
+  test("succeeds for valid location", async () => {
+    const body = Factories.UserDataBody.build({
+      type: UserDataType.LOCATION,
+      value: "geo:12.34,-123.45",
+    });
+    expect(validations.validateUserDataAddBody(body)).toEqual(ok(body));
+  });
+
   describe("fails", () => {
     let body: protobufs.UserDataBody;
     let hubErrorMessage: string;
@@ -1082,6 +1098,102 @@ describe("validateUserDataAddBody", () => {
         value: faker.random.alphaNumeric(257),
       });
       hubErrorMessage = "url value > 256";
+    });
+
+    test("when latitude is too low", () => {
+      body = Factories.UserDataBody.build({
+        type: protobufs.UserDataType.LOCATION,
+        value: "geo:-90.01,12.34",
+      });
+      hubErrorMessage = "Latitude value outside valid range";
+    });
+
+    test("when latitude is too high", () => {
+      body = Factories.UserDataBody.build({
+        type: protobufs.UserDataType.LOCATION,
+        value: "geo:90.01,12.34",
+      });
+      hubErrorMessage = "Latitude value outside valid range";
+    });
+
+    test("when longitude is too low", () => {
+      body = Factories.UserDataBody.build({
+        type: protobufs.UserDataType.LOCATION,
+        value: "geo:12.34,-180.01",
+      });
+      hubErrorMessage = "Longitude value outside valid range";
+    });
+
+    test("when longitude is too high", () => {
+      body = Factories.UserDataBody.build({
+        type: protobufs.UserDataType.LOCATION,
+        value: "geo:12.34,180.01",
+      });
+      hubErrorMessage = "Longitude value outside valid range";
+    });
+
+    test("when latitude has too much precision", () => {
+      body = Factories.UserDataBody.build({
+        type: protobufs.UserDataType.LOCATION,
+        value: "geo:12.345,12.34",
+      });
+      hubErrorMessage = "Wrong precision for latitude or longitude";
+    });
+
+    test("when latitude has insufficient precision", () => {
+      body = Factories.UserDataBody.build({
+        type: protobufs.UserDataType.LOCATION,
+        value: "geo:12,12.34",
+      });
+      hubErrorMessage = "Wrong precision for latitude or longitude";
+    });
+
+    test("when longitude has too much precision", () => {
+      body = Factories.UserDataBody.build({
+        type: protobufs.UserDataType.LOCATION,
+        value: "geo:12.34,12.345",
+      });
+      hubErrorMessage = "Wrong precision for latitude or longitude";
+    });
+
+    test("when longitude has insufficient precision", () => {
+      body = Factories.UserDataBody.build({
+        type: protobufs.UserDataType.LOCATION,
+        value: "geo:12.345,12.34",
+      });
+      hubErrorMessage = "Wrong precision for latitude or longitude";
+    });
+
+    test("when latitude is an invalid number", () => {
+      body = Factories.UserDataBody.build({
+        type: protobufs.UserDataType.LOCATION,
+        value: "geo:xx,12.34",
+      });
+      hubErrorMessage = "Latitude or longitude is not a valid number";
+    });
+
+    test("when longitude is an invalid number", () => {
+      body = Factories.UserDataBody.build({
+        type: protobufs.UserDataType.LOCATION,
+        value: "geo:12.34,xx",
+      });
+      hubErrorMessage = "Latitude or longitude is not a valid number";
+    });
+
+    test("when location is missing geo prefix", () => {
+      body = Factories.UserDataBody.build({
+        type: protobufs.UserDataType.LOCATION,
+        value: "12.34,12.34",
+      });
+      hubErrorMessage = "Location missing geo: prefix";
+    });
+
+    test("when location is missing a coordinate", () => {
+      body = Factories.UserDataBody.build({
+        type: protobufs.UserDataType.LOCATION,
+        value: "geo:12.34",
+      });
+      hubErrorMessage = "Invalid coordinates in Geo URI";
     });
   });
 });

--- a/packages/core/src/validations.test.ts
+++ b/packages/core/src/validations.test.ts
@@ -1050,10 +1050,18 @@ describe("validateUserDataAddBody", () => {
     expect(validations.validateUserDataAddBody(body)).toEqual(ok(body));
   });
 
-  test("succeeds for valid location", async () => {
+  test("succeeds for valid location: negative longitude", async () => {
     const body = Factories.UserDataBody.build({
       type: UserDataType.LOCATION,
       value: "geo:12.34,-123.45",
+    });
+    expect(validations.validateUserDataAddBody(body)).toEqual(ok(body));
+  });
+
+  test("succeeds for valid location: negative latitude", async () => {
+    const body = Factories.UserDataBody.build({
+      type: UserDataType.LOCATION,
+      value: "geo:-12.34,123.45",
     });
     expect(validations.validateUserDataAddBody(body)).toEqual(ok(body));
   });

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -172,7 +172,7 @@ export const validateUserLocation = (location: string) => {
   const coordParts = coords.split(",");
 
   if (coordParts === undefined || coordParts.length < 2) {
-    return err(new HubError("bad_request.validation_failure", "Invalid coordinates in Geo URI"));
+    return err(new HubError("bad_request.validation_failure", "Location contains invalid coordinates"));
   }
 
   if (coordParts[0] === undefined) {

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -113,7 +113,7 @@ export const validateMessageHash = (hash?: Uint8Array): HubResult<Uint8Array> =>
 const validateNumber = (value: string) => {
   const number = parseFloat(value);
   if (Number.isNaN(number)) {
-    return err(new HubError("bad_request.validation_failure", "Latitude or longitude is not a valid number"));
+    return err(undefined);
   }
   return ok(number);
 };
@@ -131,7 +131,7 @@ const validateLatitude = (value: string) => {
   const number = validateNumber(value);
 
   if (number.isErr()) {
-    return err(number.error);
+    return err(new HubError("bad_request.validation_failure", "Latitude is not a valid number"));
   }
 
   if (number.value < -90 || number.value > 90) {
@@ -145,7 +145,7 @@ const validateLongitude = (value: string) => {
   const number = validateNumber(value);
 
   if (number.isErr()) {
-    return err(number.error);
+    return err(new HubError("bad_request.validation_failure", "Longitude is not a valid number"));
   }
 
   if (number.value < -180 || number.value > 180) {
@@ -162,8 +162,10 @@ export const validateUserLocation = (location: string) => {
     return ok(location);
   }
 
-  if (!location.startsWith("geo:")) {
-    return err(new HubError("bad_request.validation_failure", "Location missing geo: prefix"));
+  const result = location.match(/^geo:-?\d{1,2}\.\d{2},-?\d{1,3}\.\d{2}$/);
+
+  if (result === null || result.length !== 1 || result[0] !== location) {
+    return err(new HubError("bad_request.validation_failure", "Invalid location string"));
   }
 
   const coords = location.substring(4);

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -121,7 +121,7 @@ const validateNumber = (value: string) => {
 const validateDecimalPlaces = (value: string) => {
   const [_, decimals] = value.split(".");
   if (decimals === undefined || decimals.length !== 2) {
-    return err(new HubError("bad_request.validation_failure", "Wrong precision for latitude/longitude"));
+    return err(new HubError("bad_request.validation_failure", "Wrong precision for latitude or longitude"));
   }
 
   return ok(value);
@@ -163,7 +163,7 @@ export const validateUserLocation = (location: string) => {
   }
 
   if (!location.startsWith("geo:")) {
-    return err(new HubError("bad_request.validation_failure", "Invalid Geo URI"));
+    return err(new HubError("bad_request.validation_failure", "Location missing geo: prefix"));
   }
 
   const coords = location.substring(4);
@@ -176,7 +176,7 @@ export const validateUserLocation = (location: string) => {
   }
 
   if (coordParts[0] === undefined) {
-    return err(new HubError("bad_request.validation_failure", "Geo URI missing latitude"));
+    return err(new HubError("bad_request.validation_failure", "Location missing latitude"));
   }
 
   const latitude = validateLatitude(coordParts[0]);
@@ -185,7 +185,7 @@ export const validateUserLocation = (location: string) => {
   }
 
   if (coordParts[1] === undefined) {
-    return err(new HubError("bad_request.validation_failure", "Geo URI missing longitude"));
+    return err(new HubError("bad_request.validation_failure", "Location missing longitude"));
   }
 
   const longitude = validateLongitude(coordParts[1]);

--- a/packages/hub-nodejs/src/generated/message.ts
+++ b/packages/hub-nodejs/src/generated/message.ts
@@ -242,6 +242,8 @@ export enum UserDataType {
   URL = 5,
   /** USERNAME - Preferred Name for the user */
   USERNAME = 6,
+  /** LOCATION - Current location for the user */
+  LOCATION = 7,
 }
 
 export function userDataTypeFromJSON(object: any): UserDataType {
@@ -264,6 +266,9 @@ export function userDataTypeFromJSON(object: any): UserDataType {
     case 6:
     case "USER_DATA_TYPE_USERNAME":
       return UserDataType.USERNAME;
+    case 7:
+    case "USER_DATA_TYPE_LOCATION":
+      return UserDataType.LOCATION;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }
@@ -283,6 +288,8 @@ export function userDataTypeToJSON(object: UserDataType): string {
       return "USER_DATA_TYPE_URL";
     case UserDataType.USERNAME:
       return "USER_DATA_TYPE_USERNAME";
+    case UserDataType.LOCATION:
+      return "USER_DATA_TYPE_LOCATION";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }

--- a/packages/hub-web/src/generated/message.ts
+++ b/packages/hub-web/src/generated/message.ts
@@ -242,6 +242,8 @@ export enum UserDataType {
   URL = 5,
   /** USERNAME - Preferred Name for the user */
   USERNAME = 6,
+  /** LOCATION - Current location for the user */
+  LOCATION = 7,
 }
 
 export function userDataTypeFromJSON(object: any): UserDataType {
@@ -264,6 +266,9 @@ export function userDataTypeFromJSON(object: any): UserDataType {
     case 6:
     case "USER_DATA_TYPE_USERNAME":
       return UserDataType.USERNAME;
+    case 7:
+    case "USER_DATA_TYPE_LOCATION":
+      return UserDataType.LOCATION;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }
@@ -283,6 +288,8 @@ export function userDataTypeToJSON(object: UserDataType): string {
       return "USER_DATA_TYPE_URL";
     case UserDataType.USERNAME:
       return "USER_DATA_TYPE_USERNAME";
+    case UserDataType.LOCATION:
+      return "USER_DATA_TYPE_LOCATION";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }

--- a/protobufs/schemas/message.proto
+++ b/protobufs/schemas/message.proto
@@ -97,6 +97,7 @@ enum UserDataType {
   USER_DATA_TYPE_BIO = 3; // Bio for the user
   USER_DATA_TYPE_URL = 5; // URL of the user
   USER_DATA_TYPE_USERNAME = 6; // Preferred Name for the user
+  USER_DATA_TYPE_LOCATION = 7; // Current location for the user
 }
 
 message Embed {


### PR DESCRIPTION
This is required to decentralize user location. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new feature to add user location data to the protocol, including validation for latitude and longitude, and updates across several files to support this functionality.

### Detailed summary
- Added `USER_DATA_TYPE_LOCATION` to `protobufs/schemas/message.proto`.
- Updated `userDataTypeFromJSON` and `userDataTypeToJSON` functions to handle location type.
- Implemented location handling in `packages/hub-web`, `packages/hub-nodejs`, and `packages/core`.
- Created validation functions for latitude and longitude.
- Added tests for user location data handling in `apps/hubble/src/rpc/test/userDataService.test.ts` and `packages/core/src/validations.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->