### PR TITLE
Improve Grammar in Docs

### DIFF
--- a/apps/hubble/src/network/p2p/connectionFilter.ts
+++ b/apps/hubble/src/network/p2p/connectionFilter.ts
@@ -7,7 +7,7 @@ const log = logger.child({
 });
 
 /**
- * ConnectionFilter ensures that nodes only collect to peers in a specific allowlist.
+ * ConnectionFilter ensures that nodes only connect to peers in a specific allowlist.
  *
  * It implements the entire libp2p ConnectionGater interface to intercept calls at the lowest level
  * and prevent the connection.


### PR DESCRIPTION
Corrected `nodes only collect to peers` to `nodes only connect to peers`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a typo in the documentation comment for the `ConnectionFilter` class, ensuring clarity in the description of its functionality.

### Detailed summary
- Updated the comment in `ConnectionFilter` to change "collect" to "connect" for better accuracy in describing its purpose regarding peer connections.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->