### PR TITLE
chore: Release 1.19

### DIFF
--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hubble
 
+## 1.19.0
+
+### Minor Changes
+
+- chore: Release 1.19
+
 ## 1.18.0
 
 ### Minor Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -119,7 +119,7 @@ export const SNAPSHOT_S3_UPLOAD_BUCKET = "farcaster-snapshots";
 export const SNAPSHOT_S3_DOWNLOAD_BUCKET = "download.farcaster.xyz";
 export const S3_REGION = "auto";
 
-export const FARCASTER_VERSION = "2025.1.8";
+export const FARCASTER_VERSION = "2025.2.19";
 export const FARCASTER_VERSIONS_SCHEDULE: VersionSchedule[] = [
   { version: "2023.3.1", expiresAt: 1682553600000 }, // expires at 4/27/23 00:00 UTC
   { version: "2023.4.19", expiresAt: 1686700800000 }, // expires at 6/14/23 00:00 UTC
@@ -138,6 +138,7 @@ export const FARCASTER_VERSIONS_SCHEDULE: VersionSchedule[] = [
   { version: "2024.10.16", expiresAt: 1733875200000 }, // expires at 12/11/24 00:00 UTC
   { version: "2024.11.27", expiresAt: 1737504000000 }, // expires at 1/22/25 00:00 UTC
   { version: "2025.1.8", expiresAt: 1741132800000 }, // expires at 1/22/25 00:00 UTC
+  { version: "2025.2.19", expiresAt: 1744761600000 }, // expires at 4/16/25 00:00 UTC
 ];
 
 const MAX_CONTACT_INFO_AGE_MS = 1000 * 60 * 60; // 60 minutes


### PR DESCRIPTION
## Why is this change needed?

Release 1.19. This is a no-op release, and likely the final hub release before snapchain goes live.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the versioning and release notes for the `hubble` application, including a version bump in `package.json`, an update to the `FARCASTER_VERSION`, and the addition of a new version in the `FARCASTER_VERSIONS_SCHEDULE`.

### Detailed summary
- Updated `CHANGELOG.md` for version `1.19.0` release.
- Bumped `version` in `package.json` from `1.18.0` to `1.19.0`.
- Updated `FARCASTER_VERSION` in `hubble.ts` from `2025.1.8` to `2025.2.19`.
- Added new version `2025.2.19` to `FARCASTER_VERSIONS_SCHEDULE`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->