### PR TITLE
chore: release new shuttle version

### DIFF
--- a/.changeset/heavy-suits-look.md
+++ b/.changeset/heavy-suits-look.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-fix: handle retries on server-side termination properly in HubSubscriber

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.9.1
+
+### Patch Changes
+
+- 5460d914: fix: handle retries on server-side termination properly in HubSubscriber
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Why is this change needed?

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of the `@farcaster/shuttle` package from `0.9.0` to `0.9.1`, along with a changelog entry detailing a bug fix related to server-side termination handling in `HubSubscriber`.

### Detailed summary
- Updated `version` in `packages/shuttle/package.json` from `0.9.0` to `0.9.1`.
- Added changelog entry in `packages/shuttle/CHANGELOG.md` for version `0.9.1`:
  - Fix: handle retries on server-side termination properly in `HubSubscriber`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->