### PR TITLE
Fix typos

### DIFF
--- a/apps/hubble/src/test/e2e/gossipNetworkBundle.test.ts
+++ b/apps/hubble/src/test/e2e/gossipNetworkBundle.test.ts
@@ -102,7 +102,7 @@ describe("gossip network with bundle tests", () => {
       expect(duplicatePublishResult.isErr()).toBeTruthy();
       expect(duplicatePublishResult._unsafeUnwrapErr().errCode).toBe("bad_request.duplicate");
 
-      // Gossiping a invalid bundle will succeed, beacuse the broadcast will succeed but each individual node
+      // Gossiping an invalid bundle will succeed, beacuse the broadcast will succeed but each individual node
       // will report it as invalid, and it will not spread through the network
       const invalidPublishResult = await randomNode.gossipBundle(invalidBundle);
       expect(invalidPublishResult.isOk()).toBeTruthy();

--- a/apps/hubble/src/test/e2e/gossipNetworkMessageToBundle.test.ts
+++ b/apps/hubble/src/test/e2e/gossipNetworkMessageToBundle.test.ts
@@ -32,7 +32,7 @@ describe("gossip network with bundle tests", () => {
   }, TEST_TIMEOUT_SHORT);
 
   test(
-    "broadcast a individual messages that get bundled via gossip to other nodes",
+    "broadcast an individual messages that get bundled via gossip to other nodes",
     async () => {
       // Connect the first node to every other node by dialing them manually
       for (const n of nodes.slice(1)) {


### PR DESCRIPTION
This change fixes grammatical errors in comments within test files `gossipNetworkBundle.test.ts` and `gossipNetworkMessageToBundle.test.ts`. 
Specifically, the incorrect use of the article "a" was replaced with "an" before words starting with vowel sounds ("invalid" and "individual").  

This update improves code readability and aligns with proper English grammar standards.  

## Merge Checklist  
- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard  
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)  
- [ ] PR has been tagged with a change label(s) (i.e., documentation, feature, bugfix, or chore)  
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary  

This is a minor but essential fix to ensure consistency and professionalism in project documentation.  

### Edits Summary  
- Changed `a invalid` to `an invalid` in `gossipNetworkBundle.test.ts`  
- Changed `a individual` to `an individual` in `gossipNetworkMessageToBundle.test.ts`  


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting minor typographical errors in the test descriptions within two test files related to the gossip network functionality.

### Detailed summary
- In `gossipNetworkMessageToBundle.test.ts`, changed "broadcast a individual messages" to "broadcast an individual messages".
- In `gossipNetworkBundle.test.ts`, changed "Gossiping a invalid bundle" to "Gossiping an invalid bundle".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->