### PR TITLE
fix: update Node.js version and ID Register events

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -285,16 +285,16 @@ are at all unsure about how to proceed, please reach out to Varun ([Github](http
 1. Checkout a new branch and run `yarn changeset version`
 2. Review CHANGELOG.md and confirm that it is accurate
 3. Check that `package.json` was bumped correctly
-3. If the protocol version changes, bump `FARCASTER_VERSIONS_SCHEDULE` and  `FARCASTER_VERSION`
-4. Create commit, merge to main, check out commit on main and run `yarn build`
-5. Publish changes by running `yarn changeset publish`
-6. Fetch and update tags with `git fetch origin --tags && yarn changeset tag && git tag -f @latest`
-7. Delete the biome tags `git tag -d biome-config-custom@0.0.1`
-8. Push tags with `git push origin HEAD --tags -f`
-9. If docker build does not start `git push upstream --delete @farcaster/hubble@<version> && git push upstream --tags @farcaster/hubble@<version>` to re-trigger it.
-10. Create a GitHub Release for Hubble, copying over the changelog and marking it as the latest.
-11. If this is a non-patch change, create an NFT for the release.
-12. Make sure that the Docker image for the latest release gets built and published to [Docker hub](https://hub.docker.com/r/farcasterxyz/hubble/tags).
+4. If the protocol version changes, bump `FARCASTER_VERSIONS_SCHEDULE` and `FARCASTER_VERSION`
+5. Create commit, merge to main, check out commit on main and run `yarn build`
+6. Publish changes by running `yarn changeset publish`
+7. Fetch and update tags with `git fetch origin --tags && yarn changeset tag && git tag -f @latest`
+8. Delete the biome tags `git tag -d biome-config-custom@0.0.1`
+9. Push tags with `git push origin HEAD --tags -f`
+10. If docker build does not start `git push upstream --delete @farcaster/hubble@<version> && git push upstream --tags @farcaster/hubble@<version>` to re-trigger it.
+11. Create a GitHub Release for Hubble, copying over the changelog and marking it as the latest.
+12. If this is a non-patch change, create an NFT for the release.
+13. Make sure that the Docker image for the latest release gets built and published to [Docker hub](https://hub.docker.com/r/farcasterxyz/hubble/tags).
 
 ### 3.7 Working in Rust
 

--- a/Dockerfile.hubble
+++ b/Dockerfile.hubble
@@ -5,7 +5,7 @@
 ############## Stage 1: Create pruned version of monorepo #####################
 ###############################################################################
 
-FROM node:22.4.1-slim AS prune
+FROM node:20.4.1-slim AS prune
 
 USER node
 RUN mkdir /home/node/app
@@ -21,7 +21,7 @@ RUN /home/node/.yarn/bin/turbo prune --scope=@farcaster/hubble --docker
 ############## Stage 2: Build the code using a full node image ################
 ###############################################################################
 
-FROM node:22.4.1-slim AS build
+FROM node:20.4.1-slim AS build
 
 # Needed for compilation step
 RUN apt-get update && apt-get install -y cmake curl g++ libclang-dev linux-headers-generic make protobuf-compiler python3
@@ -64,7 +64,7 @@ RUN rm -rf node_modules && yarn install --production --ignore-scripts --prefer-o
 ########## Stage 3: Copy over the built code to a leaner alpine image #########
 ###############################################################################
 
-FROM node:22.4.1-slim as app
+FROM node:20.4.1-slim as app
 
 RUN apt-get update && apt-get install -y curl procps
 

--- a/apps/hubble/www/docs/docs/onchain_events.md
+++ b/apps/hubble/www/docs/docs/onchain_events.md
@@ -73,9 +73,9 @@
 | Name                                   | Number | Description |
 |----------------------------------------|--------|-------------|
 | ID_REGISTER_EVENT_TYPE_NONE            | 0      |             |
-| ID_REGISTER_EVENT_TYPE_REGISTER        | 0      |             |
-| ID_REGISTER_EVENT_TYPE_TRANSFER        | 0      |             |
-| ID_REGISTER_EVENT_TYPE_CHANGE_RECOVERY | 0      |             |
+| ID_REGISTER_EVENT_TYPE_REGISTER        | 1      |             |
+| ID_REGISTER_EVENT_TYPE_TRANSFER        | 2      |             |
+| ID_REGISTER_EVENT_TYPE_CHANGE_RECOVERY | 3      |             |
 
 <a name="-StorageRentEventBody"></a>
 ### StorageRentEventBody


### PR DESCRIPTION
## Changes Description
This PR includes the following changes:

1. Downgrade Node.js version from 22.4.1 to 20.4.1 in Dockerfile.hubble for all build stages
2. Fix ID Register event type numbering in documentation
3. Update release process in CONTRIBUTING.md

## Change Details

### Dockerfile.hubble
- Downgrade Node.js version from 22.4.1 to 20.4.1 for prune, build, and app stages

### onchain_events.md
- Fixed ID_REGISTER_EVENT_TYPE numbering:
  - REGISTER: from 0 to 1
  - TRANSFER: from 0 to 2
  - CHANGE_RECOVERY: from 0 to 3

### CONTRIBUTING.md
- Improved release steps list formatting
- Fixed documentation indentation

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `onchain_events.md` documentation and modifying the `Dockerfile.hubble` to use a different Node.js version. It also revises the `CONTRIBUTING.md` file by adjusting the steps for publishing and tagging.

### Detailed summary
- Updated event IDs in `onchain_events.md` with new values.
- Changed Node.js version from `22.4.1-slim` to `20.4.1-slim` in `Dockerfile.hubble`.
- Revised steps in `CONTRIBUTING.md` for clarity and sequence.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->