### PR TITLE
fix: incorrect type and error logging

### DIFF
--- a/apps/hubble/src/rpc/adminServer.ts
+++ b/apps/hubble/src/rpc/adminServer.ts
@@ -135,7 +135,7 @@ export default class AdminServer {
                   deletedCount += 1;
                 },
                 (e) => {
-                  log.error({ errCode: e.errCode }, "Failed to delete key: ${e.message}");
+                  log.error({ errCode: e.errCode }, `Failed to delete key: ${e.message}`);
                 },
               );
             });

--- a/apps/hubble/src/rpc/test/reactionService.test.ts
+++ b/apps/hubble/src/rpc/test/reactionService.test.ts
@@ -141,7 +141,7 @@ describe("getReaction", () => {
     );
 
     expect(result._unsafeUnwrapErr()).toEqual(
-      new HubError("bad_request.validation_failure", "targetId provided without type"),
+      new HubError("bad_request.validation_failure", "targetCastId provided without type"),
     );
   });
 


### PR DESCRIPTION
## Why is this change needed?

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error logging and correcting a specific error message in the `reactionService` test.

### Detailed summary
- In `apps/hubble/src/rpc/adminServer.ts`, changed string interpolation from double quotes to backticks in the error logging for better formatting.
- In `apps/hubble/src/rpc/test/reactionService.test.ts`, updated the error message from "targetId provided without type" to "targetCastId provided without type" in a `HubError` instantiation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->