### PR TITLE
fix: Correct Deletion Logic in Username Proof Transaction

### DIFF
--- a/apps/hubble/src/addon/src/store/name_registry_events.rs
+++ b/apps/hubble/src/addon/src/store/name_registry_events.rs
@@ -77,10 +77,8 @@ pub fn delete_username_proof_transaction(
     username_proof: &UserNameProof,
     existing_fid: Option<u32>,
 ) {
-    let buf = username_proof.encode_to_vec();
-
     let primary_key = make_fname_username_proof_key(&username_proof.name);
-    txn.put(primary_key.clone(), buf);
+    txn.delete(primary_key);
 
     if existing_fid.is_some() {
         let secondary_key = make_fname_username_proof_by_fid_key(existing_fid.unwrap());


### PR DESCRIPTION
## Why is this change needed?

The delete_username_proof_transaction function previously contained a put operation that reinserted the primary_key before attempting deletion. This behavior was incorrect, as the function's intent is to remove the username proof, not reinsert it.

By removing the unnecessary put operation and directly calling delete on the primary_key, this fix ensures the function behaves as expected—cleanly deleting the username proof. This prevents potential inconsistencies and aligns with standard deletion practices.

No functional changes are introduced beyond correcting the deletion logic.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the handling of username proof data in the `name_registry_events.rs` file by changing how the primary key is managed in the transaction.

### Detailed summary
- Replaced the line that adds a new entry to the transaction with a line that deletes the existing entry for the `primary_key` associated with `username_proof`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->