### PR TITLE
fix: update dataBytes length check for 10k casts

### DIFF
--- a/.changeset/late-geckos-move.md
+++ b/.changeset/late-geckos-move.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/core": patch
+---
+
+fix: update dataBytes length check for 10k casts

--- a/packages/core/src/validations.test.ts
+++ b/packages/core/src/validations.test.ts
@@ -8,9 +8,10 @@ import { Factories } from "./factories";
 import { fromFarcasterTime, getFarcasterTime } from "./time";
 import * as validations from "./validations";
 import { makeVerificationAddressClaim } from "./verifications";
-import { UserDataType, UserNameType } from "@farcaster/hub-nodejs";
+import { CastAddBody, makeCastAdd, makeCastAddData, UserDataType, UserNameType } from "@farcaster/hub-nodejs";
 import { defaultL1PublicClient } from "./eth/clients";
 import { jest } from "@jest/globals";
+import { assert } from "console";
 
 const signer = Factories.Ed25519Signer.build();
 const ethSigner = Factories.Eip712Signer.build();
@@ -1473,6 +1474,19 @@ describe("validateMessage", () => {
 
     const result = await validations.validateMessage(message);
     expect(result).toEqual(err(new HubError("bad_request.validation_failure", "invalid signature")));
+  });
+
+  test("passes for 10k cast", async () => {
+    const message = (
+      await makeCastAdd(
+        CastAddBody.create({ text: "z".repeat(10_000), type: CastType.TEN_K_CAST }),
+        { fid: Factories.Fid.build(), network: Factories.FarcasterNetwork.build() },
+        Factories.Ed25519Signer.build(),
+      )
+    )._unsafeUnwrap();
+    expect(message.dataBytes !== undefined).toBeTruthy();
+    const result = await validations.validateMessage(message);
+    expect(result.isOk()).toBeTruthy();
   });
 });
 

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -314,7 +314,9 @@ export const validateMessage = async (
 
   // 2. If the data_bytes are set, we'll validate signature against that
   if (message.dataBytes && message.dataBytes.length > 0) {
-    if (message.dataBytes.length > 2048) {
+    // This is the max size allowed for a message (link compact) on Snapchain.
+    // On Snapchain, we validate dataBytes specifically by message type and in the client side validations we validate text size for different cast types.
+    if (message.dataBytes.length > 65_536) {
       return err(new HubError("bad_request.validation_failure", "dataBytes > 2048 bytes"));
     }
     // 2a. Use the databytes as the hash to check the signature against


### PR DESCRIPTION
## Why is this change needed?
The current check only allows `dataBytes` to be max 2048 bytes. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the validation logic for `dataBytes` in messages to accommodate larger sizes, specifically for 10k casts. It also includes a new test case to ensure that messages with a length of 10,000 characters are validated correctly.

### Detailed summary
- Updated the length check for `dataBytes` from 2048 to 65,536 bytes in `packages/core/src/validations.ts`.
- Added a new test case in `packages/core/src/validations.test.ts` to validate messages with 10,000 characters using `makeCastAdd`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->