### PR TITLE
fix: add custom redis key prefix for monitoring

### DIFF
--- a/.changeset/spicy-chairs-judge.md
+++ b/.changeset/spicy-chairs-judge.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+fix: add custom redis key prefix for monitoring

--- a/packages/shuttle/src/shuttle/eventStream.ts
+++ b/packages/shuttle/src/shuttle/eventStream.ts
@@ -234,10 +234,12 @@ export class EventStreamMonitor {
   private log: pino.Logger;
   private shardKey: string; // Shard key should map to snapchain shards
   private host: string;
+  private redisPrefix: string;
 
   constructor(
     redis: Redis | Cluster,
     relevantEventTypes: HubEventType[],
+    redisPrefix: string,
     shardKey: string,
     host: string,
     log: pino.Logger,
@@ -247,10 +249,11 @@ export class EventStreamMonitor {
     this.log = log.child({ class: "EventStreamMonitor" });
     this.shardKey = shardKey;
     this.host = host;
+    this.redisPrefix = redisPrefix;
   }
 
   public streamKey() {
-    return `hub:${this.host}:evt:msg:${this.shardKey}`;
+    return `${this.redisPrefix}:${this.host}:${this.shardKey}`;
   }
 
   public blockCountsKey(blockNumber: number, eventType: number) {


### PR DESCRIPTION
## Why is this change needed?
If clients split up streams beyond host/shard, the keys in redis need a special prefix to remain unique per stream. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a custom Redis key prefix for monitoring in the `EventStreamMonitor` class, enhancing key management for event streams.

### Detailed summary
- Added a new property `redisPrefix: string;` in the `EventStreamMonitor` class.
- Updated the constructor to accept `redisPrefix: string`.
- Modified the `streamKey` method to use the new `redisPrefix` for generating keys.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->