### PR TITLE
Fix: use publicKey instead of privateKey in invalid signature test for verifyMessageHashSignature

### DIFF
--- a/packages/core/src/crypto/ed25519.test.ts
+++ b/packages/core/src/crypto/ed25519.test.ts
@@ -46,7 +46,7 @@ describe("verifyMessageHashSignature", () => {
     const messageData = Factories.CastAddData.build();
     const bytes = protobufs.MessageData.encode(messageData).finish();
     const hash = blake3(bytes, { dkLen: 20 });
-    const isValid = await ed25519.verifyMessageHashSignature(randomBytes(32), hash, privateKey);
+    const isValid = await ed25519.verifyMessageHashSignature(randomBytes(32), hash, publicKey);
     expect(isValid._unsafeUnwrapErr()).toBeInstanceOf(HubError);
   });
 });


### PR DESCRIPTION
Replaced the use of privateKey with publicKey as the third argument in the "fails with invalid signature" test for verifyMessageHashSignature. The function expects a public key, not a private key, according to its signature. This change ensures the test logic matches the intended usage and prevents false negatives.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the signature verification process in the `ed25519` cryptography tests by changing the key used for verification from `privateKey` to `publicKey`.

### Detailed summary
- Changed the parameter in `ed25519.verifyMessageHashSignature` from `privateKey` to `publicKey`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->