### PR TITLE
replace castWithEmojiLinkAttachmnent - castWithEmojiLinkAttachment  index.ts

### DIFF
--- a/packages/hub-nodejs/examples/write-data/index.ts
+++ b/packages/hub-nodejs/examples/write-data/index.ts
@@ -165,7 +165,7 @@ const NETWORK = FarcasterNetwork.TESTNET; // Network of the Hub
    * "🤓https://url-after-unicode.com can include URL immediately after emoji"
    */
 
-  const castWithEmojiLinkAttachmnent = await makeCastAdd(
+  const castWithEmojiLinkAttachment = await makeCastAdd(
     {
       text: "🤓https://url-after-unicode.com can include URL immediately after emoji",
       embeds: [{ url: "https://url-after-unicode.com" }],
@@ -176,7 +176,7 @@ const NETWORK = FarcasterNetwork.TESTNET; // Network of the Hub
     dataOptions,
     ed25519Signer,
   );
-  castResults.push(castWithEmojiLinkAttachmnent);
+  castResults.push(castWithEmojiLinkAttachment);
 
   /**
    * Example 7: A cast that replies to a URL


### PR DESCRIPTION
I reviewed the entire repository, no more typos found in docs. 
Hope this helps streamline the project!
Best regards,
Bilogweb3


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a typo in the variable name from `castWithEmojiLinkAttachmnent` to `castWithEmojiLinkAttachment` in the `packages/hub-nodejs/examples/write-data/index.ts` file, ensuring consistency and clarity in the code.

### Detailed summary
- Changed variable name from `castWithEmojiLinkAttachmnent` to `castWithEmojiLinkAttachment` for consistency.
- Updated the corresponding push to `castResults` to reflect the corrected variable name.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->