### PR TITLE
feat: Update builders and examples for snapchain

### DIFF
--- a/.changeset/breezy-birds-jam.md
+++ b/.changeset/breezy-birds-jam.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/hub-nodejs": minor
+"@farcaster/core": minor
+---
+
+feat: Update packages to support snapchain

--- a/packages/core/src/builders.ts
+++ b/packages/core/src/builders.ts
@@ -67,7 +67,8 @@ export const makeMessage = async <TMessage extends protobufs.Message>(
   if (signerKey.isErr()) return err(signerKey.error);
 
   const message = protobufs.Message.create({
-    data: messageData,
+    // data: messageData,
+    dataBytes: dataBytes, // Messages for snapchain must use dataBytes because of serialization differences between js and rust
     hash,
     hashScheme: protobufs.HashScheme.BLAKE3,
     signature: signature.value,
@@ -92,7 +93,8 @@ export const makeMessageWithSignature = async (
   const hash = blake3(dataBytes, { dkLen: 20 });
 
   const message = protobufs.Message.create({
-    data: messageData,
+    // data: messageData,
+    dataBytes: dataBytes,
     hash,
     hashScheme: protobufs.HashScheme.BLAKE3,
     ...signerOptions,

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -292,10 +292,11 @@ export const validateMessage = async (
   publicClients: PublicClients = defaultPublicClients,
 ): HubAsyncResult<protobufs.Message> => {
   // 1. Check the message data
-  const data = message.data;
-  if (!data) {
+  if (!message.data && !message.dataBytes) {
     return err(new HubError("bad_request.validation_failure", "data is missing"));
   }
+  // biome-ignore lint/style/noNonNullAssertion: data or dataBytes must be set or it will be caught above
+  const data = message.data || protobufs.MessageData.decode(Buffer.from(message.dataBytes!));
   const validData = await validateMessageData(data, publicClients);
   if (validData.isErr()) {
     return err(validData.error);

--- a/packages/hub-nodejs/examples/chron-feed/index.ts
+++ b/packages/hub-nodejs/examples/chron-feed/index.ts
@@ -20,7 +20,7 @@ const timeAgo = new TimeAgo("en-US");
  * Populate the following constants with your own values
  */
 
-const HUB_URL = "nemes.farcaster.xyz:2283"; // URL of the Hub
+const HUB_URL = "juno.farcaster.xyz:3383"; // URL of the Hub
 const FIDS = [2, 3]; // User IDs to fetch casts for
 
 /**

--- a/packages/hub-nodejs/examples/hello-world/index.ts
+++ b/packages/hub-nodejs/examples/hello-world/index.ts
@@ -54,11 +54,11 @@ const SIGNER_PRIVATE_KEY: Hex = zeroAddress; // Optional, using the default mean
 
 // Note: nemes is the Farcaster team's mainnet hub, which is password protected to prevent abuse. Use a 3rd party hub
 // provider like https://neynar.com/ Or, run your own mainnet hub and broadcast to it permissionlessly.
-const HUB_URL = "nemes.farcaster.xyz:2283"; // URL + Port of the Hub
+const HUB_URL = "juno.farcaster.xyz:3383"; // URL + Port of the Hub
 const HUB_USERNAME = ""; // Username for auth, leave blank if not using TLS
 const HUB_PASS = ""; // Password for auth, leave blank if not using TLS
 const USE_SSL = false; // set to true if talking to a hub that uses SSL (3rd party hosted hubs or hubs that require auth)
-const FC_NETWORK = FarcasterNetwork.MAINNET; // Network of the Hub
+const FC_NETWORK = FarcasterNetwork.TESTNET; // Network of the Hub
 
 const CHAIN = optimism;
 const IdGateway = { abi: idGatewayABI, address: ID_GATEWAY_ADDRESS, chain: CHAIN };
@@ -201,7 +201,7 @@ const registerFname = async (fid: number) => {
       fid: fid, // Fid making the request (must match from or to)
       owner: account.address, // Custody address of fid making the request
       timestamp: timestamp, // Current timestamp in seconds
-      signature: bytesToHex(userNameProofSignature.value), // EIP-712 signature signed by the current custody address of the fid
+      signature: bytesToHex(userNameProofSignature._unsafeUnwrap()), // EIP-712 signature signed by the current custody address of the fid
     });
     return fname;
   } catch (e) {

--- a/packages/hub-nodejs/examples/write-data/index.ts
+++ b/packages/hub-nodejs/examples/write-data/index.ts
@@ -25,7 +25,7 @@ const SIGNER = "<REQUIRED>";
 const FID = -1; // <REQUIRED>
 
 // Testnet Configuration
-const HUB_URL = "testnet1.farcaster.xyz:2283"; // URL + Port of the Hub
+const HUB_URL = "juno.farcaster.xyz:3383"; // URL + Port of the Hub
 const NETWORK = FarcasterNetwork.TESTNET; // Network of the Hub
 
 (async () => {


### PR DESCRIPTION
## Why is this change needed?

Update builders to use dataBytes so messages work with snapchain

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the package versions and modifying various `HUB_URL` configurations to support the `snapchain` functionality, alongside some validation and message handling improvements.

### Detailed summary
- Updated package versions for `@farcaster/hub-nodejs` and `@farcaster/core` to minor.
- Changed `HUB_URL` in multiple examples to point to `juno.farcaster.xyz:3383`.
- Enhanced validation by checking both `message.data` and `message.dataBytes`.
- Updated message creation to use `dataBytes` for `snapchain` compatibility.
- Adjusted signature handling to use `_unsafeUnwrap()`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->