### PR TITLE
feat: Add console example and bump protos

### DIFF
--- a/.changeset/lemon-tools-draw.md
+++ b/.changeset/lemon-tools-draw.md
@@ -1,0 +1,7 @@
+---
+"@farcaster/hub-nodejs": patch
+"@farcaster/hub-web": patch
+"@farcaster/core": patch
+---
+
+fix: Add console example and bump protos

--- a/generate-protos.sh
+++ b/generate-protos.sh
@@ -1,6 +1,6 @@
 PROTO_REPO=https://github.com/farcasterxyz/snapchain
 PROTO_PATH=src/proto
-PROTO_REV=a0367add145a74638bdbe73153775a673bb08dee # Update this if you want to generate off updated snapchain protos
+PROTO_REV=0455a15b0c278a08835b7b58d0b616d263b15f2e # Update this if you want to generate off updated snapchain protos
 
 TMPDIR=tmp-protogen
 git clone $PROTO_REPO $TMPDIR

--- a/packages/core/src/protobufs/generated/admin_rpc.ts
+++ b/packages/core/src/protobufs/generated/admin_rpc.ts
@@ -15,6 +15,11 @@ export interface RetryOnchainEventsRequest {
   blockRange?: RetryBlockNumberRange | undefined;
 }
 
+export interface RetryFnameRequest {
+  fid?: number | undefined;
+  fname?: string | undefined;
+}
+
 export interface UploadSnapshotRequest {
   shardIndexes: number[];
 }
