### PR TITLE
documentation(hub-web): Added getFnameFromFid to readme

### DIFF
--- a/packages/hub-web/README.md
+++ b/packages/hub-web/README.md
@@ -40,6 +40,27 @@ try {
 }
 ```
 
+### Get the username by FID
+
+```typescript
+const getFnameFromFid = async (
+  fid: number,
+  client: HubRpcClient
+): HubAsyncResult<string> => {
+  const result = await client.getUserData({
+    fid: fid,
+    userDataType: UserDataType.FNAME,
+  });
+  return result.map((message) => {
+    if (isUserDataAddMessage(message)) {
+      return message.data.userDataBody.value;
+    } else {
+      return '';
+    }
+  });
+};
+```
+
 ### Running the examples
 
 There are several examples in the `examples/` folder. To run the examples, please look at the individual README files in the examples directory. Most examples can be run by


### PR DESCRIPTION
## Why is this change needed?

Since changes were requested in docs (https://github.com/farcasterxyz/docs/issues/54), I have made a PR to update Farcaster's docs (https://github.com/farcasterxyz/docs/pull/356), thus decided to update the readme file.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new function for retrieving a user's first name using their FID from the `HubRpcClient`.

### Detailed summary
- Introduced a new function `getFnameFromFid`.
- The function takes `fid` (number) and `client` (`HubRpcClient`) as parameters.
- It retrieves user data of type `UserDataType.FNAME`.
- Returns the user's first name or an empty string if not found.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->