### PR TITLE
chore: Release 1.16

### DIFF
--- a/.changeset/red-bags-return.md
+++ b/.changeset/red-bags-return.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
----
-
-Add createDefaultMetadataKeyInterceptor

--- a/.changeset/tricky-badgers-tan.md
+++ b/.changeset/tricky-badgers-tan.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-feat(shuttle): Parametrize hub connection timeouts for HubSubscriber and MessageReconciliation

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @farcaster/hubble
 
+## 1.16.0
+
+### Minor Changes
+
+- chore: Update protocol version
+
+### Patch Changes
+
+- Updated dependencies [91b77204]
+  - @farcaster/hub-nodejs@0.12.6
+
 ## 1.15.7
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.15.7",
+  "version": "1.16.0",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -75,7 +75,7 @@
     "@chainsafe/libp2p-noise": "15.1.0",
     "@datastructures-js/priority-queue": "^6.3.1",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.12.5",
+    "@farcaster/hub-nodejs": "^0.12.6",
     "@fastify/cors": "^8.4.0",
     "@figma/hot-shots": "^9.0.0-figma.1",
     "@grpc/grpc-js": "~1.11.1",

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -118,7 +118,7 @@ export const SNAPSHOT_S3_UPLOAD_BUCKET = "farcaster-snapshots";
 export const SNAPSHOT_S3_DOWNLOAD_BUCKET = "download.farcaster.xyz";
 export const S3_REGION = "auto";
 
-export const FARCASTER_VERSION = "2024.9.4";
+export const FARCASTER_VERSION = "2024.10.16";
 export const FARCASTER_VERSIONS_SCHEDULE: VersionSchedule[] = [
   { version: "2023.3.1", expiresAt: 1682553600000 }, // expires at 4/27/23 00:00 UTC
   { version: "2023.4.19", expiresAt: 1686700800000 }, // expires at 6/14/23 00:00 UTC
@@ -134,6 +134,7 @@ export const FARCASTER_VERSIONS_SCHEDULE: VersionSchedule[] = [
   { version: "2024.6.12", expiresAt: 1722988800000 }, // expires at 8/7/24 00:00 UTC
   { version: "2024.7.24", expiresAt: 1726617600000 }, // expires at 9/18/24 00:00 UTC
   { version: "2024.9.4", expiresAt: 1730246400000 }, // expires at 10/30/24 00:00 UTC
+  { version: "2024.10.16", expiresAt: 1733875200000 }, // expires at 12/11/24 00:00 UTC
 ];
 
 const MAX_CONTACT_INFO_AGE_MS = 1000 * 60 * 60; // 60 minutes

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-nodejs
 
+## 0.12.6
+
+### Patch Changes
+
+- 91b77204: Add createDefaultMetadataKeyInterceptor
+
 ## 0.12.5
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hub-shuttle
 
+## 0.6.8
+
+### Patch Changes
+
+- 727041cb: feat(shuttle): Parametrize hub connection timeouts for HubSubscriber and MessageReconciliation
+- Updated dependencies [91b77204]
+  - @farcaster/hub-nodejs@0.12.6
+
 ## 0.6.7
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@farcaster/hot-shots": "^10.0.0",
-    "@farcaster/hub-nodejs": "^0.12.4",
+    "@farcaster/hub-nodejs": "^0.12.6",
     "commander": "11.0.0",
     "dotenv": "16.4.5",
     "ioredis": "^5.3.2",


### PR DESCRIPTION
## Why is this change needed?

Release 1.16

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating version numbers and changelogs for the `@farcaster/hub-nodejs` and `@farcaster/shuttle` packages, along with modifications to the `FARCASTER_VERSION` in the `hubble.ts` file.

### Detailed summary
- Updated `@farcaster/hub-nodejs` version from `0.12.5` to `0.12.6`.
- Added `createDefaultMetadataKeyInterceptor` in `CHANGELOG.md`.
- Updated `@farcaster/shuttle` version from `0.6.7` to `0.6.8`.
- Parametrized hub connection timeouts for `HubSubscriber` and `MessageReconciliation`.
- Updated `@farcaster/hubble` version from `1.15.7` to `1.16.0`.
- Changed `FARCASTER_VERSION` from `2024.9.4` to `2024.10.16`.
- Added new version `2024.10.16` to `FARCASTER_VERSIONS_SCHEDULE`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->