### PR TITLE
fix: Ensure snapchain error codes are passed through

### DIFF
--- a/.changeset/nasty-eagles-grin.md
+++ b/.changeset/nasty-eagles-grin.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hub-nodejs": patch
+---
+
+fix: Ensure snapchain error codes are passed through

--- a/packages/hub-nodejs/src/client.ts
+++ b/packages/hub-nodejs/src/client.ts
@@ -17,7 +17,8 @@ const fromServiceError = (err: ServiceError): HubError => {
   if (err.code === 14 && err.details === "No connection established") {
     context = `Connection failed: please check that the hub’s address, ports and authentication config are correct. ${context}`;
   }
-  return new HubError(err.metadata.get("errCode")[0] as HubErrorCode, context);
+  const hubErrorCode = err.metadata.get("errCode")[0] || err.metadata.get("x-err-code")[0];
+  return new HubError(hubErrorCode as HubErrorCode, context);
 };
 
 // grpc-js generates a Client stub that uses callbacks for async calls. Callbacks are


### PR DESCRIPTION
## Why is this change needed?

Snapchain sends the error codes back using a different header name. Read that as well.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error handling in the `hub-nodejs` package by ensuring that error codes from the snapchain are correctly passed through to the `HubError`.

### Detailed summary
- Updated error handling in `packages/hub-nodejs/src/client.ts`.
- Modified the way `HubError` is instantiated to use `hubErrorCode`, which retrieves error codes from both `err.metadata.get("errCode")` and `err.metadata.get("x-err-code")`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->