### PR TITLE
docs: documentation typos in Client.md and Events.md

### DIFF
--- a/packages/hub-nodejs/docs/Client.md
+++ b/packages/hub-nodejs/docs/Client.md
@@ -620,7 +620,7 @@ Returns an active reaction of a particular type made by a user to a cast.
 #### Usage
 
 ```typescript
-import { geSSLHubRpcClient, hexStringToBytes, ReactionType } from '@farcaster/hub-nodejs';
+import { getSSLHubRpcClient, hexStringToBytes, ReactionType } from '@farcaster/hub-nodejs';
 
 const hubRpcEndpoint = 'testnet1.farcaster.xyz:2283';
 const client = getSSLHubRpcClient(hubRpcEndpoint);

--- a/packages/hub-nodejs/docs/Events.md
+++ b/packages/hub-nodejs/docs/Events.md
@@ -50,7 +50,7 @@ Emit when an IdRegistryEvent is merged into the Hub.
 
 ### MergeNameRegistry
 
-Emit when an NameRegistryEvent is merged into the Hub.
+Emit when a NameRegistryEvent is merged into the Hub.
 
 | Name              | Type                            | Description                               |
 | ----------------- | ------------------------------- | ----------------------------------------- |


### PR DESCRIPTION
## Why is this change needed?

This PR addresses minor typographical errors in the documentation to improve accuracy and readability:

- **File: `Client.md`**  
  - Fixed the incorrect reference `geSSLHubRpcClient` to `getSSLHubRpcClient` in the example code.  

- **File: `Events.md`**  
  - Corrected the grammatical error by changing "an NameRegistryEvent" to "a NameRegistryEvent."

These corrections enhance clarity and ensure the examples are error-free for developers using the documentation.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.  
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets).  
- [ ] PR has been tagged with a change label(s) (e.g., documentation, feature, bugfix, or chore).  
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.  

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a function name in the import statement and making a minor grammatical adjustment in the documentation.

### Detailed summary
- Changed the import from `geSSLHubRpcClient` to `getSSLHubRpcClient` in `packages/hub-nodejs/docs/Client.md`.
- Updated the documentation in `packages/hub-nodejs/docs/Events.md` by adding a space before "Emit" in the description of `MergeNameRegistry`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->