### PR TITLE
Fix Typos in Documentation and Tests

### DIFF
--- a/apps/hubble/src/test/e2e/gossipNetworkBundle.test.ts
+++ b/apps/hubble/src/test/e2e/gossipNetworkBundle.test.ts
@@ -102,7 +102,7 @@ describe("gossip network with bundle tests", () => {
       expect(duplicatePublishResult.isErr()).toBeTruthy();
       expect(duplicatePublishResult._unsafeUnwrapErr().errCode).toBe("bad_request.duplicate");
 
-      // Gossiping a invalid bundle will succeed, beacuse the broadcast will succeed but each individual node
+      // Gossiping a invalid bundle will succeed, because the broadcast will succeed but each individual node
       // will report it as invalid, and it will not spread through the network
       const invalidPublishResult = await randomNode.gossipBundle(invalidBundle);
       expect(invalidPublishResult.isOk()).toBeTruthy();

--- a/packages/hub-nodejs/docs/signers/EthersV5Eip712Signer.md
+++ b/packages/hub-nodejs/docs/signers/EthersV5Eip712Signer.md
@@ -94,7 +94,7 @@ Generates a 256-bit signature for a VerificationClaim and returns the bytes.
 import { FarcasterNetwork, hexStringToBytes, makeVerificationEthAddressClaim } from '@farcaster/hub-nodejs';
 
 const blockHashHex = '0x1d3b0456c920eb503450c7efdcf9b5cf1f5184bf04e5d8ecbcead188a0d02018';
-const blockHashBytes = hexStringToBytes(blockHashHex)._unsafeUnwrap(); // Safety: blockHashHex is known and can't erro
+const blockHashBytes = hexStringToBytes(blockHashHex)._unsafeUnwrap(); // Safety: blockHashHex is known and can't error
 
 const ethereumAddressResult = await eip712Signer.getSignerKey();
 


### PR DESCRIPTION
# Fix Typos in Documentation and Tests

## Summary
This pull request addresses minor typos in the following files:
1. `apps/hubble/src/test/e2e/gossipNetworkBundle.test.ts`
2. `packages/hub-nodejs/docs/signers/EthersV5Eip712Signer.md`

## Changes Made
### 1. `gossipNetworkBundle.test.ts`
- Fixed a typo in the comment: 
  - From: "beacuse" 
  - To: "because"

### 2. `EthersV5Eip712Signer.md`
- Fixed a typo in the comment: 
  - From: "can't erro" 
  - To: "can't error"

## Testing
These changes only affect comments and do not impact the functionality of the code. No new tests were added as the code logic remains unchanged.

## Checklist
- [x] Followed the [contributing guidelines](link-to-guidelines).
- [x] Verified changes locally.
- [x] Added clear descriptions and comments.

---

Thank you for reviewing this PR! Let me know if there’s anything else to address.
