### PR TITLE
fix: stop producing negative storage usage

### DIFF
--- a/.changeset/empty-queens-bathe.md
+++ b/.changeset/empty-queens-bathe.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: stop producing negative storage usage

--- a/apps/hubble/src/storage/engine/index.test.ts
+++ b/apps/hubble/src/storage/engine/index.test.ts
@@ -39,7 +39,7 @@ import Engine from "../engine/index.js";
 import { sleep } from "../../utils/crypto.js";
 import { getMessage, makeTsHash, typeToSetPostfix } from "../db/message.js";
 import { StoreEvents } from "../stores/storeEventHandler.js";
-import { IdRegisterOnChainEvent, makeVerificationAddressClaim } from "@farcaster/core";
+import { IdRegisterOnChainEvent, makeVerificationAddressClaim, StoreType } from "@farcaster/core";
 import { setReferenceDateForTest } from "../../utils/versions.js";
 import { publicClient } from "../../test/utils.js";
 import { jest } from "@jest/globals";
@@ -843,6 +843,13 @@ describe("mergeMessage", () => {
       expect(usernameProofEvents.length).toBe(1);
       expect(usernameProofEvents[0]?.usernameProof).toMatchObject(message.data.usernameProofBody);
       expect(usernameProofEvents[0]?.deletedUsernameProof).toBeUndefined();
+      expect(
+        (await engine.eventHandler.getUsage(message.data.fid, StoreType.USERNAME_PROOFS))._unsafeUnwrap().used,
+      ).toEqual(1);
+      engine.clearCaches();
+      await engine.revokeMessagesBySigner(fid, signerKey);
+      await sleep(1000);
+      expect((await engine.eventHandler.getUsage(fid, StoreType.USERNAME_PROOFS))._unsafeUnwrap().used).toEqual(0);
     });
 
     test("succeeds for valid proof for verified eth address", async () => {

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -268,6 +268,7 @@ class Engine extends TypedEmitter<EngineEvents> {
     return this._db;
   }
 
+  // Only used in tests
   clearCaches() {
     this._onchainEventsStore.clearCaches();
     this.eventHandler.clearCaches();

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -270,6 +270,7 @@ class Engine extends TypedEmitter<EngineEvents> {
 
   clearCaches() {
     this._onchainEventsStore.clearCaches();
+    this.eventHandler.clearCaches();
   }
 
   get solanaVerificationsEnabled(): boolean {

--- a/apps/hubble/src/storage/stores/storageCache.ts
+++ b/apps/hubble/src/storage/stores/storageCache.ts
@@ -301,7 +301,10 @@ export class StorageCache {
         count = msgCountResult.value;
       }
 
-      this._counts.set(key, count - 1);
+      // Really, if we just queried the count fresh from the db we don't want to subtract 1 here because the queried count already incorporates the remove. The case where the count is negative is particularly bad, though because it causes a crash for clients so we protect against this case.
+      if (count - 1 >= 0) {
+        this._counts.set(key, count - 1);
+      }
 
       const tsHashResult = makeTsHash(message.data.timestamp, message.hash);
       if (!tsHashResult.isOk()) {

--- a/apps/hubble/src/storage/stores/storageCache.ts
+++ b/apps/hubble/src/storage/stores/storageCache.ts
@@ -62,6 +62,10 @@ export class StorageCache {
     this._db = db;
   }
 
+  clearCache() {
+    this._counts.clear();
+  }
+
   async syncFromDb(): Promise<void> {
     log.info("starting storage cache sync");
 

--- a/apps/hubble/src/storage/stores/storeEventHandler.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.ts
@@ -223,6 +223,10 @@ class StoreEventHandler extends TypedEmitter<StoreEvents> {
     });
   }
 
+  clearCaches() {
+    this._storageCache.clearCache();
+  }
+
   async getCacheMessageCount(fid: number, set: UserMessagePostfix, forceFetch = true): HubAsyncResult<number> {
     return await this._storageCache.getMessageCount(fid, set, forceFetch);
   }


### PR DESCRIPTION
Addresses the issue reported here: https://github.com/farcasterxyz/hub-monorepo/issues/2547

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the storage usage calculations in the `hubble` application to prevent negative values, enhancing cache management, and adding tests to ensure accurate usage reporting.

### Detailed summary
- Added `clearCaches` method to `eventHandler` and `storageCache`.
- Updated logic in `StorageCache` to prevent negative counts.
- Introduced a test for accurate storage usage when a username proof is revoked.
- Enhanced test coverage for storage usage scenarios.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->