### PR TITLE
chore: release shuttle v0.6.13

### DIFF
--- a/.changeset/wild-rabbits-tap.md
+++ b/.changeset/wild-rabbits-tap.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-feat: add envvars to shuttle for consuming from snapchain

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.6.13
+
+### Patch Changes
+
+- 63eb1407: feat: add envvars to shuttle for consuming from snapchain
+
 ## 0.6.12
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Release shuttle v0.6.13

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of the `@farcaster/shuttle` package from `0.6.12` to `0.6.13`, adds a new feature related to environment variables for `shuttle`, and removes an outdated changelog file.

### Detailed summary
- Updated `@farcaster/shuttle` version from `0.6.12` to `0.6.13` in `package.json`.
- Added a new feature: environment variables for consuming from `snapchain` in the changelog. 
- Deleted the `.changeset/wild-rabbits-tap.md` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->