### PR TITLE
feat: support social verifications for twitter and github

### DIFF
--- a/.changeset/tall-dots-roll.md
+++ b/.changeset/tall-dots-roll.md
@@ -1,0 +1,7 @@
+---
+"@farcaster/hub-nodejs": patch
+"@farcaster/hub-web": patch
+"@farcaster/core": patch
+---
+
+feat: support twitter and github usernames

--- a/packages/core/src/protobufs/generated/message.ts
+++ b/packages/core/src/protobufs/generated/message.ts
@@ -246,6 +246,8 @@ export enum UserDataType {
   LOCATION = 7,
   /** TWITTER - Username of user on twitter */
   TWITTER = 8,
+  /** GITHUB - Username of user on github */
+  GITHUB = 9,
 }
 
 export function userDataTypeFromJSON(object: any): UserDataType {
@@ -274,6 +276,9 @@ export function userDataTypeFromJSON(object: any): UserDataType {
     case 8:
     case "USER_DATA_TYPE_TWITTER":
       return UserDataType.TWITTER;
+    case 9:
+    case "USER_DATA_TYPE_GITHUB":
+      return UserDataType.GITHUB;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }
@@ -297,6 +302,8 @@ export function userDataTypeToJSON(object: UserDataType): string {
       return "USER_DATA_TYPE_LOCATION";
     case UserDataType.TWITTER:
       return "USER_DATA_TYPE_TWITTER";
+    case UserDataType.GITHUB:
+      return "USER_DATA_TYPE_GITHUB";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }

--- a/packages/core/src/protobufs/generated/message.ts
+++ b/packages/core/src/protobufs/generated/message.ts
@@ -244,6 +244,8 @@ export enum UserDataType {
   USERNAME = 6,
   /** LOCATION - Current location for the user */
   LOCATION = 7,
+  /** TWITTER - Username of user on twitter */
+  TWITTER = 8,
 }
 
 export function userDataTypeFromJSON(object: any): UserDataType {
@@ -269,6 +271,9 @@ export function userDataTypeFromJSON(object: any): UserDataType {
     case 7:
     case "USER_DATA_TYPE_LOCATION":
       return UserDataType.LOCATION;
+    case 8:
+    case "USER_DATA_TYPE_TWITTER":
+      return UserDataType.TWITTER;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }
@@ -290,6 +295,8 @@ export function userDataTypeToJSON(object: UserDataType): string {
       return "USER_DATA_TYPE_USERNAME";
     case UserDataType.LOCATION:
       return "USER_DATA_TYPE_LOCATION";
+    case UserDataType.TWITTER:
+      return "USER_DATA_TYPE_TWITTER";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }

--- a/packages/core/src/validations.test.ts
+++ b/packages/core/src/validations.test.ts
@@ -1219,6 +1219,41 @@ describe("validateUserDataAddBody", () => {
       });
       hubErrorMessage = "Invalid location string";
     });
+
+    test("succeeds for twitter usernames", async () => {
+      const body = Factories.UserDataBody.build({
+        type: UserDataType.TWITTER,
+        value: "dwr",
+      });
+      expect(validations.validateUserDataAddBody(body)).toEqual(ok(body));
+    });
+
+    test("fails for invalid twitter usernames", async () => {
+      const body1 = Factories.UserDataBody.build({
+        type: UserDataType.TWITTER,
+        value: "-wrong-info",
+      });
+      expect(validations.validateUserDataAddBody(body1)).toEqual(
+        err(
+          new HubError(
+            "bad_request.validation_failure",
+            `username "-wrong-info" doesn't match ${validations.TWITTER_REGEX}`,
+          ),
+        ),
+      );
+      const body2 = Factories.UserDataBody.build({
+        type: UserDataType.TWITTER,
+        value: "too_many_characters_for_a_username",
+      });
+      expect(validations.validateUserDataAddBody(body2)).toEqual(
+        err(
+          new HubError(
+            "bad_request.validation_failure",
+            `username "too_many_characters_for_a_username" > 15 characters`,
+          ),
+        ),
+      );
+    });
   });
 });
 

