### PR TITLE
fix: Update broken links protobufs README.md

### DIFF
--- a/protobufs/README.md
+++ b/protobufs/README.md
@@ -4,10 +4,10 @@ Specifications for API's and data formats used in Hubble, including both Farcast
 
 | Schema                                      | Type Description                         | Docs                    |
 |---------------------------------------------|------------------------------------------| ----------------------- |
-| [Message](schemas/message.proto)            | Types for Farcaster deltas               | [docs](docs/message.md) |
-| [OnChainEvent](schemas/onchain_event.proto) | Types for Farcaster onchain events       | [docs](docs/message.md) |
-| [HubEvent](schemas/hub_event.proto)         | Types for hub events                     | [docs](docs/message.md) |
-| [RPC](schemas/rpc.proto)                    | Types for gRPC APIs exposed by Hubs      | [docs](docs/rpc.md)     |
+| [Message](schemas/message.proto)            | Types for Farcaster deltas               | [docs](../apps/hubble/www/docs/docs/messages.md) |
+| [OnChainEvent](schemas/onchain_event.proto) | Types for Farcaster onchain events       | [docs](../apps/hubble/www/docs/docs/onchain_events.md) |
+| [HubEvent](schemas/hub_event.proto)         | Types for hub events                     | [docs](../apps/hubble/www/docs/docs/events.md) |
+| [RPC](schemas/rpc.proto)                    | Types for gRPC APIs exposed by Hubs      | [docs](../apps/hubble/www/docs/docs/api.md)     |
 | [Gossip](schemas/gossip.proto)              | Types for gossiping data between Hubs    |                         |
 | [HubState](schemas/hub_state.proto)         | Types for maintaining internal state     |                         |
 


### PR DESCRIPTION
## Description

This pull request fixes broken links in the `protobufs/README.md` file.

## Why is this change needed?

Broken links in the README can lead to confusion and inefficiencies when trying to access documentation. This update resolves these issues by correcting the file paths.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] PR includes a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets).
- [x] PR has been tagged with the appropriate change label(s).
- [x] Documentation updates have been included as necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the links in the `protobufs/README.md` file to point to the correct documentation paths for various schemas related to Farcaster and gRPC APIs.

### Detailed summary
- Updated the documentation links for:
  - `Message` schema to point to `../apps/hubble/www/docs/docs/messages.md`
  - `OnChainEvent` schema to point to `../apps/hubble/www/docs/docs/onchain_events.md`
  - `HubEvent` schema to point to `../apps/hubble/www/docs/docs/events.md`
  - `RPC` schema to point to `../apps/hubble/www/docs/docs/api.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->