### PR TITLE
Fix Typo in Installation Instructions

### DIFF
--- a/apps/hubble/www/docs/intro/install.md
+++ b/apps/hubble/www/docs/intro/install.md
@@ -117,7 +117,7 @@ First, ensure that the following are installed globally on your machine:
 #### Running Hubble
 To run the Hubble commands, go to the Hubble app (`cd apps/hubble`) and run the `yarn` commands.
 
-1. `yarn identity create` to create a ID
+1. `yarn identity create` to create an ID
 2. Follow the instructions to set [connect to a network](./networks.md)
 3. `yarn start --eth-mainnet-rpc-url <your ETH-mainnet-RPC-URL> --l2-rpc-url <your Optimism-L2-RPC-URL> --hub-operator-fid <your FID>`
 


### PR DESCRIPTION
This PR addresses a typo in the installation instructions for setting up Hubble. The word "ID" was incorrectly written as "Id", and this change ensures consistency with the rest of the documentation. The updated line now correctly reflects the intended meaning.

## Merge Checklist

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the installation instructions for the Hubble app, specifically clarifying the creation of an ID.

### Detailed summary
- Changed "create a ID" to "create an ID" for grammatical accuracy.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->