### PR TITLE
Update gossipNode.ts

### DIFF
--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -490,7 +490,7 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
   /** Connects to a peer GossipNode through at least one multiaddr */
   async connect(peerNode: GossipNode): Promise<HubResult<void>> {
     const multiaddrs = peerNode.multiaddrs();
-    if (!multiaddrs || multiaddr.length === 0) {
+    if (!multiaddrs || multiaddrs.length === 0) {
       return err(new HubError("unavailable", { message: "no peer id" }));
     }
 


### PR DESCRIPTION
 Fixed variable reference:
- if (!multiaddrs || multiaddr.length === 0)
+ if (!multiaddrs || multiaddrs.length === 0) 
Reason: Fixes incorrect array length check by using proper multiaddrs variable

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a bug in the `connect` method of the `GossipNode` class. It corrects a typo in the conditional check for the `multiaddrs` array.

### Detailed summary
- Changed `multiaddr.length === 0` to `multiaddrs.length === 0` in the `connect` method.
- Ensures proper validation of the `multiaddrs` before returning an error.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->