### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/packages/core/src/protobufs/generated/message.ts
+++ b/packages/core/src/protobufs/generated/message.ts
@@ -244,7 +244,7 @@ export enum UserDataType {
   USERNAME = 6,
   /** LOCATION - Current location for the user */
   LOCATION = 7,
-  /** TWITTER - Username of user on twitter */
+  /** TWITTER - Username of user on x */
   TWITTER = 8,
   /** GITHUB - Username of user on github */
   GITHUB = 9,

--- a/packages/hub-nodejs/src/generated/message.ts
+++ b/packages/hub-nodejs/src/generated/message.ts
@@ -244,7 +244,7 @@ export enum UserDataType {
   USERNAME = 6,
   /** LOCATION - Current location for the user */
   LOCATION = 7,
-  /** TWITTER - Username of user on twitter */
+  /** TWITTER - Username of user on x */
   TWITTER = 8,
   /** GITHUB - Username of user on github */
   GITHUB = 9,

--- a/packages/hub-web/CHANGELOG.md
+++ b/packages/hub-web/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- 913c0f67: feat: support twitter and github usernames
+- 913c0f67: feat: support x and github usernames
 - Updated dependencies [913c0f67]
   - @farcaster/core@0.15.6
 

--- a/protobufs/schemas/message.proto
+++ b/protobufs/schemas/message.proto
@@ -98,7 +98,7 @@ enum UserDataType {
   USER_DATA_TYPE_URL = 5; // URL of the user
   USER_DATA_TYPE_USERNAME = 6; // Preferred Name for the user
   USER_DATA_TYPE_LOCATION = 7; // Current location for the user
-  USER_DATA_TYPE_TWITTER = 8; // Username of user on twitter
+  USER_DATA_TYPE_TWITTER = 8; // Username of user on x
   USER_DATA_TYPE_GITHUB = 9; // Username of user on github
 }
 


### PR DESCRIPTION
Replaced the outdated Twitter URL (twitter) with the updated x.com format (x) to align with the platform's rebranding.



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates references from "twitter" to "x" across multiple files to reflect the rebranding of Twitter to X.

### Detailed summary
- Updated `CHANGELOG.md` to change "twitter" to "x".
- In `message.ts` files (both `hub-nodejs` and `core`), modified the comment for `TWITTER` from "Username of user on twitter" to "Username of user on x".
- In `message.proto`, changed the comment for `USER_DATA_TYPE_TWITTER` from "Username of user on twitter" to "Username of user on x".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->