### PR TITLE
Fix incorrect method call in the test

### DIFF
--- a/apps/hubble/src/rpc/test/messageService.test.ts
+++ b/apps/hubble/src/rpc/test/messageService.test.ts
@@ -132,12 +132,12 @@ describe("validateMessage", () => {
   });
 
   test("fails without signer", async () => {
-    const castResult = await client.submitMessage(castAdd);
+    const castResult = await client.validateMessage(castAdd);
     const castErr = castResult._unsafeUnwrapErr();
     expect(castErr.errCode).toEqual("bad_request.unknown_fid");
     expect(castErr.message).toMatch("unknown fid");
 
-    const frameResult = await client.submitMessage(frameAction);
+    const frameResult = await client.validateMessage(frameAction);
     const frameErr = frameResult._unsafeUnwrapErr();
     expect(frameErr.errCode).toEqual("bad_request.unknown_fid");
     expect(frameErr.message).toMatch("unknown fid");


### PR DESCRIPTION
## Why is this change needed?

In the test block "validateMessage", the test "fails without signer" incorrectly calls the method submitMessage instead of validateMessage.
## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the test cases in the `messageService.test.ts` file to replace calls to `client.submitMessage` with `client.validateMessage`, ensuring that the validation logic is tested instead of the submission logic.

### Detailed summary
- Changed `client.submitMessage(castAdd)` to `client.validateMessage(castAdd)`.
- Changed `client.submitMessage(frameAction)` to `client.validateMessage(frameAction)`.
- Updated the error handling expectations to reflect changes in the message validation process.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->