### PR TITLE
Fix grammatical errors and typo in code

### DIFF
--- a/apps/hubble/www/docs/docs/cli.md
+++ b/apps/hubble/www/docs/docs/cli.md
@@ -9,7 +9,7 @@ Documentation for the Hubble CLI.
 5. `profile` - profile the storage usage of the db.
 6. `console` - start an interactive repl console for debugging.
 
-Commands must invoked with yarn by running:
+Commands must be invoked with yarn by running:
 
 ```
 # if using docker

--- a/packages/hub-nodejs/docs/Client.md
+++ b/packages/hub-nodejs/docs/Client.md
@@ -529,7 +529,7 @@ Returns all active casts that are replies to a specific cast in reverse chronolo
 #### Usage
 
 ```typescript
-import { geSSLHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs';
+import { getSSLHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs';
 
 const hubRpcEndpoint = 'testnet1.farcaster.xyz:2283';
 const client = getSSLHubRpcClient(hubRpcEndpoint);


### PR DESCRIPTION
Fixed:

Changed "Commands must" to "Commands must be" for grammatical correctness.
Corrected "import { geSSLHubRpcClient" to "import { getSSLHubRpcClient" to fix the typo.
Why it's useful:
These changes fix grammatical errors and a typo, ensuring the code is syntactically correct and easier to read.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a typo in the documentation and updating a function name in the code.

### Detailed summary
- In `apps/hubble/www/docs/docs/cli.md`, the phrase "Commands must invoked" was corrected to "Commands must be invoked".
- In `packages/hub-nodejs/docs/Client.md`, the function name `geSSLHubRpcClient` was updated to `getSSLHubRpcClient`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->