### PR TITLE
fix(hubble.sh): handle invalid commands gracefully

### DIFF
--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -703,3 +703,7 @@ if [ $# -eq 0 ] || [ "$1" == "help" ]; then
     echo "add SKIP_CRONTAB=true to your .env to skip installing the autoupgrade crontab"
     exit 0
 fi
+
+echo "❌ Invalid command: $1"
+echo ""
+exec "$0" help


### PR DESCRIPTION
## Why is this change needed?  
This change improves the usability of the `hubble.sh` script by ensuring that invalid commands are handled gracefully. When an invalid command is entered, the script now redirects the user to the help menu, preventing confusion and providing guidance on available options.  

## Merge Checklist  
- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard  
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)  
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)  
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary  


<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves user feedback in the `hubble.sh` script by adding error messages for invalid commands.

### Detailed summary
- Added an error message: `echo "❌ Invalid command: $1"` to notify the user about the invalid command.
- Added a blank line for better readability: `echo ""`.
- Executed the help command: `exec "$0" help` to provide usage instructions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->