### PR TITLE
fix: Switch from Warp to standard runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ concurrency:
 
 jobs:
   build-image:
-    timeout-minutes: 10
-    runs-on: 'warp-ubuntu-latest-arm64-16x'
+    timeout-minutes: 25
+    runs-on: ['runs-on=${{ github.run_id }}', 'runner=4cpu-linux-arm64']
 
     steps:
       - uses: actions/checkout@v4
@@ -53,17 +53,17 @@ jobs:
           on_retry_command: docker logs hub
 
   test:
-    timeout-minutes: 10
+    timeout-minutes: 25
 
     strategy:
       matrix:
         include:
           - node_version: 20
-            runs_on: 'warp-ubuntu-latest-x64-16x'
+            runs_on: ['runs-on=${{ github.run_id }}', 'runner=4cpu-linux-x64']
           - node_version: 22.4.1 # HACK: There's an issue with node 22.7.0
-            runs_on: 'warp-ubuntu-latest-arm64-16x' # Only works on ARM for now
+            runs_on: ['runs-on=${{ github.run_id }}', 'runner=4cpu-linux-arm64']
           - node_version: 22.4.1 # HACK: There's an issue with node 22.7.0
-            runs_on: 'warp-ubuntu-latest-x64-16x'
+            runs_on: ['runs-on=${{ github.run_id }}', 'runner=4cpu-linux-x64']
 
     runs-on: ${{ matrix.runs_on }}
     name: test (${{ matrix.node_version }})


### PR DESCRIPTION
## Why is this change needed?

To fix builds

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the GitHub Actions workflow configuration by increasing timeout durations and modifying the runner specifications for various jobs, enhancing the CI process.

### Detailed summary
- Increased `timeout-minutes` from 10 to 25 for `build-image` and `test` jobs.
- Changed `runs-on` specifications to use a dynamic runner format for both ARM and x64 architectures.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->