### PR TITLE
chore: fix handling of error logging in API request

### DIFF
--- a/packages/hub-web/README.md
+++ b/packages/hub-web/README.md
@@ -36,7 +36,7 @@ try {
     console.log(`The first cast's text is ${response.messages[0].data.castAddBody.text}`);
 } catch (e) {
     // Handle errors
-    console.log(response);
+    console.log(e);
 }
 ```
 


### PR DESCRIPTION
## Why is this change needed?

I've fixed the issue where the `response` variable might not be available in the `catch` block. Instead of trying to log the `response` when an error occurs, we now log the actual error (`e`).
This ensures better error tracking even when the request fails.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error handling in the code by changing the logged output when an error occurs.

### Detailed summary
- In the `catch` block, the logged output was changed from `console.log(response);` to `console.log(e);`, ensuring that the actual error `e` is logged instead of the `response`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->