### PR TITLE
feat: More Snapchain updates

### DIFF
--- a/.changeset/heavy-roses-confess.md
+++ b/.changeset/heavy-roses-confess.md
@@ -1,0 +1,8 @@
+---
+"@farcaster/hub-nodejs": patch
+"@farcaster/hub-web": patch
+"@farcaster/shuttle": patch
+"@farcaster/core": patch
+---
+
+feat: Add snapchain fields to hub event

--- a/.changeset/mighty-queens-sip.md
+++ b/.changeset/mighty-queens-sip.md
@@ -1,0 +1,8 @@
+---
+"@farcaster/hub-nodejs": patch
+"@farcaster/hub-web": patch
+"@farcaster/shuttle": patch
+"@farcaster/core": patch
+---
+
+fix: Populate data and dataBytes for better compatibility

--- a/apps/hubble/src/addon/src/store/store.rs
+++ b/apps/hubble/src/addon/src/store/store.rs
@@ -318,6 +318,9 @@ pub trait StoreDef: Send + Sync {
                 },
             )),
             id: 0,
+            block_number: 0,
+            shard_index: 0,
+            timestamp: 0,
         }
     }
 
@@ -340,6 +343,9 @@ pub trait StoreDef: Send + Sync {
                 },
             })),
             id: 0,
+            block_number: 0,
+            shard_index: 0,
+            timestamp: 0,
         }
     }
 
@@ -352,6 +358,9 @@ pub trait StoreDef: Send + Sync {
                 },
             )),
             id: 0,
+            block_number: 0,
+            shard_index: 0,
+            timestamp: 0,
         }
     }
 }

--- a/apps/hubble/src/addon/src/store/user_data_store.rs
+++ b/apps/hubble/src/addon/src/store/user_data_store.rs
@@ -398,6 +398,9 @@ impl UserDataStore {
                 },
             )),
             id: 0,
+            block_number: 0,
+            shard_index: 0,
+            timestamp: 0,
         };
         let id = store
             .event_handler()

--- a/apps/hubble/src/addon/src/store/username_proof_store.rs
+++ b/apps/hubble/src/addon/src/store/username_proof_store.rs
@@ -298,6 +298,9 @@ impl StoreDef for UsernameProofStoreDef {
                 },
             )),
             id: 0,
+            block_number: 0,
+            shard_index: 0,
+            timestamp: 0,
         }
     }
 
@@ -338,6 +341,9 @@ impl StoreDef for UsernameProofStoreDef {
                 },
             )),
             id: 0,
+            block_number: 0,
+            shard_index: 0,
+            timestamp: 0,
         }
     }
 

--- a/apps/hubble/src/storage/stores/storeEventHandler.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.ts
@@ -117,7 +117,7 @@ export type StoreEvents = {
   mergeOnChainEvent: (event: MergeOnChainEventHubEvent) => void;
 };
 
