### PR TITLE
Fix: Update HTTP API documentation link to the correct Farcaster docs

### DIFF
--- a/packages/hub-web/README.md
+++ b/packages/hub-web/README.md
@@ -19,7 +19,7 @@ yarn add -D @types/axios
 
 ## Documentation
 
-The HTTP API endpoints are [documented here](https://www.thehubble.xyz/docs/httpapi/httpapi.html).
+The HTTP API endpoints are [documented here](https://docs.farcaster.xyz/reference/hubble/httpapi/message).
 
 ### Getting started: fetching casts
 


### PR DESCRIPTION
Replaced the outdated and broken link to the HTTP API documentation in the README with the correct URL pointing to the official Farcaster Hubble HTTP API docs. This ensures users can easily find up-to-date API reference material.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation link for the HTTP API endpoints in the `README.md` file to point to a new URL.

### Detailed summary
- Updated the link for the HTTP API endpoints from `https://www.thehubble.xyz/docs/httpapi/httpapi.html` to `https://docs.farcaster.xyz/reference/hubble/httpapi/message`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->