### PR TITLE
chore: fix duplicate  errors.ts

### DIFF
--- a/apps/hubble/www/docs/intro/monitoring.md
+++ b/apps/hubble/www/docs/intro/monitoring.md
@@ -30,4 +30,4 @@ yarn start --statsd-metrics-server 127.0.0.1:8125
 
 ## Troubleshooting
 
-- Make sure that the `grafana/data` directory is writeable to all users. 
+- Make sure that the `grafana/data` directory is writable to all users. 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -23,7 +23,7 @@ export class HubError extends Error {
   /* Hub classification of error types */
   public readonly errCode: HubErrorCode;
 
-  /* Indicates if if error message can be presented to the user */
+  /* Indicates if error message can be presented to the user */
   public readonly presentable: boolean = false;
 
   /**


### PR DESCRIPTION
Duplicate "if" in error message description.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving documentation clarity and correcting a comment in the codebase. 

### Detailed summary
- Updated the wording in `monitoring.md` to change "writeable" to "writable".
- Corrected a comment in `errors.ts` by removing the redundant "if" in "if if error message".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->