### PR TITLE
Improve Grammar in Docs

### DIFF
--- a/apps/hubble/src/storage/stores/userDataStore.ts
+++ b/apps/hubble/src/storage/stores/userDataStore.ts
@@ -105,7 +105,7 @@ class UserDataStore extends RustStoreBase<UserDataAddMessage, never> {
       throw result.error;
     }
 
-    // Read the reuslt bytes as a HubEvent
+    // Read the result bytes as a HubEvent
     const resultBytes = new Uint8Array(result.value);
     const hubEvent = HubEvent.decode(resultBytes);
 

--- a/apps/hubble/src/utils/lruCache.ts
+++ b/apps/hubble/src/utils/lruCache.ts
@@ -26,7 +26,7 @@ export class LRUCache<K, T> {
    * Get the value associated with the given key. If the key is not found in the cache, the
    * provided function is called to get the value.
    *
-   * If the get functon throws, the key is not added to the cache.
+   * If the get function throws, the key is not added to the cache.
    * and this function will throw the same error.
    *
    * @param key The key to lookup


### PR DESCRIPTION
Corrected reuslt to result
Corrected functon to function

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing typos in comments within two files: `userDataStore.ts` and `lruCache.ts`. 

### Detailed summary
- In `userDataStore.ts`, corrected "reuslt" to "result" in a comment.
- In `lruCache.ts`, corrected "functon" to "function" in a comment.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->