### PR TITLE
Fix typos in various files

### DIFF
--- a/apps/hubble/src/network/p2p/connectionFilter.ts
+++ b/apps/hubble/src/network/p2p/connectionFilter.ts
@@ -20,9 +20,9 @@ export class ConnectionFilter implements ConnectionGater {
   private allowedPeers: string[] | undefined;
   private deniedPeers: string[];
 
-  constructor(addrs: string[] | undefined, deiniedPeers: string[] | undefined) {
+  constructor(addrs: string[] | undefined, deniedPeers: string[] | undefined) {
     this.allowedPeers = addrs;
-    this.deniedPeers = deiniedPeers ?? [];
+    this.deniedPeers = deniedPeers ?? [];
   }
 
   updateAllowedPeers(addrs: string[] | undefined) {

--- a/apps/hubble/src/network/sync/merkleTrie.test.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.test.ts
@@ -224,7 +224,7 @@ describe("MerkleTrie", () => {
       const rootHash = await trie.rootHash();
 
       // Unload the trie
-      await trie.unloadChidrenAtRoot();
+      await trie.unloadChildrenAtRoot();
 
       // Expect the root hash to be the same
       expect(await trie.rootHash()).toEqual(rootHash);
@@ -485,7 +485,7 @@ describe("MerkleTrie", () => {
       const rootHash = await trie.rootHash();
 
       // Unload all the children of the first node
-      await trie.unloadChidrenAtRoot();
+      await trie.unloadChildrenAtRoot();
 
       // Now try deleting syncId1
       expect(await trie.delete(syncId1)).toBeTruthy();
@@ -641,7 +641,7 @@ describe("MerkleTrie", () => {
     const trie = await trieWithIds([1665182332, 1665182343, 1665182345]);
 
     // Unload all the children of the first node
-    await trie.unloadChidrenAtRoot();
+    await trie.unloadChildrenAtRoot();
 
     let values = await trie.getAllValues(new Uint8Array(Buffer.from("16651823")));
     expect(values?.length).toEqual(3);

--- a/apps/hubble/src/network/sync/merkleTrie.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.ts
@@ -378,7 +378,7 @@ class MerkleTrie {
     return await rsMerkleTrieRootHash(this._rustTrie);
   }
 
-  public async unloadChidrenAtRoot(): Promise<void> {
+  public async unloadChildrenAtRoot(): Promise<void> {
     return await rsMerkleTrieUnloadChildren(this._rustTrie);
   }
 
@@ -388,7 +388,7 @@ class MerkleTrie {
   }
 
   public async commitToDb(): Promise<void> {
-    return await this.unloadChidrenAtRoot();
+    return await this.unloadChildrenAtRoot();
   }
 }
 

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -778,7 +778,7 @@ describe("Multi peer sync engine with streams", () => {
 
     const messageStats2 = (await syncHealthProbe.computeSyncHealthMessageStats(start, stop))._unsafeUnwrap();
 
-    // Query is inclusive of the start time and exclusive of the stop time. We cound 150, 170, 180 on engine1 and  150, 170 on engine 2
+    // Query is inclusive of the start time and exclusive of the stop time. We count 150, 170, 180 on engine1 and  150, 170 on engine 2
     expect(messageStats2.primaryNumMessages).toEqual(3);
     expect(messageStats2.peerNumMessages).toEqual(2);
 


### PR DESCRIPTION
## Why is this change needed?
This pull request fixes multiple typos across several files in the repository to enhance code clarity and maintainability. Correcting these typos improves the readability of the code and prevents potential confusion for contributors and maintainers.

## Summary of Changes
1. **`apps/hubble/src/network/p2p/connectionFilter.ts`**
   - Fixed typo: `deiniedPeers` → `deniedPeers`.

2. **`apps/hubble/src/network/sync/merkleTrie.test.ts`**
   - Fixed typo: `unloadChidrenAtRoot` → `unloadChildrenAtRoot`.

3. **`apps/hubble/src/network/sync/merkleTrie.ts`**
   - Fixed typos: `unloadChidrenAtRoot` → `unloadChildrenAtRoot`.

4. **`apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts`**
   - Fixed typo in comment: `cound` → `count`.

## Merge Checklist
- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets).
- [x] PR has been tagged with a change label (e.g., documentation, bugfix).
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

---

**Allow edits by maintainers:** ✅

Appreciate your time and review!

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting typographical errors in method names and comments across multiple files, enhancing code clarity and maintainability.

### Detailed summary
- Corrected method name from `unloadChidrenAtRoot` to `unloadChildrenAtRoot` in `merkleTrie.ts` and its test file.
- Fixed parameter name from `deiniedPeers` to `deniedPeers` in the constructor of `connectionFilter.ts`.
- Corrected the spelling of "count" in a comment in `multiPeerSyncEngine.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->