### PR TITLE
chore: Release client library and shuttle

### DIFF
--- a/.changeset/afraid-news-agree.md
+++ b/.changeset/afraid-news-agree.md
@@ -1,6 +1,0 @@
----
-"@farcaster/shuttle": patch
-"@farcaster/core": patch
----
-
-fix: Fix event timestamp calculation for snapchain

--- a/.changeset/angry-geckos-breathe.md
+++ b/.changeset/angry-geckos-breathe.md
@@ -1,5 +1,0 @@
----
-"@farcaster/core": patch
----
-
-fix: add typeguards for TierPurchase onchain event

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/core
 
+## 0.17.1
+
+### Patch Changes
+
+- 1290c93c: fix: Fix event timestamp calculation for snapchain
+- 05733a44: fix: add typeguards for TierPurchase onchain event
+
 ## 0.17.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hub-nodejs
 
+## 0.14.1
+
+### Patch Changes
+
+- Updated dependencies [1290c93c]
+- Updated dependencies [05733a44]
+  - @farcaster/core@0.17.1
+
 ## 0.14.0
 
 ### Minor Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -20,7 +20,7 @@
     "url": "https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/hub-nodejs"
   },
   "dependencies": {
-    "@farcaster/core": "0.17.0",
+    "@farcaster/core": "0.17.1",
     "@grpc/grpc-js": "~1.11.1",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/hub-shuttle
 
+## 0.6.17
+
+### Patch Changes
+
+- 1290c93c: fix: Fix event timestamp calculation for snapchain
+  - @farcaster/hub-nodejs@0.14.1
+
 ## 0.6.16
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@farcaster/hot-shots": "^10.0.0",
-    "@farcaster/hub-nodejs": "^0.14.0",
+    "@farcaster/hub-nodejs": "^0.14.1",
     "commander": "11.0.0",
     "dotenv": "16.4.5",
     "ioredis": "^5.3.2",


### PR DESCRIPTION
## Why is this change needed?

Release client and shuttle some snapchain bug fixes

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the versions of various packages and fixing issues related to event timestamp calculations and type guards in the `@farcaster/core` and `@farcaster/hub-nodejs` packages.

### Detailed summary
- Updated `@farcaster/core` version from `0.17.0` to `0.17.1`.
- Updated `@farcaster/hub-nodejs` version from `0.14.0` to `0.14.1`.
- Updated `@farcaster/shuttle` version from `0.6.16` to `0.6.17`.
- Fixed event timestamp calculation for snapchain.
- Added type guards for `TierPurchase` on-chain event.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->