-export type HubEventArgs = Omit<HubEvent, "id">;
+export type HubEventArgs = Omit<HubEvent, "id" | "blockNumber" | "shardIndex" | "timestamp">;
 
 const makeEventKey = (id?: number): Buffer => {
   const buffer = Buffer.alloc(1 + (id ? 8 : 0));

--- a/packages/core/src/builders.ts
+++ b/packages/core/src/builders.ts
@@ -67,7 +67,7 @@ export const makeMessage = async <TMessage extends protobufs.Message>(
   if (signerKey.isErr()) return err(signerKey.error);
 
   const message = protobufs.Message.create({
-    // data: messageData,
+    data: messageData,
     dataBytes: dataBytes, // Messages for snapchain must use dataBytes because of serialization differences between js and rust
     hash,
     hashScheme: protobufs.HashScheme.BLAKE3,
@@ -93,7 +93,7 @@ export const makeMessageWithSignature = async (
   const hash = blake3(dataBytes, { dkLen: 20 });
 
   const message = protobufs.Message.create({
-    // data: messageData,
+    data: messageData,
     dataBytes: dataBytes,
     hash,
     hashScheme: protobufs.HashScheme.BLAKE3,

--- a/packages/core/src/protobufs/generated/hub_event.ts
+++ b/packages/core/src/protobufs/generated/hub_event.ts
@@ -22,6 +22,7 @@ export enum HubEventType {
    *  HUB_EVENT_TYPE_MERGE_STORAGE_ADMIN_REGISTRY_EVENT = 8;
    */
   MERGE_ON_CHAIN_EVENT = 9,
+  MERGE_FAILURE = 10,
 }
 
 export function hubEventTypeFromJSON(object: any): HubEventType {
@@ -44,6 +45,9 @@ export function hubEventTypeFromJSON(object: any): HubEventType {
     case 9:
     case "HUB_EVENT_TYPE_MERGE_ON_CHAIN_EVENT":
       return HubEventType.MERGE_ON_CHAIN_EVENT;
+    case 10:
+    case "HUB_EVENT_TYPE_MERGE_FAILURE":
+      return HubEventType.MERGE_FAILURE;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum HubEventType");
   }
@@ -63,6 +67,8 @@ export function hubEventTypeToJSON(object: HubEventType): string {
       return "HUB_EVENT_TYPE_MERGE_USERNAME_PROOF";
     case HubEventType.MERGE_ON_CHAIN_EVENT:
       return "HUB_EVENT_TYPE_MERGE_ON_CHAIN_EVENT";
+    case HubEventType.MERGE_FAILURE:
+      return "HUB_EVENT_TYPE_MERGE_FAILURE";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum HubEventType");
   }
@@ -75,6 +81,12 @@ export interface MergeMessageBody {
 
 export interface PruneMessageBody {
   message: Message | undefined;
+}
+
+export interface MergeFailureBody {
+  message: Message | undefined;
+  code: string;
+  reason: string;
 }
 
 export interface RevokeMessageBody {
@@ -114,6 +126,10 @@ export interface HubEvent {
    *    MergeStorageAdminRegistryEventBody merge_storage_admin_registry_event_body = 10;
    */
   mergeOnChainEventBody?: MergeOnChainEventBody | undefined;
+  mergeFailure?: MergeFailureBody | undefined;
+  blockNumber: number;
+  shardIndex: number;
+  timestamp: number;
 }
 
 function createBaseMergeMessageBody(): MergeMessageBody {
@@ -249,6 +265,92 @@ export const PruneMessageBody = {
     message.message = (object.message !== undefined && object.message !== null)
       ? Message.fromPartial(object.message)
       : undefined;
+    return message;
+  },
+};
+
+function createBaseMergeFailureBody(): MergeFailureBody {
+  return { message: undefined, code: "", reason: "" };
+}
+
+export const MergeFailureBody = {
+  encode(message: MergeFailureBody, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.message !== undefined) {
+      Message.encode(message.message, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.code !== "") {
+      writer.uint32(18).string(message.code);
+    }
+    if (message.reason !== "") {
+      writer.uint32(26).string(message.reason);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MergeFailureBody {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMergeFailureBody();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.message = Message.decode(reader, reader.uint32());
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.code = reader.string();
+          continue;
+        case 3:
+          if (tag != 26) {
+            break;
+          }
+
+          message.reason = reader.string();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MergeFailureBody {
+    return {
+      message: isSet(object.message) ? Message.fromJSON(object.message) : undefined,
+      code: isSet(object.code) ? String(object.code) : "",
+      reason: isSet(object.reason) ? String(object.reason) : "",
+    };
+  },
+
+  toJSON(message: MergeFailureBody): unknown {
+    const obj: any = {};
+    message.message !== undefined && (obj.message = message.message ? Message.toJSON(message.message) : undefined);
+    message.code !== undefined && (obj.code = message.code);
+    message.reason !== undefined && (obj.reason = message.reason);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<MergeFailureBody>, I>>(base?: I): MergeFailureBody {
+    return MergeFailureBody.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MergeFailureBody>, I>>(object: I): MergeFailureBody {
+    const message = createBaseMergeFailureBody();
+    message.message = (object.message !== undefined && object.message !== null)
+      ? Message.fromPartial(object.message)
+      : undefined;
+    message.code = object.code ?? "";
+    message.reason = object.reason ?? "";
     return message;
   },
 };
@@ -504,6 +606,10 @@ function createBaseHubEvent(): HubEvent {
     revokeMessageBody: undefined,
     mergeUsernameProofBody: undefined,
     mergeOnChainEventBody: undefined,
+    mergeFailure: undefined,
+    blockNumber: 0,
+    shardIndex: 0,
+    timestamp: 0,
   };
 }
 
@@ -529,6 +635,18 @@ export const HubEvent = {
     }
     if (message.mergeOnChainEventBody !== undefined) {
       MergeOnChainEventBody.encode(message.mergeOnChainEventBody, writer.uint32(90).fork()).ldelim();
+    }
+    if (message.mergeFailure !== undefined) {
+      MergeFailureBody.encode(message.mergeFailure, writer.uint32(106).fork()).ldelim();
+    }
+    if (message.blockNumber !== 0) {
+      writer.uint32(96).uint64(message.blockNumber);
+    }
+    if (message.shardIndex !== 0) {
+      writer.uint32(112).uint32(message.shardIndex);
+    }
+    if (message.timestamp !== 0) {
+      writer.uint32(120).uint64(message.timestamp);
     }
     return writer;
   },
@@ -589,6 +707,34 @@ export const HubEvent = {
 
           message.mergeOnChainEventBody = MergeOnChainEventBody.decode(reader, reader.uint32());
           continue;
+        case 13:
+          if (tag != 106) {
+            break;
+          }
+
+          message.mergeFailure = MergeFailureBody.decode(reader, reader.uint32());
+          continue;
+        case 12:
+          if (tag != 96) {
+            break;
+          }
+
+          message.blockNumber = longToNumber(reader.uint64() as Long);
+          continue;
+        case 14:
+          if (tag != 112) {
+            break;
+          }
+
+          message.shardIndex = reader.uint32();
+          continue;
+        case 15:
+          if (tag != 120) {
+            break;
+          }
+
+          message.timestamp = longToNumber(reader.uint64() as Long);
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -613,6 +759,10 @@ export const HubEvent = {
       mergeOnChainEventBody: isSet(object.mergeOnChainEventBody)
         ? MergeOnChainEventBody.fromJSON(object.mergeOnChainEventBody)
         : undefined,
+      mergeFailure: isSet(object.mergeFailure) ? MergeFailureBody.fromJSON(object.mergeFailure) : undefined,
+      blockNumber: isSet(object.blockNumber) ? Number(object.blockNumber) : 0,
+      shardIndex: isSet(object.shardIndex) ? Number(object.shardIndex) : 0,
+      timestamp: isSet(object.timestamp) ? Number(object.timestamp) : 0,
     };
   },
 
@@ -633,6 +783,11 @@ export const HubEvent = {
     message.mergeOnChainEventBody !== undefined && (obj.mergeOnChainEventBody = message.mergeOnChainEventBody
       ? MergeOnChainEventBody.toJSON(message.mergeOnChainEventBody)
       : undefined);
+    message.mergeFailure !== undefined &&
+      (obj.mergeFailure = message.mergeFailure ? MergeFailureBody.toJSON(message.mergeFailure) : undefined);
+    message.blockNumber !== undefined && (obj.blockNumber = Math.round(message.blockNumber));
+    message.shardIndex !== undefined && (obj.shardIndex = Math.round(message.shardIndex));
+    message.timestamp !== undefined && (obj.timestamp = Math.round(message.timestamp));
     return obj;
   },
 
@@ -661,6 +816,12 @@ export const HubEvent = {
       (object.mergeOnChainEventBody !== undefined && object.mergeOnChainEventBody !== null)
         ? MergeOnChainEventBody.fromPartial(object.mergeOnChainEventBody)
         : undefined;
+    message.mergeFailure = (object.mergeFailure !== undefined && object.mergeFailure !== null)
+      ? MergeFailureBody.fromPartial(object.mergeFailure)
+      : undefined;
+    message.blockNumber = object.blockNumber ?? 0;
+    message.shardIndex = object.shardIndex ?? 0;
+    message.timestamp = object.timestamp ?? 0;
     return message;
   },
 };

--- a/packages/core/src/protobufs/typeguards.ts
+++ b/packages/core/src/protobufs/typeguards.ts
@@ -218,6 +218,14 @@ export const isPruneMessageHubEvent = (event: hubEventProtobufs.HubEvent): event
   );
 };
 
+export const isMergeFailureHubEvent = (event: hubEventProtobufs.HubEvent): event is types.MergeMessageHubEvent => {
+  return (
+    event.type === hubEventProtobufs.HubEventType.MERGE_FAILURE &&
+    typeof event.mergeFailure !== "undefined" &&
+    typeof event.mergeFailure.message !== "undefined"
+  );
+};
+
 export const isMergeOnChainHubEvent = (event: hubEventProtobufs.HubEvent): event is types.MergeOnChainEventHubEvent => {
   return (
     event.type === hubEventProtobufs.HubEventType.MERGE_ON_CHAIN_EVENT &&

--- a/packages/hub-nodejs/src/generated/hub_event.ts
+++ b/packages/hub-nodejs/src/generated/hub_event.ts
@@ -22,6 +22,7 @@ export enum HubEventType {
    *  HUB_EVENT_TYPE_MERGE_STORAGE_ADMIN_REGISTRY_EVENT = 8;
    */
   MERGE_ON_CHAIN_EVENT = 9,
+  MERGE_FAILURE = 10,
 }
 
 export function hubEventTypeFromJSON(object: any): HubEventType {
@@ -44,6 +45,9 @@ export function hubEventTypeFromJSON(object: any): HubEventType {
     case 9:
     case "HUB_EVENT_TYPE_MERGE_ON_CHAIN_EVENT":
       return HubEventType.MERGE_ON_CHAIN_EVENT;
+    case 10:
+    case "HUB_EVENT_TYPE_MERGE_FAILURE":
+      return HubEventType.MERGE_FAILURE;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum HubEventType");
   }
@@ -63,6 +67,8 @@ export function hubEventTypeToJSON(object: HubEventType): string {
       return "HUB_EVENT_TYPE_MERGE_USERNAME_PROOF";
     case HubEventType.MERGE_ON_CHAIN_EVENT:
       return "HUB_EVENT_TYPE_MERGE_ON_CHAIN_EVENT";
+    case HubEventType.MERGE_FAILURE:
+      return "HUB_EVENT_TYPE_MERGE_FAILURE";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum HubEventType");
   }
@@ -75,6 +81,12 @@ export interface MergeMessageBody {
 
 export interface PruneMessageBody {
   message: Message | undefined;
+}
+
+export interface MergeFailureBody {
+  message: Message | undefined;
+  code: string;
+  reason: string;
 }
 
 export interface RevokeMessageBody {
@@ -114,6 +126,10 @@ export interface HubEvent {
    *    MergeStorageAdminRegistryEventBody merge_storage_admin_registry_event_body = 10;
    */
   mergeOnChainEventBody?: MergeOnChainEventBody | undefined;
+  mergeFailure?: MergeFailureBody | undefined;
+  blockNumber: number;
+  shardIndex: number;
+  timestamp: number;
 }
 
 function createBaseMergeMessageBody(): MergeMessageBody {
@@ -249,6 +265,92 @@ export const PruneMessageBody = {
     message.message = (object.message !== undefined && object.message !== null)
       ? Message.fromPartial(object.message)
       : undefined;
+    return message;
+  },
+};
+
+function createBaseMergeFailureBody(): MergeFailureBody {
+  return { message: undefined, code: "", reason: "" };
+}
+
+export const MergeFailureBody = {
+  encode(message: MergeFailureBody, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.message !== undefined) {
+      Message.encode(message.message, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.code !== "") {
+      writer.uint32(18).string(message.code);
+    }
+    if (message.reason !== "") {
+      writer.uint32(26).string(message.reason);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MergeFailureBody {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMergeFailureBody();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.message = Message.decode(reader, reader.uint32());
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.code = reader.string();
+          continue;
+        case 3:
+          if (tag != 26) {
+            break;
+          }
+
+          message.reason = reader.string();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MergeFailureBody {
+    return {
+      message: isSet(object.message) ? Message.fromJSON(object.message) : undefined,
+      code: isSet(object.code) ? String(object.code) : "",
+      reason: isSet(object.reason) ? String(object.reason) : "",
+    };
+  },
+
+  toJSON(message: MergeFailureBody): unknown {
+    const obj: any = {};
+    message.message !== undefined && (obj.message = message.message ? Message.toJSON(message.message) : undefined);
+    message.code !== undefined && (obj.code = message.code);
+    message.reason !== undefined && (obj.reason = message.reason);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<MergeFailureBody>, I>>(base?: I): MergeFailureBody {
+    return MergeFailureBody.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MergeFailureBody>, I>>(object: I): MergeFailureBody {
+    const message = createBaseMergeFailureBody();
+    message.message = (object.message !== undefined && object.message !== null)
+      ? Message.fromPartial(object.message)
+      : undefined;
+    message.code = object.code ?? "";
+    message.reason = object.reason ?? "";
     return message;
   },
 };
@@ -504,6 +606,10 @@ function createBaseHubEvent(): HubEvent {
     revokeMessageBody: undefined,
     mergeUsernameProofBody: undefined,
     mergeOnChainEventBody: undefined,
+    mergeFailure: undefined,
+    blockNumber: 0,
+    shardIndex: 0,
+    timestamp: 0,
   };
 }
 
@@ -529,6 +635,18 @@ export const HubEvent = {
     }
     if (message.mergeOnChainEventBody !== undefined) {
       MergeOnChainEventBody.encode(message.mergeOnChainEventBody, writer.uint32(90).fork()).ldelim();
+    }
+    if (message.mergeFailure !== undefined) {
+      MergeFailureBody.encode(message.mergeFailure, writer.uint32(106).fork()).ldelim();
+    }
+    if (message.blockNumber !== 0) {
+      writer.uint32(96).uint64(message.blockNumber);
+    }
+    if (message.shardIndex !== 0) {
+      writer.uint32(112).uint32(message.shardIndex);
+    }
+    if (message.timestamp !== 0) {
+      writer.uint32(120).uint64(message.timestamp);
     }
     return writer;
   },
@@ -589,6 +707,34 @@ export const HubEvent = {
 
           message.mergeOnChainEventBody = MergeOnChainEventBody.decode(reader, reader.uint32());
           continue;
+        case 13:
+          if (tag != 106) {
+            break;
+          }
+
+          message.mergeFailure = MergeFailureBody.decode(reader, reader.uint32());
+          continue;
+        case 12:
+          if (tag != 96) {
+            break;
+          }
+
+          message.blockNumber = longToNumber(reader.uint64() as Long);
+          continue;
+        case 14:
+          if (tag != 112) {
+            break;
+          }
+
+          message.shardIndex = reader.uint32();
+          continue;
+        case 15:
+          if (tag != 120) {
+            break;
+          }
+
+          message.timestamp = longToNumber(reader.uint64() as Long);
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -613,6 +759,10 @@ export const HubEvent = {
       mergeOnChainEventBody: isSet(object.mergeOnChainEventBody)
         ? MergeOnChainEventBody.fromJSON(object.mergeOnChainEventBody)
         : undefined,
+      mergeFailure: isSet(object.mergeFailure) ? MergeFailureBody.fromJSON(object.mergeFailure) : undefined,
+      blockNumber: isSet(object.blockNumber) ? Number(object.blockNumber) : 0,
+      shardIndex: isSet(object.shardIndex) ? Number(object.shardIndex) : 0,
+      timestamp: isSet(object.timestamp) ? Number(object.timestamp) : 0,
     };
   },
 
@@ -633,6 +783,11 @@ export const HubEvent = {
     message.mergeOnChainEventBody !== undefined && (obj.mergeOnChainEventBody = message.mergeOnChainEventBody
       ? MergeOnChainEventBody.toJSON(message.mergeOnChainEventBody)
       : undefined);
+    message.mergeFailure !== undefined &&
+      (obj.mergeFailure = message.mergeFailure ? MergeFailureBody.toJSON(message.mergeFailure) : undefined);
+    message.blockNumber !== undefined && (obj.blockNumber = Math.round(message.blockNumber));
+    message.shardIndex !== undefined && (obj.shardIndex = Math.round(message.shardIndex));
+    message.timestamp !== undefined && (obj.timestamp = Math.round(message.timestamp));
     return obj;
   },
 
@@ -661,6 +816,12 @@ export const HubEvent = {
       (object.mergeOnChainEventBody !== undefined && object.mergeOnChainEventBody !== null)
         ? MergeOnChainEventBody.fromPartial(object.mergeOnChainEventBody)
         : undefined;
+    message.mergeFailure = (object.mergeFailure !== undefined && object.mergeFailure !== null)
+      ? MergeFailureBody.fromPartial(object.mergeFailure)
+      : undefined;
+    message.blockNumber = object.blockNumber ?? 0;
+    message.shardIndex = object.shardIndex ?? 0;
+    message.timestamp = object.timestamp ?? 0;
     return message;
   },
 };

--- a/packages/hub-web/src/generated/hub_event.ts
+++ b/packages/hub-web/src/generated/hub_event.ts
@@ -22,6 +22,7 @@ export enum HubEventType {
    *  HUB_EVENT_TYPE_MERGE_STORAGE_ADMIN_REGISTRY_EVENT = 8;
    */
   MERGE_ON_CHAIN_EVENT = 9,
+  MERGE_FAILURE = 10,
 }
 
 export function hubEventTypeFromJSON(object: any): HubEventType {
@@ -44,6 +45,9 @@ export function hubEventTypeFromJSON(object: any): HubEventType {
     case 9:
     case "HUB_EVENT_TYPE_MERGE_ON_CHAIN_EVENT":
       return HubEventType.MERGE_ON_CHAIN_EVENT;
+    case 10:
+    case "HUB_EVENT_TYPE_MERGE_FAILURE":
+      return HubEventType.MERGE_FAILURE;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum HubEventType");
   }
@@ -63,6 +67,8 @@ export function hubEventTypeToJSON(object: HubEventType): string {
       return "HUB_EVENT_TYPE_MERGE_USERNAME_PROOF";
     case HubEventType.MERGE_ON_CHAIN_EVENT:
       return "HUB_EVENT_TYPE_MERGE_ON_CHAIN_EVENT";
+    case HubEventType.MERGE_FAILURE:
+      return "HUB_EVENT_TYPE_MERGE_FAILURE";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum HubEventType");
   }
@@ -75,6 +81,12 @@ export interface MergeMessageBody {
 
 export interface PruneMessageBody {
   message: Message | undefined;
+}
+
+export interface MergeFailureBody {
+  message: Message | undefined;
+  code: string;
+  reason: string;
 }
 
 export interface RevokeMessageBody {
@@ -114,6 +126,10 @@ export interface HubEvent {
    *    MergeStorageAdminRegistryEventBody merge_storage_admin_registry_event_body = 10;
    */
   mergeOnChainEventBody?: MergeOnChainEventBody | undefined;
+  mergeFailure?: MergeFailureBody | undefined;
+  blockNumber: number;
+  shardIndex: number;
+  timestamp: number;
 }
 
 function createBaseMergeMessageBody(): MergeMessageBody {
@@ -249,6 +265,92 @@ export const PruneMessageBody = {
     message.message = (object.message !== undefined && object.message !== null)
       ? Message.fromPartial(object.message)
       : undefined;
+    return message;
+  },
+};
+
+function createBaseMergeFailureBody(): MergeFailureBody {
+  return { message: undefined, code: "", reason: "" };
+}
+
+export const MergeFailureBody = {
+  encode(message: MergeFailureBody, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.message !== undefined) {
+      Message.encode(message.message, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.code !== "") {
+      writer.uint32(18).string(message.code);
+    }
+    if (message.reason !== "") {
+      writer.uint32(26).string(message.reason);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MergeFailureBody {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMergeFailureBody();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 10) {
+            break;
+          }
+
+          message.message = Message.decode(reader, reader.uint32());
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.code = reader.string();
+          continue;
+        case 3:
+          if (tag != 26) {
+            break;
+          }
+
+          message.reason = reader.string();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MergeFailureBody {
+    return {
+      message: isSet(object.message) ? Message.fromJSON(object.message) : undefined,
+      code: isSet(object.code) ? String(object.code) : "",
+      reason: isSet(object.reason) ? String(object.reason) : "",
+    };
+  },
+
+  toJSON(message: MergeFailureBody): unknown {
+    const obj: any = {};
+    message.message !== undefined && (obj.message = message.message ? Message.toJSON(message.message) : undefined);
+    message.code !== undefined && (obj.code = message.code);
+    message.reason !== undefined && (obj.reason = message.reason);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<MergeFailureBody>, I>>(base?: I): MergeFailureBody {
+    return MergeFailureBody.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MergeFailureBody>, I>>(object: I): MergeFailureBody {
+    const message = createBaseMergeFailureBody();
+    message.message = (object.message !== undefined && object.message !== null)
+      ? Message.fromPartial(object.message)
+      : undefined;
+    message.code = object.code ?? "";
+    message.reason = object.reason ?? "";
     return message;
   },
 };
@@ -504,6 +606,10 @@ function createBaseHubEvent(): HubEvent {
     revokeMessageBody: undefined,
     mergeUsernameProofBody: undefined,
     mergeOnChainEventBody: undefined,
+    mergeFailure: undefined,
+    blockNumber: 0,
+    shardIndex: 0,
+    timestamp: 0,
   };
 }
 
@@ -529,6 +635,18 @@ export const HubEvent = {
     }
     if (message.mergeOnChainEventBody !== undefined) {
       MergeOnChainEventBody.encode(message.mergeOnChainEventBody, writer.uint32(90).fork()).ldelim();
+    }
+    if (message.mergeFailure !== undefined) {
+      MergeFailureBody.encode(message.mergeFailure, writer.uint32(106).fork()).ldelim();
+    }
+    if (message.blockNumber !== 0) {
+      writer.uint32(96).uint64(message.blockNumber);
+    }
+    if (message.shardIndex !== 0) {
+      writer.uint32(112).uint32(message.shardIndex);
+    }
+    if (message.timestamp !== 0) {
+      writer.uint32(120).uint64(message.timestamp);
     }
     return writer;
   },
@@ -589,6 +707,34 @@ export const HubEvent = {
 
           message.mergeOnChainEventBody = MergeOnChainEventBody.decode(reader, reader.uint32());
           continue;
+        case 13:
+          if (tag != 106) {
+            break;
+          }
+
+          message.mergeFailure = MergeFailureBody.decode(reader, reader.uint32());
+          continue;
+        case 12:
+          if (tag != 96) {
+            break;
+          }
+
+          message.blockNumber = longToNumber(reader.uint64() as Long);
+          continue;
+        case 14:
+          if (tag != 112) {
+            break;
+          }
+
+          message.shardIndex = reader.uint32();
+          continue;
+        case 15:
+          if (tag != 120) {
+            break;
+          }
+
+          message.timestamp = longToNumber(reader.uint64() as Long);
+          continue;
       }
       if ((tag & 7) == 4 || tag == 0) {
         break;
@@ -613,6 +759,10 @@ export const HubEvent = {
       mergeOnChainEventBody: isSet(object.mergeOnChainEventBody)
         ? MergeOnChainEventBody.fromJSON(object.mergeOnChainEventBody)
         : undefined,
+      mergeFailure: isSet(object.mergeFailure) ? MergeFailureBody.fromJSON(object.mergeFailure) : undefined,
+      blockNumber: isSet(object.blockNumber) ? Number(object.blockNumber) : 0,
+      shardIndex: isSet(object.shardIndex) ? Number(object.shardIndex) : 0,
+      timestamp: isSet(object.timestamp) ? Number(object.timestamp) : 0,
     };
   },
 
@@ -633,6 +783,11 @@ export const HubEvent = {
     message.mergeOnChainEventBody !== undefined && (obj.mergeOnChainEventBody = message.mergeOnChainEventBody
       ? MergeOnChainEventBody.toJSON(message.mergeOnChainEventBody)
       : undefined);
+    message.mergeFailure !== undefined &&
+      (obj.mergeFailure = message.mergeFailure ? MergeFailureBody.toJSON(message.mergeFailure) : undefined);
+    message.blockNumber !== undefined && (obj.blockNumber = Math.round(message.blockNumber));
+    message.shardIndex !== undefined && (obj.shardIndex = Math.round(message.shardIndex));
+    message.timestamp !== undefined && (obj.timestamp = Math.round(message.timestamp));
     return obj;
   },
 
@@ -661,6 +816,12 @@ export const HubEvent = {
       (object.mergeOnChainEventBody !== undefined && object.mergeOnChainEventBody !== null)
         ? MergeOnChainEventBody.fromPartial(object.mergeOnChainEventBody)
         : undefined;
+    message.mergeFailure = (object.mergeFailure !== undefined && object.mergeFailure !== null)
+      ? MergeFailureBody.fromPartial(object.mergeFailure)
+      : undefined;
+    message.blockNumber = object.blockNumber ?? 0;
+    message.shardIndex = object.shardIndex ?? 0;
+    message.timestamp = object.timestamp ?? 0;
     return message;
   },
 };

--- a/packages/hub-web/src/generated/message.ts
+++ b/packages/hub-web/src/generated/message.ts
@@ -244,7 +244,7 @@ export enum UserDataType {
   USERNAME = 6,
   /** LOCATION - Current location for the user */
   LOCATION = 7,
-  /** TWITTER - Username of user on twitter */
+  /** TWITTER - Username of user on x */
   TWITTER = 8,
   /** GITHUB - Username of user on github */
   GITHUB = 9,

--- a/protobufs/schemas/hub_event.proto
+++ b/protobufs/schemas/hub_event.proto
@@ -17,6 +17,7 @@ enum HubEventType {
 //  HUB_EVENT_TYPE_MERGE_RENT_REGISTRY_EVENT = 7;
 //  HUB_EVENT_TYPE_MERGE_STORAGE_ADMIN_REGISTRY_EVENT = 8;
   HUB_EVENT_TYPE_MERGE_ON_CHAIN_EVENT = 9;
+  HUB_EVENT_TYPE_MERGE_FAILURE = 10;
 }
 
 message MergeMessageBody {
@@ -26,6 +27,12 @@ message MergeMessageBody {
 
 message PruneMessageBody {
   Message message = 1;
+}
+
+message MergeFailureBody {
+  Message message = 1;
+  string code = 2;
+  string reason = 3;
 }
 
 message RevokeMessageBody {
@@ -58,5 +65,9 @@ message HubEvent {
 //    MergeRentRegistryEventBody merge_rent_registry_event_body = 9;
 //    MergeStorageAdminRegistryEventBody merge_storage_admin_registry_event_body = 10;
     MergeOnChainEventBody merge_on_chain_event_body = 11;
+    MergeFailureBody merge_failure = 13;
   };
+  uint64 block_number = 12;
+  uint32 shard_index = 14;
+  uint64 timestamp = 15;
 }


### PR DESCRIPTION
## Why is this change needed?

 - Add new fields from snapchain to hubble protos and libraries so shuttle can access them
 - Update shuttle to use getInfo for max fid
 - Populate data and databytes for convenience (snapchain updated to prioritize dataBytes https://github.com/farcasterxyz/snapchain/pull/454)

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new fields related to `snapchain` events, enhances compatibility by populating additional data, and modifies existing event structures to include `block_number`, `shard_index`, and `timestamp`. It also updates documentation for clarity.

### Detailed summary
- Added `block_number`, `shard_index`, and `timestamp` fields to various stores and event structures.
- Introduced `MergeFailureBody` to handle merge failures with `message`, `code`, and `reason`.
- Updated comments and documentation to reflect changes in event types.
- Enhanced `HubEventArgs` to omit additional fields for better compatibility.
- Modified `makeMessageWithSignature` to use `dataBytes` for serialization differences.
- Updated event type handling in generated files to include `MERGE_FAILURE`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->