### PR TITLE
chore: release hubble v1.16.1

### DIFF
--- a/.changeset/warm-cheetahs-drive.md
+++ b/.changeset/warm-cheetahs-drive.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: validate that fid on username add message matches fid on ens proof

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hubble
 
+## 1.16.1
+
+### Patch Changes
+
+- c2140e26: fix: validate that fid on username add message matches fid on ens proof
+
 ## 1.16.0
 
 ### Minor Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",


### PR DESCRIPTION
Releasing hubble v1.16.1. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of the `@farcaster/hubble` package from `1.16.0` to `1.16.1` and documenting the changes in the `CHANGELOG.md`.

### Detailed summary
- Updated version in `apps/hubble/package.json` from `1.16.0` to `1.16.1`.
- Added a new entry in `CHANGELOG.md` for version `1.16.1`:
  - Patch change: Fixed validation for `fid` on username add message to match `fid` on ENS proof.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->