### PR TITLE
fix: Correct logic in `delete_username_proof_transaction` to delete instead of re-adding

### DIFF
--- a/apps/hubble/src/addon/src/store/name_registry_events.rs
+++ b/apps/hubble/src/addon/src/store/name_registry_events.rs
@@ -80,7 +80,7 @@ pub fn delete_username_proof_transaction(
     let buf = username_proof.encode_to_vec();
 
     let primary_key = make_fname_username_proof_key(&username_proof.name);
-    txn.put(primary_key.clone(), buf);
+    txn.delete(primary_key);
 
     if existing_fid.is_some() {
         let secondary_key = make_fname_username_proof_by_fid_key(existing_fid.unwrap());


### PR DESCRIPTION
## Why is this change needed?

The current implementation of the `delete_username_proof_transaction` function incorrectly re-adds the username proof after encoding it instead of deleting it. This PR corrects that logic by replacing the re-add operation with the proper deletion operation. It ensures that the function now correctly removes the username proof from the database when called, fixing the logic and ensuring the expected behavior.


## Merge Checklist

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the handling of a primary key in the `name_registry_events.rs` file, specifically changing how data is stored in a transaction.

### Detailed summary
- Removed the line that puts the `primary_key` into the transaction (`txn.put(primary_key.clone(), buf);`).
- Added a line that deletes the `primary_key` from the transaction (`txn.delete(primary_key);`).

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->