### PR TITLE
chore: Release shuttle version

### DIFF
--- a/.changeset/shaggy-hounds-scream.md
+++ b/.changeset/shaggy-hounds-scream.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-fix: Use statsd host from env

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.6.11
+
+### Patch Changes
+
+- d34a86df: fix: Use statsd host from env
+
 ## 0.6.10
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Why is this change needed?

Release shuttle

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of the `@farcaster/shuttle` package from `0.6.10` to `0.6.11`, along with a corresponding entry in the `CHANGELOG.md` to document a bug fix related to using the `statsd` host from the environment.

### Detailed summary
- Updated version of `@farcaster/shuttle` from `0.6.10` to `0.6.11` in `packages/shuttle/package.json`.
- Added changelog entry for version `0.6.11` documenting a fix for using `statsd` host from the environment.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->