### PR TITLE
docs: Correct post commands typos and spelling errors

### DIFF
--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -382,7 +382,7 @@ describe("SyncEngine", () => {
     const result = await syncEngine.mergeMessages([castAdd], rpcClient);
     expect(result.successCount).toEqual(1);
 
-    // Should sync should return true becuase the excluded hashes don't match
+    // Should sync should return true because the excluded hashes don't match
     expect(oldSnapshot.excludedHashes).not.toEqual((await syncEngine.getSnapshot())._unsafeUnwrap().excludedHashes);
     expect((await syncEngine.syncStatus("test", oldSnapshot))._unsafeUnwrap().shouldSync).toBeTruthy();
 


### PR DESCRIPTION
## Why is this change needed?

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a typo in the comment of the `syncEngine.test.ts` file and ensuring that the test expectations regarding the synchronization functionality are clearly articulated.

### Detailed summary
- Corrected the typo in the comment from "becuase" to "because".
- Confirmed that the `result.successCount` is expected to equal `1`.
- Verified that `oldSnapshot.excludedHashes` does not equal the excluded hashes from the new snapshot.
- Checked that the `shouldSync` status from `syncEngine.syncStatus` is truthy.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->