### PR TITLE
feat: add createDefaultMetadataKeyInterceptor

### DIFF
--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -2260,3 +2260,28 @@ export class Hub implements HubInterface {
     return `snapshots/${network}/DB_SCHEMA_${LATEST_DB_SCHEMA_VERSION - (prevVersionCounter ?? 0)}`;
   }
 }
+
+export function createDefaultMetadataKeyInterceptor(apiKey: string, apiKeyName = 'x-api-key') {
+  return function metadataKeyInterceptor(options: any, nextCall: any) {
+      var requester = {
+          start: function (metadata: any, listener: any, next: any) {
+              if (metadata.get(apiKeyName) == false) {
+                  metadata.add(apiKeyName, apiKey);
+              }
+              var newListener = {
+                  onReceiveMetadata: function (metadata, next) {
+                      next(metadata);
+                  },
+                  onReceiveMessage: function (message, next) {
+                      next(message);
+                  },
+                  onReceiveStatus: function (status, next) {
+                      next(status);
+                  },
+              };
+              next(metadata, newListener);
+          },
+      };
+      return new grpc.InterceptingCall(nextCall(options), requester);
+  };
+}


### PR DESCRIPTION
## Why is this change needed?

Neynar requires x-api-key to access its hubs. This change makes it easy to include that (or any other) header.

I tried to run the changeset, but it failed. Am I running it from the wrong directory maybe?

```
% yarn changeset
yarn run v1.22.22
error Command "changeset" not found.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
bryan@Bryan-Neynar hub-monorepo % yarn run changeset 
yarn run v1.22.22
error Command "changeset" not found.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
