### PR TITLE
feat: Store backups in separate top-level directory

### DIFF
--- a/.changeset/shaggy-stingrays-rest.md
+++ b/.changeset/shaggy-stingrays-rest.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+Place backups in dedicated directory

--- a/apps/hubble/src/addon/src/db/rocksdb.rs
+++ b/apps/hubble/src/addon/src/db/rocksdb.rs
@@ -1011,7 +1011,7 @@ impl RocksDB {
             .to_string();
 
         let start = std::time::SystemTime::now();
-        info!(logger, "Creating chunked tar.gz snapshot for directory: {}", 
+        info!(logger, "Creating chunked tar.gz snapshot for directory: {}",
             input_dir; o!("output_file_path" => &chunked_output_dir, "base_name" => &base_name));
 
         let mut multi_chunk_writer = MultiChunkWriter::new(
@@ -1049,12 +1049,11 @@ impl RocksDB {
         let timestamp = chrono::NaiveDateTime::from_timestamp_millis(timestamp_ms)
             .unwrap_or(chrono::Utc::now().naive_utc());
 
-        let main_backup_path = Path::new(&format!(
-            "{}-{}.backup",
-            main_db_path,
-            timestamp.format("%Y-%m-%d-%s")
-        ))
-        .join("rocks.hub._default");
+        let main_backup_path = Path::new(&main_db_path)
+            .join("..") // Create backup as sibling directory of normal path
+            .join("backup")
+            .join(format!("{}.backup", timestamp.format("%Y-%m-%d-%s")))
+            .join("rocks.hub._default");
 
         // rm -rf this path if it exists
         if main_backup_path.exists() {


### PR DESCRIPTION
## Why is this change needed?

This allows the backups directory to be mounted on a separate volume so that it doesn't take away from the main storage volume.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the backup functionality in the `RocksDB` implementation by changing the backup directory structure and enhancing logging.

### Detailed summary
- Updated the log message format for creating a snapshot.
- Changed the `main_backup_path` construction to place backups in a dedicated `backup` directory, which is a sibling of the `main_db_path`.
- Adjusted the backup file naming format to include a timestamp.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->