### PR TITLE
“01/01/2022” instead of “01/01/2021”

### DIFF
--- a/packages/core/src/time.ts
+++ b/packages/core/src/time.ts
@@ -18,7 +18,7 @@ export const getFarcasterTime = (): HubResult<number> => {
  */
 export const toFarcasterTime = (time: number): HubResult<number> => {
   if (time < FARCASTER_EPOCH) {
-    return err(new HubError("bad_request.invalid_param", "time must be after Farcaster epoch (01/01/2022)"));
+    return err(new HubError("bad_request.invalid_param", "time must be after Farcaster epoch (01/01/2021)"));
   }
   const secondsSinceEpoch = Math.round((time - FARCASTER_EPOCH) / 1000);
   if (secondsSinceEpoch > 2 ** 32 - 1) {


### PR DESCRIPTION
In the code, the epoch is set to January 1, 2021, but there's a typo in the error message referencing “01/01/2022” instead of “01/01/2021”. 


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the error message in the `toFarcasterTime` function to reflect a change in the acceptable time range, adjusting the Farcaster epoch date from "01/01/2022" to "01/01/2021".

### Detailed summary
- Updated the error message in the `toFarcasterTime` function.
- Changed the date in the message from "01/01/2022" to "01/01/2021" to specify the new Farcaster epoch threshold.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->