### PR TITLE
chore: release new packages

### DIFF
--- a/.changeset/lemon-tools-draw.md
+++ b/.changeset/lemon-tools-draw.md
@@ -1,7 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
-"@farcaster/hub-web": patch
-"@farcaster/core": patch
----
-
-fix: Add console example and bump protos

--- a/.changeset/spotty-icons-move.md
+++ b/.changeset/spotty-icons-move.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-fix: make shard id required for the hub subscriber

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/core
 
+## 0.18.2
+
+### Patch Changes
+
+- 74149586: fix: Add console example and bump protos
+
 ## 0.18.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hub-nodejs
 
+## 0.15.2
+
+### Patch Changes
+
+- 74149586: fix: Add console example and bump protos
+- Updated dependencies [74149586]
+  - @farcaster/core@0.18.2
+
 ## 0.15.1
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -20,7 +20,7 @@
     "url": "https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/hub-nodejs"
   },
   "dependencies": {
-    "@farcaster/core": "0.18.1",
+    "@farcaster/core": "0.18.2",
     "@grpc/grpc-js": "~1.11.1",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"

--- a/packages/hub-web/CHANGELOG.md
+++ b/packages/hub-web/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hub-web
 
+## 0.11.2
+
+### Patch Changes
+
+- 74149586: fix: Add console example and bump protos
+- Updated dependencies [74149586]
+  - @farcaster/core@0.18.2
+
 ## 0.11.1
 
 ### Patch Changes

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-web",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -32,7 +32,7 @@
     "ts-proto": "^1.146.0"
   },
   "dependencies": {
-    "@farcaster/core": "^0.18.1",
+    "@farcaster/core": "^0.18.2",
     "@improbable-eng/grpc-web": "^0.15.0",
     "rxjs": "^7.8.0"
   }

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hub-shuttle
 
+## 0.9.0
+
+### Minor Changes
+
+- 83a95868: fix: make shard id required for the hub subscriber
+- Updated dependencies [74149586]
+  - @farcaster/hub-nodejs@0.15.2
+
 ## 0.8.2
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@farcaster/hot-shots": "^10.0.0",
-    "@farcaster/hub-nodejs": "^0.15.1",
+    "@farcaster/hub-nodejs": "^0.15.2",
     "commander": "11.0.0",
     "dotenv": "16.4.5",
     "ioredis": "^5.3.2",


### PR DESCRIPTION
## Why is this change needed?

Release new packages 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the versions of various packages, particularly `@farcaster/core`, `@farcaster/hub-nodejs`, and `@farcaster/hub-web`, along with adding a console example and making adjustments to dependencies and changelogs.

### Detailed summary
- Updated `@farcaster/core` version to `0.18.2` from `0.18.1`.
- Updated `@farcaster/hub-web` version to `0.11.2` from `0.11.1`.
- Updated `@farcaster/hub-nodejs` version to `0.15.2` from `0.15.1`.
- Updated `@farcaster/shuttle` version to `0.9.0` from `0.8.2`.
- Added a console example and bumped protos in changelogs.
- Noted dependency updates for `@farcaster/hub-nodejs` and `@farcaster/core` in respective changelogs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->