### PR TITLE
docs: Fix incorrect StatsD URL in monitoring.md

### DIFF
--- a/apps/hubble/www/docs/intro/monitoring.md
+++ b/apps/hubble/www/docs/intro/monitoring.md
@@ -24,7 +24,7 @@ yarn start --statsd-metrics-server 127.0.0.1:8125
 
 4. Open Grafana in a browser at `127.0.0.1:3000`. The default username/password is `admin`/`admin`. You will need to change your password on the first login
 
-5. Go to `Administration -> Data sources -> Add new data source` and select `Graphite`. Set the URL to `http://statsd:80` and click `Save & Test` to make sure it is working
+5. Go to `Administration -> Data sources -> Add new data source` and select `Graphite`. Set the URL to `http://statsd:8125` and click `Save & Test` to make sure it is working
 
 6. Go to `Dashboards -> New -> Import`, and in the `Import from Panel JSON`, paste the contents of the [Default Grafana Dashboard](https://github.com/farcasterxyz/hub-monorepo/blob/main/apps/hubble/grafana/grafana-dashboard.json)
 


### PR DESCRIPTION
## Why is this change needed?

A small issue in the documentation where the URL for setting up the StatsD data source in Grafana is incorrect. In point 5, the URL is currently set to `http://statsd:80`, but StatsD typically uses port **8125** for receiving metrics. This aligns with the `STATSD_METRICS_SERVER=statsd:8125` variable mentioned in point 2. I’ve updated the URL to `http://statsd:8125` to ensure consistency and accuracy.  

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the URL for the `Graphite` data source configuration in the Grafana setup instructions.

### Detailed summary
- Changed the URL for the `Graphite` data source from `http://statsd:80` to `http://statsd:8125`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->