### PR TITLE
docs: Fix duplicate Number values in IdRegisterEventType table

### DIFF
--- a/apps/hubble/www/docs/docs/onchain_events.md
+++ b/apps/hubble/www/docs/docs/onchain_events.md
@@ -73,9 +73,9 @@
 | Name                                   | Number | Description |
 |----------------------------------------|--------|-------------|
 | ID_REGISTER_EVENT_TYPE_NONE            | 0      |             |
-| ID_REGISTER_EVENT_TYPE_REGISTER        | 0      |             |
-| ID_REGISTER_EVENT_TYPE_TRANSFER        | 0      |             |
-| ID_REGISTER_EVENT_TYPE_CHANGE_RECOVERY | 0      |             |
+| ID_REGISTER_EVENT_TYPE_REGISTER        | 1      |             |
+| ID_REGISTER_EVENT_TYPE_TRANSFER        | 2      |             |
+| ID_REGISTER_EVENT_TYPE_CHANGE_RECOVERY | 3      |             |
 
 <a name="-StorageRentEventBody"></a>
 ### StorageRentEventBody


### PR DESCRIPTION
## Why is this change needed?
 
I noticed that the `Number` values for `ID_REGISTER_EVENT_TYPE_REGISTER`, `ID_REGISTER_EVENT_TYPE_TRANSFER`, and `ID_REGISTER_EVENT_TYPE_CHANGE_RECOVERY` in the `IdRegisterEventType` table were all set to `0`, which conflicts with `ID_REGISTER_EVENT_TYPE_NONE`. This is incorrect, as each event type should have a unique value.  

I've updated the table to assign the correct unique numbers:  
- `ID_REGISTER_EVENT_TYPE_REGISTER` → `1`  
- `ID_REGISTER_EVENT_TYPE_TRANSFER` → `2`  
- `ID_REGISTER_EVENT_TYPE_CHANGE_RECOVERY` → `3`  

This ensures consistency and avoids potential issues with event type identification.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `onchain_events.md` documentation to reflect changes in the event type IDs for registration, transfer, and recovery events.

### Detailed summary
- Updated `ID_REGISTER_EVENT_TYPE_REGISTER` from `0` to `1`.
- Updated `ID_REGISTER_EVENT_TYPE_TRANSFER` from `0` to `2`.
- Updated `ID_REGISTER_EVENT_TYPE_CHANGE_RECOVERY` from `0` to `3`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->