### PR TITLE
chore: release new shuttle version

### DIFF
--- a/.changeset/fast-suits-knock.md
+++ b/.changeset/fast-suits-knock.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-fix: revert changes to the event stream to process events in order

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.8.1
+
+### Patch Changes
+
+- 54dd939c: fix: revert changes to the event stream to process events in order
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Why is this change needed?

Release new shuttle version with the revert for the previous change. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of the `@farcaster/shuttle` package from `0.8.0` to `0.8.1`, along with a changelog entry that documents a fix related to event stream processing.

### Detailed summary
- Updated `version` in `packages/shuttle/package.json` from `0.8.0` to `0.8.1`.
- Added changelog entry for version `0.8.1` in `packages/shuttle/CHANGELOG.md`:
  - Reverted changes to the event stream to ensure events are processed in order.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->