### PR TITLE
fix: update where we emit errors on hub subscriber disconnects

### DIFF
--- a/packages/shuttle/src/shuttle/hubSubscriber.ts
+++ b/packages/shuttle/src/shuttle/hubSubscriber.ts
@@ -172,11 +172,12 @@ export class BaseHubSubscriber extends HubSubscriber {
         clearTimeout(cancel);
         // biome-ignore lint/suspicious/noExplicitAny: error catching
       } catch (e: any) {
-        this.emit("onError", e, this.stopped);
         this.log.info(
           `Hub event stream processing halted unexpectedly: ${e.message}. HubSubscriber will attempt ${this.label} restarting hub event stream in 5 seconds...`,
         );
         await sleep(5_000);
+        // Do this after the sleep so that stopped state accurately reflects whether we'll retry.
+        this.emit("onError", e, this.stopped);
         // It's important to check if the subscription is stopped after sleeping because in cases where the server is unresponsive, we end up in this catch block and the stream is closed some time shortly after. If we attempt to retry anyway then we end up raising due to the stream being closed.
         if (this.stopped) {
           this.log.info(`Hub event stream processing stopped, aborting retry: ${e.message}`);


### PR DESCRIPTION
## Why is this change needed?
Emitting here ensures that the `stopped` state properly reflects whether a retry will happen. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.
