### PR TITLE
fix: track event stream stats by host

### DIFF
--- a/.changeset/gold-glasses-brake.md
+++ b/.changeset/gold-glasses-brake.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+fix: track event stream stats by host


### PR DESCRIPTION
## Why is this change needed?

Track event stream stats by both shard and host since streams are per host. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `EventStreamMonitor` and `HubEventStreamConsumer` classes to track event stream statistics by `host`, improving monitoring capabilities for events processed in a distributed environment.

### Detailed summary
- Added a new `host` property to `EventStreamMonitor`.
- Updated the constructor of `EventStreamMonitor` to accept `host` as a parameter.
- Modified methods to use `streamKey()` for generating keys.
- Enhanced statistics tracking by including `host` in metrics.
- Adjusted `HubEventStreamConsumer` to call `onEventProcessed` with `hubEvt`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->