### PR TITLE
feat: add envvars to shuttle for consuming from snapchain

### DIFF
--- a/.changeset/wild-rabbits-tap.md
+++ b/.changeset/wild-rabbits-tap.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+feat: add envvars to shuttle for consuming from snapchain

--- a/packages/shuttle/src/example-app/app.ts
+++ b/packages/shuttle/src/example-app/app.ts
@@ -41,6 +41,8 @@ import {
   REDIS_URL,
   SHARD_INDEX,
   TOTAL_SHARDS,
+  USE_STREAMING_RPCS_FOR_BACKFILL,
+  SUBSCRIBE_RPC_TIMEOUT,
 } from "./env";
 import * as process from "node:process";
 import url from "node:url";
@@ -99,6 +101,7 @@ export class App implements MessageHandler {
       null,
       totalShards,
       shardIndex,
+      SUBSCRIBE_RPC_TIMEOUT,
     );
     const streamConsumer = new HubEventStreamConsumer(hub, eventStreamForRead, shardKey);
 
@@ -213,8 +216,14 @@ export class App implements MessageHandler {
   }
 
   async reconcileFids(fids: number[]) {
-    // biome-ignore lint/style/noNonNullAssertion: client is always initialized
-    const reconciler = new MessageReconciliation(this.hubSubscriber.hubClient!, this.db, log);
+    const reconciler = new MessageReconciliation(
+      // biome-ignore lint/style/noNonNullAssertion: client is always initialized
+      this.hubSubscriber.hubClient!,
+      this.db,
+      log,
+      undefined,
+      USE_STREAMING_RPCS_FOR_BACKFILL,
+    );
     for (const fid of fids) {
       await reconciler.reconcileMessagesForFid(
         fid,

--- a/packages/shuttle/src/example-app/env.ts
+++ b/packages/shuttle/src/example-app/env.ts
@@ -22,3 +22,5 @@ export const STATSD_HOST = process.env["STATSD_HOST"];
 export const STATSD_METRICS_PREFIX = process.env["STATSD_METRICS_PREFIX"] || "shuttle.";
 
 export const CONCURRENCY = parseInt(process.env["CONCURRENCY"] || "2");
+export const USE_STREAMING_RPCS_FOR_BACKFILL = process.env["USE_STREAMING_RPCS_FOR_BACKFILL"] === "true" ? true : false;
+export const SUBSCRIBE_RPC_TIMEOUT = parseInt(process.env["SUBSCRIBE_RPC_TIMEOUT"] || "30000");

--- a/packages/shuttle/src/shuttle/messageReconciliation.ts
+++ b/packages/shuttle/src/shuttle/messageReconciliation.ts
@@ -37,12 +37,14 @@ export class MessageReconciliation {
   private log: pino.Logger;
   private connectionTimeout: number; // milliseconds
 
-  constructor(client: HubRpcClient, db: DB, log: pino.Logger, connectionTimeout = 30000) {
+  constructor(client: HubRpcClient, db: DB, log: pino.Logger, connectionTimeout = 30000, useStreamingRpcs = true) {
     this.client = client;
     this.db = db;
     this.log = log;
     this.connectionTimeout = connectionTimeout;
-    this.establishStream();
+    if (useStreamingRpcs) {
+      this.establishStream();
+    }
   }
 
   async establishStream() {


### PR DESCRIPTION
For subscribing to the snapchain cluster, it's useful to have a longer subscribe rpc timeout given there isn't consistent activity on the cluster and it's required to use the standard (non-streaming) bulk rpcs. This feature adds config via envvars for these parameters. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding environment variables to the `shuttle` application for configuration, particularly for streaming RPCs and timeout settings.

### Detailed summary
- Introduced `USE_STREAMING_RPCS_FOR_BACKFILL` and `SUBSCRIBE_RPC_TIMEOUT` environment variables in `env.ts`.
- Modified the `constructor` in `MessageReconciliation` to accept a new parameter `useStreamingRpcs`.
- Updated `establishStream` method call to conditionally execute based on `useStreamingRpcs`.
- Adjusted the instantiation of `MessageReconciliation` in `reconcileFids` to include `USE_STREAMING_RPCS_FOR_BACKFILL`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->