### PR TITLE
fix: 404 links and spelling

### DIFF
--- a/apps/hubble/src/storage/db/migrations/11.fnameIndex.ts
+++ b/apps/hubble/src/storage/db/migrations/11.fnameIndex.ts
@@ -8,7 +8,7 @@ import { ResultAsync } from "neverthrow";
 const log = logger.child({ component: "fnameIndex" });
 
 /**
- * Up untill now, we were accidentally writing the fid index for the fname messages as Little Endian
+ * Up until now, we were accidentally writing the fid index for the fname messages as Little Endian
  * instead of Big Endian in name_registry_events.rs:make_fname_username_proof_by_fid_key.
  * This migration will fix that to be big endian, and also remove the little endian index keys
  */

--- a/packages/hub-nodejs/docs/signers/EthersEip712Signer.md
+++ b/packages/hub-nodejs/docs/signers/EthersEip712Signer.md
@@ -125,7 +125,7 @@ if (ethereumAddressResult.isOk()) {
 
 | Name    | Type                                                                             | Description                         |
 | :------ | :------------------------------------------------------------------------------- | :---------------------------------- |
-| `claim` | [`VerificationEthAddressClaim`](../modules/types.md#verificationethaddressclaim) | The body of the claim to be signed. |
+| `claim` | `VerificationEthAddressClaim` | The body of the claim to be signed. |
 
 ---
 

--- a/packages/hub-nodejs/docs/signers/EthersV5Eip712Signer.md
+++ b/packages/hub-nodejs/docs/signers/EthersV5Eip712Signer.md
@@ -125,7 +125,7 @@ if (ethereumAddressResult.isOk()) {
 
 | Name    | Type                                                                             | Description                         |
 | :------ | :------------------------------------------------------------------------------- | :---------------------------------- |
-| `claim` | [`VerificationEthAddressClaim`](../modules/types.md#verificationethaddressclaim) | The body of the claim to be signed. |
+| `claim` | `VerificationEthAddressClaim`| The body of the claim to be signed. |
 
 ---
 

--- a/packages/hub-nodejs/docs/signers/ViemLocalEip712Signer.md
+++ b/packages/hub-nodejs/docs/signers/ViemLocalEip712Signer.md
@@ -125,7 +125,7 @@ if (ethereumAddressResult.isOk()) {
 
 | Name    | Type                                                                             | Description                         |
 | :------ | :------------------------------------------------------------------------------- | :---------------------------------- |
-| `claim` | [`VerificationEthAddressClaim`](../modules/types.md#verificationethaddressclaim) | The body of the claim to be signed. |
+| `claim` | `VerificationEthAddressClaim` | The body of the claim to be signed. |
 
 ---
 

--- a/packages/hub-nodejs/examples/hello-world/README.md
+++ b/packages/hub-nodejs/examples/hello-world/README.md
@@ -13,8 +13,6 @@ Given a custody address with ~10$ worth of funds on OP Mainnet, this example wil
 
 We do not recommend running this example in a cloud environment because it requires your custody address.
 
-You can try out a web version of this at https://farcaster-signup-demo-wkulikowski.vercel.app. Source: https://github.com/wojtekwtf/farcaster-signup-demo by [@woj.eth](https://warpcast.com/woj.eth).
-
 ### Run locally
 
 1. Clone the repo locally


### PR DESCRIPTION
## Why is this change needed?

Hi! This pull request addresses several broken links in the documentation, which have been removed. Additionally, a typo `untill` has been corrected to `until`. Removing the broken links improves the accessibility and functionality of the documentation.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting the documentation and migration comments related to the handling of the `fid` index for `fname` messages, as well as improving the clarity of type references in documentation files.

### Detailed summary
- Updated comment in `11.fnameIndex.ts` to correct "Up untill" to "Up until".
- Changed type references from markdown links to plain text in:
  - `EthersEip712Signer.md`
  - `EthersV5Eip712Signer.md`
  - `ViemLocalEip712Signer.md`
- Added a newline at the end of `README.md` in the `hello-world` example.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->