### PR TITLE
chore: fix misleading test name

### DIFF
--- a/apps/hubble/src/rpc/test/castService.test.ts
+++ b/apps/hubble/src/rpc/test/castService.test.ts
@@ -81,7 +81,7 @@ describe("getCast", () => {
     expect(result._unsafeUnwrapErr().errCode).toEqual("not_found");
   });
 
-  test("fails without fid or tsHash", async () => {
+  test("fails without fid", async () => {
     const result = await client.getCast(CastId.create({ fid: 0, hash: new Uint8Array() }));
     expect(result._unsafeUnwrapErr()).toEqual(new HubError("bad_request.validation_failure", "fid is missing"));
   });


### PR DESCRIPTION
## Why is this change needed?

Noticed that the test was named *"fails without fid or tsHash"*, but it actually only checks for the absence of *fid*.
Updated the name to *"fails without fid"* to match the actual behavior.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying a test case in the `castService.test.ts` file to ensure it accurately reflects the validation of the `fid` parameter.

### Detailed summary
- Changed the test description from `"fails without fid or tsHash"` to `"fails without fid"`.
- The test now only checks for the absence of `fid` when calling `client.getCast` with `fid: 0` and an empty hash, expecting a `HubError` indicating that `"fid is missing"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->