@@ -204,6 +209,77 @@ export const RetryOnchainEventsRequest = {
     message.blockRange = (object.blockRange !== undefined && object.blockRange !== null)
       ? RetryBlockNumberRange.fromPartial(object.blockRange)
       : undefined;
+    return message;
+  },
+};
+
+function createBaseRetryFnameRequest(): RetryFnameRequest {
+  return { fid: undefined, fname: undefined };
+}
+
+export const RetryFnameRequest = {
+  encode(message: RetryFnameRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.fid !== undefined) {
+      writer.uint32(8).uint64(message.fid);
+    }
+    if (message.fname !== undefined) {
+      writer.uint32(18).string(message.fname);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): RetryFnameRequest {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseRetryFnameRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.fid = longToNumber(reader.uint64() as Long);
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.fname = reader.string();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): RetryFnameRequest {
+    return {
+      fid: isSet(object.fid) ? Number(object.fid) : undefined,
+      fname: isSet(object.fname) ? String(object.fname) : undefined,
+    };
+  },
+
+  toJSON(message: RetryFnameRequest): unknown {
+    const obj: any = {};
+    message.fid !== undefined && (obj.fid = Math.round(message.fid));
+    message.fname !== undefined && (obj.fname = message.fname);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<RetryFnameRequest>, I>>(base?: I): RetryFnameRequest {
+    return RetryFnameRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<RetryFnameRequest>, I>>(object: I): RetryFnameRequest {
+    const message = createBaseRetryFnameRequest();
+    message.fid = object.fid ?? undefined;
+    message.fname = object.fname ?? undefined;
     return message;
   },
 };

--- a/packages/hub-nodejs/examples/console/adminCommand.ts
+++ b/packages/hub-nodejs/examples/console/adminCommand.ts
@@ -1,0 +1,23 @@
+import { AdminRpcClient } from "@farcaster/hub-nodejs";
+import { ConsoleCommandInterface } from "./console.js";
+
+export class AdminCommand implements ConsoleCommandInterface {
+  constructor(private readonly adminClient: AdminRpcClient) {}
+
+  commandName(): string {
+    return "admin";
+  }
+  shortHelp(): string {
+    return "Admin commands";
+  }
+  help(): string {
+    return `
+        Usage: admin.rebuildSyncTrie()
+            Rebuild the sync trie by deleting the trie and reconstructing it from all the messages in the database.
+            Be careful not to be connected to any other node or syncing while rebuilding the trie.
+        `;
+  }
+  object() {
+    return {};
+  }
+}

--- a/packages/hub-nodejs/examples/console/console.ts
+++ b/packages/hub-nodejs/examples/console/console.ts
@@ -1,0 +1,116 @@
+import {
+  Metadata,
+  getAdminRpcClient,
+  getAuthMetadata,
+  getInsecureHubRpcClient,
+  getSSLHubRpcClient,
+  toFarcasterTime,
+  fromFarcasterTime,
+  bytesToHexString,
+  hexStringToBytes,
+} from "@farcaster/hub-nodejs";
+import * as hub from "@farcaster/hub-nodejs";
+import path from "path";
+import * as repl from "repl";
+import { AdminCommand } from "./adminCommand.js";
+import { FactoriesCommand, ProtobufCommand } from "./protobufCommand.js";
+import { RpcClientCommand } from "./rpcClientCommand.js";
+
+export const DEFAULT_RPC_CONSOLE = "127.0.0.1:3383";
+
+export interface ConsoleCommandInterface {
+  commandName(): string;
+  shortHelp(): string;
+  help(): string;
+  // biome-ignore lint/suspicious/noExplicitAny: legacy code, avoid using ignore for new code
+  object(): any;
+}
+
+export const startConsole = async (addressString: string, useInsecure: boolean) => {
+  const replServer = repl
+    .start({
+      prompt: `${addressString} hub> `,
+      useColors: true,
+      useGlobal: true,
+      breakEvalOnSigint: true,
+    })
+    .on("exit", () => {
+      process.exit(0);
+    });
+
+  replServer.output.write("\nWelcome to the Hub console. Type '.help' for a list of commands.\n");
+  replServer.output.write(`Connecting to hub at "${addressString}"\n`);
+
+  replServer.setupHistory(path.join(process.cwd(), ".hub_history"), (err) => {
+    if (err) {
+      console.error("Error setting up history:", err);
+    }
+  });
+
+  let rpcClient;
+  if (useInsecure) {
+    rpcClient = getInsecureHubRpcClient(addressString);
+  } else {
+    rpcClient = getSSLHubRpcClient(addressString);
+  }
+
+  // Admin server is only available on localhost
+  const adminClient = await getAdminRpcClient(addressString);
+
+  const commands: ConsoleCommandInterface[] = [
+    new RpcClientCommand(rpcClient),
+    new ProtobufCommand(),
+    new FactoriesCommand(),
+    new AdminCommand(adminClient),
+  ];
+
+  replServer.defineCommand("help", {
+    help: "Show this help",
+    action() {
+      this.clearBufferedCommand();
+
+      this.output.write("Available commands:\n");
+      commands.forEach((command) => {
+        this.output.write(`\t${command.commandName()} - ${command.shortHelp()}\n`);
+      });
+
+      this.displayPrompt();
+    },
+  });
+
+  commands.forEach((command) => {
+    replServer.context[command.commandName()] = command.object();
+  });
+
+  // Add some utility functions
+  replServer.context["getAuthMetadata"] = getAuthMetadata;
+  replServer.context["toFarcasterTime"] = toFarcasterTime;
+  replServer.context["fromFarcasterTime"] = fromFarcasterTime;
+  replServer.context["bytesToHex"] = bytesToHexString;
+  replServer.context["hexToBytes"] = hexStringToBytes;
+  replServer.context["adminClient"] = adminClient;
+
+  // Run the info command to start
+
+  const info = await rpcClient.getInfo({}, new Metadata(), {
+    deadline: Date.now() + 2000,
+  });
+
+  if (info.isErr()) {
+    replServer.output.write(`Could not connect to hub at "${addressString}"\n`);
+    console.log(info.error);
+    process.exit(1);
+  }
+
+  replServer.output.write(`Connected Info: ${JSON.stringify(info.value)}\n`);
+
+  replServer.displayPrompt();
+};
+
+const addressString = process.argv[2] || DEFAULT_RPC_CONSOLE;
+const useInsecure = process.argv[3] === "insecure";
+
+startConsole(addressString, useInsecure).catch((err) => {
+  console.error("Error starting console:", err);
+  process.exit(1);
+});

--- a/packages/hub-nodejs/examples/console/package.json
+++ b/packages/hub-nodejs/examples/console/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "console-example",
+  "private": true,
+  "type": "module",
+  "version": "0.0.0",
+  "main": "console.ts",
+  "scripts": {
+    "start": "tsx console.ts",
+    "typecheck": "yarn tsc --noEmit"
+  },
+  "dependencies": {
+    "@farcaster/hub-nodejs": "^0.15.1"
+  },
+  "devDependencies": {
+    "tsx": "^4.20.3",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/hub-nodejs/examples/console/protobufCommand.ts
+++ b/packages/hub-nodejs/examples/console/protobufCommand.ts
@@ -1,0 +1,43 @@
+import * as hubNodejs from "@farcaster/hub-nodejs";
+import { Factories } from "@farcaster/hub-nodejs";
+import { ConsoleCommandInterface } from "./console.js";
+
+export class ProtobufCommand implements ConsoleCommandInterface {
+  commandName(): string {
+    return "protobufs";
+  }
+  shortHelp(): string {
+    return "Use the protobufs library to create and parse messages";
+  }
+  help(): string {
+    return `
+        Usage: protobufs.<protobuf>.<method>(<args>)
+            eg.: protobufs.FidRequest.create({fid: 1})
+            
+        Note: Some protobuf methods are async, so you'll have to await them.            
+        `;
+  }
+  object() {
+    return hubNodejs;
+  }
+}
+
+export class FactoriesCommand implements ConsoleCommandInterface {
+  commandName(): string {
+    return "factories";
+  }
+  shortHelp(): string {
+    return "Use the factories library to create test messages";
+  }
+  help(): string {
+    return `
+        Usage: factories.<factory>.<method>(<args>)
+            eg.: factories.Fid.build()
+            
+        Note: Some factory methods are async, so you'll have to await them.            
+        `;
+  }
+  object() {
+    return Factories;
+  }
+}

--- a/packages/hub-nodejs/examples/console/rpcClientCommand.ts
+++ b/packages/hub-nodejs/examples/console/rpcClientCommand.ts
@@ -1,0 +1,18 @@
+import { HubRpcClient } from "@farcaster/hub-nodejs";
+import { ConsoleCommandInterface } from "./console.js";
+
+export class RpcClientCommand implements ConsoleCommandInterface {
+  constructor(private readonly rpcClient: HubRpcClient) {}
+  commandName(): string {
+    return "rpcClient";
+  }
+  shortHelp(): string {
+    return "Use the RPC client connected to the Hub";
+  }
+  help(): string {
+    return "Usage: rpcClient.<rpc>(<args>)";
+  }
+  object(): HubRpcClient {
+    return this.rpcClient;
+  }
+}

--- a/packages/hub-nodejs/examples/console/trackHubDelayCommand.ts
+++ b/packages/hub-nodejs/examples/console/trackHubDelayCommand.ts
@@ -1,0 +1,88 @@
+import { HubEvent, HubRpcClient, SubscribeRequest, fromFarcasterTime } from "@farcaster/hub-nodejs";
+import { ConsoleCommandInterface } from "./console.js";
+
+export class TrackHubDelayCommand implements ConsoleCommandInterface {
+  constructor(private readonly rpcClient: HubRpcClient) {}
+
+  commandName(): string {
+    return "trackHubDelay";
+  }
+  shortHelp(): string {
+    return "Track the delay between the hub's eventId timestamp and the message's timestamp";
+  }
+  help(): string {
+    return `
+    Usage: trackHubDelay()
+
+        Track the amount of delay that the connected hub is experiencing while merging messages
+    `;
+  }
+  object() {
+    return {
+      start: async () => {
+        // Create a client stream to connect to the hub
+        const request = SubscribeRequest.create({});
+        const streamResult = await this.rpcClient.subscribe(request);
+        if (streamResult.isErr()) {
+          console.error("Failed to subscribe to hub");
+          return;
+        }
+
+        // Get the stream from the result
+        const stream = streamResult.value;
+
+        let totalDelay = 0;
+        let numMessages = 0;
+
+        const interval = setInterval(() => {
+          if (numMessages > 0) {
+            console.log(
+              `Average delay: ${
+                Math.round((totalDelay * 10 ** 2) / numMessages) / 10 ** 2
+              } s from ${numMessages} messages`,
+            );
+          }
+        }, 5 * 1000);
+
+        // Listen for messages from the hub
+        stream.on("data", (hubEvent: HubEvent) => {
+          // Get the timestamp of the event
+          const eventTimestamp = hubEvent.id / 4096 / 1000;
+
+          // Get the message timeStamp
+          const messageTimestamp = hubEvent.mergeMessageBody?.message?.data?.timestamp ?? 0;
+
+          if (messageTimestamp) {
+            // Calculate the delay
+            const delay = eventTimestamp - messageTimestamp;
+            if (delay > 1000) {
+              console.log(
+                `Huge Delay: ${Math.round(delay / 1000)}s.  Message timestamp: ${new Date(
+                  fromFarcasterTime(messageTimestamp)._unsafeUnwrap(),
+                )}`,
+              );
+            } else {
+              totalDelay += delay;
+              numMessages++;
+            }
+          }
+        });
+
+        const finished = new Promise((resolve) => {
+          stream.on("close", () => {
+            resolve(true);
+          });
+          stream.on("end", () => {
+            resolve(true);
+          });
+          stream.on("error", () => {
+            resolve(true);
+          });
+        });
+
+        await finished;
+        clearInterval(interval);
+      },
+    };
+  }
+}

--- a/packages/hub-nodejs/src/generated/admin_rpc.ts
+++ b/packages/hub-nodejs/src/generated/admin_rpc.ts
@@ -29,6 +29,11 @@ export interface RetryOnchainEventsRequest {
   blockRange?: RetryBlockNumberRange | undefined;
 }
 
+export interface RetryFnameRequest {
+  fid?: number | undefined;
+  fname?: string | undefined;
+}
+
 export interface UploadSnapshotRequest {
   shardIndexes: number[];
 }
@@ -222,6 +227,77 @@ export const RetryOnchainEventsRequest = {
   },
 };
 
+function createBaseRetryFnameRequest(): RetryFnameRequest {
+  return { fid: undefined, fname: undefined };
+}
+
+export const RetryFnameRequest = {
+  encode(message: RetryFnameRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.fid !== undefined) {
+      writer.uint32(8).uint64(message.fid);
+    }
+    if (message.fname !== undefined) {
+      writer.uint32(18).string(message.fname);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): RetryFnameRequest {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseRetryFnameRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.fid = longToNumber(reader.uint64() as Long);
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.fname = reader.string();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): RetryFnameRequest {
+    return {
+      fid: isSet(object.fid) ? Number(object.fid) : undefined,
+      fname: isSet(object.fname) ? String(object.fname) : undefined,
+    };
+  },
+
+  toJSON(message: RetryFnameRequest): unknown {
+    const obj: any = {};
+    message.fid !== undefined && (obj.fid = Math.round(message.fid));
+    message.fname !== undefined && (obj.fname = message.fname);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<RetryFnameRequest>, I>>(base?: I): RetryFnameRequest {
+    return RetryFnameRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<RetryFnameRequest>, I>>(object: I): RetryFnameRequest {
+    const message = createBaseRetryFnameRequest();
+    message.fid = object.fid ?? undefined;
+    message.fname = object.fname ?? undefined;
+    return message;
+  },
+};
+
 function createBaseUploadSnapshotRequest(): UploadSnapshotRequest {
   return { shardIndexes: [] };
 }
@@ -332,6 +408,15 @@ export const AdminServiceService = {
     responseSerialize: (value: Empty) => Buffer.from(Empty.encode(value).finish()),
     responseDeserialize: (value: Buffer) => Empty.decode(value),
   },
+  retryFnameEvents: {
+    path: "/AdminService/RetryFnameEvents",
+    requestStream: false,
+    responseStream: false,
+    requestSerialize: (value: RetryFnameRequest) => Buffer.from(RetryFnameRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => RetryFnameRequest.decode(value),
+    responseSerialize: (value: Empty) => Buffer.from(Empty.encode(value).finish()),
+    responseDeserialize: (value: Buffer) => Empty.decode(value),
+  },
 } as const;
 
 export interface AdminServiceServer extends UntypedServiceImplementation {
@@ -339,6 +424,7 @@ export interface AdminServiceServer extends UntypedServiceImplementation {
   submitUserNameProof: handleUnaryCall<UserNameProof, UserNameProof>;
   uploadSnapshot: handleUnaryCall<UploadSnapshotRequest, Empty>;
   retryOnchainEvents: handleUnaryCall<RetryOnchainEventsRequest, Empty>;
+  retryFnameEvents: handleUnaryCall<RetryFnameRequest, Empty>;
 }
 
 export interface AdminServiceClient extends Client {
@@ -398,6 +484,21 @@ export interface AdminServiceClient extends Client {
   ): ClientUnaryCall;
   retryOnchainEvents(
     request: RetryOnchainEventsRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: Empty) => void,
+  ): ClientUnaryCall;
+  retryFnameEvents(
+    request: RetryFnameRequest,
+    callback: (error: ServiceError | null, response: Empty) => void,
+  ): ClientUnaryCall;
+  retryFnameEvents(
+    request: RetryFnameRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: Empty) => void,
+  ): ClientUnaryCall;
+  retryFnameEvents(
+    request: RetryFnameRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: Empty) => void,

--- a/packages/hub-web/src/generated/admin_rpc.ts
+++ b/packages/hub-web/src/generated/admin_rpc.ts
@@ -19,6 +19,11 @@ export interface RetryOnchainEventsRequest {
   blockRange?: RetryBlockNumberRange | undefined;
 }
 
+export interface RetryFnameRequest {
+  fid?: number | undefined;
+  fname?: string | undefined;
+}
+
 export interface UploadSnapshotRequest {
   shardIndexes: number[];
 }
@@ -212,6 +217,77 @@ export const RetryOnchainEventsRequest = {
   },
 };
 
+function createBaseRetryFnameRequest(): RetryFnameRequest {
+  return { fid: undefined, fname: undefined };
+}
+
+export const RetryFnameRequest = {
+  encode(message: RetryFnameRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.fid !== undefined) {
+      writer.uint32(8).uint64(message.fid);
+    }
+    if (message.fname !== undefined) {
+      writer.uint32(18).string(message.fname);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): RetryFnameRequest {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseRetryFnameRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.fid = longToNumber(reader.uint64() as Long);
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.fname = reader.string();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): RetryFnameRequest {
+    return {
+      fid: isSet(object.fid) ? Number(object.fid) : undefined,
+      fname: isSet(object.fname) ? String(object.fname) : undefined,
+    };
+  },
+
+  toJSON(message: RetryFnameRequest): unknown {
+    const obj: any = {};
+    message.fid !== undefined && (obj.fid = Math.round(message.fid));
+    message.fname !== undefined && (obj.fname = message.fname);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<RetryFnameRequest>, I>>(base?: I): RetryFnameRequest {
+    return RetryFnameRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<RetryFnameRequest>, I>>(object: I): RetryFnameRequest {
+    const message = createBaseRetryFnameRequest();
+    message.fid = object.fid ?? undefined;
+    message.fname = object.fname ?? undefined;
+    return message;
+  },
+};
+
 function createBaseUploadSnapshotRequest(): UploadSnapshotRequest {
   return { shardIndexes: [] };
 }
@@ -288,6 +364,7 @@ export interface AdminService {
   submitUserNameProof(request: DeepPartial<UserNameProof>, metadata?: grpc.Metadata): Promise<UserNameProof>;
   uploadSnapshot(request: DeepPartial<UploadSnapshotRequest>, metadata?: grpc.Metadata): Promise<Empty>;
   retryOnchainEvents(request: DeepPartial<RetryOnchainEventsRequest>, metadata?: grpc.Metadata): Promise<Empty>;
+  retryFnameEvents(request: DeepPartial<RetryFnameRequest>, metadata?: grpc.Metadata): Promise<Empty>;
 }
 
 export class AdminServiceClientImpl implements AdminService {
@@ -299,6 +376,7 @@ export class AdminServiceClientImpl implements AdminService {
     this.submitUserNameProof = this.submitUserNameProof.bind(this);
     this.uploadSnapshot = this.uploadSnapshot.bind(this);
     this.retryOnchainEvents = this.retryOnchainEvents.bind(this);
+    this.retryFnameEvents = this.retryFnameEvents.bind(this);
   }
 
   submitOnChainEvent(request: DeepPartial<OnChainEvent>, metadata?: grpc.Metadata): Promise<OnChainEvent> {
@@ -315,6 +393,10 @@ export class AdminServiceClientImpl implements AdminService {
 
   retryOnchainEvents(request: DeepPartial<RetryOnchainEventsRequest>, metadata?: grpc.Metadata): Promise<Empty> {
     return this.rpc.unary(AdminServiceRetryOnchainEventsDesc, RetryOnchainEventsRequest.fromPartial(request), metadata);
+  }
+
+  retryFnameEvents(request: DeepPartial<RetryFnameRequest>, metadata?: grpc.Metadata): Promise<Empty> {
+    return this.rpc.unary(AdminServiceRetryFnameEventsDesc, RetryFnameRequest.fromPartial(request), metadata);
   }
 }
 
@@ -397,6 +479,29 @@ export const AdminServiceRetryOnchainEventsDesc: UnaryMethodDefinitionish = {
   requestType: {
     serializeBinary() {
       return RetryOnchainEventsRequest.encode(this).finish();
+    },
+  } as any,
+  responseType: {
+    deserializeBinary(data: Uint8Array) {
+      const value = Empty.decode(data);
+      return {
+        ...value,
+        toObject() {
+          return value;
+        },
+      };
+    },
+  } as any,
+};
+
+export const AdminServiceRetryFnameEventsDesc: UnaryMethodDefinitionish = {
+  methodName: "RetryFnameEvents",
+  service: AdminServiceDesc,
+  requestStream: false,
+  responseStream: false,
+  requestType: {
+    serializeBinary() {
+      return RetryFnameRequest.encode(this).finish();
     },
   } as any,
   responseType: {


### PR DESCRIPTION
## Why is this change needed?

Port the yarn console from hubble as an example app

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the console commands for the `@farcaster/hub-nodejs` package by adding new functionalities and updating existing ones. It also updates the protobuf definitions and dependencies.

### Detailed summary
- Added `console-example` in `packages/hub-nodejs/examples/console/package.json`.
- Introduced new commands: `RpcClientCommand`, `AdminCommand`, `ProtobufCommand`, `FactoriesCommand`, and `TrackHubDelayCommand`.
- Updated `generate-protos.sh` with a new `PROTO_REV`.
- Enhanced `RetryFnameRequest` and added related methods in protobuf files.
- Improved console utility functions and command help descriptions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->