### PR TITLE
fix: typos in documentation files

### DIFF
--- a/apps/hubble/src/rustfunctions.ts
+++ b/apps/hubble/src/rustfunctions.ts
@@ -168,7 +168,7 @@ export const rsDbSnapshotBackup = async (mainDb: RustDb, trieDb: RustDb, timesta
  * dropped right after the iterator is finished.
 
   This specifically means that we need to use iterators as callbacks. The way the iterators are set up is:
-  - Call the `forEachIteartor` method with your callback (Either in JS or Rust)
+  - Call the `forEachIterator` method with your callback (Either in JS or Rust)
   - Perform all actions in the callback
   - At the end of the iteration, the iterator is returned and closed by Rust
 

--- a/packages/shuttle/src/shuttle.integration.test.ts
+++ b/packages/shuttle/src/shuttle.integration.test.ts
@@ -561,7 +561,7 @@ describe("shuttle", () => {
           }),
         );
       },
-      getAllVerficationMessagesByFid: async (
+      getAllVerificationMessagesByFid: async (
         _request: FidRequest,
         _metadata: Metadata,
         _options: Partial<CallOptions>,


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `forEachIteartor` to `forEachIterator`
Corrected `Verfication` to `Verification`

Please review the changes and let me know if any additional changes are needed.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a typo in the function name and clarifying the documentation regarding the use of iterators in the `rustfunctions.ts` file.

### Detailed summary
- Renamed the function `getAllVerficationMessagesByFid` to `getAllVerificationMessagesByFid` in `shuttle.integration.test.ts`.
- Corrected the spelling of `forEachIteartor` to `forEachIterator` in the documentation within `rustfunctions.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->