### PR TITLE
fix: Remove temporary files after script exit

### DIFF
--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -84,6 +84,7 @@ self_upgrade() {
     fi
 
     local tmp_file
+    trap 'rm -f "$tmp_file"' EXIT
     tmp_file=$(mktemp)
     fetch_file_from_repo "$SCRIPT_FILE_PATH" "$tmp_file"
 


### PR DESCRIPTION
## Why is this change needed?

We don't need to keep the temporary files around after the script has run. Remove them after script termination.

Suggested in #2356.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a cleanup mechanism in the `scripts/hubble.sh` file to ensure that a temporary file is removed upon script exit.

### Detailed summary
- Added a `trap` command to remove the temporary file (`tmp_file`) when the script exits, ensuring no leftover files remain after execution.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->