### PR TITLE
Correcting Invalid Links with Valid URLs

### DIFF
--- a/packages/hub-nodejs/docs/signers/EthersEip712Signer.md
+++ b/packages/hub-nodejs/docs/signers/EthersEip712Signer.md
@@ -1,6 +1,6 @@
 # EthersEip712Signer
 
-An Eip712Signer that is initialized with an [Ethers v6](https://github.com/ethers-io/ethers.js/) Ethereum wallet and can be used with [Builders](../builders/builders.md) to sign Farcaster Messages. If you're looking for Ethers v5 support, see [this troubleshooting guide](../README.md#ethers-v5).
+An Eip712Signer that is initialized with an [Ethers v6](https://github.com/ethers-io/ethers.js/) Ethereum wallet and can be used with [Builders](https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/hub-nodejs/docs/Builders.md) to sign Farcaster Messages. If you're looking for Ethers v5 support, see [this troubleshooting guide](../README.md#ethers-v5).
 
 ## Properties
 

--- a/packages/hub-nodejs/docs/signers/EthersV5Eip712Signer.md
+++ b/packages/hub-nodejs/docs/signers/EthersV5Eip712Signer.md
@@ -1,6 +1,6 @@
 # EthersV5Eip712Signer
 
-An Eip712Signer that is initialized with an [Ethers v5](https://github.com/ethers-io/ethers.js/tree/v5) Ethereum wallet and can be used with [Builders](../builders/builders.md) to sign Farcaster Messages.
+An Eip712Signer that is initialized with an [Ethers v5](https://github.com/ethers-io/ethers.js/tree/v5) Ethereum wallet and can be used with [Builders](https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/hub-nodejs/docs/Builders.md) to sign Farcaster Messages.
 
 ## Properties
 

--- a/packages/hub-nodejs/docs/signers/NobleEd25519Signer.md
+++ b/packages/hub-nodejs/docs/signers/NobleEd25519Signer.md
@@ -1,6 +1,6 @@
 # NobleEd25519Signer
 
-An Ed25519Signer that is initialized with an Ed25519 key pair and can be used with [Builders](../builders/builders.md) to sign Farcaster Messages.
+An Ed25519Signer that is initialized with an Ed25519 key pair and can be used with [Builders](https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/hub-nodejs/docs/Builders.md) to sign Farcaster Messages.
 
 ## Properties
 

--- a/packages/hub-nodejs/docs/signers/ViemLocalEip712Signer.md
+++ b/packages/hub-nodejs/docs/signers/ViemLocalEip712Signer.md
@@ -1,6 +1,6 @@
 # ViemLocalEip712Signer
 
-An Eip712Signer that is initialized with an [Viem](https://viem.sh/docs/getting-started) LocalACcount and can be used with [Builders](../builders/builders.md) to sign Farcaster Messages.
+An Eip712Signer that is initialized with an [Viem](https://viem.sh/docs/getting-started) LocalACcount and can be used with [Builders](https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/hub-nodejs/docs/Builders.md) to sign Farcaster Messages.
 
 ## Properties
 


### PR DESCRIPTION
### Replacing not working links to working
**Before:**
![image](https://github.com/user-attachments/assets/60a60f28-f3b4-42d1-abf8-c881adb83a05)

**After:**
![image](https://github.com/user-attachments/assets/c157433b-d975-4c63-a17e-a2100fe832db)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation for several signers in the `hub-nodejs` package, specifically changing the links to the `Builders` documentation from relative URLs to absolute URLs.

### Detailed summary
- Updated link to `Builders` documentation in `NobleEd25519Signer.md`
- Updated link to `Builders` documentation in `ViemLocalEip712Signer.md`
- Updated link to `Builders` documentation in `EthersV5Eip712Signer.md`
- Updated link to `Builders` documentation in `EthersEip712Signer.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->