### PR TITLE
chore: release hubble v1.15.7

### DIFF
--- a/.changeset/serious-bulldogs-sort.md
+++ b/.changeset/serious-bulldogs-sort.md
@@ -1,8 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
-"@farcaster/hub-web": patch
-"@farcaster/core": patch
-"@farcaster/hubble": patch
----
-
-feat: add user location to the protocol

--- a/.changeset/strong-teachers-cover.md
+++ b/.changeset/strong-teachers-cover.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-chore: add metrics for http/rpc/streaming requests for grafana

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @farcaster/hubble
 
+## 1.15.7
+
+### Patch Changes
+
+- aa9cde75: feat: add user location to the protocol
+- d22394f5: chore: add metrics for http/rpc/streaming requests for grafana
+- Updated dependencies [aa9cde75]
+  - @farcaster/hub-nodejs@0.12.5
+
 ## 1.15.6
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.15.6",
+  "version": "1.15.7",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -75,7 +75,7 @@
     "@chainsafe/libp2p-noise": "15.1.0",
     "@datastructures-js/priority-queue": "^6.3.1",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.12.4",
+    "@farcaster/hub-nodejs": "^0.12.5",
     "@fastify/cors": "^8.4.0",
     "@figma/hot-shots": "^9.0.0-figma.1",
     "@grpc/grpc-js": "~1.11.1",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/core
 
+## 0.15.5
+
+### Patch Changes
+
+- aa9cde75: feat: add user location to the protocol
+
 ## 0.15.4
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hub-nodejs
 
+## 0.12.5
+
+### Patch Changes
+
+- aa9cde75: feat: add user location to the protocol
+- Updated dependencies [aa9cde75]
+  - @farcaster/core@0.15.5
+
 ## 0.12.4
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -20,7 +20,7 @@
     "url": "https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/hub-nodejs"
   },
   "dependencies": {
-    "@farcaster/core": "0.15.4",
+    "@farcaster/core": "0.15.5",
     "@grpc/grpc-js": "~1.11.1",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"

--- a/packages/hub-web/CHANGELOG.md
+++ b/packages/hub-web/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hub-web
 
+## 0.9.4
+
+### Patch Changes
+
+- aa9cde75: feat: add user location to the protocol
+- Updated dependencies [aa9cde75]
+  - @farcaster/core@0.15.5
+
 ## 0.9.3
 
 ### Patch Changes

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-web",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -32,7 +32,7 @@
     "ts-proto": "^1.146.0"
   },
   "dependencies": {
-    "@farcaster/core": "^0.15.3",
+    "@farcaster/core": "^0.15.5",
     "@improbable-eng/grpc-web": "^0.15.0",
     "rxjs": "^7.8.0"
   }


### PR DESCRIPTION
Releasing hubble v1.15.7.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of `@farcaster/core`, `@farcaster/hub-web`, and `@farcaster/hub-nodejs` packages to `0.15.5`, `0.9.4`, and `0.12.5` respectively, while also adding a feature for user location to the protocol and updating dependencies across various packages.

### Detailed summary
- Updated `@farcaster/core` version to `0.15.5`.
- Updated `@farcaster/hub-web` version to `0.9.4`.
- Updated `@farcaster/hub-nodejs` version to `0.12.5`.
- Added user location feature to the protocol.
- Updated dependencies in `@farcaster/hub-web` and `@farcaster/hub-nodejs`.
- Updated changelogs for multiple packages.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->