### PR TITLE
docs: typo fix Update publish-image.sh

### DIFF
--- a/scripts/publish-image.sh
+++ b/scripts/publish-image.sh
@@ -5,7 +5,7 @@
 #
 # MUST be run from the root of the repository so the Docker build context is correct.
 #
-# You must `docker login ...` first so that we have the necessary permissions to
+# You must `docker login ...` first so that we have the necessary permission to
 # push the image layers + tags to Docker Hub.
 
 HUBBLE_VERSION=$(node -e "console.log(require('./apps/hubble/package.json').version);")


### PR DESCRIPTION
## Why is this change needed?

The word "permissions" is used in plural form. However, it would be more accurate to use "**permission**" in singular, as it typically refers to general access rather than multiple specific rights in this context.

## Merge Checklist

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting the grammatical error in the comments of the `scripts/publish-image.sh` file regarding permissions for Docker login.

### Detailed summary
- Changed "necessary permissions" to "necessary permission" in the comment about Docker login.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->