### PR TITLE
Fix incorrect type reference and enum value in Events.md

### DIFF
--- a/packages/hub-nodejs/docs/Events.md
+++ b/packages/hub-nodejs/docs/Events.md
@@ -75,7 +75,7 @@ Emit when an onchain event occurs in the IdRegistry which registers or transfers
 | logIndex        | `number`                    | The log index of the event in the transaction.           |
 | to              | `Uint8Array`                | The address which now owns the fid.                      |
 | transactionHash | `Uint8Array`                | The hash of the transaction in which the event occurred. |
-| type            | [`NameRegistryEventType`]() | The type of event which occurred.                        |
+| type            | [`IdRegistryEventType`](#idregistryeventtype) | The type of event which occurred.                        |
 
 ### NameRegistryEvent
 
@@ -122,4 +122,4 @@ The Farcaster network that will accept the message.
 | --------------------------------- | ------ | ----------------------------------- |
 | NAME_REGISTRY_EVENT_TYPE_NONE     | 0      |                                     |
 | NAME_REGISTRY_EVENT_TYPE_TRANSFER | 1      | An fname was minted or transferred. |
-| NAME_REGISTRY_EVENT_TYPE_RENEW    | 1      | An fname was renewed.               |
+| NAME_REGISTRY_EVENT_TYPE_RENEW    | 2      | An fname was renewed.               |


### PR DESCRIPTION

Changes in packages/hub-nodejs/docs/Events.md:

1. Fixed IdRegistryEvent type reference:
- Old: [`NameRegistryEventType`]()
- New: [`IdRegistryEventType`](#idregistryeventtype)

2. Fixed NameRegistryEventType enum value:
- Changed NAME_REGISTRY_EVENT_TYPE_RENEW from 1 to 2

Why:
- Corrects incorrect type reference for proper documentation linking
- Fixes duplicate enum value to maintain proper enumeration consistency


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation for events related to the Farcaster network, specifically changing event types and correcting the associated values in the `NameRegistryEvent` section.

### Detailed summary
- Changed the type of event from `NameRegistryEventType` to `IdRegistryEventType`.
- Updated the value for `NAME_REGISTRY_EVENT_TYPE_RENEW` from `1` to `2`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->