### PR TITLE
Fix typos

### DIFF
--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -176,7 +176,7 @@ export interface HubOptions {
   /** Farcaster network */
   network: FarcasterNetwork;
 
-  /** Wether to log individual submitMessage status */
+  /** Whether to log individual submitMessage status */
   logIndividualMessages?: boolean;
 
   /** The PeerId of this Hub */
@@ -1437,7 +1437,7 @@ export class Hub implements HubInterface {
         );
       }
       // If message is older than seenTTL, we will try to merge it, but report it as invalid so it doesn't
-      // propogate across the network
+      // propagate across the network
       const cutOffTime = getFarcasterTime().unwrapOr(0) - GOSSIP_SEEN_TTL / 1000;
 
       if (gossipMessage.timestamp < cutOffTime) {

--- a/apps/hubble/src/network/sync/merkleTrie.test.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.test.ts
@@ -163,7 +163,7 @@ describe("MerkleTrie", () => {
     });
 
     test(
-      "inserting multiple doesnt cause unload conflict",
+      "inserting multiple doesn't cause unload conflict",
       async () => {
         const syncIds = await NetworkFactories.SyncId.createList(500);
 

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -1675,7 +1675,7 @@ describe("Multi peer sync engine with rpcs", () => {
 
     const messageStats2 = (await syncHealthProbe.computeSyncHealthMessageStats(start, stop))._unsafeUnwrap();
 
-    // Query is inclusive of the start time and exclusive of the stop time. We cound 150, 170, 180 on engine1 and  150, 170 on engine 2
+    // Query is inclusive of the start time and exclusive of the stop time. We count 150, 170, 180 on engine1 and  150, 170 on engine 2
     expect(messageStats2.primaryNumMessages).toEqual(3);
     expect(messageStats2.peerNumMessages).toEqual(2);
 

--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -371,7 +371,7 @@ describe("SyncEngine", () => {
     expect((await syncEngine.syncStatus("test", oldSnapshot))._unsafeUnwrap().shouldSync).toBeTruthy();
   });
 
-  test("syncStatus.shouldSync is false if we didnt merge any messages successfully recently", async () => {
+  test("syncStatus.shouldSync is false if we didn't merge any messages successfully recently", async () => {
     await engine.mergeOnChainEvent(custodyEvent);
     await engine.mergeOnChainEvent(signerEvent);
     await engine.mergeOnChainEvent(storageEvent);

--- a/apps/hubble/src/storage/engine/index.test.ts
+++ b/apps/hubble/src/storage/engine/index.test.ts
@@ -63,7 +63,7 @@ const fNameProvider = new FNameRegistryEventsProvider(
     submitUserNameProof: (proof: UserNameProof) => engine.mergeUserNameProof(proof),
     getHubState: () => ResultAsync.fromSafePromise(Promise.resolve({ lastFnameProof: 0 })),
     putHubState: () => undefined,
-    // biome-ignore lint/suspicious/noExplicitAny: mock doesnt specify full interface
+    // biome-ignore lint/suspicious/noExplicitAny: mock doesn't specify full interface
   } as any,
   false,
 );
@@ -1102,7 +1102,7 @@ describe("mergeMessages", () => {
     expect(new Set(mergedMessages)).toEqual(new Set([castAdd, reactionAdd, linkAdd, userDataAdd, verificationAdd]));
   });
 
-  test("succeds with linkAdd and compaction messages", async () => {
+  test("succeeds with linkAdd and compaction messages", async () => {
     const linkCompactState = await Factories.LinkCompactStateMessage.create(
       {
         data: {

--- a/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/validateOrRevokeMessagesJob.ts
@@ -41,7 +41,7 @@ export class ValidateOrRevokeMessagesJobScheduler {
   private _cronTask?: cron.ScheduledTask;
   private _running = false;
 
-  // Wether to check all messages for fid%14 == new Date().getDate()%14
+  // Whether to check all messages for fid%14 == new Date().getDate()%14
   private _checkAllFids;
 
   constructor(db: RocksDB, engine: Engine, checkAllFids = true) {

--- a/apps/hubble/src/storage/stores/userDataStore.ts
+++ b/apps/hubble/src/storage/stores/userDataStore.ts
@@ -105,7 +105,7 @@ class UserDataStore extends RustStoreBase<UserDataAddMessage, never> {
       throw result.error;
     }
 
-    // Read the reuslt bytes as a HubEvent
+    // Read the result bytes as a HubEvent
     const resultBytes = new Uint8Array(result.value);
     const hubEvent = HubEvent.decode(resultBytes);
 

--- a/apps/hubble/src/utils/logger.ts
+++ b/apps/hubble/src/utils/logger.ts
@@ -59,7 +59,7 @@ class BufferedLogger {
   private buffering = false;
   private logger: Logger;
 
-  // Keep track of all worker thread loggers so we can propogate the flush event
+  // Keep track of all worker thread loggers so we can propagate the flush event
   private workerThreadLoggerCallbacks: (() => void)[] = [];
 
   constructor() {

--- a/apps/hubble/src/utils/lruCache.ts
+++ b/apps/hubble/src/utils/lruCache.ts
@@ -26,7 +26,7 @@ export class LRUCache<K, T> {
    * Get the value associated with the given key. If the key is not found in the cache, the
    * provided function is called to get the value.
    *
-   * If the get functon throws, the key is not added to the cache.
+   * If the get function throws, the key is not added to the cache.
    * and this function will throw the same error.
    *
    * @param key The key to lookup

--- a/apps/hubble/src/utils/syncHealth.ts
+++ b/apps/hubble/src/utils/syncHealth.ts
@@ -746,7 +746,7 @@ export const printSyncHealth = async (
         }
         peerRpcClient.close();
       } catch (err) {
-        console.log("Rasied while computing sync health", err);
+        console.log("Raised while computing sync health", err);
       }
     }
 

--- a/packages/hub-web/examples/rust-submitmessage/src/main.rs
+++ b/packages/hub-web/examples/rust-submitmessage/src/main.rs
@@ -35,7 +35,7 @@ async fn main() {
     msg_data.set_cast_add_body(cast_add);
 
     let msg_data_bytes = msg_data.write_to_bytes().unwrap();
-    // Calculate the blake3 hash, trucated to 20 bytes
+    // Calculate the blake3 hash, truncated to 20 bytes
     let hash = blake3::hash(&msg_data_bytes).as_bytes()[0..20].to_vec();
 
     // Construct the actual message


### PR DESCRIPTION
## Why is this change needed?

Fix some typos

## Changes:
- Fixed typo: `Rasied` to `Raised` in `syncHealth.ts`.
- Corrected `reuslt` to `result` in `userDataStore.ts`.
- Changed `doesnt` to `doesn't` in `merkleTrie.test.ts`.
- Fixed `propogate` to `propagate` in `logger.ts` and `hubble.ts`.
- Corrected `Wether` to `Whether` in `validateOrRevokeMessagesJob.ts` and `hubble.ts`.
- Fixed `trucated` to `truncated` in `main.rs`.
- Changed `cound` to `count` in `multiPeerSyncEngine.test.ts`.
- Corrected `succeds` to `succeeds` in `index.test.ts`.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting typos and improving comments throughout the codebase for better clarity and readability.

### Detailed summary
- Fixed typo: `Rasied` to `Raised` in `syncHealth.ts`.
- Corrected `reuslt` to `result` in `userDataStore.ts`.
- Changed `doesnt` to `doesn't` in `merkleTrie.test.ts`.
- Fixed `propogate` to `propagate` in `logger.ts` and `hubble.ts`.
- Corrected `Wether` to `Whether` in `validateOrRevokeMessagesJob.ts` and `hubble.ts`.
- Fixed `trucated` to `truncated` in `main.rs`.
- Changed `cound` to `count` in `multiPeerSyncEngine.test.ts`.
- Corrected `succeds` to `succeeds` in `index.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->