### PR TITLE
Fix variable reference for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       # Log in so we can push the image layers + tags to Docker Hub
       - uses: docker/login-action@v2
         with:
-          username: ${{ secrets.FARCASTERXYZ_DOCKER_HUB_USER }}
+          username: ${{ vars.FARCASTERXYZ_DOCKER_HUB_USER }}
           password: ${{ secrets.FARCASTERXYZ_DOCKER_HUB_TOKEN }}
 
       - uses: depot/setup-action@v1


### PR DESCRIPTION
## Why is this change needed?

Due to a change in the visibility of the secret, our release process stopped working.

## Merge Checklist

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
