### PR TITLE
correction hubSubscriber.ts

### DIFF
--- a/packages/shuttle/src/shuttle/hubSubscriber.ts
+++ b/packages/shuttle/src/shuttle/hubSubscriber.ts
@@ -115,7 +115,7 @@ export class BaseHubSubscriber extends HubSubscriber {
     if (fromId) {
       this.log.info(`HubSubscriber ${this.label} Found last hub event ID: ${fromId}`);
     } else {
-      this.log.warn("No last hub event ID found, starting from beginning");
+      this.log.warn("No last hub event ID found, starting from the beginning");
     }
 
     const subscribeParams = {


### PR DESCRIPTION
from beginning - from the beginning

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the logging message in the `hubSubscriber.ts` file for clarity.

### Detailed summary
- Updated the warning log message from `"No last hub event ID found, starting from beginning"` to `"No last hub event ID found, starting from the beginning"` for better readability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->