### PR TITLE
chore: bump version

### DIFF
--- a/.changeset/shaggy-stingrays-rest.md
+++ b/.changeset/shaggy-stingrays-rest.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-Place backups in dedicated directory

--- a/.changeset/tall-dots-roll.md
+++ b/.changeset/tall-dots-roll.md
@@ -1,7 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
-"@farcaster/hub-web": patch
-"@farcaster/core": patch
----
-
-feat: support twitter and github usernames

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hubble
 
+## 1.16.2
+
+### Patch Changes
+
+- 36847dfc: Place backups in dedicated directory
+- Updated dependencies [913c0f67]
+  - @farcaster/hub-nodejs@0.12.7
+
 ## 1.16.1
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -75,7 +75,7 @@
     "@chainsafe/libp2p-noise": "15.1.0",
     "@datastructures-js/priority-queue": "^6.3.1",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.12.6",
+    "@farcaster/hub-nodejs": "^0.12.7",
     "@fastify/cors": "^8.4.0",
     "@figma/hot-shots": "^9.0.0-figma.1",
     "@grpc/grpc-js": "~1.11.1",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/core
 
+## 0.15.6
+
+### Patch Changes
+
+- 913c0f67: feat: support twitter and github usernames
+
 ## 0.15.5
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hub-nodejs
 
+## 0.12.7
+
+### Patch Changes
+
+- 913c0f67: feat: support twitter and github usernames
+- Updated dependencies [913c0f67]
+  - @farcaster/core@0.15.6
+
 ## 0.12.6
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -20,7 +20,7 @@
     "url": "https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/hub-nodejs"
   },
   "dependencies": {
-    "@farcaster/core": "0.15.5",
+    "@farcaster/core": "0.15.6",
     "@grpc/grpc-js": "~1.11.1",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"

--- a/packages/hub-web/CHANGELOG.md
+++ b/packages/hub-web/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hub-web
 
+## 0.9.5
+
+### Patch Changes
+
+- 913c0f67: feat: support twitter and github usernames
+- Updated dependencies [913c0f67]
+  - @farcaster/core@0.15.6
+
 ## 0.9.4
 
 ### Patch Changes

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-web",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -32,7 +32,7 @@
     "ts-proto": "^1.146.0"
   },
   "dependencies": {
-    "@farcaster/core": "^0.15.5",
+    "@farcaster/core": "^0.15.6",
     "@improbable-eng/grpc-web": "^0.15.0",
     "rxjs": "^7.8.0"
   }


### PR DESCRIPTION
## Why is this change needed?

Bumping version to release social verifications

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the versioning of several packages, enhancing support for Twitter and GitHub usernames, and making various dependency updates across the `@farcaster` ecosystem.

### Detailed summary
- Updated `@farcaster/core` version from `0.15.5` to `0.15.6`.
- Added support for Twitter and GitHub usernames in `@farcaster/core`.
- Updated `@farcaster/hub-nodejs` version from `0.12.6` to `0.12.7`.
- Updated `@farcaster/hub-web` version from `0.9.4` to `0.9.5`.
- Updated `@farcaster/hubble` version from `1.16.1` to `1.16.2`.
- Placed backups in a dedicated directory in `@farcaster/hub`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->