### PR TITLE
fix: bug report message error

### DIFF
--- a/apps/hubble/src/rpc/test/linkService.test.ts
+++ b/apps/hubble/src/rpc/test/linkService.test.ts
@@ -124,7 +124,7 @@ describe("getLink", () => {
     );
 
     expect(result._unsafeUnwrapErr()).toEqual(
-      new HubError("bad_request.validation_failure", "targetId provided without type"),
+      new HubError("bad_request.validation_failure", "targetFid provided without type"),
     );
   });
 


### PR DESCRIPTION
## Why is this change needed?

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the error message in the `linkService.test.ts` file to reflect a change in the expected property name from `targetId` to `targetFid`.

### Detailed summary
- Modified the error message in the expectation from:
  - `new HubError("bad_request.validation_failure", "targetId provided without type")`
  - to `new HubError("bad_request.validation_failure", "targetFid provided without type")`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->