### PR TITLE
Corrected the number index.ts

### DIFF
--- a/packages/hub-nodejs/examples/write-data/index.ts
+++ b/packages/hub-nodejs/examples/write-data/index.ts
@@ -179,7 +179,7 @@ const NETWORK = FarcasterNetwork.TESTNET; // Network of the Hub
   castResults.push(castWithEmojiLinkAttachment);
 
   /**
-   * Example 7: A cast that replies to a URL
+   * Example 8: A cast that replies to a URL
    *
    * "I think this is a great protocol 🚀"
    */


### PR DESCRIPTION
Corrected the numbering for accuracy and consistency.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the example number in the documentation comment of the `index.ts` file within the `packages/hub-nodejs/examples/write-data` directory.

### Detailed summary
- Changed the example number from 7 to 8 in the documentation comment.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->