### PR TITLE
chore: Release shuttle

### DIFF
--- a/.changeset/itchy-feet-cough.md
+++ b/.changeset/itchy-feet-cough.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-feat(shuttle): Pipe connectionTimeout arg through EventStreamHubSubscriber

--- a/.changeset/nasty-numbers-attack.md
+++ b/.changeset/nasty-numbers-attack.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-chore: add event timestamp metric for event subscription monitoring

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/hub-shuttle
 
+## 0.6.9
+
+### Patch Changes
+
+- a9c45a3d: feat(shuttle): Pipe connectionTimeout arg through EventStreamHubSubscriber
+- 99982106: chore: add event timestamp metric for event subscription monitoring
+
 ## 0.6.8
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Why is this change needed?

Release shuttle 0.6.9

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of the `@farcaster/shuttle` package from `0.6.8` to `0.6.9` and includes notable changes in the changelog.

### Detailed summary
- Updated `version` in `packages/shuttle/package.json` from `0.6.8` to `0.6.9`.
- Added a new section for `0.6.9` in `packages/shuttle/CHANGELOG.md`:
  - `feat(shuttle)`: Pipe `connectionTimeout` argument through `EventStreamHubSubscriber`.
  - `chore`: Add event timestamp metric for event subscription monitoring.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->