### PR TITLE
Fix typo in connection filter tests

### DIFF
--- a/apps/hubble/src/network/p2p/connectionFilter.test.ts
+++ b/apps/hubble/src/network/p2p/connectionFilter.test.ts
@@ -29,7 +29,7 @@ describe("connectionFilter tests", () => {
     });
     await expect(filter.denyDialPeer(allowedPeerId)).resolves.toBeTruthy();
     await expect(filter.denyDialMultiaddr(multiaddr(allowedMultiAddrStr))).resolves.toBeTruthy();
-    // Incepient Inbound Connections are always allowed
+    // Incipient Inbound Connections are always allowed
     await expect(filter.denyInboundConnection(remoteConnection)).resolves.toBeFalsy();
     await expect(filter.denyInboundEncryptedConnection(allowedPeerId, remoteConnection)).resolves.toBeTruthy();
     await expect(filter.denyInboundUpgradedConnection(allowedPeerId, remoteConnection)).resolves.toBeTruthy();
@@ -47,7 +47,7 @@ describe("connectionFilter tests", () => {
     });
     await expect(filter.denyDialPeer(allowedPeerId)).resolves.toBeFalsy();
     await expect(filter.denyDialMultiaddr(multiaddr(allowedMultiAddrStr))).resolves.toBeFalsy();
-    // Incepient Inbound Connections are always allowed
+    // Incipient Inbound Connections are always allowed
     await expect(filter.denyInboundConnection(remoteConnection)).resolves.toBeFalsy();
     await expect(filter.denyInboundEncryptedConnection(allowedPeerId, remoteConnection)).resolves.toBeFalsy();
     await expect(filter.denyInboundUpgradedConnection(allowedPeerId, remoteConnection)).resolves.toBeFalsy();
@@ -65,7 +65,7 @@ describe("connectionFilter tests", () => {
     });
     await expect(filter.denyDialPeer(allowedPeerId)).resolves.toBeFalsy();
     await expect(filter.denyDialPeer(blockedPeerId)).resolves.toBeTruthy();
-    // Incepient Inbound Connections are always allowed
+    // Incipient Inbound Connections are always allowed
     await expect(filter.denyInboundConnection(remoteConnection)).resolves.toBeFalsy();
     await expect(filter.denyOutboundConnection(blockedPeerId, remoteConnection)).resolves.toBeTruthy();
     await expect(filter.filterMultiaddrForPeer(blockedPeerId)).resolves.toBeFalsy();
@@ -79,7 +79,7 @@ describe("connectionFilter tests", () => {
     });
     await expect(filter.denyDialPeer(allowedPeerId)).resolves.toBeFalsy();
     await expect(filter.denyDialPeer(blockedPeerId)).resolves.toBeTruthy();
-    // Incepient Inbound Connections are always allowed
+    // Incipient Inbound Connections are always allowed
     await expect(filter.denyInboundConnection(remoteConnection)).resolves.toBeFalsy();
     await expect(filter.denyOutboundConnection(blockedPeerId, remoteConnection)).resolves.toBeTruthy();
     await expect(filter.filterMultiaddrForPeer(blockedPeerId)).resolves.toBeFalsy();
@@ -93,7 +93,7 @@ describe("connectionFilter tests", () => {
     });
     await expect(filter.denyDialPeer(blockedPeerId)).resolves.toBeTruthy();
     await expect(filter.denyDialMultiaddr(multiaddr(allowedMultiAddrStr))).resolves.toBeTruthy();
-    // Incepient Inbound Connections are always allowed
+    // Incipient Inbound Connections are always allowed
     await expect(filter.denyInboundConnection(remoteConnection)).resolves.toBeFalsy();
     await expect(filter.denyOutboundConnection(blockedPeerId, remoteConnection)).resolves.toBeTruthy();
     await expect(filter.filterMultiaddrForPeer(blockedPeerId)).resolves.toBeFalsy();
@@ -107,7 +107,7 @@ describe("connectionFilter tests", () => {
     });
     await expect(filter.denyDialPeer(allowedPeerId)).resolves.toBeFalsy();
     await expect(filter.denyDialPeer(blockedPeerId)).resolves.toBeFalsy();
-    // Incepient Inbound Connections are always allowed
+    // Incipient Inbound Connections are always allowed
     await expect(filter.denyInboundConnection(remoteConnection)).resolves.toBeFalsy();
     await expect(filter.denyOutboundConnection(allowedPeerId, remoteConnection)).resolves.toBeFalsy();
     await expect(filter.filterMultiaddrForPeer(allowedPeerId)).resolves.toBeTruthy();


### PR DESCRIPTION
Fixed a spelling error in the comments of `connectionFilter.test.ts` where `Incepient` was incorrectly used instead of `Incipient` when describing inbound connections behavior.

**Changes made:**
- Corrected spelling in multiple comment lines
- No functional changes, only comment fixes

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a spelling mistake in the comments of the `connectionFilter.test.ts` file, changing "Incepient" to "Incipient." It ensures clarity and accuracy in the test descriptions.

### Detailed summary
- Corrected the comment from "// Incepient Inbound Connections are always allowed" to "// Incipient Inbound Connections are always allowed" in multiple locations within the `connectionFilter.test.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->