### PR TITLE
fix: defer version expiry to April 30

### DIFF
--- a/.changeset/kind-parrots-hear.md
+++ b/.changeset/kind-parrots-hear.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+fix: Defer version expiry to April 30

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -138,7 +138,7 @@ export const FARCASTER_VERSIONS_SCHEDULE: VersionSchedule[] = [
   { version: "2024.10.16", expiresAt: 1733875200000 }, // expires at 12/11/24 00:00 UTC
   { version: "2024.11.27", expiresAt: 1737504000000 }, // expires at 1/22/25 00:00 UTC
   { version: "2025.1.8", expiresAt: 1741132800000 }, // expires at 1/22/25 00:00 UTC
-  { version: "2025.2.19", expiresAt: 1744761600000 }, // expires at 4/16/25 00:00 UTC
+  { version: "2025.2.19", expiresAt: 1745971200000 }, // expires at 4/30/25 00:00 UTC
 ];
 
 const MAX_CONTACT_INFO_AGE_MS = 1000 * 60 * 60; // 60 minutes


### PR DESCRIPTION
## Why is this change needed?

Defer version expiry to April 30 to provide time to migrate to snapchain

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version expiry date for a specific version in the `hubble.ts` file and includes a patch for the `@farcaster/hubble` package.

### Detailed summary
- Updated the expiry date for version `2025.2.19` from `4/16/25` to `4/30/25` in `hubble.ts`.
- Added a patch entry for `@farcaster/hubble` in the changeset file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->