### PR TITLE
fix: add typeguards for TierPurchase onchain event

### DIFF
--- a/packages/core/src/protobufs/typeguards.ts
+++ b/packages/core/src/protobufs/typeguards.ts
@@ -192,6 +192,15 @@ export const isStorageRentOnChainEvent = (
   );
 };
 
+export const isTierPurchaseOnChainEvent = (
+  event: onChainEventProtobufs.OnChainEvent,
+): event is types.TierPurchaseOnChainEvent => {
+  return (
+    event.type === onChainEventProtobufs.OnChainEventType.EVENT_TYPE_TIER_PURCHASE &&
+    typeof event.tierPurchaseEventBody !== "undefined"
+  );
+};
+
 /** Hub event typeguards */
 
 export const isMergeMessageHubEvent = (event: hubEventProtobufs.HubEvent): event is types.MergeMessageHubEvent => {

--- a/packages/core/src/protobufs/types.ts
+++ b/packages/core/src/protobufs/types.ts
@@ -146,6 +146,11 @@ export type StorageRentOnChainEvent = onchainEventProtobufs.OnChainEvent & {
   storageRentEventBody: onchainEventProtobufs.StorageRentEventBody;
 };
 
+export type TierPurchaseOnChainEvent = onchainEventProtobufs.OnChainEvent & {
+  type: onchainEventProtobufs.OnChainEventType.EVENT_TYPE_TIER_PURCHASE;
+  tierPurchaseEventBody: onchainEventProtobufs.TierPurchaseBody;
+};
+
 /** Hub event types */
 
 export type MergeMessageHubEvent = hubEventProtobufs.HubEvent & {


### PR DESCRIPTION
## Why is this change needed?

The typeguard for the new tier purchase event is required for processing these events cleanly out of the event stream. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
