### PR TITLE
chore: add event timestamp metric for event subscription monitoring

### DIFF
--- a/.changeset/nasty-numbers-attack.md
+++ b/.changeset/nasty-numbers-attack.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+chore: add event timestamp metric for event subscription monitoring

--- a/packages/shuttle/src/shuttle/hubSubscriber.ts
+++ b/packages/shuttle/src/shuttle/hubSubscriber.ts
@@ -1,4 +1,10 @@
-import { ClientReadableStream, HubEvent, HubEventType, HubRpcClient } from "@farcaster/hub-nodejs";
+import {
+  ClientReadableStream,
+  extractEventTimestamp,
+  HubEvent,
+  HubEventType,
+  HubRpcClient,
+} from "@farcaster/hub-nodejs";
 import { err, ok, Result } from "neverthrow";
 import { Logger } from "../log";
 import { TypedEmitter } from "tiny-typed-emitter";
@@ -280,6 +286,11 @@ export class EventStreamHubSubscriber extends BaseHubSubscriber {
       }
 
       const processTime = Date.now() - startTime;
+
+      if (events[0]) {
+        const startEventTimestamp = extractEventTimestamp(events[0].id);
+        statsd.gauge("hub.event.subscriber.last_batch_earliest_event_timestamp", startEventTimestamp);
+      }
 
       statsd.gauge("hub.event.subscriber.last_batch_size", events.length, { source: this.shardKey });
 


### PR DESCRIPTION
This will help us understand if hub are sending events from far back in time. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces an event timestamp metric for monitoring event subscriptions in the `EventStreamHubSubscriber` class. It enhances the telemetry by adding the earliest event timestamp and associates the metrics with the `hub` property.

### Detailed summary
- Added a new private property `hub` to store the hub client host.
- Extracted the earliest event timestamp using `extractEventTimestamp` and recorded it with `statsd.gauge`.
- Updated existing metrics to include the `hub` property for better context in monitoring.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->