### PR TITLE
feat: set up monitoring for event stream based on snapchain block numbers

### DIFF
--- a/.changeset/witty-items-punch.md
+++ b/.changeset/witty-items-punch.md
@@ -1,0 +1,8 @@
+---
+"@farcaster/hub-nodejs": patch
+"@farcaster/hub-web": patch
+"@farcaster/shuttle": patch
+"@farcaster/core": patch
+---
+
+feat: set up monitoring for event stream based on snapchain block numbers

--- a/generate-protos.sh
+++ b/generate-protos.sh
@@ -1,6 +1,6 @@
 PROTO_REPO=https://github.com/farcasterxyz/snapchain
 PROTO_PATH=src/proto
-PROTO_REV=f82a7e559711deac60b819c4d92bad1aaca55946 # Update this if you want to generate off updated snapchain protos
+PROTO_REV=a0367add145a74638bdbe73153775a673bb08dee # Update this if you want to generate off updated snapchain protos
 
 TMPDIR=tmp-protogen
 git clone $PROTO_REPO $TMPDIR

--- a/packages/core/src/protobufs/types.ts
+++ b/packages/core/src/protobufs/types.ts
@@ -193,5 +193,5 @@ export type MergeFailureHubEvent = hubEventProtobufs.HubEvent & {
 
 export type BlockConfirmedHubEvent = hubEventProtobufs.HubEvent & {
   type: hubEventProtobufs.HubEventType.BLOCK_CONFIRMED;
-  mergeFailure: hubEventProtobufs.BlockConfirmedBody;
+  blockConfirmedBody: hubEventProtobufs.BlockConfirmedBody;
 };

--- a/packages/shuttle/src/shuttle/hubSubscriber.ts
+++ b/packages/shuttle/src/shuttle/hubSubscriber.ts
@@ -43,7 +43,7 @@ export abstract class HubSubscriber extends TypedEmitter<HubEventsEmitter> {
   }
 }
 
-const DEFAULT_EVENT_TYPES = [
+export const DEFAULT_EVENT_TYPES = [
   HubEventType.MERGE_ON_CHAIN_EVENT,
   HubEventType.MERGE_MESSAGE,
   HubEventType.MERGE_USERNAME_PROOF,

--- a/packages/shuttle/src/shuttle/hubSubscriber.ts
+++ b/packages/shuttle/src/shuttle/hubSubscriber.ts
@@ -43,7 +43,7 @@ export abstract class HubSubscriber extends TypedEmitter<HubEventsEmitter> {
   }
 }
 
-export const DEFAULT_EVENT_TYPES = [
+const DEFAULT_EVENT_TYPES = [
   HubEventType.MERGE_ON_CHAIN_EVENT,
   HubEventType.MERGE_MESSAGE,
   HubEventType.MERGE_USERNAME_PROOF,


### PR DESCRIPTION
## Why is this change needed?

Detect when there are missed events using the `BlockConfirmed` event. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the event stream monitoring capabilities by introducing new types and methods to track block events, including event counts by type, and updating the related structures across multiple packages.

### Detailed summary
- Introduced `eventCountsByType` in `BlockConfirmedBody`.
- Added `BlockConfirmedBody_EventCountsByTypeEntry` interface.
- Modified `createBaseBlockConfirmedBody` to initialize `eventCountsByType`.
- Updated serialization and deserialization logic for `BlockConfirmedBody` to handle `eventCountsByType`.
- Created `EventStreamMonitor` class to manage event counts and monitor block events.
- Integrated `EventStreamMonitor` into `HubEventStreamConsumer`.
- Enhanced error handling and logging for missed events and old events in the event stream.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->