### PR TITLE
fix: Ensure we always have a minimum number of connected peers

### DIFF
--- a/.changeset/silent-crews-explain.md
+++ b/.changeset/silent-crews-explain.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Ensure we always have a minimum number of connected peers

--- a/apps/hubble/src/network/p2p/connectionFilter.ts
+++ b/apps/hubble/src/network/p2p/connectionFilter.ts
@@ -33,6 +33,10 @@ export class ConnectionFilter implements ConnectionGater {
     this.deniedPeers = addrs;
   }
 
+  addDeniedPeer(peerId: string) {
+    this.deniedPeers.push(peerId);
+  }
+
   denyDialPeer = async (peerId: PeerId): Promise<boolean> => {
     const deny = this.shouldDeny(peerId.toString());
     if (deny) {

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -244,7 +244,9 @@ export class LibP2PNode {
         ...(peerId && { peerId }),
         connectionGater: this._connectionGater,
         connectionManager: {
-          minConnections: 0,
+          // Set between the default DLo and DHi values. So we always have some connections, and not just the bootstrap peers.
+          // This is also helpful in case the node starts with a clean db, since the only explicit connections are to bootstrap peers and db peers.
+          minConnections: 7,
         },
         addresses: {
           listen: [listenMultiAddrStr],

--- a/apps/hubble/src/network/p2p/gossipNodeWorker.ts
+++ b/apps/hubble/src/network/p2p/gossipNodeWorker.ts
@@ -425,6 +425,8 @@ export class LibP2PNode {
   /** Removes the peer from the address book and hangs up on them */
   async removePeerFromAddressBook(peerId: PeerId) {
     if (this._node) {
+      // Add to the connection gater so the autodial doesn't reconnect. Not persisted on restart.
+      this._connectionGater?.addDeniedPeer(peerId.toString());
       const hangupResult = await ResultAsync.fromPromise(
         this._node.hangUp(peerId),
         (error) => new HubError("unavailable", error as Error),


### PR DESCRIPTION
## Why is this change needed?

In case the db didn't already have sufficient peers we wouldn't connect to enough peers because the autodial was disabled.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the peer-to-peer connection management in the `hubble` application by ensuring a minimum number of connected peers and adding functionality to manage denied peers.

### Detailed summary
- Updated `minConnections` from `0` to `7` in `connectionManager` for better connection stability.
- Introduced `addDeniedPeer(peerId: string)` method in `connectionFilter.ts` to manage denied peers.
- Added logic to prevent autodial reconnections for denied peers in `removePeerFromAddressBook`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->