### PR TITLE
fix: Correct variable/property name spelling

### DIFF
--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -891,7 +891,7 @@ export class Hub implements HubInterface {
       this.options.allowlistedImmunePeers,
       this.options.strictContactInfoValidation,
       this.options.strictNoSign,
-      this.engine.solanaVerficationsEnabled,
+      this.engine.solanaVerificationsEnabled,
       this.options.useStreaming,
     );
 

--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -382,7 +382,7 @@ describe("SyncEngine", () => {
     const result = await syncEngine.mergeMessages([castAdd], rpcClient);
     expect(result.successCount).toEqual(1);
 
-    // Should sync should return true becuase the excluded hashes don't match
+    // Should sync should return true because the excluded hashes don't match
     expect(oldSnapshot.excludedHashes).not.toEqual((await syncEngine.getSnapshot())._unsafeUnwrap().excludedHashes);
     expect((await syncEngine.syncStatus("test", oldSnapshot))._unsafeUnwrap().shouldSync).toBeTruthy();
 

--- a/apps/hubble/src/profile/gossipProfile.ts
+++ b/apps/hubble/src/profile/gossipProfile.ts
@@ -9,7 +9,7 @@ export enum ProfileWorkerAction {
   WaitForMessages = 3,
   Stop = 4,
   GetMultiAddres = 5,
-  ConnectToMutliAddr = 6,
+  ConnectToMultiAddr = 6,
   ReportPeers = 7,
 }
 
@@ -104,7 +104,7 @@ export async function profileGossipServer(nodeConfig = "3:10") {
     const workerResponse = await callWorkerMethod(workers[i - 1] as Worker, ProfileWorkerAction.GetMultiAddres);
     const prevMultiAddrs = workerResponse.response as MultiAddrResponse;
 
-    await callWorkerMethod(workers[i] as Worker, ProfileWorkerAction.ConnectToMutliAddr, {
+    await callWorkerMethod(workers[i] as Worker, ProfileWorkerAction.ConnectToMultiAddr, {
       multiAddr: prevMultiAddrs?.multiAddrs ?? [],
     });
 

--- a/apps/hubble/src/profile/gossipProfileWorker.ts
+++ b/apps/hubble/src/profile/gossipProfileWorker.ts
@@ -34,7 +34,7 @@ parentPort?.on("message", (data) => {
     } else if (action === ProfileWorkerAction.GetMultiAddres) {
       const response = getMultiAddrs();
       parentPort?.postMessage({ id, action, response });
-    } else if (action === ProfileWorkerAction.ConnectToMutliAddr) {
+    } else if (action === ProfileWorkerAction.ConnectToMultiAddr) {
       const { multiAddr } = args as ConnectToMultiAddrArgs;
       connectToMultiAddr(multiAddr);
 

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -148,7 +148,7 @@ class Engine extends TypedEmitter<EngineEvents> {
 
   private _totalPruneSize: number;
 
-  private _solanaVerficationsEnabled = false;
+  private _solanaVerificationsEnabled = false;
 
   private _fNameRetryRateLimiter = new RateLimiterMemory({ points: 60, duration: 60 }); // 60 retries per minute allowed
 
@@ -272,13 +272,13 @@ class Engine extends TypedEmitter<EngineEvents> {
     this._onchainEventsStore.clearCaches();
   }
 
-  get solanaVerficationsEnabled(): boolean {
-    return this._solanaVerficationsEnabled;
+  get solanaVerificationsEnabled(): boolean {
+    return this._solanaVerificationsEnabled;
   }
 
   setSolanaVerifications(enabled: boolean) {
-    if (this._solanaVerficationsEnabled !== enabled) {
-      this._solanaVerficationsEnabled = enabled;
+    if (this._solanaVerificationsEnabled !== enabled) {
+      this._solanaVerificationsEnabled = enabled;
       logger.info(`Solana verifications toggled to: ${enabled}`);
     }
   }
@@ -1317,7 +1317,7 @@ class Engine extends TypedEmitter<EngineEvents> {
       isVerificationAddAddressMessage(message) &&
       message.data.verificationAddAddressBody.protocol === Protocol.SOLANA
     ) {
-      if (!this._solanaVerficationsEnabled) {
+      if (!this._solanaVerificationsEnabled) {
         return err(new HubError("bad_request.validation_failure", "solana verifications are not enabled"));
       }
     }

--- a/apps/hubble/src/storage/stores/rustStoreBase.ts
+++ b/apps/hubble/src/storage/stores/rustStoreBase.ts
@@ -116,7 +116,7 @@ export abstract class RustStoreBase<TAdd extends Message, TRemove extends Messag
         mergeResults.set(i, err(result.error));
       } else {
         const hubEvent = HubEvent.decode(new Uint8Array(result.value));
-        void this._eventHandler.processRustCommitedTransaction(hubEvent);
+        void this._eventHandler.processRustCommittedTransaction(hubEvent);
         mergeResults.set(i, ok(hubEvent.id));
       }
     }
@@ -148,7 +148,7 @@ export abstract class RustStoreBase<TAdd extends Message, TRemove extends Messag
     const resultBytes = new Uint8Array(result.value);
     const hubEvent = HubEvent.decode(resultBytes);
 
-    void this._eventHandler.processRustCommitedTransaction(hubEvent);
+    void this._eventHandler.processRustCommittedTransaction(hubEvent);
     return hubEvent.id;
   }
 
@@ -162,7 +162,7 @@ export abstract class RustStoreBase<TAdd extends Message, TRemove extends Messag
     const resultBytes = new Uint8Array(result.value);
     const hubEvent = HubEvent.decode(resultBytes);
 
-    void this._eventHandler.processRustCommitedTransaction(hubEvent);
+    void this._eventHandler.processRustCommittedTransaction(hubEvent);
     return ok(hubEvent.id);
   }
 
@@ -201,7 +201,7 @@ export abstract class RustStoreBase<TAdd extends Message, TRemove extends Messag
     for (const resultBytes of result.value) {
       const hubEvent = HubEvent.decode(new Uint8Array(resultBytes));
       commits.push(hubEvent.id);
-      void this._eventHandler.processRustCommitedTransaction(hubEvent);
+      void this._eventHandler.processRustCommittedTransaction(hubEvent);
     }
 
     return ok(commits);

--- a/apps/hubble/src/storage/stores/storeEventHandler.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.ts
@@ -381,7 +381,7 @@ class StoreEventHandler extends TypedEmitter<StoreEvents> {
       });
   }
 
-  async processRustCommitedTransaction(event: HubEvent): HubAsyncResult<void> {
+  async processRustCommittedTransaction(event: HubEvent): HubAsyncResult<void> {
     void this._storageCache.processEvent(event);
     void this.broadcastEvent(event);
     return ok(undefined);

--- a/apps/hubble/src/storage/stores/userDataStore.ts
+++ b/apps/hubble/src/storage/stores/userDataStore.ts
@@ -109,7 +109,7 @@ class UserDataStore extends RustStoreBase<UserDataAddMessage, never> {
     const resultBytes = new Uint8Array(result.value);
     const hubEvent = HubEvent.decode(resultBytes);
 
-    void this._eventHandler.processRustCommitedTransaction(hubEvent);
+    void this._eventHandler.processRustCommittedTransaction(hubEvent);
     return hubEvent.id;
   }
 }


### PR DESCRIPTION
## Why is this change needed?

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on correcting typos related to `solanaVerificationsEnabled` and `processRustCommittedTransaction` across multiple files, ensuring consistency in naming conventions and improving code readability.

### Detailed summary
- Fixed typo: `solanaVerficationsEnabled` to `solanaVerificationsEnabled` in `hubble.ts`, `index.ts`.
- Corrected `processRustCommitedTransaction` to `processRustCommittedTransaction` in `userDataStore.ts`, `storeEventHandler.ts`, `rustStoreBase.ts`.
- Updated `ConnectToMutliAddr` to `ConnectToMultiAddr` in `gossipProfileWorker.ts`, `gossipProfile.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->