### PR TITLE
 Fix documentation typos and grammar

### DIFF
--- a/packages/hub-nodejs/docs/Client.md
+++ b/packages/hub-nodejs/docs/Client.md
@@ -102,7 +102,7 @@ successful response of type `<T>` or an error value. There are three types of re
 - [MessagesResult<T>](#messagesresult)
 - [FidsResult<T>](#fidsresult)
 
-Results always return an object of type `Message` instead of a more specific type like `CastAddMessage` due to a quick of the protobuf-generated types. This can be easily remedied by passing responses through a typeguard:
+Results always return an object of type `Message` instead of a more specific type like `CastAddMessage` due to a quirk of the protobuf-generated types. This can be easily remedied by passing responses through a typeguard:
 
 ```typescript
 import { isCastAddMessage } from '@farcaster/hub-nodejs';
@@ -1137,7 +1137,7 @@ client.$.waitForReady(Date.now() + 5000, async (e) => {
 
 A documentation alias for `HubAsyncResult<Message>` where the success value contains a single message.
 
-Message are of the type <T> requested but this is an implicit guarantee since ts-proto does not generate bindings
+Messages are of the type <T> requested but this is an implicit guarantee since ts-proto does not generate bindings
 correctly to reflect this in the returned types.
 
 ---

--- a/protobufs/README.md
+++ b/protobufs/README.md
@@ -6,7 +6,7 @@ Specifications for API's and data formats used in Hubble, including both Farcast
 |---------------------------------------------|------------------------------------------| ----------------------- |
 | [Message](schemas/message.proto)            | Types for Farcaster deltas               | [docs](docs/message.md) |
 | [OnChainEvent](schemas/onchain_event.proto) | Types for Farcaster onchain events       | [docs](docs/message.md) |
-| [HubEvent](schemas/hub_event.proto)         | Types for hub events              | [docs](docs/message.md) |
+| [HubEvent](schemas/hub_event.proto)         | Types for hub events                     | [docs](docs/message.md) |
 | [RPC](schemas/rpc.proto)                    | Types for gRPC APIs exposed by Hubs      | [docs](docs/rpc.md)     |
 | [Gossip](schemas/gossip.proto)              | Types for gossiping data between Hubs    |                         |
 | [HubState](schemas/hub_state.proto)         | Types for maintaining internal state     |                         |
@@ -25,4 +25,4 @@ Coming soon
 
 ### Docs
 
-Docs for the protobufs is under `../apps/hubble/www/docs/docs`
+Docs for the protobufs are under `../apps/hubble/www/docs/docs`


### PR DESCRIPTION
> Changes:

> 1. In packages/hub-nodejs/docs/Client.md:
 - Changed "quick" to "quirk"
 - Reason: The word "quick" (meaning fast/rapid) was incorrectly used where "quirk" (meaning peculiarity/oddity) was intended when describing protobuf-generated types behavior.

> 2. In packages/hub-nodejs/docs/Client.md:
 - Changed "Message are" to "Messages are"
 - Reason: Fixed subject-verb agreement as "Messages" is plural and requires the plural verb form "are".

> 3. In protobufs/README.md:
 - Changed "Docs for the protobufs is" to "Docs for the protobufs are"
 - Reason: Fixed subject-verb agreement as "Docs" (documentation) is treated as plural in this context and requires the plural verb form "are".
 These changes improve the documentation's readability and grammatical correctness without altering any technical content.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on improving documentation clarity in the `protobufs/README.md` and `packages/hub-nodejs/docs/Client.md` files, correcting minor typographical errors and ensuring consistency in language.

### Detailed summary
- Fixed a minor typographical error in `protobufs/README.md` regarding the documentation description.
- Corrected "quick" to "quirk" in `packages/hub-nodejs/docs/Client.md`.
- Changed "Docs for the protobufs is" to "Docs for the protobufs are" for grammatical accuracy in `protobufs/README.md`.
- Changed "Message are" to "Messages are" in `packages/hub-nodejs/docs/Client.md` for grammatical accuracy.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->