### PR TITLE
fix: Update isMergeFailureHubEvent typeguard to return correct type

### DIFF
--- a/.changeset/flat-beers-help.md
+++ b/.changeset/flat-beers-help.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/core": patch
+---
+
+fix: Update isMergeFailureHubEvent type guard to return correct type

--- a/packages/core/src/protobufs/typeguards.ts
+++ b/packages/core/src/protobufs/typeguards.ts
@@ -218,7 +218,7 @@ export const isPruneMessageHubEvent = (event: hubEventProtobufs.HubEvent): event
   );
 };
 
-export const isMergeFailureHubEvent = (event: hubEventProtobufs.HubEvent): event is types.MergeMessageHubEvent => {
+export const isMergeFailureHubEvent = (event: hubEventProtobufs.HubEvent): event is types.MergeFailureHubEvent => {
   return (
     event.type === hubEventProtobufs.HubEventType.MERGE_FAILURE &&
     typeof event.mergeFailure !== "undefined" &&

--- a/packages/core/src/protobufs/types.ts
+++ b/packages/core/src/protobufs/types.ts
@@ -180,3 +180,8 @@ export type MergeUsernameProofHubEvent = hubEventProtobufs.HubEvent & {
   type: hubEventProtobufs.HubEventType.MERGE_USERNAME_PROOF;
   mergeUsernameProofBody: hubEventProtobufs.MergeUserNameProofBody;
 };
+
+export type MergeFailureHubEvent = hubEventProtobufs.HubEvent & {
+  type: hubEventProtobufs.HubEventType.MERGE_FAILURE;
+  mergeFailure: hubEventProtobufs.MergeFailureBody;
+};


### PR DESCRIPTION
## Why is this change needed?

The typeguard was incorrect.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the type guard `isMergeFailureHubEvent` to correctly identify `MergeFailureHubEvent` instances in the codebase.

### Detailed summary
- Updated the return type of `isMergeFailureHubEvent` to correctly reflect `types.MergeFailureHubEvent`.
- Introduced the `MergeFailureHubEvent` type in `types.ts`, which includes the `mergeFailure` property.
- Ensured the type guard checks for the `MERGE_FAILURE` event type.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->