### PR TITLE
fix: Fix openSUSE ID Check Update hubble-bootstrap.sh

### DIFF
--- a/scripts/hubble-bootstrap.sh
+++ b/scripts/hubble-bootstrap.sh
@@ -39,7 +39,7 @@ install_jq() {
         sudo dnf install -y jq
 
     # openSUSE
-    elif [[ -f /etc/os-release ]] && grep -q "ID=openSUSE" /etc/os-release; then
+    elif [[ -f /etc/os-release ]] && grep -iq "ID=opensuse" /etc/os-release; then
         sudo zypper install -y jq
 
     # Arch Linux


### PR DESCRIPTION
## Why is this change needed?

This update addresses an issue in the bootstrap script where the detection of openSUSE systems was not functioning correctly.  

#### Problem:  
The script checks `/etc/os-release` for `ID=openSUSE`, but the actual value is `ID=opensuse` (lowercase). This mismatch causes the script to fail in identifying openSUSE systems.  

#### Solution:  
- Updated the condition to use `grep -iq "ID=opensuse"` to ensure the check is case-insensitive.  
- This change ensures compatibility with all openSUSE installations.  

### Before:  
```bash
elif [[ -f /etc/os-release ]] && grep -q "ID=openSUSE" /etc/os-release; then
```

### After:  
```bash
elif [[ -f /etc/os-release ]] && grep -iq "ID=opensuse" /etc/os-release; then
```

#### Additional Notes:  
- Tested on multiple Linux distributions to confirm compatibility.  
- The fix ensures a smoother user experience for openSUSE users.  

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the detection of the openSUSE operating system in the `scripts/hubble-bootstrap.sh` script to ensure case-insensitive matching for the `ID` field in `/etc/os-release`.

### Detailed summary
- Changed the grep command from `grep -q "ID=openSUSE"` to `grep -iq "ID=opensuse"` for case-insensitive matching.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->