### PR TITLE
docs: Fix typo in ETH-mainnet-RPC-url flag Update install.md

### DIFF
--- a/apps/hubble/www/docs/intro/install.md
+++ b/apps/hubble/www/docs/intro/install.md
@@ -119,7 +119,7 @@ To run the Hubble commands, go to the Hubble app (`cd apps/hubble`) and run the 
 
 1. `yarn identity create` to create an ID
 2. Follow the instructions to set [connect to a network](./networks.md)
-3. `yarn start --eth-mainnet-rpc-url <your ETH-mainnet-RPC-URL> --l2-rpc-url <your Optimism-L2-RPC-URL> --hub-operator-fid <your FID>`
+3. `yarn start --eth-mainnet-rpc-url <your_ETH_MAINNET_RPC_URL> --l2-rpc-url <your_Optimism_L2_RPC_URL> --hub-operator-fid <your_FID>`
 
 ### Upgrading Hubble
 


### PR DESCRIPTION
## Why is this change needed?

I noticed a inconsistency in the documentation. The flag `--eth-mainnet-rpc-url` uses a hyphen in `ETH-mainnet-RPC-URL`, while the correct format (as seen in the `.env` file and other parts of the docs) uses underscores: `ETH_MAINNET_RPC_URL`.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the command syntax in the installation instructions for improved clarity by changing the placeholder format for the Ethereum and Optimism RPC URLs.

### Detailed summary
- Updated the command in `install.md` from:
  - `yarn start --eth-mainnet-rpc-url <your ETH-mainnet-RPC-URL> --l2-rpc-url <your Optimism-L2-RPC-URL> --hub-operator-fid <your FID>`
- To:
  - `yarn start --eth-mainnet-rpc-url <your_ETH_MAINNET_RPC_URL> --l2-rpc-url <your_Optimism_L2_RPC_URL> --hub-operator-fid <your_FID>`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->