### PR TITLE
Fixed typos and improved clarity in documentation

### DIFF
--- a/packages/core/src/limits.test.ts
+++ b/packages/core/src/limits.test.ts
@@ -24,7 +24,7 @@ describe("getDefaultStoreLimit", () => {
 });
 
 describe("getStoreLimit", () => {
-  test("returns correct limits for multiple unit typos", () => {
+  test("returns correct limits for multiple unit types", () => {
     // single unit type
     expect(getStoreLimit(StoreType.CASTS, [{ unitType: StorageUnitType.UNIT_TYPE_LEGACY, unitSize: 1 }])).toEqual(5000);
 

--- a/packages/hub-nodejs/docs/signers/ViemLocalEip712Signer.md
+++ b/packages/hub-nodejs/docs/signers/ViemLocalEip712Signer.md
@@ -1,6 +1,6 @@
 # ViemLocalEip712Signer
 
-An Eip712Signer that is initialized with an [Viem](https://viem.sh/docs/getting-started) LocalACcount and can be used with [Builders](https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/hub-nodejs/docs/Builders.md) to sign Farcaster Messages.
+An Eip712Signer that is initialized with an [Viem](https://viem.sh/docs/getting-started) LocalAccount and can be used with [Builders](https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/hub-nodejs/docs/Builders.md) to sign Farcaster Messages.
 
 ## Properties
 


### PR DESCRIPTION
Changes made:

typos - types ( Correcting a typo to the intended word)
LocalACcount - LocalAccount (Fixing the capitalization error to match the proper format)



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting typos in test descriptions and documentation related to the `getStoreLimit` function and the `Eip712Signer` class.

### Detailed summary
- Changed the test description from "multiple unit typos" to "multiple unit types" in `packages/core/src/limits.test.ts`.
- Corrected "LocalACcount" to "LocalAccount" in `packages/hub-nodejs/docs/signers/ViemLocalEip712Signer.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->