### PR TITLE
fix: typos in documentation files

### DIFF
--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -599,7 +599,7 @@ describe("Multi peer sync engine with streams", () => {
     expect(await syncEngine2.trie.items()).toEqual(3 + 2); // 2 onchain events + 2 castAdds
     expect(await syncEngine1.trie.items()).toEqual(3 + 1); // 2 onchain events + 1 castAdd
 
-    // Attempt to sync engine2 <-- engine1. Engine1 has only singerAdd
+    // Attempt to sync engine2 <-- engine1. Engine1 has only signerAdd
     await syncEngine2.performSync("engine1", clientForServer1);
 
     // The sync engine should realize that castAdd2 is not in it's engine, so it should be removed from the sync trie
@@ -1496,7 +1496,7 @@ describe("Multi peer sync engine with rpcs", () => {
     expect(await syncEngine2.trie.items()).toEqual(3 + 2); // 2 onchain events + 2 castAdds
     expect(await syncEngine1.trie.items()).toEqual(3 + 1); // 2 onchain events + 1 castAdd
 
-    // Attempt to sync engine2 <-- engine1. Engine1 has only singerAdd
+    // Attempt to sync engine2 <-- engine1. Engine1 has only signerAdd
     await syncEngine2.performSync("engine1", clientForServer1);
 
     // The sync engine should realize that castAdd2 is not in it's engine, so it should be removed from the sync trie


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `singerAdd` to `signerAdd` x2


Please review the changes and let me know if any additional changes are needed.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a typo in the comments of the `multiPeerSyncEngine.test.ts` file, changing "singerAdd" to "signerAdd" to ensure clarity regarding the synchronization process between `syncEngine1` and `syncEngine2`.

### Detailed summary
- Corrected the comment from "singerAdd" to "signerAdd" in two instances to accurately reflect the functionality of `syncEngine1`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->