### PR TITLE
fix: use shard id from event in stream monitoring

### DIFF
--- a/.changeset/giant-masks-deny.md
+++ b/.changeset/giant-masks-deny.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+fix: use shard id from event in stream monitoring


### PR DESCRIPTION
## Why is this change needed?

If we subscribe to all shards in a single event stream, using a shard index that's provided by the user at initialization doesn't work. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `EventStreamMonitor` class by incorporating `shardId` into various methods to improve event streaming and monitoring capabilities.

### Detailed summary
- Updated `streamKey` to include `shardId`.
- Modified `blockCountsKey`, `currentBlockNumberKey`, and `currentBlockTimestampKey` to accept `shardId`.
- Adjusted `setBlockCounts`, `blockCompleted`, and `onEventProcessed` methods to use `shardId`.
- Changed Redis key retrievals to utilize `shardId`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->