### PR TITLE
fix: correct typos in rustfunctions.ts and shuttle.integration.test.ts

### DIFF
--- a/apps/hubble/src/rustfunctions.ts
+++ b/apps/hubble/src/rustfunctions.ts
@@ -168,7 +168,7 @@ export const rsDbSnapshotBackup = async (mainDb: RustDb, trieDb: RustDb, timesta
  * dropped right after the iterator is finished.
 
   This specifically means that we need to use iterators as callbacks. The way the iterators are set up is:
-  - Call the `forEachIteartor` method with your callback (Either in JS or Rust)
+  - Call the `forEachIterator` method with your callback (Either in JS or Rust)
   - Perform all actions in the callback
   - At the end of the iteration, the iterator is returned and closed by Rust
 

--- a/packages/shuttle/src/shuttle.integration.test.ts
+++ b/packages/shuttle/src/shuttle.integration.test.ts
@@ -561,7 +561,7 @@ describe("shuttle", () => {
           }),
         );
       },
-      getAllVerficationMessagesByFid: async (
+      getAllVerificationMessagesByFid: async (
         _request: FidRequest,
         _metadata: Metadata,
         _options: Partial<CallOptions>,


### PR DESCRIPTION

## Why is this change needed?

Hi! This PR fixes minor typos in `rustfunctions.ts` and `shuttle.integration.test.ts`. The incorrect method name `forEachIteartor` was corrected to `forEachIterator`, and `getAllVerficationMessagesByFid` was fixed to `getAllVerificationMessagesByFid`. These fixes improve code readability and prevent potential confusion.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

This is a simple typo fix with no functional changes. Ready for review!

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting typos in method names and improving documentation clarity regarding the use of iterators in the codebase.

### Detailed summary
- Renamed the method `getAllVerficationMessagesByFid` to `getAllVerificationMessagesByFid` in `packages/shuttle/src/shuttle.integration.test.ts`.
- Corrected the method name from `forEachIteartor` to `forEachIterator` in `apps/hubble/src/rustfunctions.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->