### PR TITLE
chore: release new shuttle version

### DIFF
--- a/.changeset/young-jobs-flash.md
+++ b/.changeset/young-jobs-flash.md
@@ -1,5 +1,0 @@
----
-"@farcaster/shuttle": patch
----
-
-fix: update where we emit errors on hub subscriber disconnects

--- a/packages/shuttle/CHANGELOG.md
+++ b/packages/shuttle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/hub-shuttle
 
+## 0.9.2
+
+### Patch Changes
+
+- e3dc87e5: fix: update where we emit errors on hub subscriber disconnects
+
 ## 0.9.1
 
 ### Patch Changes

--- a/packages/shuttle/package.json
+++ b/packages/shuttle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/shuttle",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Why is this change needed?

Release shuttle version. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of the `@farcaster/shuttle` package from `0.9.1` to `0.9.2`, adds a new entry in the `CHANGELOG.md` for version `0.9.2`, and includes a fix related to error emission on hub subscriber disconnects.

### Detailed summary
- Updated `version` in `packages/shuttle/package.json` from `0.9.1` to `0.9.2`.
- Added `CHANGELOG.md` entry for version `0.9.2`:
  - Fix: updated error emission on hub subscriber disconnects.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->