### PR TITLE
Improve Readability of Error Messages

### DIFF
--- a/apps/hubble/src/addon/src/store/link_store.rs
+++ b/apps/hubble/src/addon/src/store/link_store.rs
@@ -295,7 +295,7 @@ impl LinkStore {
             && (link_body.r#type.is_empty() || link_body.r#type.len() == 0)
         {
             return Err(HubError::validation_failure(
-                "targetId provided without type",
+                "target ID provided without type",
             ));
         }
 
@@ -344,7 +344,7 @@ impl LinkStore {
             && (link_body.r#type.is_empty() || link_body.r#type.len() == 0)
         {
             return Err(HubError::validation_failure(
-                "targetID provided without type",
+                "target ID provided without type",
             ));
         }
 

--- a/apps/hubble/src/addon/src/store/reaction_store.rs
+++ b/apps/hubble/src/addon/src/store/reaction_store.rs
@@ -227,7 +227,7 @@ impl ReactionStoreDef {
         if target.is_some() && r#type == 0 {
             return Err(HubError {
                 code: "bad_request.validation_failure".to_string(),
-                message: "targetId provided without type".to_string(),
+                message: "target ID provided without type".to_string(),
             });
         }
         let mut key = Vec::with_capacity(33 + 1 + 1 + 28);
@@ -253,7 +253,7 @@ impl ReactionStoreDef {
         if target.is_some() && r#type == 0 {
             return Err(HubError {
                 code: "bad_request.validation_failure".to_string(),
-                message: "targetId provided without type".to_string(),
+                message: "target ID provided without type".to_string(),
             });
         }
         let mut key = Vec::with_capacity(33 + 1 + 1 + 28);


### PR DESCRIPTION
This pull request enhances the readability and consistency of error messages related to targetId.

Changes Made

Old Message: "targetId provided without type"
New Message: "target ID provided without type"

