### PR TITLE
chore: Extend hubble expiry by a few weeks

### DIFF
--- a/.changeset/witty-kangaroos-sell.md
+++ b/.changeset/witty-kangaroos-sell.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/hubble": patch
+---
+
+chore: Extend hubble expiry by a few weeks

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -138,7 +138,7 @@ export const FARCASTER_VERSIONS_SCHEDULE: VersionSchedule[] = [
   { version: "2024.10.16", expiresAt: 1733875200000 }, // expires at 12/11/24 00:00 UTC
   { version: "2024.11.27", expiresAt: 1737504000000 }, // expires at 1/22/25 00:00 UTC
   { version: "2025.1.8", expiresAt: 1741132800000 }, // expires at 1/22/25 00:00 UTC
-  { version: "2025.2.19", expiresAt: 1745971200000 }, // expires at 4/30/25 00:00 UTC
+  { version: "2025.2.19", expiresAt: 1747353600000 }, // expires at 5/16/25 00:00 UTC
 ];
 
 const MAX_CONTACT_INFO_AGE_MS = 1000 * 60 * 60; // 60 minutes


### PR DESCRIPTION
## Why is this change needed?

Extend expiry by a few weeks for those who need more time to migrate to snapchain

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the expiry dates of certain versions in the `hubble` application to extend their validity.

### Detailed summary
- Updated expiry date for version `2025.2.19` from `4/30/25` to `5/16/25` in `apps/hubble/src/hubble.ts`.
- Added a patch entry for `@farcaster/hubble` in the changeset.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->