### PR TITLE
fix: Fix compatibility issue with replaceAll for older Node.js versio…

### DIFF
--- a/apps/hubble/scripts/grafanadash.cjs
+++ b/apps/hubble/scripts/grafanadash.cjs
@@ -20,7 +20,7 @@ module.exports = function grafana() {
       lineNumber++;
 
       // Check if the current line contains the undesired datasource entry
-      if (line.includes('"datasource":') && !line.replaceAll(" ", "").includes('"datasource":"Graphite"')) {
+      if (line.includes('"datasource":') && !line.replace(/ /g, "").includes('"datasource":"Graphite"')) {
         return lineNumber;
       }
     }


### PR DESCRIPTION
## Why is this change needed?

In the previous implementation, the `replaceAll` method was used, which was introduced in ECMAScript 2021. This causes compatibility issues in older versions of Node.js or other environments that do not support this method.

To ensure broader compatibility, I have replaced `replaceAll(" ", "")` with `replace(/ /g, "")`, which uses regular expressions and works in older environments.

This change should resolve any issues for users running on older versions of Node.js or environments that do not support `replaceAll`. 

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the way whitespace is removed from the `line` variable when checking for the undesired datasource entry. It changes the method used to replace spaces in the `line`.

### Detailed summary
- Replaced `line.replaceAll(" ", "")` with `line.replace(/ /g, "")` to remove spaces from the `line` variable.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->