### PR TITLE
Fix typos and improve consistency across documentation files

### DIFF
--- a/packages/hub-nodejs/docs/Events.md
+++ b/packages/hub-nodejs/docs/Events.md
@@ -64,7 +64,7 @@ Emitted by contracts whenever the ownership of fids or fnames changes.
 
 ### IdRegistryEvent
 
-Emit when an onchain event occurs in the IdRegistry which registers or transfers an fid.
+Emit when an onchain event occurs in the IdRegistry which registers or transfers a fid.
 
 | Name            | Type                        | Description                                              |
 | --------------- | --------------------------- | -------------------------------------------------------- |

--- a/packages/hub-nodejs/docs/Events.md
+++ b/packages/hub-nodejs/docs/Events.md
@@ -79,7 +79,7 @@ Emit when an onchain event occurs in the IdRegistry which registers or transfers
 
 ### NameRegistryEvent
 
-Emit when an onchain event occurs in the NameRegistry which registers, transfers or renews an fname.
+Emit when an onchain event occurs in the NameRegistry which registers, transfers or renews a fname.
 
 | Name            | Type                                              | Description                                              |
 | --------------- | ------------------------------------------------- | -------------------------------------------------------- |
@@ -105,8 +105,8 @@ The Farcaster network that will accept the message.
 | HUB_EVENT_TYPE_MERGE_MESSAGE             | 1      | A message was merged into the Hub                 |
 | HUB_EVENT_TYPE_PRUNE_MESSAGE             | 2      | A message was pruned because a limit was exceeded |
 | HUB_EVENT_TYPE_REVOKE_MESSAGE            | 3      | A message was revoked by a user                   |
-| HUB_EVENT_TYPE_MERGE_ID_REGISTRY_EVENT   | 4      | An fid was issued or transferred.                 |
-| HUB_EVENT_TYPE_MERGE_NAME_REGISTRY_EVENT | 5      | An fname was issued, transferred or renewed.      |
+| HUB_EVENT_TYPE_MERGE_ID_REGISTRY_EVENT   | 4      | A fid was issued or transferred.                 |
+| HUB_EVENT_TYPE_MERGE_NAME_REGISTRY_EVENT | 5      | A fname was issued, transferred or renewed.      |
 
 ### IdRegistryEventType
 
@@ -121,5 +121,5 @@ The Farcaster network that will accept the message.
 | Name                              | Number | Description                         |
 | --------------------------------- | ------ | ----------------------------------- |
 | NAME_REGISTRY_EVENT_TYPE_NONE     | 0      |                                     |
-| NAME_REGISTRY_EVENT_TYPE_TRANSFER | 1      | An fname was minted or transferred. |
-| NAME_REGISTRY_EVENT_TYPE_RENEW    | 1      | An fname was renewed.               |
+| NAME_REGISTRY_EVENT_TYPE_TRANSFER | 1      | A fname was minted or transferred. |
+| NAME_REGISTRY_EVENT_TYPE_RENEW    | 1      | A fname was renewed.               |

--- a/packages/hub-nodejs/docs/signers/ViemLocalEip712Signer.md
+++ b/packages/hub-nodejs/docs/signers/ViemLocalEip712Signer.md
@@ -1,6 +1,6 @@
 # ViemLocalEip712Signer
 
-An Eip712Signer that is initialized with an [Viem](https://viem.sh/docs/getting-started) LocalACcount and can be used with [Builders](../builders/builders.md) to sign Farcaster Messages.
+A Eip712Signer that is initialized with a [Viem](https://viem.sh/docs/getting-started) LocalAсcount and can be used with [Builders](../builders/builders.md) to sign Farcaster Messages.
 
 ## Properties
 

--- a/packages/hub-nodejs/examples/contract-signatures/README.md
+++ b/packages/hub-nodejs/examples/contract-signatures/README.md
@@ -4,7 +4,7 @@ This example app demonstrates how to create and use EIP-712 signatures to sponso
 
 Every onchain action in the Farcaster protocol can be performed by a third party on behalf of the end user by collecting a typed signature and providing it to the Farcaster smart contracts. This makes it possible to pay gas and sponsor onchain transactions for your users without asking them to pay a fee or send a transaction from their wallet.
 
-The structured format of EIP-712 signatures makes them more secure for the end user and easier for wallets to parse, but they can be difficult to construct and work with as an application developer. This demo app shows how to call every signature based function in the Farcaster contracts, including registering an account, transferring an fid, and adding/removing signer keys.
+The structured format of EIP-712 signatures makes them more secure for the end user and easier for wallets to parse, but they can be difficult to construct and work with as an application developer. This demo app shows how to call every signature based function in the Farcaster contracts, including registering an account, transferring a fid, and adding/removing signer keys.
 
 This example uses [Hardhat](https://hardhat.org/) to run a local node that simulates OP Mainnet, where the Farcaster contracts are deployed.
 

--- a/packages/hub-nodejs/examples/hello-world/README.md
+++ b/packages/hub-nodejs/examples/hello-world/README.md
@@ -6,7 +6,7 @@ Given a custody address with ~10$ worth of funds on OP Mainnet, this example wil
  - Register an FID on the IdRegistry contract
  - Purchase 1 unit of storage on the StorageContract
  - Create a signer on the KeyRegistry contract
- - Register an fname on the fname registry server
+ - Register a fname on the fname registry server
  - Update the user's profile
 
 ### Run on StackBlitz


### PR DESCRIPTION
This pull request addresses several typos and consistency issues in various documentation files across the repo. The following changes have been made:

- Corrected typos such as "an fid" to "a fid" and "an fname" to "a fname" to ensure correct usage of indefinite articles.
- Fixed the use of "A" vs "An" before words starting with consonant and vowel sounds where necessary.
- Updated descriptions and fixed formatting for clarity and consistency.

## Why is this change needed?
This change is needed to maintain consistency and clarity in the documentation, making it easier to understand and follow. It also ensures that all references to terms like "fid" and "fname" are grammatically correct.

## Merge Checklist:
- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary



<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on minor textual corrections and improvements in documentation related to the `ViemLocalEip712Signer`, `IdRegistryEvent`, and `NameRegistryEvent` in the Farcaster protocol.

### Detailed summary
- Corrected spelling of `LocalAсcount` in `ViemLocalEip712Signer.md`.
- Removed redundant wording in `README.md` files and ensured consistency.
- Clarified descriptions in `Events.md` for `IdRegistryEvent` and `NameRegistryEvent`.
- Improved formatting of event types in `Events.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->