### PR TITLE
Fix variables and registerDebugListeners method

### DIFF
--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -490,7 +490,7 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
   /** Connects to a peer GossipNode through at least one multiaddr */
   async connect(peerNode: GossipNode): Promise<HubResult<void>> {
     const multiaddrs = peerNode.multiaddrs();
-    if (!multiaddrs || multiaddr.length === 0) {
+    if (!multiaddrs || multiaddrs.length === 0) {
       return err(new HubError("unavailable", { message: "no peer id" }));
     }
 
@@ -615,7 +615,7 @@ export class GossipNode extends TypedEmitter<NodeEvents> {
 
   registerDebugListeners() {
     this._nodeEvents?.addListener("peer:discovery", (detail) => {
-      log.info({ identity: this.identity }, `Found peer: ${detail.multiaddrs}  }`);
+      log.info({ identity: this.identity }, `Found peer: ${detail.multiaddrs}`);
     });
     this._nodeEvents?.addListener("connection:open", (detail: Connection) => {
       log.info({ identity: this.identity }, `Connection established to: ${detail.remotePeer.toString()}`);

--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -525,7 +525,7 @@ describe("SyncEngine", () => {
         expect((await syncEngine.getDbStats()).numFnames).toEqual(1);
       });
 
-      test("adds sync ids to the trie when not present and egnine rejects as duplicate", async () => {
+      test("adds sync ids to the trie when not present and engine rejects as duplicate", async () => {
         await engine.mergeOnChainEvent(custodyEvent);
         await engine.mergeUserNameProof(userNameProof);
 


### PR DESCRIPTION
## Why is this change needed?

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing minor issues in the test descriptions and correcting a typo in the `gossipNode.ts` file, as well as cleaning up log messages for better clarity.

### Detailed summary
- Corrected the typo in the test description from `egnine` to `engine` in `syncEngine.test.ts`.
- Fixed a typo in the condition check from `multiaddr.length` to `multiaddrs.length` in `gossipNode.ts`.
- Cleaned up the log message formatting in `gossipNode.ts` by removing an extra brace.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->