### PR TITLE
Avoiding conflict with reserved keyword type in Rust

### DIFF
--- a/packages/hub-web/examples/rust-submitmessage/src/message.rs
+++ b/packages/hub-web/examples/rust-submitmessage/src/message.rs
@@ -3523,7 +3523,7 @@ impl ::protobuf::reflect::ProtobufValue for VerificationRemoveBody {
 #[derive(PartialEq,Clone,Default)]
 pub struct LinkBody {
     // message fields
-    pub field_type: ::std::string::String,
+    pub type: ::std::string::String,
     pub displayTimestamp: u32,
     // message oneof groups
     pub target: ::std::option::Option<LinkBody_oneof_target>,


### PR DESCRIPTION
Renaming the field from `field_type` to `type` in this context causes a conflict with the reserved keyword `type` in Rust. Using `field_type` instead of `type` is the correct solution as it prevents a compilation error and adheres to the language rules.
