### PR TITLE
docs: Update 5.fnameSyncIds.test.ts file

### DIFF
--- a/apps/hubble/src/storage/db/migrations/5.fnameSyncIds.test.ts
+++ b/apps/hubble/src/storage/db/migrations/5.fnameSyncIds.test.ts
@@ -13,7 +13,7 @@ const TEST_TIMEOUT_LONG = 10_000;
 
 describe("fnameSyncIds migration", () => {
   test(
-    "should delete unpaddded fname syncIds",
+    "should delete unpadded fname syncIds",
     async () => {
       const syncTrie = new MerkleTrie(db);
       const trieDb = syncTrie.getDb();


### PR DESCRIPTION
## Why is this change needed?

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a typo in the test description for the `fnameSyncIds` migration.

### Detailed summary
- Changed the test description from `"should delete unpaddded fname syncIds"` to `"should delete unpadded fname syncIds"` in the file `apps/hubble/src/storage/db/migrations/5.fnameSyncIds.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->