### PR TITLE
correction 003_onchain_events.ts

### DIFF
--- a/packages/shuttle/src/example-app/migrations/003_onchain_events.ts
+++ b/packages/shuttle/src/example-app/migrations/003_onchain_events.ts
@@ -2,7 +2,7 @@ import { Kysely, sql } from "kysely";
 
 // biome-ignore lint/suspicious/noExplicitAny: legacy code, avoid using ignore for new code
 export const up = async (db: Kysely<any>) => {
-  // Casts -------------------------------------------------------------------------------------
+  // Onchain Events -------------------------------------------------------------------------------------
   await db.schema
     .createTable("onchain_events")
     .addColumn("id", "uuid", (col) => col.defaultTo(sql`generate_ulid()`))


### PR DESCRIPTION
must be Onchain Events

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates a migration file for creating an `onchain_events` table in the database. It changes the comment header to reflect the focus on onchain events and maintains the functionality of creating a table with a UUID column.

### Detailed summary
- Changed comment header from "Casts" to "Onchain Events".
- Maintained the creation of the `onchain_events` table with an `id` column of type `uuid`, defaulting to `generate_ulid()`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->