### PR TITLE
Update description to specify link direction for FID

### DIFF
--- a/apps/hubble/www/docs/docs/httpapi/links.md
+++ b/apps/hubble/www/docs/docs/httpapi/links.md
@@ -94,7 +94,7 @@ Get all links to a target FID
 **Query Parameters**
 | Parameter | Description | Example |
 | --------- | ----------- | ------- |
-| target_fid       | The FID of the reaction's creator | `target_fid=6833` |
+| target_fid       | The FID of the reaction's target | `target_fid=6833` |
 | link_type | The type of link, as a string value| `link_type=follow` |
 
 


### PR DESCRIPTION
## Why is this change needed?

The wording in the original documented listed both the `fid` and the `target_fid` as belonging to the same user. This one-word change clarifies the distinction to make the wording match the examples.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation in `links.md` to clarify the description of the `target_fid` parameter.

### Detailed summary
- Changed the description of the `target_fid` parameter from "The FID of the reaction's creator" to "The FID of the reaction's target".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->