### PR TITLE
Fix typo Update CHANGELOG.md

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -67,7 +67,7 @@
 
 ### Patch Changes
 
-- eacf29c9: fix: http endoint return not found instead of internal database error
+- eacf29c9: fix: http endpoint return not found instead of internal database error
 
 ## 0.14.16
 


### PR DESCRIPTION
# Fix Typo in CHANGELOG.md

## Summary of Changes
- Corrected a typo: "endoint" to "endpoint" in the `packages/core/CHANGELOG.md` file.

---

## Additional Notes
This is a minor documentation update and does not affect the functionality of the project.  
Please review and merge at your convenience. Thank you! 😊


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on a fix in the `http` endpoint's response behavior, ensuring it returns a "not found" status instead of an internal database error.

### Detailed summary
- Fixed the `http` endpoint to return "not found" instead of an internal database error.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->