### PR TITLE
docs: Fix grammar and HTML encoding

### DIFF
--- a/apps/hubble/www/docs/docs/messages.md
+++ b/apps/hubble/www/docs/docs/messages.md
@@ -30,7 +30,7 @@ A MessageData object contains properties common to all MessageTypes and wraps a 
 
 ### 1.2 HashScheme
 
-Type of hashing scheme used to produce a digest of MessageData
+Type of a hashing scheme used to produce a digest of MessageData
 
 | Name               | Number | Description                            |
 | ------------------ | ------ | -------------------------------------- |
@@ -179,7 +179,7 @@ Adds or removes a Link
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| type | [string](#string) |  | Type of link, &lt;= 8 characters |
+| type | [string](#string) |  | Type of link, <= characters |
 | displayTimestamp | [uint32](#uint32) | optional | User-defined timestamp that preserves original timestamp when message.data.timestamp needs to be updated for compaction |
 | target_fid | [uint64](#uint64) |  | The fid the link relates to |
 


### PR DESCRIPTION
## Why is this change needed?

Correct a missing article "a" in "Type of hashing scheme..." and added it for correctness, also replaced unnecessary `&lt;=` with plain `<=` in the LinkBody section.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on minor textual corrections in the `messages.md` documentation, enhancing clarity and fixing a typographical error.

### Detailed summary
- Changed "Type of hashing scheme used" to "Type of a hashing scheme used" for clarity.
- Corrected "Type of link, &lt;= 8 characters" to "Type of link, <= characters" to fix a typographical error.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->