### PR TITLE
chore: Release client libs for snapchain 0.3

### DIFF
--- a/.changeset/thick-radios-end.md
+++ b/.changeset/thick-radios-end.md
@@ -1,7 +1,0 @@
----
-"@farcaster/hub-nodejs": minor
-"@farcaster/hub-web": minor
-"@farcaster/core": minor
----
-
-feat: Support snapchain 0.3 protocol features: pro, basenames and primary address

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/core
 
+## 0.17.0
+
+### Minor Changes
+
+- 6307171a: feat: Support snapchain 0.3 protocol features: pro, basenames and primary address
+
 ## 0.16.5
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.16.5",
+  "version": "0.17.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @farcaster/hub-nodejs
 
+## 0.14.0
+
+### Minor Changes
+
+- 6307171a: feat: Support snapchain 0.3 protocol features: pro, basenames and primary address
+
+### Patch Changes
+
+- Updated dependencies [6307171a]
+  - @farcaster/core@0.17.0
+
 ## 0.13.6
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.13.6",
+  "version": "0.14.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -20,7 +20,7 @@
     "url": "https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/hub-nodejs"
   },
   "dependencies": {
-    "@farcaster/core": "0.16.5",
+    "@farcaster/core": "0.17.0",
     "@grpc/grpc-js": "~1.11.1",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"

--- a/packages/hub-web/CHANGELOG.md
+++ b/packages/hub-web/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @farcaster/hub-web
 
+## 0.10.0
+
+### Minor Changes
+
+- 6307171a: feat: Support snapchain 0.3 protocol features: pro, basenames and primary address
+
+### Patch Changes
+
+- Updated dependencies [6307171a]
+  - @farcaster/core@0.17.0
+
 ## 0.9.7
 
 ### Patch Changes

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-web",
-  "version": "0.9.7",
+  "version": "0.10.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -32,7 +32,7 @@
     "ts-proto": "^1.146.0"
   },
   "dependencies": {
-    "@farcaster/core": "^0.16.3",
+    "@farcaster/core": "^0.17.0",
     "@improbable-eng/grpc-web": "^0.15.0",
     "rxjs": "^7.8.0"
   }

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/hub-shuttle
 
+## 0.6.16
+
+### Patch Changes
+
+- Updated dependencies [6307171a]
+  - @farcaster/hub-nodejs@0.14.0
+
 ## 0.6.15
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@farcaster/hot-shots": "^10.0.0",
-    "@farcaster/hub-nodejs": "^0.13.4",
+    "@farcaster/hub-nodejs": "^0.14.0",
     "commander": "11.0.0",
     "dotenv": "16.4.5",
     "ioredis": "^5.3.2",


### PR DESCRIPTION
## Why is this change needed?

Release client library for snapchain 0.3

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the versions of various `@farcaster` packages, enhancing features related to the snapchain 0.3 protocol, and adjusting dependencies.

### Detailed summary
- Deleted `.changeset/thick-radios-end.md`
- Updated `@farcaster/hub-nodejs` to version `0.14.0`
- Updated `@farcaster/core` to version `0.17.0`
- Updated `@farcaster/hub-web` to version `0.10.0`
- Updated version numbers in `package.json` files for `@farcaster/core`, `@farcaster/hub-web`, `@farcaster/shuttle`, and `@farcaster/hub-nodejs`
- Added support for snapchain 0.3 protocol features in `CHANGELOG.md` files

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->