### PR TITLE
chore: introduce a pattern to help standardize log tag names 

### DIFF
--- a/.changeset/nice-lions-tickle.md
+++ b/.changeset/nice-lions-tickle.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+chore: introduce a pattern to help standardize log tag names

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -1758,7 +1758,7 @@ export class Hub implements HubInterface {
       }
     }
 
-    log.info(new Tags().addPeerId(peerId.toString()).build(), "falling back to addressbook lookup for peer");
+    log.info(new Tags({ peerId: peerId.toString() }), "falling back to addressbook lookup for peer");
     const peerAddresses = await this.gossipNode.getPeerAddresses(peerId);
     if (!peerAddresses) {
       log.info({ function: "getRPCClientForPeer", peer }, `failed to find peer's address to request simple sync`);

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -51,6 +51,7 @@ import {
   onChainEventToLog,
   SubmitMessageSuccessLogCache,
   usernameProofToLog,
+  Tags,
 } from "./utils/logger.js";
 import {
   addressInfoFromGossip,
@@ -1757,7 +1758,7 @@ export class Hub implements HubInterface {
       }
     }
 
-    log.info({ peerId }, "falling back to addressbook lookup for peer");
+    log.info(new Tags().addPeerId(peerId.toString()).build(), "falling back to addressbook lookup for peer");
     const peerAddresses = await this.gossipNode.getPeerAddresses(peerId);
     if (!peerAddresses) {
       log.info({ function: "getRPCClientForPeer", peer }, `failed to find peer's address to request simple sync`);

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -267,7 +267,7 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
   async putPeerAddrToDB(peerIdStr: string, addr: string) {
     if (this._db) {
       await this._db.put(this.makePeerKey(peerIdStr), Buffer.from(addr));
-      log.info(new Tags({ addr }).addPeerId(peerIdStr).build(), "Added peer to DB");
+      log.info(new Tags({ addr, peerId: peerIdStr }), "Added peer to DB");
     }
   }
 
@@ -302,9 +302,9 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
       const peerAddr = multiaddr(addr);
       const result = await this.connectAddress(peerAddr);
       if (result.isOk()) {
-        log.info(new Tags({ addr }).addPeerId(peerIdStr).build(), "Connected to peer from DB");
+        log.info(new Tags({ addr, peerId: peerIdStr }), "Connected to peer from DB");
       } else {
-        log.debug(new Tags({ addr, error: result.error }).addPeerId(peerIdStr), "Failed to connect to peer from DB");
+        log.debug(new Tags({ addr, error: result.error, peerId: peerIdStr }), "Failed to connect to peer from DB");
       }
 
       // Sleep for a bit to avoid overwhelming the network

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -25,7 +25,7 @@ import { peerIdFromBytes, peerIdFromString } from "@libp2p/peer-id";
 import { multiaddr, Multiaddr } from "@multiformats/multiaddr";
 import { err, ok, Result } from "neverthrow";
 import { TypedEmitter } from "tiny-typed-emitter";
-import { logger, messageTypeToName } from "../../utils/logger.js";
+import { logger, messageTypeToName, Tags } from "../../utils/logger.js";
 import { PeriodicPeerCheckScheduler } from "./periodicPeerCheck.js";
 import { GOSSIP_PROTOCOL_VERSION } from "./protocol.js";
 import { AddrInfo } from "@chainsafe/libp2p-gossipsub/types";
@@ -267,7 +267,7 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
   async putPeerAddrToDB(peerIdStr: string, addr: string) {
     if (this._db) {
       await this._db.put(this.makePeerKey(peerIdStr), Buffer.from(addr));
-      log.info({ peerId: peerIdStr, addr }, "Added peer to DB");
+      log.info(new Tags({ addr }).addPeerId(peerIdStr).build(), "Added peer to DB");
     }
   }
 
@@ -302,9 +302,9 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
       const peerAddr = multiaddr(addr);
       const result = await this.connectAddress(peerAddr);
       if (result.isOk()) {
-        log.info({ peerIdStr, addr }, "Connected to peer from DB");
+        log.info(new Tags({ addr }).addPeerId(peerIdStr).build(), "Connected to peer from DB");
       } else {
-        log.debug({ peerIdStr, addr, error: result.error }, "Failed to connect to peer from DB");
+        log.debug(new Tags({ addr, error: result.error }).addPeerId(peerIdStr), "Failed to connect to peer from DB");
       }
 
       // Sleep for a bit to avoid overwhelming the network
@@ -546,11 +546,12 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
     this._nodeEvents?.addListener("connection:open", (detail: Connection) => {
       // console.log("Peer Connected", JSON.stringify(detail, null, 2));
       log.info(
-        {
-          peer: detail.remotePeer,
+        new Tags({
           addrs: detail.remoteAddr,
           type: detail.direction,
-        },
+        })
+          .addPeerId(detail.remotePeer.toString())
+          .build(),
         "P2P Connection established",
       );
       this.emit("peerConnect", detail);
@@ -561,12 +562,12 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
       this.putPeerAddrToDB(detail.remotePeer.toString(), detail.remoteAddr.toString());
     });
     this._nodeEvents?.addListener("connection:close", (detail: Connection) => {
-      log.info({ peer: detail.remotePeer }, "P2P Connection disconnected");
+      log.info(new Tags().addPeerId(detail.remotePeer.toString()).build(), "P2P Connection disconnected");
       this.emit("peerDisconnect", detail);
       this.updateStatsdPeerGauges();
     });
     this._nodeEvents?.addListener("peer:discovery", (detail) => {
-      log.info({ peer: detail }, "Discovered peer");
+      log.info(new Tags().addPeerId(detail.remotePeer.toString()).build(), "Discovered peer");
     });
     this._nodeEvents?.addListener("gossipsub:message", (detail: GossipsubMessage) => {
       log.debug({

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -549,9 +549,8 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
         new Tags({
           addrs: detail.remoteAddr,
           type: detail.direction,
-        })
-          .addPeerId(detail.remotePeer.toString())
-          .build(),
+          peerId: detail.remotePeer.toString(),
+        }),
         "P2P Connection established",
       );
       this.emit("peerConnect", detail);
@@ -562,12 +561,12 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
       this.putPeerAddrToDB(detail.remotePeer.toString(), detail.remoteAddr.toString());
     });
     this._nodeEvents?.addListener("connection:close", (detail: Connection) => {
-      log.info(new Tags().addPeerId(detail.remotePeer.toString()).build(), "P2P Connection disconnected");
+      log.info(new Tags({ peerId: detail.remotePeer.toString() }), "P2P Connection disconnected");
       this.emit("peerDisconnect", detail);
       this.updateStatsdPeerGauges();
     });
     this._nodeEvents?.addListener("peer:discovery", (detail) => {
-      log.info(new Tags().addPeerId(detail.remotePeer.toString()).build(), "Discovered peer");
+      log.info(new Tags({ peerId: detail.remotePeer.toString() }), "Discovered peer");
     });
     this._nodeEvents?.addListener("gossipsub:message", (detail: GossipsubMessage) => {
       log.debug({

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -566,7 +566,7 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
       this.updateStatsdPeerGauges();
     });
     this._nodeEvents?.addListener("peer:discovery", (detail) => {
-      log.info(new Tags({ peerId: detail.remotePeer.toString() }), "Discovered peer");
+      log.info(new Tags({ peerId: detail.remotePeer?.toString() }), "Discovered peer");
     });
     this._nodeEvents?.addListener("gossipsub:message", (detail: GossipsubMessage) => {
       log.debug({

--- a/apps/hubble/src/utils/logger.ts
+++ b/apps/hubble/src/utils/logger.ts
@@ -144,6 +144,7 @@ export type TagFields = {
   [key: string]: any;
 };
 
+// Always go through this class to construct log tags so that tag names are standardized.
 export class Tags {
   private fields: TagFields;
 

--- a/apps/hubble/src/utils/logger.ts
+++ b/apps/hubble/src/utils/logger.ts
@@ -151,10 +151,6 @@ export class Tags {
     this.fields = fields;
   }
 
-  merge(tags: Tags) {
-    this.fields = { ...this.fields, ...tags.fields };
-  }
-
   toString() {
     const extraFields = Object.fromEntries(
       Object.entries(this.fields).filter(([key, value]) => {

--- a/apps/hubble/src/utils/logger.ts
+++ b/apps/hubble/src/utils/logger.ts
@@ -134,6 +134,54 @@ class BufferedLogger {
   }
 }
 
+export class Tags {
+  private fields: Object;
+
+  constructor(obj = {}) {
+    this.fields = obj;
+  }
+
+  addTimestamp(timestamp: number) {
+    return new Tags({ ...this.fields, timestamp: fromFarcasterTime(timestamp)._unsafeUnwrap() });
+  }
+
+  addFid(fid: number) {
+    return new Tags({ ...this.fields, fid });
+  }
+
+  addMessageType(messageType: MessageType) {
+    return new Tags({ ...this.fields, messageType: MessageType[messageType] });
+  }
+
+  addPeerId(peerId: string) {
+    return new Tags({ ...this.fields, peerId });
+  }
+
+  addErrorMessage(errMsg: string) {
+    return new Tags({ ...this.fields, errMsg });
+  }
+
+  addMessageFields(message: Message) {
+    return new Tags({
+      ...this.fields,
+      messageFields: {
+        timestamp: fromFarcasterTime(message.data?.timestamp || 0)._unsafeUnwrap(),
+        hash: bytesToHexString(message.hash)._unsafeUnwrap(),
+        fid: message.data?.fid,
+        type: message.data?.type,
+      },
+    });
+  }
+
+  merge(tags: Tags) {
+    return new Tags({ ...this.fields, ...tags.fields });
+  }
+
+  build() {
+    return this.fields;
+  }
+}
+
 export const logger = new BufferedLogger().createProxy();
 export type Logger = pino.Logger;
 


### PR DESCRIPTION
It's hard to filter logs by tag if we name the same tag different things in different places. Introduce a pattern for constructing logs that pushes us toward standardizing log tag names. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on standardizing log tag names by introducing a `Tags` class, which is used throughout the codebase to create consistent log entries.

### Detailed summary
- Introduced `Tags` class in `apps/hubble/src/utils/logger.ts` for standardized log tags.
- Updated logging in `apps/hubble/src/hubble.ts`, `apps/hubble/src/network/p2p/gossipNode.ts`, and `apps/hubble/src/network/sync/syncHealthJob.ts` to use `Tags`.
- Added `TagFields` type definition for better structure of log fields.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->