### PR TITLE
chore: upgrade hubble to v1.19.1

### DIFF
--- a/.changeset/empty-queens-bathe.md
+++ b/.changeset/empty-queens-bathe.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hubble": patch
----
-
-fix: stop producing negative storage usage

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hubble
 
+## 1.19.1
+
+### Patch Changes
+
+- b13e650c: fix: stop producing negative storage usage
+
 ## 1.19.0
 
 ### Minor Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",


### PR DESCRIPTION
Release hubble 1.19.1

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of the `@farcaster/hubble` package from `1.19.0` to `1.19.1`, along with a corresponding change in the `CHANGELOG.md` to document a bug fix.

### Detailed summary
- Updated `version` in `apps/hubble/package.json` from `1.19.0` to `1.19.1`.
- Added entry in `CHANGELOG.md` for version `1.19.1` noting a fix for negative storage usage. 
- Deleted `.changeset/empty-queens-bathe.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->