### PR TITLE
initial scaffolding

### DIFF
--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -1382,7 +1382,7 @@ class Engine extends TypedEmitter<EngineEvents> {
     let resolvedAddressString;
     try {
       // Use the appropriate client based on the username type
-      const client = nameProof.type === UserNameType.USERNAME_TYPE_ENS_L2 ? this._l2PublicClient : this._publicClient;
+      const client = nameProof.type === UserNameType.USERNAME_TYPE_BASE ? this._l2PublicClient : this._publicClient;
       if (!client) {
         return err(new HubError("unavailable.network_failure", "no client available for ENS resolution"));
       }

--- a/packages/core/src/eth/chains.ts
+++ b/packages/core/src/eth/chains.ts
@@ -1,3 +1,3 @@
-import { mainnet, goerli, optimism, optimismGoerli } from "viem/chains";
+import { mainnet, goerli, optimism, optimismGoerli, base } from "viem/chains";
 
-export const CHAIN_IDS = [mainnet.id, goerli.id, optimism.id, optimismGoerli.id] as const;
+export const CHAIN_IDS = [mainnet.id, goerli.id, optimism.id, optimismGoerli.id, base.id] as const;

--- a/packages/core/src/factories.ts
+++ b/packages/core/src/factories.ts
@@ -78,9 +78,10 @@ const FnameFactory = Factory.define<Uint8Array>(() => {
   return bytes;
 });
 
-const EnsNameFactory = Factory.define<Uint8Array>(() => {
+const EnsNameFactory = Factory.define<Uint8Array, { nameType?: "Basename" | "ENS_L1" }>(({ transientParams }) => {
   const ensName = faker.random.alphaNumeric(faker.datatype.number({ min: 3, max: 16 }));
-  return utf8StringToBytes(ensName.concat(".eth"))._unsafeUnwrap();
+  const suffix = transientParams.nameType === "Basename" ? ".base.eth" : ".eth";
+  return utf8StringToBytes(ensName.concat(suffix))._unsafeUnwrap();
 });
 
 /** Eth */
@@ -670,8 +671,9 @@ const UserDataAddMessageFactory = Factory.define<protobufs.UserDataAddMessage, {
 const UsernameProofDataFactory = Factory.define<protobufs.UsernameProofData>(() => {
   const proofBody = UserNameProofFactory.build({
     type: UserNameType.USERNAME_TYPE_ENS_L1,
-    name: EnsNameFactory.build(),
+    name: EnsNameFactory.build({}, { transient: { nameType: "ENS_L1" } }),
   });
+
   return MessageDataFactory.build({
     usernameProofBody: proofBody,
     type: protobufs.MessageType.USERNAME_PROOF,

--- a/packages/core/src/protobufs/generated/username_proof.ts
+++ b/packages/core/src/protobufs/generated/username_proof.ts
@@ -6,6 +6,7 @@ export enum UserNameType {
   USERNAME_TYPE_NONE = 0,
   USERNAME_TYPE_FNAME = 1,
   USERNAME_TYPE_ENS_L1 = 2,
+  USERNAME_TYPE_BASE = 3,
 }
 
 export function userNameTypeFromJSON(object: any): UserNameType {
@@ -19,6 +20,9 @@ export function userNameTypeFromJSON(object: any): UserNameType {
     case 2:
     case "USERNAME_TYPE_ENS_L1":
       return UserNameType.USERNAME_TYPE_ENS_L1;
+    case 3:
+    case "USERNAME_TYPE_BASE":
+      return UserNameType.USERNAME_TYPE_BASE;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserNameType");
   }
@@ -32,6 +36,8 @@ export function userNameTypeToJSON(object: UserNameType): string {
       return "USERNAME_TYPE_FNAME";
     case UserNameType.USERNAME_TYPE_ENS_L1:
       return "USERNAME_TYPE_ENS_L1";
+    case UserNameType.USERNAME_TYPE_BASE:
+      return "USERNAME_TYPE_BASE";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserNameType");
   }

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -1108,7 +1108,7 @@ export const validateFname = <T extends string | Uint8Array>(fnameP?: T | null):
 
   return ok(fnameP);
 };
-
+// TODO: Add basename validation
 export const validateEnsName = <T extends string | Uint8Array>(ensNameP?: T | null): HubResult<T> => {
   if (ensNameP === undefined || ensNameP === null || ensNameP === "") {
     return err(new HubError("bad_request.validation_failure", "ensName is missing"));

--- a/packages/hub-nodejs/src/generated/username_proof.ts
+++ b/packages/hub-nodejs/src/generated/username_proof.ts
@@ -6,6 +6,7 @@ export enum UserNameType {
   USERNAME_TYPE_NONE = 0,
   USERNAME_TYPE_FNAME = 1,
   USERNAME_TYPE_ENS_L1 = 2,
+  USERNAME_TYPE_BASE = 3,
 }
 
 export function userNameTypeFromJSON(object: any): UserNameType {
@@ -19,6 +20,9 @@ export function userNameTypeFromJSON(object: any): UserNameType {
     case 2:
     case "USERNAME_TYPE_ENS_L1":
       return UserNameType.USERNAME_TYPE_ENS_L1;
+    case 3:
+    case "USERNAME_TYPE_BASE":
+      return UserNameType.USERNAME_TYPE_BASE;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserNameType");
   }
@@ -32,6 +36,8 @@ export function userNameTypeToJSON(object: UserNameType): string {
       return "USERNAME_TYPE_FNAME";
     case UserNameType.USERNAME_TYPE_ENS_L1:
       return "USERNAME_TYPE_ENS_L1";
+    case UserNameType.USERNAME_TYPE_BASE:
+      return "USERNAME_TYPE_BASE";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserNameType");
   }

--- a/packages/hub-web/src/generated/username_proof.ts
+++ b/packages/hub-web/src/generated/username_proof.ts
@@ -6,6 +6,7 @@ export enum UserNameType {
   USERNAME_TYPE_NONE = 0,
   USERNAME_TYPE_FNAME = 1,
   USERNAME_TYPE_ENS_L1 = 2,
+  USERNAME_TYPE_BASE = 3,
 }
 
 export function userNameTypeFromJSON(object: any): UserNameType {
@@ -19,6 +20,9 @@ export function userNameTypeFromJSON(object: any): UserNameType {
     case 2:
     case "USERNAME_TYPE_ENS_L1":
       return UserNameType.USERNAME_TYPE_ENS_L1;
+    case 3:
+    case "USERNAME_TYPE_BASE":
+      return UserNameType.USERNAME_TYPE_BASE;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserNameType");
   }
@@ -32,6 +36,8 @@ export function userNameTypeToJSON(object: UserNameType): string {
       return "USERNAME_TYPE_FNAME";
     case UserNameType.USERNAME_TYPE_ENS_L1:
       return "USERNAME_TYPE_ENS_L1";
+    case UserNameType.USERNAME_TYPE_BASE:
+      return "USERNAME_TYPE_BASE";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserNameType");
   }

--- a/protobufs/schemas/username_proof.proto
+++ b/protobufs/schemas/username_proof.proto
@@ -4,6 +4,7 @@ enum UserNameType {
   USERNAME_TYPE_NONE = 0;
   USERNAME_TYPE_FNAME = 1;
   USERNAME_TYPE_ENS_L1 = 2;
+  USERNAME_TYPE_BASE = 3;
 }
 
 message UserNameProof {


### PR DESCRIPTION
## Why is this change needed?

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `USERNAME_TYPE_BASE` to the `UserNameType` enum, expands the `CHAIN_IDS` to include `base`, and updates various functions and validation logic to accommodate the new username type, enhancing support for the Base network.

### Detailed summary
- Added `USERNAME_TYPE_BASE` to `UserNameType` in multiple files.
- Updated `CHAIN_IDS` in `packages/core/src/eth/chains.ts` to include `base`.
- Modified `userNameTypeFromJSON` and `userNameTypeToJSON` functions to handle `USERNAME_TYPE_BASE`.
- Adjusted `EnsNameFactory` to support `.base.eth` suffix.
- Enhanced validation logic to include checks for `USERNAME_TYPE_BASE`.
- Created a new client for Base network in `apps/hubble/src/storage/engine/validation.worker.ts`.
- Updated EIP-712 domain definitions to include Base network.
- Added `validateUsernameProofSignature` function for signature validation.
- Expanded `validateUsernameProofBody` to allow both ENS and Base types.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->