### PR TITLE
Update path in README.md

### DIFF
--- a/packages/hub-nodejs/examples/write-data/README.md
+++ b/packages/hub-nodejs/examples/write-data/README.md
@@ -11,6 +11,6 @@ We do not recommend running this example in a cloud environment because it requi
 ### Run locally
 
 1. Clone the repo locally
-2. Navigate to this folder with `cd packages/hub-nodejs/examples/make-cast`
+2. Navigate to this folder with `cd packages/hub-nodejs/examples/write-data`
 3. Run `yarn install` to install dependencies
 4. Run `yarn start`


### PR DESCRIPTION
## Why is this change needed?

The existing README.md for the write-data example contains an incorrect path, instructing users to navigate to the 'make-cast' instead of 'write-data'.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the instructions in the `README.md` file for the `write-data` example in the `hub-nodejs` package. It corrects the navigation command and ensures the instructions are accurate for users.

### Detailed summary
- Changed navigation command from `cd packages/hub-nodejs/examples/make-cast` to `cd packages/hub-nodejs/examples/write-data`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->