### PR TITLE
chore: Remove node 20 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - node_version: 20
-            runs_on: 'warp-ubuntu-latest-x64-16x'
           - node_version: 22.4.1 # HACK: There's an issue with node 22.7.0
             runs_on: 'warp-ubuntu-latest-arm64-16x' # Only works on ARM for now
           - node_version: 22.4.1 # HACK: There's an issue with node 22.7.0


### PR DESCRIPTION
## Why is this change needed?

Remove node 20

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `ci.yml` workflow configuration for the GitHub Actions CI pipeline, specifically adjusting the `node_version` and `runs_on` parameters for different runner environments.

### Detailed summary
- Added `node_version: 20` to the `matrix.include`.
- Changed `runs_on` for the first configuration to `['runs-on=${{ github.run_id }}', 'runner=4cpu-linux-x64']`.
- Updated `runs_on` for the second configuration to `['runs-on=${{ github.run_id }}', 'runner=4cpu-linux-arm64']`.
- Retained `node_version: 22.4.1` with a comment regarding an issue with `node 22.7.0`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->