### PR TITLE
Fix typo Update EthersV5Eip712Signer.md

### DIFF
--- a/packages/hub-nodejs/docs/signers/EthersV5Eip712Signer.md
+++ b/packages/hub-nodejs/docs/signers/EthersV5Eip712Signer.md
@@ -94,7 +94,7 @@ Generates a 256-bit signature for a VerificationClaim and returns the bytes.
 import { FarcasterNetwork, hexStringToBytes, makeVerificationEthAddressClaim } from '@farcaster/hub-nodejs';
 
 const blockHashHex = '0x1d3b0456c920eb503450c7efdcf9b5cf1f5184bf04e5d8ecbcead188a0d02018';
-const blockHashBytes = hexStringToBytes(blockHashHex)._unsafeUnwrap(); // Safety: blockHashHex is known and can't erro
+const blockHashBytes = hexStringToBytes(blockHashHex)._unsafeUnwrap(); // Safety: blockHashHex is known and can't error
 
 const ethereumAddressResult = await eip712Signer.getSignerKey();
 


### PR DESCRIPTION
# Pull Request Title
**Fix typo Update EthersV5Eip712Signer.md**

## Description
This PR fixes a typo in the `EthersV5Eip712Signer.md` file. The word "erro" has been corrected to "error."

### Changes:
- Corrected the typo: "erro" → "error" in the `EthersV5Eip712Signer.md` file.

## Related Issues
- #3456 (replace with relevant issue number, if applicable)

## How to Test
- Review the `EthersV5Eip712Signer.md` file to ensure the typo has been corrected.

## Checklist:
- [x] The code has been tested.
- [x] The documentation has been updated (if necessary).
- [x] I have followed the contributing guidelines.

## Notes:
- This is a minor fix and does not affect the functionality of the project.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on a minor code correction in the documentation for the `EthersV5Eip712Signer`. It specifically addresses a typo in a comment regarding the safety of the `blockHashHex` variable.

### Detailed summary
- Corrected the comment from "can't erro" to "can't error" for clarity on the safety of `blockHashHex`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->