### PR TITLE
chore: release @farcaster/hub-nodejs 0.13.6 and @farcaster/core 0.16.5

### DIFF
--- a/.changeset/afraid-impalas-kiss.md
+++ b/.changeset/afraid-impalas-kiss.md
@@ -1,5 +1,0 @@
----
-"@farcaster/core": patch
----
-
-chore: bring protos to parity with Snapchain for client library

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/core
 
+## 0.16.5
+
+### Patch Changes
+
+- 7e742a8d: chore: bring protos to parity with Snapchain for client library
+
 ## 0.16.4
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.16.4",
+  "version": "0.16.5",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/hub-nodejs
 
+## 0.13.6
+
+### Patch Changes
+
+- Updated dependencies [7e742a8d]
+  - @farcaster/core@0.16.5
+
 ## 0.13.5
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -20,7 +20,7 @@
     "url": "https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/hub-nodejs"
   },
   "dependencies": {
-    "@farcaster/core": "0.16.4",
+    "@farcaster/core": "0.16.5",
     "@grpc/grpc-js": "~1.11.1",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"


### PR DESCRIPTION
## Why is this change needed?

Release hub-nodejs and core

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of the `@farcaster/core` and `@farcaster/hub-nodejs` packages, along with their changelogs and dependencies.

### Detailed summary
- Deleted `CHANGELOG.md` for `afraid-impalas-kiss`.
- Added version `0.13.6` for `@farcaster/hub-nodejs` with updated dependencies.
- Added version `0.16.5` for `@farcaster/core` with a change to bring protos to parity with Snapchain.
- Updated `version` in `package.json` for both packages.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->