### PR TITLE
 Fix spelling error in `syncEngine.test.ts`, `shuttle.integration.test.ts`, `11.fnameIndex.ts`

### DIFF
--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -502,13 +502,13 @@ describe("SyncEngine", () => {
         expect((await syncEngine.getDbStats()).numFnames).toEqual(0);
       });
       test("removes deleted fname proofs", async () => {
-        const supercedingUserNameProof = Factories.UserNameProof.build({
+        const supersedingUserNameProof = Factories.UserNameProof.build({
           name: userNameProof.name,
           timestamp: userNameProof.timestamp + 10,
         });
 
         expect(await syncEngine.trie.exists(SyncId.fromFName(userNameProof))).toBeFalsy();
-        expect(await syncEngine.trie.exists(SyncId.fromFName(supercedingUserNameProof))).toBeFalsy();
+        expect(await syncEngine.trie.exists(SyncId.fromFName(supersedingUserNameProof))).toBeFalsy();
         expect((await syncEngine.getDbStats()).numFnames).toEqual(0);
 
         await engine.mergeUserNameProof(userNameProof);
@@ -517,11 +517,11 @@ describe("SyncEngine", () => {
         expect(await syncEngine.trie.exists(SyncId.fromFName(userNameProof))).toBeTruthy();
         expect((await syncEngine.getDbStats()).numFnames).toEqual(1);
 
-        await engine.mergeUserNameProof(supercedingUserNameProof);
+        await engine.mergeUserNameProof(supersedingUserNameProof);
         await sleepWhile(() => syncEngine.syncTrieQSize > 0, SLEEPWHILE_TIMEOUT);
 
         expect(await syncEngine.trie.exists(SyncId.fromFName(userNameProof))).toBeFalsy();
-        expect(await syncEngine.trie.exists(SyncId.fromFName(supercedingUserNameProof))).toBeTruthy();
+        expect(await syncEngine.trie.exists(SyncId.fromFName(supersedingUserNameProof))).toBeTruthy();
         expect((await syncEngine.getDbStats()).numFnames).toEqual(1);
       });
 

--- a/apps/hubble/src/storage/db/migrations/11.fnameIndex.ts
+++ b/apps/hubble/src/storage/db/migrations/11.fnameIndex.ts
@@ -8,7 +8,7 @@ import { ResultAsync } from "neverthrow";
 const log = logger.child({ component: "fnameIndex" });
 
 /**
- * Up untill now, we were accidentally writing the fid index for the fname messages as Little Endian
+ * Up until now, we were accidentally writing the fid index for the fname messages as Little Endian
  * instead of Big Endian in name_registry_events.rs:make_fname_username_proof_by_fid_key.
  * This migration will fix that to be big endian, and also remove the little endian index keys
  */

--- a/packages/shuttle/src/shuttle.integration.test.ts
+++ b/packages/shuttle/src/shuttle.integration.test.ts
@@ -561,7 +561,7 @@ describe("shuttle", () => {
           }),
         );
       },
-      getAllVerficationMessagesByFid: async (
+      getAllVerificationMessagesByFid: async (
         _request: FidRequest,
         _metadata: Metadata,
         _options: Partial<CallOptions>,


### PR DESCRIPTION
  - `"superceding"` → `"superseding"`  
  - `"getAllVerficationMessagesByFid"` → `"getAllVerificationMessagesByFid"`  
  - `"Up untill"` → `"Up until"` 


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting typos and improving clarity in function names and comments, as well as ensuring consistent naming conventions in the test cases.

### Detailed summary
- Renamed `getAllVerficationMessagesByFid` to `getAllVerificationMessagesByFid`.
- Fixed typo in the comment from "Up untill" to "Up until".
- Renamed `supercedingUserNameProof` to `supersedingUserNameProof` for consistency.
- Updated references to `supercedingUserNameProof` to `supersedingUserNameProof` in assertions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->