### PR TITLE
Fix invalid key usage in ed25519 test

### DIFF
--- a/packages/core/src/crypto/ed25519.test.ts
+++ b/packages/core/src/crypto/ed25519.test.ts
@@ -46,7 +46,7 @@ describe("verifyMessageHashSignature", () => {
     const messageData = Factories.CastAddData.build();
     const bytes = protobufs.MessageData.encode(messageData).finish();
     const hash = blake3(bytes, { dkLen: 20 });
-    const isValid = await ed25519.verifyMessageHashSignature(randomBytes(32), hash, privateKey);
+    const isValid = await ed25519.verifyMessageHashSignature(randomBytes(32), hash, publicKey);
     expect(isValid._unsafeUnwrapErr()).toBeInstanceOf(HubError);
   });
 });


### PR DESCRIPTION
## Why is this change needed?
Fixed a logical error in the "fails with invalid signature" test where the private key was incorrectly used instead of the public key in the verifyMessageHashSignature function call.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the signature verification process in the `ed25519` test by changing the key used from `privateKey` to `publicKey`, ensuring that the verification correctly utilizes the public key for validating message signatures.

### Detailed summary
- Changed the argument from `privateKey` to `publicKey` in the `ed25519.verifyMessageHashSignature` function call.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->