### PR TITLE
fix: validate that fid on username add message matches fid on ens proof

### DIFF
--- a/.changeset/warm-cheetahs-drive.md
+++ b/.changeset/warm-cheetahs-drive.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: validate that fid on username add message matches fid on ens proof

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -1279,23 +1279,28 @@ class Engine extends TypedEmitter<EngineEvents> {
           return err(nameProof.error);
         }
 
-        if (nameProof.value.type === UserNameType.USERNAME_TYPE_FNAME) {
-          // Check that the fid for the fname and message are the same
-          if (nameProof.value.fid !== message.data.fid) {
-            return err(
-              new HubError(
-                "bad_request.validation_failure",
-                `fname fid ${nameProof.value.fid} does not match message fid ${message.data.fid}`,
-              ),
-            );
-          }
-        } else if (nameProof.value.type === UserNameType.USERNAME_TYPE_ENS_L1) {
+        if (
+          nameProof.value.type !== UserNameType.USERNAME_TYPE_FNAME &&
+          nameProof.value.type !== UserNameType.USERNAME_TYPE_ENS_L1
+        ) {
+          return err(new HubError("bad_request.validation_failure", "invalid username type"));
+        }
+
+        // Check that the fid for the fname/ens name and message are the same
+        if (nameProof.value.fid !== message.data.fid) {
+          return err(
+            new HubError(
+              "bad_request.validation_failure",
+              `fid ${nameProof.value.fid} does not match message fid ${message.data.fid}`,
+            ),
+          );
+        }
+
+        if (nameProof.value.type === UserNameType.USERNAME_TYPE_ENS_L1) {
           const result = await this.validateEnsUsernameProof(nameProof.value, custodyAddress);
           if (result.isErr()) {
             return err(result.error);
           }
-        } else {
-          return err(new HubError("bad_request.validation_failure", "invalid username type"));
         }
       }
     }


### PR DESCRIPTION
This fixes a bug which allows an users to assume an arbitrary user's ens name as their own. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the validation of `fid` in user data messages to ensure that it matches the `fid` associated with the username proof, specifically for `fname` and `ENS` types.

### Detailed summary
- Updated validation logic in `index.ts` to check if `fid` matches for `fname` and `ENS` username types.
- Added error handling for invalid username types.
- Introduced a new test case in `index.test.ts` to verify failure when `fid` on message does not match `fid` on ENS name proof.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->