### PR TITLE
chore: Release shuttle 0.6.12

### DIFF
--- a/.changeset/brave-panthers-walk.md
+++ b/.changeset/brave-panthers-walk.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-feat(shuttle): Revert unsafe "Support deleting messages on DB that are missing on hub" #2341

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.6.12
+
+### Patch Changes
+
+- a302bcd1: feat(shuttle): Revert unsafe "Support deleting messages on DB that are missing on hub" #2341
+
 ## 0.6.11
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Why is this change needed?

Release shuttle with revert for reconciliation issue.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of the `@farcaster/shuttle` package from `0.6.11` to `0.6.12`, along with a changelog entry that documents a specific feature revert.

### Detailed summary
- Updated `version` of `@farcaster/shuttle` from `0.6.11` to `0.6.12`.
- Added changelog entry for version `0.6.12` noting the revert of the feature "Support deleting messages on DB that are missing on hub" (#2341).

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->