### PR TITLE
chore: release new core,hub-nodejs,hub-web packages

### DIFF
--- a/.changeset/late-geckos-move.md
+++ b/.changeset/late-geckos-move.md
@@ -1,5 +1,0 @@
----
-"@farcaster/core": patch
----
-
-fix: update dataBytes length check for 10k casts

--- a/.changeset/tender-melons-fail.md
+++ b/.changeset/tender-melons-fail.md
@@ -1,7 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
-"@farcaster/hub-web": patch
-"@farcaster/core": patch
----
-
-chore: pull in updated Snapchain protos

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/core
 
+## 0.18.5
+
+### Patch Changes
+
+- 83f4721a: fix: update dataBytes length check for 10k casts
+- c37a6370: chore: pull in updated Snapchain protos
+
 ## 0.18.4
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.18.4",
+  "version": "0.18.5",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @farcaster/hub-nodejs
 
+## 0.15.5
+
+### Patch Changes
+
+- c37a6370: chore: pull in updated Snapchain protos
+- Updated dependencies [83f4721a]
+- Updated dependencies [c37a6370]
+  - @farcaster/core@0.18.5
+
 ## 0.15.4
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -20,7 +20,7 @@
     "url": "https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/hub-nodejs"
   },
   "dependencies": {
-    "@farcaster/core": "0.18.4",
+    "@farcaster/core": "0.18.5",
     "@grpc/grpc-js": "~1.11.1",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"

--- a/packages/hub-web/CHANGELOG.md
+++ b/packages/hub-web/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @farcaster/hub-web
 
+## 0.11.4
+
+### Patch Changes
+
+- c37a6370: chore: pull in updated Snapchain protos
+- Updated dependencies [83f4721a]
+- Updated dependencies [c37a6370]
+  - @farcaster/core@0.18.5
+
 ## 0.11.3
 
 ### Patch Changes

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-web",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -32,7 +32,7 @@
     "ts-proto": "^1.146.0"
   },
   "dependencies": {
-    "@farcaster/core": "^0.18.3",
+    "@farcaster/core": "^0.18.5",
     "@improbable-eng/grpc-web": "^0.15.0",
     "rxjs": "^7.8.0"
   }


### PR DESCRIPTION
## Why is this change needed?

Release new packages. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of the `@farcaster/core` package and making corresponding updates in the `@farcaster/hub-web` and `@farcaster/hub-nodejs` packages. It also includes changelog entries for the new versions.

### Detailed summary
- Updated `@farcaster/core` version from `0.18.4` to `0.18.5`.
- Updated `@farcaster/hub-web` version from `0.11.3` to `0.11.4`.
- Updated `@farcaster/hub-nodejs` version from `0.15.4` to `0.15.5`.
- Added changelog entries for versions `0.18.5`, `0.11.4`, and `0.15.5`.
- Notable fixes and updates related to Snapchain protos and dataBytes length check.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->