### PR TITLE
fix: errors in profileStorageUsed function

### DIFF
--- a/apps/hubble/src/profile/profile.ts
+++ b/apps/hubble/src/profile/profile.ts
@@ -280,12 +280,12 @@ export async function profileStorageUsed(rocksDB: RocksDB, fidProfileFileName?: 
   const allKeys = new KeysProfile("All Keys");
   const prefixKeys = Array.from(
     { length: getMaxValue(RootPrefix) + 1 },
-    (_v, i: number) => new KeysProfile(RootPrefix[i]?.toString()),
+    (_v, i: number) => new KeysProfile(RootPrefix[i]?.toString() || ""),
   );
 
   const userPostfixKeys = Array.from(
     { length: getMaxValue(UserPostfix) + 1 },
-    (_v, i: number) => new KeysProfile(UserPostfix[i]?.toString()),
+    (_v, i: number) => new KeysProfile(UserPostfix[i]?.toString() || ""),
   );
 
   const onchainPostfixKeys = Array.from(


### PR DESCRIPTION
## Why is this change needed?

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of potentially `undefined` values in the `KeysProfile` constructor by providing a default empty string when the value is `undefined`.

### Detailed summary
- Updated the `prefixKeys` array mapping to use `|| ""` for `RootPrefix[i]?.toString()`.
- Updated the `userPostfixKeys` array mapping to use `|| ""` for `UserPostfix[i]?.toString()`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->