### PR TITLE
chore: bring protos to parity with Snapchain for client library

### DIFF
--- a/.changeset/afraid-impalas-kiss.md
+++ b/.changeset/afraid-impalas-kiss.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/core": patch
+---
+
+chore: bring protos to parity with Snapchain for client library

--- a/packages/core/src/protobufs/generated/message.ts
+++ b/packages/core/src/protobufs/generated/message.ts
@@ -248,6 +248,12 @@ export enum UserDataType {
   TWITTER = 8,
   /** GITHUB - Username of user on github */
   GITHUB = 9,
+  /** BANNER - Banner image for the user */
+  BANNER = 10,
+  /** USER_DATA_PRIMARY_ADDRESS_ETHEREUM - Primary address for the user on Ethereum */
+  USER_DATA_PRIMARY_ADDRESS_ETHEREUM = 11,
+  /** USER_DATA_PRIMARY_ADDRESS_SOLANA - Primary address for the user on Solana */
+  USER_DATA_PRIMARY_ADDRESS_SOLANA = 12,
 }
 
 export function userDataTypeFromJSON(object: any): UserDataType {
@@ -279,6 +285,15 @@ export function userDataTypeFromJSON(object: any): UserDataType {
     case 9:
     case "USER_DATA_TYPE_GITHUB":
       return UserDataType.GITHUB;
+    case 10:
+    case "USER_DATA_TYPE_BANNER":
+      return UserDataType.BANNER;
+    case 11:
+    case "USER_DATA_PRIMARY_ADDRESS_ETHEREUM":
+      return UserDataType.USER_DATA_PRIMARY_ADDRESS_ETHEREUM;
+    case 12:
+    case "USER_DATA_PRIMARY_ADDRESS_SOLANA":
+      return UserDataType.USER_DATA_PRIMARY_ADDRESS_SOLANA;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }
@@ -304,6 +319,12 @@ export function userDataTypeToJSON(object: UserDataType): string {
       return "USER_DATA_TYPE_TWITTER";
     case UserDataType.GITHUB:
       return "USER_DATA_TYPE_GITHUB";
+    case UserDataType.BANNER:
+      return "USER_DATA_TYPE_BANNER";
+    case UserDataType.USER_DATA_PRIMARY_ADDRESS_ETHEREUM:
+      return "USER_DATA_PRIMARY_ADDRESS_ETHEREUM";
+    case UserDataType.USER_DATA_PRIMARY_ADDRESS_SOLANA:
+      return "USER_DATA_PRIMARY_ADDRESS_SOLANA";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }
@@ -313,6 +334,7 @@ export function userDataTypeToJSON(object: UserDataType): string {
 export enum CastType {
   CAST = 0,
   LONG_CAST = 1,
+  TEN_K_CAST = 2,
 }
 
 export function castTypeFromJSON(object: any): CastType {
@@ -323,6 +345,9 @@ export function castTypeFromJSON(object: any): CastType {
     case 1:
     case "LONG_CAST":
       return CastType.LONG_CAST;
+    case 2:
+    case "TEN_K_CAST":
+      return CastType.TEN_K_CAST;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum CastType");
   }
@@ -334,6 +359,8 @@ export function castTypeToJSON(object: CastType): string {
       return "CAST";
     case CastType.LONG_CAST:
       return "LONG_CAST";
+    case CastType.TEN_K_CAST:
+      return "TEN_K_CAST";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum CastType");
   }

--- a/packages/core/src/protobufs/generated/onchain_event.ts
+++ b/packages/core/src/protobufs/generated/onchain_event.ts
@@ -8,6 +8,7 @@ export enum OnChainEventType {
   EVENT_TYPE_SIGNER_MIGRATED = 2,
   EVENT_TYPE_ID_REGISTER = 3,
   EVENT_TYPE_STORAGE_RENT = 4,
+  EVENT_TYPE_TIER_PURCHASE = 5,
 }
 
 export function onChainEventTypeFromJSON(object: any): OnChainEventType {
@@ -27,6 +28,9 @@ export function onChainEventTypeFromJSON(object: any): OnChainEventType {
     case 4:
     case "EVENT_TYPE_STORAGE_RENT":
       return OnChainEventType.EVENT_TYPE_STORAGE_RENT;
+    case 5:
+    case "EVENT_TYPE_TIER_PURCHASE":
+      return OnChainEventType.EVENT_TYPE_TIER_PURCHASE;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum OnChainEventType");
   }
@@ -44,8 +48,39 @@ export function onChainEventTypeToJSON(object: OnChainEventType): string {
       return "EVENT_TYPE_ID_REGISTER";
     case OnChainEventType.EVENT_TYPE_STORAGE_RENT:
       return "EVENT_TYPE_STORAGE_RENT";
+    case OnChainEventType.EVENT_TYPE_TIER_PURCHASE:
+      return "EVENT_TYPE_TIER_PURCHASE";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum OnChainEventType");
+  }
+}
+
+export enum TierType {
+  None = 0,
+  Pro = 1,
+}
+
+export function tierTypeFromJSON(object: any): TierType {
+  switch (object) {
+    case 0:
+    case "None":
+      return TierType.None;
+    case 1:
+    case "Pro":
+      return TierType.Pro;
+    default:
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum TierType");
+  }
+}
+
+export function tierTypeToJSON(object: TierType): string {
+  switch (object) {
+    case TierType.None:
+      return "None";
+    case TierType.Pro:
+      return "Pro";
+    default:
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum TierType");
   }
 }
 
@@ -144,8 +179,15 @@ export interface OnChainEvent {
   signerMigratedEventBody?: SignerMigratedEventBody | undefined;
   idRegisterEventBody?: IdRegisterEventBody | undefined;
   storageRentEventBody?: StorageRentEventBody | undefined;
+  tierPurchaseEventBody?: TierPurchaseBody | undefined;
   txIndex: number;
   version: number;
+}
+
+export interface TierPurchaseBody {
+  tierType: TierType;
+  forDays: number;
+  payer: Uint8Array;
 }
 
 export interface SignerEventBody {
@@ -187,6 +229,7 @@ function createBaseOnChainEvent(): OnChainEvent {
     signerMigratedEventBody: undefined,
     idRegisterEventBody: undefined,
     storageRentEventBody: undefined,
+    tierPurchaseEventBody: undefined,
     txIndex: 0,
     version: 0,
   };
@@ -229,6 +272,9 @@ export const OnChainEvent = {
     }
     if (message.storageRentEventBody !== undefined) {
       StorageRentEventBody.encode(message.storageRentEventBody, writer.uint32(98).fork()).ldelim();
+    }
+    if (message.tierPurchaseEventBody !== undefined) {
+      TierPurchaseBody.encode(message.tierPurchaseEventBody, writer.uint32(122).fork()).ldelim();
     }
     if (message.txIndex !== 0) {
       writer.uint32(104).uint32(message.txIndex);
@@ -330,6 +376,13 @@ export const OnChainEvent = {
 
           message.storageRentEventBody = StorageRentEventBody.decode(reader, reader.uint32());
           continue;
+        case 15:
+          if (tag != 122) {
+            break;
+          }
+
+          message.tierPurchaseEventBody = TierPurchaseBody.decode(reader, reader.uint32());
+          continue;
         case 13:
           if (tag != 104) {
             break;
@@ -373,6 +426,9 @@ export const OnChainEvent = {
       storageRentEventBody: isSet(object.storageRentEventBody)
         ? StorageRentEventBody.fromJSON(object.storageRentEventBody)
         : undefined,
+      tierPurchaseEventBody: isSet(object.tierPurchaseEventBody)
+        ? TierPurchaseBody.fromJSON(object.tierPurchaseEventBody)
+        : undefined,
       txIndex: isSet(object.txIndex) ? Number(object.txIndex) : 0,
       version: isSet(object.version) ? Number(object.version) : 0,
     };
@@ -402,6 +458,9 @@ export const OnChainEvent = {
       : undefined);
     message.storageRentEventBody !== undefined && (obj.storageRentEventBody = message.storageRentEventBody
       ? StorageRentEventBody.toJSON(message.storageRentEventBody)
+      : undefined);
+    message.tierPurchaseEventBody !== undefined && (obj.tierPurchaseEventBody = message.tierPurchaseEventBody
+      ? TierPurchaseBody.toJSON(message.tierPurchaseEventBody)
       : undefined);
     message.txIndex !== undefined && (obj.txIndex = Math.round(message.txIndex));
     message.version !== undefined && (obj.version = Math.round(message.version));
@@ -435,8 +494,97 @@ export const OnChainEvent = {
     message.storageRentEventBody = (object.storageRentEventBody !== undefined && object.storageRentEventBody !== null)
       ? StorageRentEventBody.fromPartial(object.storageRentEventBody)
       : undefined;
+    message.tierPurchaseEventBody =
+      (object.tierPurchaseEventBody !== undefined && object.tierPurchaseEventBody !== null)
+        ? TierPurchaseBody.fromPartial(object.tierPurchaseEventBody)
+        : undefined;
     message.txIndex = object.txIndex ?? 0;
     message.version = object.version ?? 0;
+    return message;
+  },
+};
+
+function createBaseTierPurchaseBody(): TierPurchaseBody {
+  return { tierType: 0, forDays: 0, payer: new Uint8Array() };
+}
+
+export const TierPurchaseBody = {
+  encode(message: TierPurchaseBody, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.tierType !== 0) {
+      writer.uint32(8).int32(message.tierType);
+    }
+    if (message.forDays !== 0) {
+      writer.uint32(16).uint64(message.forDays);
+    }
+    if (message.payer.length !== 0) {
+      writer.uint32(26).bytes(message.payer);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): TierPurchaseBody {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseTierPurchaseBody();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.tierType = reader.int32() as any;
+          continue;
+        case 2:
+          if (tag != 16) {
+            break;
+          }
+
+          message.forDays = longToNumber(reader.uint64() as Long);
+          continue;
+        case 3:
+          if (tag != 26) {
+            break;
+          }
+
+          message.payer = reader.bytes();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): TierPurchaseBody {
+    return {
+      tierType: isSet(object.tierType) ? tierTypeFromJSON(object.tierType) : 0,
+      forDays: isSet(object.forDays) ? Number(object.forDays) : 0,
+      payer: isSet(object.payer) ? bytesFromBase64(object.payer) : new Uint8Array(),
+    };
+  },
+
+  toJSON(message: TierPurchaseBody): unknown {
+    const obj: any = {};
+    message.tierType !== undefined && (obj.tierType = tierTypeToJSON(message.tierType));
+    message.forDays !== undefined && (obj.forDays = Math.round(message.forDays));
+    message.payer !== undefined &&
+      (obj.payer = base64FromBytes(message.payer !== undefined ? message.payer : new Uint8Array()));
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<TierPurchaseBody>, I>>(base?: I): TierPurchaseBody {
+    return TierPurchaseBody.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<TierPurchaseBody>, I>>(object: I): TierPurchaseBody {
+    const message = createBaseTierPurchaseBody();
+    message.tierType = object.tierType ?? 0;
+    message.forDays = object.forDays ?? 0;
+    message.payer = object.payer ?? new Uint8Array();
     return message;
   },
 };

--- a/packages/core/src/protobufs/generated/username_proof.ts
+++ b/packages/core/src/protobufs/generated/username_proof.ts
@@ -6,6 +6,7 @@ export enum UserNameType {
   USERNAME_TYPE_NONE = 0,
   USERNAME_TYPE_FNAME = 1,
   USERNAME_TYPE_ENS_L1 = 2,
+  USERNAME_TYPE_BASENAME = 3,
 }
 
 export function userNameTypeFromJSON(object: any): UserNameType {
@@ -19,6 +20,9 @@ export function userNameTypeFromJSON(object: any): UserNameType {
     case 2:
     case "USERNAME_TYPE_ENS_L1":
       return UserNameType.USERNAME_TYPE_ENS_L1;
+    case 3:
+    case "USERNAME_TYPE_BASENAME":
+      return UserNameType.USERNAME_TYPE_BASENAME;
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserNameType");
   }
@@ -32,6 +36,8 @@ export function userNameTypeToJSON(object: UserNameType): string {
       return "USERNAME_TYPE_FNAME";
     case UserNameType.USERNAME_TYPE_ENS_L1:
       return "USERNAME_TYPE_ENS_L1";
+    case UserNameType.USERNAME_TYPE_BASENAME:
+      return "USERNAME_TYPE_BASENAME";
     default:
       throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserNameType");
   }

--- a/packages/core/src/time.test.ts
+++ b/packages/core/src/time.test.ts
@@ -12,7 +12,7 @@ describe("toFarcasterTime", () => {
 
   test("fails for time before 01/01/2021", () => {
     expect(toFarcasterTime(FARCASTER_EPOCH - 1)).toEqual(
-      err(new HubError("bad_request.invalid_param", "time must be after Farcaster epoch (01/01/2022)")),
+      err(new HubError("bad_request.invalid_param", "time must be after Farcaster epoch (01/01/2021)")),
     );
   });
 

--- a/protobufs/schemas/message.proto
+++ b/protobufs/schemas/message.proto
@@ -100,6 +100,9 @@ enum UserDataType {
   USER_DATA_TYPE_LOCATION = 7; // Current location for the user
   USER_DATA_TYPE_TWITTER = 8; // Username of user on x
   USER_DATA_TYPE_GITHUB = 9; // Username of user on github
+  USER_DATA_TYPE_BANNER = 10; // Banner image for the user
+  USER_DATA_PRIMARY_ADDRESS_ETHEREUM = 11; // Primary address for the user on Ethereum
+  USER_DATA_PRIMARY_ADDRESS_SOLANA = 12; // Primary address for the user on Solana
 }
 
 message Embed {
@@ -113,6 +116,7 @@ message Embed {
 enum CastType {
   CAST = 0;
   LONG_CAST = 1;
+  TEN_K_CAST = 2;
 }
 
 

--- a/protobufs/schemas/onchain_event.proto
+++ b/protobufs/schemas/onchain_event.proto
@@ -6,6 +6,7 @@ enum OnChainEventType {
   EVENT_TYPE_SIGNER_MIGRATED = 2;
   EVENT_TYPE_ID_REGISTER = 3;
   EVENT_TYPE_STORAGE_RENT = 4;
+  EVENT_TYPE_TIER_PURCHASE = 5;
 }
 
 message OnChainEvent {
@@ -22,9 +23,21 @@ message OnChainEvent {
     SignerMigratedEventBody signer_migrated_event_body = 10;
     IdRegisterEventBody id_register_event_body = 11;
     StorageRentEventBody storage_rent_event_body = 12;
+    TierPurchaseBody tier_purchase_event_body = 15;
   }
   uint32 tx_index = 13;
   uint32 version = 14;
+}
+
+enum TierType {
+  None = 0;
+  Pro = 1;
+}
+
+message TierPurchaseBody {
+  TierType tier_type = 1;
+  uint64 for_days = 2;
+  bytes payer = 3;
 }
 
 enum SignerEventType {

--- a/protobufs/schemas/request_response.proto
+++ b/protobufs/schemas/request_response.proto
@@ -181,10 +181,16 @@ message OnChainEventResponse {
   optional bytes next_page_token = 2;
 }
 
+message TierDetails {
+  TierType tier_type = 1;
+  uint64 expires_at = 2;
+}
+
 message StorageLimitsResponse {
   repeated StorageLimit limits = 1;
   uint32 units = 2;
   repeated StorageUnitDetails unit_details = 3;
+  repeated TierDetails tier_subscriptions = 4;
 }
 
 enum StoreType {

--- a/protobufs/schemas/username_proof.proto
+++ b/protobufs/schemas/username_proof.proto
@@ -4,6 +4,7 @@ enum UserNameType {
   USERNAME_TYPE_NONE = 0;
   USERNAME_TYPE_FNAME = 1;
   USERNAME_TYPE_ENS_L1 = 2;
+  USERNAME_TYPE_BASENAME = 3;
 }
 
 message UserNameProof {


### PR DESCRIPTION
## Why is this change needed?

The new proto definitions need to be exposed via the client library to build on new features. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the protocol buffers in the client library to align with the Snapchain implementation. It introduces new message types, enums, and fields to enhance functionality, particularly around tier management and user data handling.

### Detailed summary
- Added `USERNAME_TYPE_BASENAME` to `username_proof.proto`.
- Introduced `TierDetails` message and `tier_subscriptions` field in `StorageLimitsResponse`.
- Updated error message date in `time.test.ts` to 01/01/2021.
- Added new user data types: `USER_DATA_TYPE_BANNER`, `USER_DATA_PRIMARY_ADDRESS_ETHEREUM`, and `USER_DATA_PRIMARY_ADDRESS_SOLANA`.
- Introduced `TEN_K_CAST` enum in `message.proto`.
- Added `EVENT_TYPE_TIER_PURCHASE` in `onchain_event.proto`.
- Created `TierPurchaseBody` message with relevant fields.
- Updated `OnChainEvent` to include `tierPurchaseEventBody`.
- Added methods for handling `TierType` in JSON conversions.
- Enhanced `StorageLimitsResponse` to include `tierSubscriptions`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->