### PR TITLE
feat(shuttle): Pipe connectionTimeout arg through EventStreamHubSubscriber

### DIFF
--- a/.changeset/itchy-feet-cough.md
+++ b/.changeset/itchy-feet-cough.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+feat(shuttle): Pipe connectionTimeout arg through EventStreamHubSubscriber

--- a/packages/shuttle/src/shuttle/hubSubscriber.ts
+++ b/packages/shuttle/src/shuttle/hubSubscriber.ts
@@ -217,9 +217,10 @@ export class EventStreamHubSubscriber extends BaseHubSubscriber {
     eventTypes?: HubEventType[],
     totalShards?: number,
     shardIndex?: number,
+    connectionTimeout?: number,
     options?: EventStreamHubSubscriberOptions,
   ) {
-    super(label, hubClient.client, log, eventTypes, totalShards, shardIndex);
+    super(label, hubClient.client, log, eventTypes, totalShards, shardIndex, connectionTimeout);
     this.eventStream = eventStream;
     this.redis = redis;
     this.streamKey = `hub:${hubClient.host}:evt:msg:${shardKey}`;


### PR DESCRIPTION


## Why is this change needed?

Follow-up to https://github.com/farcasterxyz/hub-monorepo/pull/2367. I missed piping through BaseHubSubscriber's new `connectionTimeout` param through to EventStreamHubSubscriber, which means `connectionTimeout` isn't really configurable for streaming right now like it should be.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new optional parameter, `connectionTimeout`, to the `EventStreamHubSubscriber` class, allowing for better control over connection timeouts.

### Detailed summary
- Added `connectionTimeout?: number` as an optional parameter in the constructor of `EventStreamHubSubscriber`.
- Updated the call to `super` in the constructor to include the new `connectionTimeout` argument.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->