### PR TITLE
chore: correct method call in `stop()`

### DIFF
--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -251,7 +251,7 @@ class Engine extends TypedEmitter<EngineEvents> {
     this.eventHandler.off("mergeUsernameProofEvent", this.handleMergeUsernameProofEvent);
     this.eventHandler.off("mergeOnChainEvent", this.handleMergeOnChainEvent);
 
-    this._revokeSignerWorker.start();
+    this._revokeSignerWorker.stop();
 
     if (this._validationWorkers) {
       for (const worker of this._validationWorkers) {


### PR DESCRIPTION
## Why is this change needed?

In the `stop()` method, `this._revokeSignerWorker.start();` was incorrectly called instead of `this._revokeSignerWorker.stop();`. Since the purpose of this method is to stop processes, calling the appropriate stop method is more consistent with the expected behavior.  

This change aligns the `stop()` method with the logic used in `start()`.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the behavior of the `revokeSignerWorker` in the `index.ts` file, changing its state from starting to stopping, and adjusting the event handler for `mergeOnChainEvent`.

### Detailed summary
- Removed the line that starts the `revokeSignerWorker`: `this._revokeSignerWorker.start();`
- Added a line that stops the `revokeSignerWorker`: `this._revokeSignerWorker.stop();`
- No changes were made to the handling of `_validationWorkers`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->