### PR TITLE
fix: typo correction validations.test.ts

### DIFF
--- a/packages/core/src/validations.test.ts
+++ b/packages/core/src/validations.test.ts
@@ -59,7 +59,7 @@ describe("validateFname", () => {
     expect(validations.validateFname(fname)).toEqual(ok(fname));
   });
 
-  test("succeeds with valid string inpt", () => {
+  test("succeeds with valid string input", () => {
     const fname = bytesToUtf8String(Factories.Fname.build())._unsafeUnwrap();
     expect(validations.validateFname(fname)).toEqual(ok(fname));
   });


### PR DESCRIPTION
### Why is this change needed?
Corrected a typographical error in the test description. Changed "inpt" to "input" in `validations.test.ts`.  
This fix improves code readability and consistency.

---

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets).
- [ ] PR has been tagged with a change label(s) (i.e., documentation, feature, bugfix, or chore).
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

---

## Commits

- **Commit:** `typo validations.test.ts`  
  - Changed "inpt" to "input" in the file `packages/core/src/validations.test.ts`.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a typo in a test description within the `validations.test.ts` file.

### Detailed summary
- Changed the test description from `"succeeds with valid string inpt"` to `"succeeds with valid string input"` in the `test` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->