### PR TITLE
docs: Fix typo Update README.md

### DIFF
--- a/packages/hub-web/README.md
+++ b/packages/hub-web/README.md
@@ -33,7 +33,7 @@ try {
     const response = await axios.get(`${server}/v1/castsByFid?fid=${fid}`);
 
     console.log(`API Returned HTTP status ${response.status}`);    
-    console.log(`First Cast's text is ${response.messages[0].data.castAddBody.text}`);
+    console.log(`The first cast's text is ${response.messages[0].data.castAddBody.text}`);
 } catch (e) {
     // Handle errors
     console.log(response);


### PR DESCRIPTION
## Why is this change needed?

<img width="852" alt="Снимок экрана 2024-12-10 в 19 00 33" src="https://github.com/user-attachments/assets/6a803a7a-ff1c-43bb-972f-c78318266766">

The problem lies in the use of "Cast's," which could be unclear or grammatically incorrect in this context. The possessive form of "Cast" may not be necessary here, and it could be better to rewrite it as:

`console.log(`The first cast's text is ${response.messages[0].data.castAddBody.text}`);`

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the wording in a log message for clarity.

### Detailed summary
- Changed the log message from `First Cast's text is` to `The first cast's text is` to improve readability and consistency in the console output.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->