### PR TITLE
fix: Correct typo in Factory builder

### DIFF
--- a/apps/hubble/src/storage/db/message.test.ts
+++ b/apps/hubble/src/storage/db/message.test.ts
@@ -199,8 +199,6 @@ describe("getAllMessagesBySigner", () => {
   });
 
   test("succeeds with no results", async () => {
-    await expect(getAllMessagesBySigner(castMessage.data.fid, Factories.Ed25519PPublicKey.build())).resolves.toEqual(
-      [],
-    );
+    await expect(getAllMessagesBySigner(castMessage.data.fid, Factories.Ed25519PublicKey.build())).resolves.toEqual([]);
   });
 });

--- a/packages/core/src/validations.test.ts
+++ b/packages/core/src/validations.test.ts
@@ -1372,7 +1372,7 @@ describe("validateMessage", () => {
   test("fails with invalid signature", async () => {
     const message = await Factories.Message.create({
       signature: Factories.Ed25519Signature.build(),
-      signer: Factories.Ed25519PPublicKey.build(),
+      signer: Factories.Ed25519PublicKey.build(),
     });
 
     const result = await validations.validateMessage(message);
@@ -1382,7 +1382,7 @@ describe("validateMessage", () => {
   test("fails with invalid signature data", async () => {
     const message = await Factories.Message.create({
       signature: Factories.Bytes.build({}, { transient: { length: 0 } }),
-      signer: Factories.Ed25519PPublicKey.build(),
+      signer: Factories.Ed25519PublicKey.build(),
     });
 
     const result = await validations.validateMessage(message);


### PR DESCRIPTION
## Why is this change needed?

Typo was breaking tests.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the use of `Factories.Ed25519PPublicKey` to `Factories.Ed25519PublicKey` in test files to ensure consistency and correctness in the handling of public key types.

### Detailed summary
- In `apps/hubble/src/storage/db/message.test.ts`, changed `Factories.Ed25519PPublicKey.build()` to `Factories.Ed25519PublicKey.build()` in a test case.
- In `packages/core/src/validations.test.ts`, updated `Factories.Ed25519PPublicKey.build()` to `Factories.Ed25519PublicKey.build()` in two instances where a message is created for validation testing.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->