### PR TITLE
fix: bug report error 

### DIFF
--- a/apps/hubble/src/addon/src/store/user_data_store.rs
+++ b/apps/hubble/src/addon/src/store/user_data_store.rs
@@ -70,7 +70,7 @@ impl StoreDef for UserDataStoreDef {
     ) -> Result<(), HubError> {
         Err(HubError {
             code: "bad_request.invalid_param".to_string(),
-            message: "UserDataStoree doesn't support merging removes".to_string(),
+            message: "UserDataStore doesn't support merging removes".to_string(),
         })
     }
 


### PR DESCRIPTION
## Why is this change needed?

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a typo in the error message of the `UserDataStore` within the `user_data_store.rs` file.

### Detailed summary
- Fixed typo in error message from `"UserDataStoree doesn't support merging removes"` to `"UserDataStore doesn't support merging removes"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->