### PR TITLE
chore: add logging for event stream monitor

### DIFF
--- a/.changeset/calm-hornets-confess.md
+++ b/.changeset/calm-hornets-confess.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+chore: add logging for event stream monitor

--- a/packages/shuttle/src/shuttle/eventStream.ts
+++ b/packages/shuttle/src/shuttle/eventStream.ts
@@ -291,7 +291,7 @@ export class EventStreamMonitor {
           host: this.host,
           type: eventType,
         });
-        this.log.error({ blockNumber, eventType }, "Missed events for block");
+        this.log.error({ blockNumber, eventType, numMissedEvents: count }, "Missed events for block");
       }
     }
   }

--- a/packages/shuttle/src/shuttle/eventStream.ts
+++ b/packages/shuttle/src/shuttle/eventStream.ts
@@ -291,7 +291,7 @@ export class EventStreamMonitor {
           host: this.host,
           type: eventType,
         });
-        this.log.error({ blockNumber, eventType, numMissedEvents: count }, "Missed events for block");
+        this.log.error({ blockNumber, eventType }, "Missed events for block");
       }
     }
   }
@@ -319,7 +319,7 @@ export class EventStreamMonitor {
           host: this.host,
         });
         this.log.error(
-          { lastBlock: currentBlockNumber, currentBlock: event.blockNumber },
+          { lastBlock: currentBlockNumber, currentBlock: event.blockNumber, eventShardId: event.shardIndex },
           "Skipped events in block range",
         );
       }
@@ -346,6 +346,8 @@ export class EventStreamMonitor {
           eventId: event.id,
           eventType: event.type,
           eventTimestamp: extractTimestampFromEvent(event),
+          eventShardId: event.shardIndex,
+          currentBlockNumber: Number(currentBlockNumber),
         },
         "Received event for old block",
       );
@@ -358,7 +360,12 @@ export class EventStreamMonitor {
     } else if (new_count < 0) {
       await this.redis.del(key);
       this.log.info(
-        { blockNumber: event.blockNumber, eventType: event.type, eventTimestamp: extractTimestampFromEvent(event) },
+        {
+          blockNumber: event.blockNumber,
+          eventType: event.type,
+          eventTimestamp: extractTimestampFromEvent(event),
+          eventShardId: event.shardIndex,
+        },
         "Received unexpected event",
       );
     }


### PR DESCRIPTION
## Why is this change needed?

Add logging required to debug missed blocks

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing logging in the `EventStreamMonitor` class to include additional context about events being processed, specifically the `eventShardId` and `currentBlockNumber`. 

### Detailed summary
- Added `eventShardId` to the error logging in `this.log.error`.
- Included `eventShardId` and `currentBlockNumber` in the event object being logged.
- Updated logging for unexpected events to include `eventShardId`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->