### PR TITLE
chore: release new shuttle version

### DIFF
--- a/.changeset/calm-hornets-confess.md
+++ b/.changeset/calm-hornets-confess.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-chore: add logging for event stream monitor

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.8.2
+
+### Patch Changes
+
+- 8877a5f7: chore: add logging for event stream monitor
+
 ## 0.8.1
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Why is this change needed?

Release new shuttle version 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of the `@farcaster/shuttle` package from `0.8.1` to `0.8.2`, including a new logging feature for the event stream monitor.

### Detailed summary
- Deleted the `.changeset/calm-hornets-confess.md` file.
- Updated `CHANGELOG.md` to include version `0.8.2` with a new logging feature.
- Changed the `version` in `package.json` from `0.8.1` to `0.8.2`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->