### PR TITLE
fix: typos in documentation files

### DIFF
--- a/apps/hubble/src/storage/db/types.ts
+++ b/apps/hubble/src/storage/db/types.ts
@@ -56,7 +56,7 @@ export enum RootPrefix {
   // Deprecated, DO NOT USE
   // GossipMetrics = 18,
 
-  /* Used to index user submited username proofs */
+  /* Used to index user submitted username proofs */
   UserNameProofByName = 19,
 
   // Deprecated

--- a/apps/hubble/src/storage/stores/storeEventHandler.test.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.test.ts
@@ -228,7 +228,7 @@ describe("getCurrentStorageUnitsForFid", () => {
     expect(slot.units).toEqual(newEvent.storageRentEventBody.units);
     const newUnitExpiration = toFarcasterTime((newEvent.blockTimestamp + 365 * 24 * 60 * 60) * 1000)._unsafeUnwrap();
 
-    // Invalidate at is resset to the new event's expiration (which comes first)
+    // Invalidate at is reset to the new event's expiration (which comes first)
     expect(slot.invalidateAt).toEqual(newUnitExpiration);
   });
 });

--- a/apps/hubble/src/test/e2e/gossipNetworkBundle.test.ts
+++ b/apps/hubble/src/test/e2e/gossipNetworkBundle.test.ts
@@ -102,7 +102,7 @@ describe("gossip network with bundle tests", () => {
       expect(duplicatePublishResult.isErr()).toBeTruthy();
       expect(duplicatePublishResult._unsafeUnwrapErr().errCode).toBe("bad_request.duplicate");
 
-      // Gossiping a invalid bundle will succeed, beacuse the broadcast will succeed but each individual node
+      // Gossiping a invalid bundle will succeed, because the broadcast will succeed but each individual node
       // will report it as invalid, and it will not spread through the network
       const invalidPublishResult = await randomNode.gossipBundle(invalidBundle);
       expect(invalidPublishResult.isOk()).toBeTruthy();


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `submited` to `submitted`
Corrected `resset` to `reset`
Corrected `beacuse` to `because`

Please review the changes and let me know if any additional changes are needed.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting typographical errors and improving comments throughout the codebase.

### Detailed summary
- Corrected "submited" to "submitted" in the comment for `UserNameProofByName`.
- Fixed "resset" to "reset" in the comment regarding expiration in `storeEventHandler.test.ts`.
- Changed "beacuse" to "because" in the comment about gossiping an invalid bundle in `gossipNetworkBundle.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->