### PR TITLE
Remove duplicate Snapshots Options section

### DIFF
--- a/apps/hubble/www/docs/docs/cli.md
+++ b/apps/hubble/www/docs/docs/cli.md
@@ -87,11 +87,6 @@ Networking Options:
   --rpc-rate-limit <number>             RPC rate limit for peers specified in rpm. Set to -1 for none. (default: 20k/min)
   --rpc-subscribe-per-ip-limit <number> Maximum RPC subscriptions per IP address (default: 4)
 
-Snapshots Options:
-  --enable-snapshot-to-s3               Enable daily snapshots to be uploaded to S3. (default: disabled)
-  --s3-snapshot-bucket <bucket>         The S3 bucket to upload snapshots to
-  --disable-snapshot-sync               Disable syncing from snapshots. (default: enabled)
-
 Metrics:
   --statsd-metrics-server <host>        The host to send statsd metrics to, eg "127.0.0.1:8125". (default: disabled)
 

--- a/packages/hub-nodejs/docs/Messages.md
+++ b/packages/hub-nodejs/docs/Messages.md
@@ -48,8 +48,8 @@ Due to a quirk of how gRPC compiles types to TypeScript, MessageData has many op
 | `signerRemoveBody?`              | [`SignerRemoveBody`](#signerremovebody)                           | Present if type is SIGNER_REMOVE                   |
 | `userDataBody?`                  | [`UserDataBody`](#userdatabody)                                   | Present if type is USER_DATA_ADD                   |
 | `castAddBody?`                   | [`CastAddBody`](#castaddbody)                                     | Present if type is CAST_ADD                        |
-| `castRemoveBody?`                | [`CastRemoveBody`](#messagebody)                                  | Present if type is CAST_REMOVE                     |
-| `reactionBody?`                  | [`MessageBody`](#castremovebody)                                  | Present if type is REACTION_ADD or REACTION_REMOVE |
+| `castRemoveBody?`                | [`CastRemoveBody`](#castremovebody)                               | Present if type is CAST_REMOVE                     |
+| `reactionBody?`                  | [`MessageBody`](#messagebody)                                     | Present if type is REACTION_ADD or REACTION_REMOVE |
 | `verificationAddEthAddressBody?` | [`VerificationAddEthAddressBody`](#verificationaddethaddressbody) | Present if type is VERIFICATION_ADD_ETH_ADDRESS    |
 | `verificationRemoveBody?`        | [`VerificationRemoveBody`](#verificationremovebody)               | Present if type is VERIFICATION_REMOVE             |
 


### PR DESCRIPTION
Changes:
- Removed duplicate "Snapshots Options" section from CLI documentation as it already exists in the main options list.

Before (appears twice):
Snapshots Options:
  --enable-snapshot-to-s3               Enable daily snapshots to be uploaded to S3. (default: disabled)
  --s3-snapshot-bucket <bucket>         The S3 bucket to upload snapshots to
  --disable-snapshot-sync               Disable syncing from snapshots. (default: enabled)

File changed: apps/hubble/www/docs/docs/cli.md

Screenshot needed: 
![image](https://github.com/user-attachments/assets/d8646547-da29-4636-8d34-355df4cf3034)

