### PR TITLE
chore: Release hub-nodejs 0.13.1

### DIFF
--- a/.changeset/nasty-eagles-grin.md
+++ b/.changeset/nasty-eagles-grin.md
@@ -1,5 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
----
-
-fix: Ensure snapchain error codes are passed through

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -75,7 +75,7 @@
     "@chainsafe/libp2p-noise": "15.1.0",
     "@datastructures-js/priority-queue": "^6.3.1",
     "@faker-js/faker": "~7.6.0",
-    "@farcaster/hub-nodejs": "^0.13.0",
+    "@farcaster/hub-nodejs": "^0.13.1",
     "@fastify/cors": "^8.4.0",
     "@figma/hot-shots": "^9.0.0-figma.1",
     "@grpc/grpc-js": "~1.11.1",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-nodejs
 
+## 0.13.1
+
+### Patch Changes
+
+- b39166ec: fix: Ensure snapchain error codes are passed through
+
 ## 0.13.0
 
 ### Minor Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Why is this change needed?

Release hub-nodejs 0.13.1

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of the `@farcaster/hub-nodejs` package from `0.13.0` to `0.13.1` and includes a changelog entry for the patch changes made.

### Detailed summary
- Deleted the file `.changeset/nasty-eagles-grin.md`.
- Updated `CHANGELOG.md` to include version `0.13.1` with a patch change for snapchain error codes.
- Updated `packages/hub-nodejs/package.json` version from `0.13.0` to `0.13.1`.
- Updated `apps/hubble/package.json` to reflect the new version `^0.13.1` for `@farcaster/hub-nodejs`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->