### PR TITLE
chore: release new shuttle version

### DIFF
--- a/.changeset/spicy-chairs-judge.md
+++ b/.changeset/spicy-chairs-judge.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-fix: add custom redis key prefix for monitoring

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.7.2
+
+### Patch Changes
+
+- 3cd6a779: fix: add custom redis key prefix for monitoring
+
 ## 0.7.1
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Why is this change needed?

Release new version of shuttle. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of the `@farcaster/shuttle` package from `0.7.1` to `0.7.2`, including a new patch change that adds a custom Redis key prefix for monitoring.

### Detailed summary
- Updated `version` in `packages/shuttle/package.json` from `0.7.1` to `0.7.2`
- Added a new entry in `CHANGELOG.md` for version `0.7.2`:
  - Patch Change: `3cd6a779`: fix: add custom redis key prefix for monitoring
- Removed the `.changeset/spicy-chairs-judge.md` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->