### PR TITLE
Fix Potential Vulnerabilities: hubble.sh

### DIFF
--- a/scripts/hubble-bootstrap.sh
+++ b/scripts/hubble-bootstrap.sh
@@ -21,7 +21,7 @@ install_jq() {
         if command -v brew >/dev/null 2>&1; then
             brew install jq
         else
-            echo "Homebrew is not installed. Please install Homebrew first."
+            echo "❌ Homebrew is not installed. Please install Homebrew first."
             return 1
         fi
 
@@ -47,7 +47,7 @@ install_jq() {
         sudo pacman -S jq
 
     else
-        echo "Unsupported operating system. Please install jq manually."
+        echo "❌ Unsupported operating system. Please install jq manually."
         return 1
     fi
 
@@ -64,27 +64,27 @@ fetch_file_from_repo() {
 
     # Download the file using curl, and save it to the local filename. If the download fails,
     # exit with an error.
-    curl -sS -o "$local_filename" "$download_url" || { echo "Failed to fetch $download_url."; exit 1; }
+    curl -sS -o "$local_filename" "$download_url" || { echo "❌ Failed to fetch $download_url. Check your internet connection or the file path."; exit 1; }
 }
 
 do_bootstrap() {
     # Make the ~/hubble directory if it doesn't exist
-    mkdir -p ~/hubble
+    mkdir -p ~/hubble || { echo "❌ Failed to create ~/hubble directory."; exit 1; }
     
     local tmp_file
     tmp_file=$(mktemp)
     fetch_file_from_repo "$SCRIPT_FILE_PATH" "$tmp_file"
 
-    mv "$tmp_file" ~/hubble/hubble.sh
-    chmod +x ~/hubble/hubble.sh
+    mv "$tmp_file" ~/hubble/hubble.sh || { echo "❌ Failed to move $tmp_file to ~/hubble/hubble.sh."; exit 1; }
+    chmod +x ~/hubble/hubble.sh || { echo "❌ Failed to make ~/hubble/hubble.sh executable."; exit 1; }
 
     # Run the hubble.sh script
     cd ~/hubble
-    exec ./hubble.sh "upgrade" < /dev/tty
+    ./hubble.sh "upgrade" < /dev/tty || { echo "❌ Failed to run ~/hubble/hubble.sh."; exit 1; }
 }
 
 # Install jq
-install_jq
+install_jq || { echo "❌ jq installation failed. Exiting."; exit 1; }
 
 # Bootstrap
 do_bootstrap


### PR DESCRIPTION


## Why is this change needed?
To improve the reliability, readability, and error handling of the bootstrap script for installing Hubble.
Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Merge Checklist

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a function name in the import statement
and making a minor grammatical adjustment in the documentation.

### Detailed summary
- Changed the import from scripts/hubble-bootstrap.sh
- Improved Error Handling:
- Improved Code Readability:
-Fixed Potential Vulnerabilities:
> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your
question}`

<!-- end pr-codex -->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances error messaging in the `hubble-bootstrap.sh` script by adding visual indicators (❌) to error messages and implementing error handling for various operations, improving user experience and troubleshooting.

### Detailed summary
- Updated error messages to include a ❌ symbol for clarity.
- Added error handling for:
  - Creating the `~/hubble` directory.
  - Moving the temporary file to `~/hubble/hubble.sh`.
  - Making `~/hubble/hubble.sh` executable.
  - Running `~/hubble/hubble.sh`.
  - Installing `jq`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->