--- a/packages/hub-nodejs/src/generated/message.ts
+++ b/packages/hub-nodejs/src/generated/message.ts
@@ -246,6 +246,8 @@ export enum UserDataType {
   LOCATION = 7,
   /** TWITTER - Username of user on twitter */
   TWITTER = 8,
+  /** GITHUB - Username of user on github */
+  GITHUB = 9,
 }
 
 export function userDataTypeFromJSON(object: any): UserDataType {
@@ -274,6 +276,9 @@ export function userDataTypeFromJSON(object: any): UserDataType {
     case 8:
     case "USER_DATA_TYPE_TWITTER":
       return UserDataType.TWITTER;
+    case 9:
+    case "USER_DATA_TYPE_GITHUB":
+      return UserDataType.GITHUB;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }
@@ -297,6 +302,8 @@ export function userDataTypeToJSON(object: UserDataType): string {
       return "USER_DATA_TYPE_LOCATION";
     case UserDataType.TWITTER:
       return "USER_DATA_TYPE_TWITTER";
+    case UserDataType.GITHUB:
+      return "USER_DATA_TYPE_GITHUB";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }

--- a/packages/hub-nodejs/src/generated/message.ts
+++ b/packages/hub-nodejs/src/generated/message.ts
@@ -244,6 +244,8 @@ export enum UserDataType {
   USERNAME = 6,
   /** LOCATION - Current location for the user */
   LOCATION = 7,
+  /** TWITTER - Username of user on twitter */
+  TWITTER = 8,
 }
 
 export function userDataTypeFromJSON(object: any): UserDataType {
@@ -269,6 +271,9 @@ export function userDataTypeFromJSON(object: any): UserDataType {
     case 7:
     case "USER_DATA_TYPE_LOCATION":
       return UserDataType.LOCATION;
+    case 8:
+    case "USER_DATA_TYPE_TWITTER":
+      return UserDataType.TWITTER;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }
@@ -290,6 +295,8 @@ export function userDataTypeToJSON(object: UserDataType): string {
       return "USER_DATA_TYPE_USERNAME";
     case UserDataType.LOCATION:
       return "USER_DATA_TYPE_LOCATION";
+    case UserDataType.TWITTER:
+      return "USER_DATA_TYPE_TWITTER";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }

--- a/packages/hub-web/src/generated/message.ts
+++ b/packages/hub-web/src/generated/message.ts
@@ -246,6 +246,8 @@ export enum UserDataType {
   LOCATION = 7,
   /** TWITTER - Username of user on twitter */
   TWITTER = 8,
+  /** GITHUB - Username of user on github */
+  GITHUB = 9,
 }
 
 export function userDataTypeFromJSON(object: any): UserDataType {
@@ -274,6 +276,9 @@ export function userDataTypeFromJSON(object: any): UserDataType {
     case 8:
     case "USER_DATA_TYPE_TWITTER":
       return UserDataType.TWITTER;
+    case 9:
+    case "USER_DATA_TYPE_GITHUB":
+      return UserDataType.GITHUB;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }
@@ -297,6 +302,8 @@ export function userDataTypeToJSON(object: UserDataType): string {
       return "USER_DATA_TYPE_LOCATION";
     case UserDataType.TWITTER:
       return "USER_DATA_TYPE_TWITTER";
+    case UserDataType.GITHUB:
+      return "USER_DATA_TYPE_GITHUB";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }

--- a/packages/hub-web/src/generated/message.ts
+++ b/packages/hub-web/src/generated/message.ts
@@ -244,6 +244,8 @@ export enum UserDataType {
   USERNAME = 6,
   /** LOCATION - Current location for the user */
   LOCATION = 7,
+  /** TWITTER - Username of user on twitter */
+  TWITTER = 8,
 }
 
 export function userDataTypeFromJSON(object: any): UserDataType {
@@ -269,6 +271,9 @@ export function userDataTypeFromJSON(object: any): UserDataType {
     case 7:
     case "USER_DATA_TYPE_LOCATION":
       return UserDataType.LOCATION;
+    case 8:
+    case "USER_DATA_TYPE_TWITTER":
+      return UserDataType.TWITTER;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }
@@ -290,6 +295,8 @@ export function userDataTypeToJSON(object: UserDataType): string {
       return "USER_DATA_TYPE_USERNAME";
     case UserDataType.LOCATION:
       return "USER_DATA_TYPE_LOCATION";
+    case UserDataType.TWITTER:
+      return "USER_DATA_TYPE_TWITTER";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }

--- a/protobufs/schemas/message.proto
+++ b/protobufs/schemas/message.proto
@@ -98,6 +98,7 @@ enum UserDataType {
   USER_DATA_TYPE_URL = 5; // URL of the user
   USER_DATA_TYPE_USERNAME = 6; // Preferred Name for the user
   USER_DATA_TYPE_LOCATION = 7; // Current location for the user
+  USER_DATA_TYPE_TWITTER = 8; // Username of user on twitter
 }
 
 message Embed {

--- a/protobufs/schemas/message.proto
+++ b/protobufs/schemas/message.proto
@@ -99,6 +99,7 @@ enum UserDataType {
   USER_DATA_TYPE_USERNAME = 6; // Preferred Name for the user
   USER_DATA_TYPE_LOCATION = 7; // Current location for the user
   USER_DATA_TYPE_TWITTER = 8; // Username of user on twitter
+  USER_DATA_TYPE_GITHUB = 9; // Username of user on github
 }
 
 message Embed {


### PR DESCRIPTION
## Why is this change needed?

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for validating `twitter` and `github` usernames in the system. It adds new constants, validation functions, and test cases to ensure username formats comply with specified rules.

### Detailed summary
- Added constants `USER_DATA_TYPE_TWITTER` and `USER_DATA_TYPE_GITHUB` in `message.proto`.
- Implemented validation functions `validateTwitterUsername` and `validateGithubUsername` in `validations.ts`.
- Added regex patterns for Twitter and GitHub usernames.
- Created test cases for Twitter username validation in `validations.test.ts`.
- Updated functions to handle new user data types in `userDataTypeFromJSON` and `userDataTypeToJSON` across several files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->