### PR TITLE
fix: Fix event timestamp calculation for snapchain

### DIFF
--- a/.changeset/afraid-news-agree.md
+++ b/.changeset/afraid-news-agree.md
@@ -1,0 +1,6 @@
+---
+"@farcaster/shuttle": patch
+"@farcaster/core": patch
+---
+
+fix: Fix event timestamp calculation for snapchain

--- a/packages/core/src/time.ts
+++ b/packages/core/src/time.ts
@@ -40,14 +40,24 @@ export const fromFarcasterTime = (time: number): HubResult<number> => {
 const TIMESTAMP_BITS = 41;
 const SEQUENCE_BITS = 12;
 
-/** Extracts a unix timestamp (ms resolution) from an event ID. */
+/** Extracts a unix timestamp (ms resolution) from an event ID.
+ * @deprecated: Snapchain event ids use block numbers. Use the timestamp field in the event instead.
+ * */
 export const extractEventTimestamp = (eventId: number): number => {
   const binaryEventId = eventId.toString(2);
   const binaryTimestamp = binaryEventId.slice(0, binaryEventId.length - SEQUENCE_BITS);
   return parseInt(binaryTimestamp, 2) + FARCASTER_EPOCH;
 };
 
-/** Generates a hub event id from a unix timestamp (ms resolution) and an optional sequence number */
+/** Extracts a unix timestamp (ms resolution) from an hub event. */
+export const extractTimestampFromEvent = (event: { timestamp: number }): number => {
+  // Hub event timestamp is in seconds since the Farcaster epoch
+  return event.timestamp * 1000 + FARCASTER_EPOCH;
+};
+
+/** Generates a hub event id from a unix timestamp (ms resolution) and an optional sequence number
+ * @deprecated: Event ids are now based on block numbers. Do not use this function to generate event ids.
+ * */
 export const makeEventId = (timestamp: number, seq = 0): number => {
   const binaryTimestamp = (timestamp - FARCASTER_EPOCH).toString(2);
   let binarySeq = seq.toString(2);

--- a/packages/shuttle/src/shuttle/eventStream.ts
+++ b/packages/shuttle/src/shuttle/eventStream.ts
@@ -2,7 +2,7 @@ import { Cluster, ClusterOptions, Redis, RedisOptions, ReplyError } from "ioredi
 import { getHubEventCacheKey, HubClient } from "./hub";
 import { inBatchesOf, sleep } from "../utils";
 import { statsd } from "../statsd";
-import { extractEventTimestamp, HubEvent } from "@farcaster/hub-nodejs";
+import { extractTimestampFromEvent, HubEvent } from "@farcaster/hub-nodejs";
 import { log } from "../log";
 import { pino } from "pino";
 import { ProcessResult } from "./index";
@@ -359,7 +359,7 @@ export class HubEventStreamConsumer extends TypedEmitter<HubEventStreamConsumerE
                   }
 
                   if (!result.value.skipped) {
-                    const e2eTime = Date.now() - extractEventTimestamp(hubEvent.id);
+                    const e2eTime = Date.now() - extractTimestampFromEvent(hubEvent);
                     statsd.timing("hub.event.stream.e2e_time", e2eTime, {
                       hub: this.hub.host,
                       source: this.shardKey,
@@ -465,7 +465,7 @@ export class HubEventStreamConsumer extends TypedEmitter<HubEventStreamConsumerE
 
               eventIdsProcessed.push(streamEvent.id);
 
-              statsd.timing("hub.event.stream.e2e_time", Date.now() - extractEventTimestamp(hubEvent.id), {
+              statsd.timing("hub.event.stream.e2e_time", Date.now() - extractTimestampFromEvent(hubEvent), {
                 hub: this.hub.host,
                 source: this.shardKey,
                 hubEventType: hubEvent.type.toString(),

--- a/packages/shuttle/src/shuttle/hubSubscriber.ts
+++ b/packages/shuttle/src/shuttle/hubSubscriber.ts
@@ -1,6 +1,6 @@
 import {
   ClientReadableStream,
-  extractEventTimestamp,
+  extractTimestampFromEvent,
   HubEvent,
   HubEventType,
   HubRpcClient,
@@ -291,7 +291,7 @@ export class EventStreamHubSubscriber extends BaseHubSubscriber {
       const processTime = Date.now() - startTime;
 
       if (events[0]) {
-        const startEventTimestamp = extractEventTimestamp(events[0].id);
+        const startEventTimestamp = extractTimestampFromEvent(events[0]);
         statsd.gauge("hub.event.subscriber.last_batch_earliest_event_timestamp", startEventTimestamp, {
           source: this.shardKey,
           hub: this.hub,


### PR DESCRIPTION
## Why is this change needed?

Deprecate existing event timestamp functions that rely on event id, and add a new one that fetch it from the itself itself. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the event timestamp handling in the `shuttle` and `core` packages. It replaces the deprecated `extractEventTimestamp` function with `extractTimestampFromEvent`, which aligns with the new event structure using timestamps instead of event IDs.

### Detailed summary
- Changed function name from `extractEventTimestamp` to `extractTimestampFromEvent` in `hubSubscriber.ts` and `eventStream.ts`.
- Updated calls to `extractEventTimestamp` to use `extractTimestampFromEvent`.
- Marked `extractEventTimestamp` as deprecated in `time.ts` with a note on using event timestamps.
- Added a new implementation for `extractTimestampFromEvent` in `time.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->