### PR TITLE
fix typo

### DIFF
--- a/apps/hubble/src/profile/gossipProfileWorker.js
+++ b/apps/hubble/src/profile/gossipProfileWorker.js
@@ -23,7 +23,7 @@ parentPort?.on("message", (data) => {
       const datas = nodes.map((node) => node.getData());
       const peerIds = nodes.map((node) => node.gossipNode.peerId?.toString());
       parentPort?.postMessage({ id, action, response: { peerIds, datas } });
-    } else if (action === ProfileWorkerAction.GetMultiAddres) {
+    } else if (action === ProfileWorkerAction.GetMultiAddress) {
       const response = getMultiAddrs();
       parentPort?.postMessage({ id, action, response });
     } else if (action === ProfileWorkerAction.ConnectToMutliAddr) {

--- a/apps/hubble/src/storage/db/migrations/11.fnameIndex.ts
+++ b/apps/hubble/src/storage/db/migrations/11.fnameIndex.ts
@@ -8,7 +8,7 @@ import { ResultAsync } from "neverthrow";
 const log = logger.child({ component: "fnameIndex" });
 
 /**
- * Up untill now, we were accidentally writing the fid index for the fname messages as Little Endian
+ * Up until now, we were accidentally writing the fid index for the fname messages as Little Endian
  * instead of Big Endian in name_registry_events.rs:make_fname_username_proof_by_fid_key.
  * This migration will fix that to be big endian, and also remove the little endian index keys
  */


### PR DESCRIPTION
fix typo

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a documentation error and fixing a typo in the `gossipProfileWorker.js` file, ensuring clarity in the code and comments.

### Detailed summary
- Updated the comment in `11.fnameIndex.ts` to correct "Up untill" to "Up until".
- Fixed a typo in `gossipProfileWorker.js` from `GetMultiAddres` to `GetMultiAddress`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->