### PR TITLE
docs: fix broken link CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ If your PR has changes to gRPC or protobuf files, you must update the [public do
 
 All PRs should have supporting documentation that makes reviewing and understanding the code easy. You should:
 
-- Update high-level changes in the [contract docs](docs/docs.md).
+- Update high-level changes in the [contract docs](https://github.com/farcasterxyz/contracts/blob/main/docs/docs.md).
 - Always use TSDoc style comments for functions, variables, constants, events and params.
 - Prefer single-line comments `/** The comment */` when the TSDoc comment fits on a single line.
 - Always use regular comments `//` for inline commentary on code.


### PR DESCRIPTION
## Description

The link in the `CONTRIBUTING.md` file was broken and has been updated to the correct URL. This ensures users are directed to the proper documentation.

---

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard  
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)  
- [x] PR has been tagged with a change label(s) (i.e. documentation)  
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary  

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the link to the `contract docs` in the `CONTRIBUTING.md` file to point directly to the GitHub repository instead of a relative path.

### Detailed summary
- Changed the link in `CONTRIBUTING.md` from a relative path to a direct link: `https://github.com/farcasterxyz/contracts/blob/main/docs/docs.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->