### PR TITLE
feat: process events from stream in order

### DIFF
--- a/.changeset/polite-eyes-protect.md
+++ b/.changeset/polite-eyes-protect.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": minor
+---
+
+feat: process events from stream in order

--- a/packages/shuttle/src/shuttle/eventStream.ts
+++ b/packages/shuttle/src/shuttle/eventStream.ts
@@ -516,6 +516,7 @@ export class HubEventStreamConsumer extends TypedEmitter<HubEventStreamConsumerE
 
         if (eventsRead === 0) {
           if (this.stopped) break;
+          await sleep(10); // Don't thrash CPU if there's no events to process
         }
       } catch (e: unknown) {
         this.log.error(e, "Error processing event, skipping");


### PR DESCRIPTION
## Why is this change needed?
With the new blockchain model for Snapchain, we want to deliver messages to clients in order. 

Previously, we always prioritized new events even if there were old events backed up. If there are backed up events, we want to process those before moving onto new events. 

This feature also changes the guarantees around error handling by the stream. Events won't be presented to the client again if the client returns an error when processing the event. It's the clients responsibility to retry event processing on errors if they want to. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `EventStreamConnection` and `HubEventStreamConsumer` classes by improving event processing, removing the `claimStale` method, and adjusting event handling logic for better performance and clarity.

### Detailed summary
- Updated event processing to ensure events are processed in order.
- Removed the `claimStale` method from `HubEventStreamConsumer`.
- Eliminated `eventProcessingTimeout` property from `HubEventStreamConsumer`.
- Refactored logic for handling skipped events and timing metrics.
- Improved error handling and event acknowledgment processes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->