### PR TITLE
chore: release hubble v1.16.3 and shuttle v0.6.10

### DIFF
--- a/.changeset/angry-deers-repair.md
+++ b/.changeset/angry-deers-repair.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-fix: Make fallback to rpc in more cases when reconcile stream errors

--- a/.changeset/nice-lions-tickle.md
+++ b/.changeset/nice-lions-tickle.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-chore: introduce a pattern to help standardize log tag names

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hubble
 
+## 1.16.3
+
+### Patch Changes
+
+- 5080bbb7: chore: introduce a pattern to help standardize log tag names
+
 ## 1.16.2
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",

--- a/packages/hub-nodejs/examples/hello-world/index.ts
+++ b/packages/hub-nodejs/examples/hello-world/index.ts
@@ -189,7 +189,7 @@ const registerFname = async (fid: number) => {
       name: fname,
       timestamp: timestamp,
       owner: account.address,
-    })
+    }),
   );
 
   console.log(`Registering fname: ${fname} to fid: ${fid}`);

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.6.10
+
+### Patch Changes
+
+- 07aaf852: fix: Make fallback to rpc in more cases when reconcile stream errors
+
 ## 0.6.9
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Release hubble v1.16.3 and shuttle v0.6.10. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on updating version numbers and changelogs for the `@farcaster/hubble` and `@farcaster/shuttle` packages, along with some minor code adjustments.

### Detailed summary
- Updated `@farcaster/hubble` version from `1.16.2` to `1.16.3`.
- Added changelog entry for `1.16.3` with a log tag standardization change.
- Updated `@farcaster/shuttle` version from `0.6.9` to `0.6.10`.
- Added changelog entry for `0.6.10` regarding RPC fallback improvements.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->