### PR TITLE
feat(shuttle): Revert unsafe "Support deleting messages on DB that are missing on hub" #2341

### DIFF
--- a/.changeset/brave-panthers-walk.md
+++ b/.changeset/brave-panthers-walk.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+feat(shuttle): Revert unsafe "Support deleting messages on DB that are missing on hub" #2341

--- a/packages/shuttle/src/example-app/app.ts
+++ b/packages/shuttle/src/example-app/app.ts
@@ -220,7 +220,7 @@ export class App implements MessageHandler {
         fid,
         async (message, missingInDb, prunedInDb, revokedInDb) => {
           if (missingInDb) {
-            await HubEventProcessor.handleMissingMessage(this.db, message, this, false);
+            await HubEventProcessor.handleMissingMessage(this.db, message, this);
           } else if (prunedInDb || revokedInDb) {
             const messageDesc = prunedInDb ? "pruned" : revokedInDb ? "revoked" : "existing";
             log.info(`Reconciled ${messageDesc} message ${bytesToHexString(message.hash)._unsafeUnwrap()}`);
@@ -228,7 +228,7 @@ export class App implements MessageHandler {
         },
         async (message, missingInHub) => {
           if (missingInHub) {
-            await HubEventProcessor.handleMissingMessage(this.db, Message.decode(message.raw), this, missingInHub);
+            log.info(`Message ${bytesToHexString(message.hash)._unsafeUnwrap()} is missing in the hub`);
           }
         },
       );

--- a/packages/shuttle/src/shuttle/hubEventProcessor.ts
+++ b/packages/shuttle/src/shuttle/hubEventProcessor.ts
@@ -42,13 +42,9 @@ export class HubEventProcessor {
     });
   }
 
-  static async handleMissingMessage(db: DB, message: Message, handler: MessageHandler, missingInHub?: boolean) {
+  static async handleMissingMessage(db: DB, message: Message, handler: MessageHandler) {
     await db.transaction().execute(async (trx) => {
-      if (missingInHub) {
-        await this.processMessage(trx, message, handler, "delete", [], true);
-      } else {
-        await this.processMessage(trx, message, handler, "merge", [], true);
-      }
+      await this.processMessage(trx, message, handler, "merge", [], true);
     });
   }
 


### PR DESCRIPTION
Reverts farcasterxyz/hub-monorepo#2341

We found this to be a fundamentally flawed action to take on messages missing in the hub. Reverting the change to not mislead other Shuttle users.

Why is this unsafe? Imagine a simple Shuttle-powered app with a `links` table written to and deleted from by its `handleMessageMerge` method. Then imagine this series of Farcaster messages submitted to the network:
1. LINK_ADD: FID 123 follows FID 234
2. LINK_REMOVE: FID 123 unfollows FID 234
3. LINK_ADD: FID 123 refollows FID 234

Obviously the correct final `links` table state should be FID 123 following FID 234. But with my changes that I'm reverting here, this won't be the case. The hubs will eventually delete message 1, meaning Shuttle's reverse reconciliation would ultimately run `handleMessageMerge()` with a `state` arg of `"deleted"` on message 1. This means the `links` table would have its row deleted that signifies FID 123 following FID 234, regardless of message 3.

I think it might be safe in general to have this `onDbMessage()` callback do something like hard delete missing-in-hub messages from the `messages` table to keep its disk usage in check, but calling into the app to have it perform all downstream deletion processing of the message like this isn't safe.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on reverting a previous change that allowed for the deletion of messages from the database if they were missing on the hub. It simplifies the `handleMissingMessage` method by removing the conditional check for `missingInHub`.

### Detailed summary
- Reverted feature: "Support deleting messages on DB that are missing on hub".
- Modified `handleMissingMessage` method in `hubEventProcessor.ts` to remove the `missingInHub` parameter.
- Updated calls to `handleMissingMessage` in `app.ts` to reflect the removal of the `missingInHub` argument.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->