### PR TITLE
chore: Fix typo and the build

### DIFF
--- a/apps/hubble/src/storage/db/message.test.ts
+++ b/apps/hubble/src/storage/db/message.test.ts
@@ -199,8 +199,6 @@ describe("getAllMessagesBySigner", () => {
   });
 
   test("succeeds with no results", async () => {
-    await expect(getAllMessagesBySigner(castMessage.data.fid, Factories.Ed25519PPublicKey.build())).resolves.toEqual(
-      [],
-    );
+    await expect(getAllMessagesBySigner(castMessage.data.fid, Factories.Ed25519PublicKey.build())).resolves.toEqual([]);
   });
 });


### PR DESCRIPTION
## Why is this change needed?

Missing typo fix was breaking the build

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a test case in the `message.test.ts` file by fixing a typo in the method used to build a public key.

### Detailed summary
- Changed `Factories.Ed25519PPublicKey.build()` to `Factories.Ed25519PublicKey.build()` in the test case.
- The test case remains unchanged in its purpose, which is to verify that `getAllMessagesBySigner` succeeds with no results.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->