### PR TITLE
bugfix: Fix Issue with Path Quoting Update hubble.sh

### DIFF
--- a/scripts/hubble.sh
+++ b/scripts/hubble.sh
@@ -664,7 +664,7 @@ fi
 
 if [ "$1" == "autoupgrade" ]; then
     # Autoupgrade cronjob needs the correct $PATH entries
-    if [[ ! -f "~/.bashrc" ]]; then
+    if [[ ! -f ~/.bashrc ]]; then
       source ~/.bashrc
     fi
 


### PR DESCRIPTION
## Why is this change needed?

**Subject:** Fix Issue with Path Quoting in `source ~/.bashrc`

A bug in the script where the `~` symbol, which represents the user's home directory, was not expanding properly. 

Specifically, in the following code:

```bash
if [[ ! -f "~/.bashrc" ]]; then
  source ~/.bashrc
fi
```

The `~` should have been outside the quotes to properly expand it to the full path. The corrected version is:

```bash
if [[ ! -f ~/.bashrc ]]; then
  source ~/.bashrc
fi
```

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on a minor adjustment in the `scripts/hubble.sh` file to correct the file path check for `~/.bashrc`. 

### Detailed summary
- Changed the conditional check from `if [[ ! -f "~/.bashrc" ]]; then` to `if [[ ! -f ~/.bashrc ]]; then` to ensure proper evaluation of the file existence.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->