### PR TITLE
fix: Update limits for 2025 storage units

### DIFF
--- a/packages/core/src/limits.ts
+++ b/packages/core/src/limits.ts
@@ -1,36 +1,44 @@
 import { StorageRentOnChainEvent, StorageUnitDetails, StorageUnitType, StoreType } from "./protobufs";
 
 export const LEGACY_STORAGE_UNIT_CUTOFF_TIMESTAMP = 1724889600; // 2024-08-29 00:00:00 UTC
+export const UNIT_TYPE_2025__CUTOFF_TIMESTAMP = 1752685200; // 2025-07-16 17:00:00 UTC
 const ONE_YEAR_IN_SECONDS = 365 * 24 * 60 * 60;
 
 const STORAGE_UNIT_DEFAULTS = {
   [StoreType.CASTS]: {
     [StorageUnitType.UNIT_TYPE_LEGACY]: 5000,
     [StorageUnitType.UNIT_TYPE_2024]: 2000,
+    [StorageUnitType.UNIT_TYPE_2025]: 100,
   },
   [StoreType.LINKS]: {
     [StorageUnitType.UNIT_TYPE_LEGACY]: 2500,
     [StorageUnitType.UNIT_TYPE_2024]: 1000,
+    [StorageUnitType.UNIT_TYPE_2025]: 200,
   },
   [StoreType.REACTIONS]: {
     [StorageUnitType.UNIT_TYPE_LEGACY]: 2500,
     [StorageUnitType.UNIT_TYPE_2024]: 1000,
+    [StorageUnitType.UNIT_TYPE_2025]: 200,
   },
   [StoreType.USER_DATA]: {
     [StorageUnitType.UNIT_TYPE_LEGACY]: 50,
     [StorageUnitType.UNIT_TYPE_2024]: 50,
+    [StorageUnitType.UNIT_TYPE_2025]: 25,
   },
   [StoreType.USERNAME_PROOFS]: {
     [StorageUnitType.UNIT_TYPE_LEGACY]: 5,
     [StorageUnitType.UNIT_TYPE_2024]: 5,
+    [StorageUnitType.UNIT_TYPE_2025]: 2,
   },
   [StoreType.VERIFICATIONS]: {
     [StorageUnitType.UNIT_TYPE_LEGACY]: 25,
     [StorageUnitType.UNIT_TYPE_2024]: 25,
+    [StorageUnitType.UNIT_TYPE_2025]: 5,
   },
   [StoreType.NONE]: {
     [StorageUnitType.UNIT_TYPE_LEGACY]: 0,
     [StorageUnitType.UNIT_TYPE_2024]: 0,
+    [StorageUnitType.UNIT_TYPE_2025]: 0,
   },
 };
 
@@ -76,6 +84,8 @@ export const getDefaultStoreLimit = (storeType: StoreType, unit_type: StorageUni
 export const getStorageUnitType = (event: StorageRentOnChainEvent) => {
   if (event.blockTimestamp < LEGACY_STORAGE_UNIT_CUTOFF_TIMESTAMP) {
     return StorageUnitType.UNIT_TYPE_LEGACY;
+  } else if (event.blockTimestamp < UNIT_TYPE_2025__CUTOFF_TIMESTAMP) {
+    return StorageUnitType.UNIT_TYPE_2025;
   } else {
     return StorageUnitType.UNIT_TYPE_2024;
   }
@@ -84,9 +94,12 @@ export const getStorageUnitType = (event: StorageRentOnChainEvent) => {
 export const getStorageUnitExpiry = (event: StorageRentOnChainEvent) => {
   if (event.blockTimestamp < LEGACY_STORAGE_UNIT_CUTOFF_TIMESTAMP) {
     // Legacy storage units expire after 2 years
+    return event.blockTimestamp + ONE_YEAR_IN_SECONDS * 3;
+  } else if (event.blockTimestamp < UNIT_TYPE_2025__CUTOFF_TIMESTAMP) {
+    // 2024 storage units expire after 2 years
     return event.blockTimestamp + ONE_YEAR_IN_SECONDS * 2;
   } else {
-    // 2024 storage units expire after 1 year
+    // 2025 storage units expire after 1 year
     return event.blockTimestamp + ONE_YEAR_IN_SECONDS;
   }
 };


### PR DESCRIPTION
## Why is this change needed?

Update limits for 2025 storage units

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for a new storage unit type for 2025 by adding a cutoff timestamp and adjusting default storage limits across various store types. It also updates the logic for determining storage unit types and their expiry durations.

### Detailed summary
- Added `UNIT_TYPE_2025__CUTOFF_TIMESTAMP` with a value of `1752685200`.
- Updated `STORAGE_UNIT_DEFAULTS` to include limits for `StorageUnitType.UNIT_TYPE_2025`.
- Modified `getStorageUnitType` to return `StorageUnitType.UNIT_TYPE_2025` based on the new cutoff.
- Adjusted `getStorageUnitExpiry` to reflect the expiry rules for 2025 storage units.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->