### PR TITLE
chore: Fix typo in class name Update factories.ts

### DIFF
--- a/packages/core/src/factories.ts
+++ b/packages/core/src/factories.ts
@@ -830,7 +830,7 @@ export const Factories = {
   EnsName: EnsNameFactory,
   TransactionHash: TransactionHashFactory,
   Ed25519PrivateKey: Ed25519PrivateKeyFactory,
-  Ed25519PPublicKey: Ed25519PublicKeyFactory,
+  Ed25519PublicKey: Ed25519PublicKeyFactory,
   Ed25519Signer: Ed25519SignerFactory,
   Ed25519Signature: Ed25519SignatureFactory,
   Eip712Signer: Eip712SignerFactory,


### PR DESCRIPTION
## Why is this change needed?

I noticed a typo in the class name `Ed25519PPublicKey` where an extra "P" was added. This doesn't align with the correct naming convention used in the codebase, particularly with the `Ed25519PublicKeyFactory` defined earlier. I've corrected the name to `Ed25519PublicKey` to ensure consistency and accuracy.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a naming inconsistency in the `packages/core/src/factories.ts` file by updating the key from `Ed25519PPublicKey` to `Ed25519PublicKey`.

### Detailed summary
- Changed the key name from `Ed25519PPublicKey` to `Ed25519PublicKey` in the export list.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->