### PR TITLE
feat: Add mentor link type

### DIFF
--- a/apps/hubble/src/rpc/test/linkService.test.ts
+++ b/apps/hubble/src/rpc/test/linkService.test.ts
@@ -17,6 +17,8 @@ import { jestRocksDB } from "../../storage/db/jestUtils.js";
 import Engine from "../../storage/engine/index.js";
 import { MockHub } from "../../test/mocks.js";
 import { setReferenceDateForTest } from "../../utils/versions.js";
+import { beforeAll, afterAll, beforeEach, describe, test, expect } from "@jest/globals";
+import { getFarcasterTime } from "../../utils";
 
 const db = jestRocksDB("protobufs.rpc.linkService.test");
 const network = FarcasterNetwork.TESTNET;
@@ -96,6 +98,21 @@ describe("getLink", () => {
     );
 
     expect(Message.toJSON(result._unsafeUnwrap())).toEqual(Message.toJSON(linkAddFollow));
+  });
+
+  test("succeeds with mentor", async () => {
+    const timestamp = getFarcasterTime()._unsafeUnwrap();
+    const linkAddMentor = await Factories.LinkAddMessage.create(
+      { data: { fid, network, timestamp, linkBody: { targetFid, type: "mentor" } } },
+      { transient: { signer } },
+    );
+    await engine.mergeMessage(linkAddMentor);
+
+    const result = await client.getLink(
+      LinkRequest.create({ fid, linkType: "mentor", targetFid: targetFid }),
+    );
+
+    expect(Message.toJSON(result._unsafeUnwrap())).toEqual(Message.toJSON(linkAddMentor));
   });
 
   test("succeeds with endorse", async () => {

--- a/apps/hubble/www/docs/docs/httpapi/links.md
+++ b/apps/hubble/www/docs/docs/httpapi/links.md
@@ -1,4 +1,3 @@
-
 # Links API
 
 The Links API will accept the following values for the `link_type` field. 
@@ -6,6 +5,7 @@ The Links API will accept the following values for the `link_type` field.
 | String |  Description |
 | ------ |  ----------- |
 | follow | Follow from FID to Target FID |
+| mentor | Indicate that Target FID is a mentor for FID |
 
 ## linkById
 Get a link by its FID and target FID.

--- a/packages/hub-nodejs/spec.yaml
+++ b/packages/hub-nodejs/spec.yaml
@@ -1303,14 +1303,7 @@ components:
         - type: object
           properties:
             data:
-              allOf:
-                - $ref: '#/components/schemas/MessageDataLink'
-                - type: object
-                  properties:
-                    type:
-                      $ref: '#/components/schemas/MessageType'
-                  required:
-                    - type
+              $ref: '#/components/schemas/MessageDataLink'
           required:
             - data
     LinkType:
@@ -1318,9 +1311,11 @@ components:
       description: |-
         Type of Link.
         - follow: Follow another user
+        - mentor: Indicate another user as mentor
       default: follow
       enum:
         - follow
+        - mentor
     MergeMessageBody:
       type: object
       properties:


### PR DESCRIPTION
- Add new "mentor" link type to support mentorship relationships between users
- Update LinkType schema in API specification
- Add documentation for mentor link type
- Add test coverage for mentor link functionality


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `link_type` value for the Links API, updates the API schema, and adds a test case for handling links of type `mentor`.

### Detailed summary
- Added `mentor` as a new value for the `link_type` field in `links.md`.
- Updated `spec.yaml` to include `mentor` in the `LinkType` enum.
- Added a test case in `linkService.test.ts` to verify functionality for links of type `mentor`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->