### PR TITLE
fix: allow uppercase x usernames

### DIFF
--- a/.changeset/bright-insects-teach.md
+++ b/.changeset/bright-insects-teach.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/core": patch
+---
+
+fix: allow uppercase x usernames

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -19,7 +19,7 @@ export const ALLOWED_CLOCK_SKEW_SECONDS = 10 * 60;
 
 export const FNAME_REGEX = /^[a-z0-9][a-z0-9-]{0,15}$/;
 export const HEX_REGEX = /^(0x)?[0-9A-Fa-f]+$/;
-export const TWITTER_REGEX = /^[a-z0-9_]{0,15}$/;
+export const TWITTER_REGEX = /^[a-zA-Z0-9_]{0,15}$/;
 export const GITHUB_REGEX = /^[a-z\d](?:[a-z\d]|-(?!-)){0,38}$/i;
 
 export const USERNAME_MAX_LENGTH = 20;


### PR DESCRIPTION
## Why is this change needed?

We currently disallow uppercase x usernames which are valid. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the username validation regex to allow uppercase letters for Twitter usernames.

### Detailed summary
- Modified the `TWITTER_REGEX` from `/^[a-z0-9_]{0,15}$/` to `/^[a-zA-Z0-9_]{0,15}$/` to permit uppercase letters in usernames.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->