### PR TITLE
docs: Fix typo in method description Update casts.md

### DIFF
--- a/apps/hubble/www/docs/docs/httpapi/casts.md
+++ b/apps/hubble/www/docs/docs/httpapi/casts.md
@@ -46,7 +46,7 @@ curl http://127.0.0.1:2281/v1/castById?fid=2&hash=0xd2b1ddc6c88e865a33cb1a565e00
 ```
 
 ## castsByFid
-Fetch all casts for authored by an FID. 
+Fetch all casts authored by a user with an FID.
 
 
 **Query Parameters**


### PR DESCRIPTION
## Why is this change needed?

A in the description of the `castsByFid` method. The current text reads:  
*"Fetch all casts for authored by an FID."*  

This seems to be missing the word "user" or "user with." I’ve updated it to:  
*"Fetch all casts authored by a user with an FID."*  

This change clarifies the intended meaning. Let me know if this looks good!
## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation for the `castsByFid` API endpoint to clarify the description of its functionality. 

### Detailed summary
- Changed the description for `castsByFid` from "Fetch all casts for authored by an FID." to "Fetch all casts authored by a user with an FID."
- Adjusted the formatting by adding a newline at the end of the file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->