### PR TITLE
Typo fix Update CHANGELOG.md

### DIFF
--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -574,7 +574,7 @@
 ### Patch Changes
 
 - 577d698d: fix: Remove score penalty for duplicate gossip messages
-- 57ce2c66: fix: reduce sync freqency to help reduce hub load
+- 57ce2c66: fix: reduce sync frequency to help reduce hub load
 
 ## 1.9.5
 


### PR DESCRIPTION
# Fix Typo in CHANGELOG.md

This pull request addresses a minor typo in the `CHANGELOG.md` file. Specifically:
- Corrected `freqency` to `frequency`.

No other changes were made, ensuring the content remains consistent and readable.

---

### Changes:
```diff
- fix: reduce sync freqency to help reduce hub load
+ fix: reduce sync frequency to help reduce hub load


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updates to the `CHANGELOG.md` file for version `1.9.5`, specifically addressing fixes related to the handling of gossip messages and synchronization frequency.

### Detailed summary
- Removed score penalty for duplicate gossip messages.
- Corrected the spelling of "frequency" in the note about reducing sync frequency to help reduce hub load.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->