### PR TITLE
fix: only maintain counts for expected events in event stream monitoring

### DIFF
--- a/.changeset/strong-horses-melt.md
+++ b/.changeset/strong-horses-melt.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+fix: only maintain counts for expected events in event stream monitoring

--- a/packages/shuttle/src/shuttle/eventStream.ts
+++ b/packages/shuttle/src/shuttle/eventStream.ts
@@ -270,8 +270,10 @@ export class EventStreamMonitor {
 
   public async setBlockCounts(event: BlockConfirmedHubEvent) {
     for (const eventType of this.relevantEventTypes) {
-      const count = event.blockConfirmedBody.eventCountsByType[eventType] ?? 0;
-      await this.redis.set(this.blockCountsKey(event.blockConfirmedBody.blockNumber, eventType), count);
+      const count = event.blockConfirmedBody.eventCountsByType[eventType];
+      if (count !== undefined) {
+        await this.redis.set(this.blockCountsKey(event.blockConfirmedBody.blockNumber, eventType), count);
+      }
     }
   }
 


### PR DESCRIPTION
## Why is this change needed?

We're producing a lot of errors with 0 missing events due to this bug. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving event stream monitoring by ensuring that only counts for expected events are maintained, thereby optimizing the handling of event data.

### Detailed summary
- Modified the `setBlockCounts` method in the `eventStream.ts` file.
- Changed the way event counts are retrieved: now checks if the count is `undefined` before setting it in Redis.
- Removed the default count of `0`, ensuring only relevant counts are stored.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->