### PR TITLE
fix: multiple typos of different importance

### DIFF
--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -1652,7 +1652,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     // If the hashes match, we do not need to do any work
     if (ourNode && ourNode.hash === theirNode.hash) return;
 
-    // If there are no messages to fetch, don't enque the work item
+    // If there are no messages to fetch, don't enqueue the work item
     if (theirNode.numMessages === 0) return;
 
     // Don't let the queue grow too large
@@ -1696,7 +1696,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
       // Replace the work queue with only the items that are not completed
       runningWorkItems = newRunningWorkItems;
 
-      // If there is an oppurtunity to do more work, we will do it
+      // If there is an opportunity to do more work, we will do it
       if (this.curSync.executingWorkCount < syncParallelism) {
         const n = Math.max(0, syncParallelism - this.curSync.executingWorkCount);
 
@@ -1766,7 +1766,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
               (c) => c.peerId !== this.curSync.peerId,
             );
 
-            // If none left, then interrupt the sync
+            // If none are left, then interrupt the sync
             if (this.curSync.secondaryRpcClients.length === 0) {
               this.curSync.interruptSync = true;
               log.warn("Perform Sync: PeerError: No more secondary peers, interrupting sync");
@@ -1789,7 +1789,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
           await this.getMessagesFromOtherNode(workItem, theirNode.numMessages);
         }
 
-        // Recurse into the children to to schedule the next set of work. Note that we didn't after  the
+        // Recurse into the children to schedule the next set of work. Note that we didn't after  the
         // `getMessagesFromOtherNode` above. This is because even after we get messages from the other node,
         // there still might be left over messages at this node (if, for eg., there are > 10k messages, and the
         // other node only sent 1k messages).

--- a/apps/hubble/src/network/utils/networkConfig.ts
+++ b/apps/hubble/src/network/utils/networkConfig.ts
@@ -118,7 +118,7 @@ export function applyNetworkConfig(
 
   if (semver.valid(minAppVersion)) {
     if (semver.lt(APP_VERSION, minAppVersion)) {
-      const errMsg = "Hubble version is too old too start. Please update your node.";
+      const errMsg = "Hubble version is too old to start. Please update your node.";
       log.fatal({ minAppVersion, ourVersion: APP_VERSION }, errMsg);
       return {
         allowedPeerIds,

--- a/apps/hubble/src/profile/gossipProfileWorker.ts
+++ b/apps/hubble/src/profile/gossipProfileWorker.ts
@@ -141,7 +141,7 @@ class GossipTestNode {
   }
 
   async start() {
-    // Override the peer score threholds. When running benchmark tests, we want to accept all messages
+    // Override the peer score thresholds. When running benchmark tests, we want to accept all messages
     // and not unnecessarily graylist peers (which libp2p does since all the connections appear to come
     // from the same IP)
     await this.gossipNode.start([], {

--- a/apps/hubble/src/storage/db/types.ts
+++ b/apps/hubble/src/storage/db/types.ts
@@ -56,7 +56,7 @@ export enum RootPrefix {
   // Deprecated, DO NOT USE
   // GossipMetrics = 18,
 
-  /* Used to index user submited username proofs */
+  /* Used to index user submitted username proofs */
   UserNameProofByName = 19,
 
   // Deprecated


### PR DESCRIPTION
# Pull Request Description

## Why is this change needed?

This change fixes multiple typos across the codebase to improve code clarity and maintain consistency. Correcting these typos ensures better readability and reduces potential misunderstandings or errors caused by ambiguous comments or messages. 

**Relevant issues:** None linked.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets).
- [x] PR has been tagged with a change label (bugfix).
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

## Notes for Reviewers

This PR contains changes in 4 files with 7 additions and 7 deletions. All changes are strictly typo corrections in comments and error messages. No functional code was altered.

### Changed Files:
1. `apps/hubble/src/network/sync/syncEngine.ts`:
   - Fixed typos in comments: "enque" -> "enqueue", "oppurtunity" -> "opportunity", etc.
2. `apps/hubble/src/network/utils/networkConfig.ts`:
   - Corrected "too old too start" -> "too old to start."
3. `apps/hubble/src/profile/gossipProfileWorker.ts`:
   - Adjusted "threholds" -> "thresholds."
4. `apps/hubble/src/storage/db/types.ts`:
   - Fixed "user submited" -> "user submitted."

All changes are cosmetic and aim to enhance code maintainability.

Thank you for reviewing this PR!


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting typos and improving code comments across multiple files in the `hubble` application, enhancing code clarity and readability.

### Detailed summary
- Fixed typo in comment: `submited` to `submitted` in `apps/hubble/src/storage/db/types.ts`.
- Corrected "too old too start" to "too old to start" in `apps/hubble/src/network/utils/networkConfig.ts`.
- Changed `threholds` to `thresholds` in `apps/hubble/src/profile/gossipProfileWorker.ts`.
- Updated "enque" to "enqueue" in `apps/hubble/src/network/sync/syncEngine.ts`.
- Corrected `oppurtunity` to `opportunity` in `apps/hubble/src/network/sync/syncEngine.ts`.
- Changed "none left" to "none are left" in `apps/hubble/src/network/sync/syncEngine.ts`.
- Fixed "to to schedule" to "to schedule" in `apps/hubble/src/network/sync/syncEngine.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->