### PR TITLE
fix: shuttle should respect validate messages flag everywhere

### DIFF
--- a/.changeset/eighty-zoos-invite.md
+++ b/.changeset/eighty-zoos-invite.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+fix: Shuttle should respect validate messages flag everywhere

--- a/.changeset/eighty-zoos-invite.md
+++ b/.changeset/eighty-zoos-invite.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-fix: Shuttle should respect validate messages flag everywhere

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.6.18
+
+### Patch Changes
+
+- 1af3e7de: fix: Shuttle should respect validate messages flag everywhere
+
 ## 0.6.17
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/shuttle/src/shuttle/hubEventProcessor.ts
+++ b/packages/shuttle/src/shuttle/hubEventProcessor.ts
@@ -66,7 +66,7 @@ export class HubEventProcessor {
         }),
       );
     } else if (operation === "merge" && MessageProcessor.isCompactStateMessage(message)) {
-      const affectedMessages = await MessageProcessor.deleteDifferenceMessages(message, trx, log);
+      const affectedMessages = await MessageProcessor.deleteDifferenceMessages(message, trx, log, shouldValidate);
       await Promise.all(
         affectedMessages.map(async (deletedMessage) => {
           const state = this.getMessageState(deletedMessage, "delete");


### PR DESCRIPTION
## Why is this change needed?

Shuttle was ignoring the should validate flag when reconciling link compact state messages

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of the `@farcaster/shuttle` package and making a modification in the `hubEventProcessor.ts` file to include a new parameter in a function call, enhancing the validation of messages.

### Detailed summary
- Updated `version` in `package.json` from `0.6.17` to `0.6.18`.
- Added a new entry in `CHANGELOG.md` for version `0.6.18`, noting a fix for respecting validate messages flag.
- Modified the function call in `hubEventProcessor.ts` to include `shouldValidate` as an additional argument in `MessageProcessor.deleteDifferenceMessages`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->