### PR TITLE
fix(shuttle): Use statsd host from env

### DIFF
--- a/.changeset/shaggy-hounds-scream.md
+++ b/.changeset/shaggy-hounds-scream.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+fix: Use statsd host from env

--- a/packages/shuttle/src/statsd.ts
+++ b/packages/shuttle/src/statsd.ts
@@ -4,7 +4,7 @@ import { isIP } from "node:net";
 import StatsD from "@farcaster/hot-shots";
 
 export const statsd = new StatsD({
-  host: "127.0.0.1", // Avoid Node.js deprecation warning by specifying explicitly
+  host: process.env["STATSD_HOST"] || "127.0.0.1",
   cacheDns: true,
   maxBufferSize: 4096 /* 4KiB */,
   udpSocketOptions: {


### PR DESCRIPTION
## Why is this change needed?

Use statsd host from env for shuttle

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `statsd` configuration in the `shuttle` package to use the `STATSD_HOST` environment variable for the host address, enhancing flexibility and avoiding hardcoded values.

### Detailed summary
- Updated `host` in `statsd` configuration from a hardcoded IP (`"127.0.0.1"`) to use `process.env["STATSD_HOST"]` with a fallback to `"127.0.0.1"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->