### PR TITLE
fix: Fix error handling Update index.ts

### DIFF
--- a/packages/hub-web/examples/profile/index.ts
+++ b/packages/hub-web/examples/profile/index.ts
@@ -14,7 +14,7 @@ async function profile(fid = 2) {
     }
   } catch (e) {
     // handle errors
-    console.error("Error getting userdata message: ", e.response.data);
+    console.error("Error getting userdata message: ", e.response?.data || e.message);
   }
 }
 


### PR DESCRIPTION
## Why is this change needed?

The error handling in the userdata fetch block assumes the error object always has a `response` property, which isn't guaranteed. This can cause crashes if the error is unrelated to an HTTP request (e.g., network issues or code errors).  

I've updated the `console.error` statement to safely handle cases where `e.response` is undefined. Now it logs either the response data or the error message, preventing potential runtime errors.  

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves error handling in the `packages/hub-web/examples/profile/index.ts` file by making the error logging more robust. It adds a fallback to log the error message if the response data is not available.

### Detailed summary
- Updated the error logging in the `catch` block.
- Changed `console.error` to log `e.response?.data` or fallback to `e.message` if `e.response.data` is undefined.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->