### PR TITLE
fix(core): optimize extractEventTimestamp function using bitwise oper…

### DIFF
--- a/packages/core/src/time.ts
+++ b/packages/core/src/time.ts
@@ -44,9 +44,7 @@ const SEQUENCE_BITS = 12;
  * @deprecated: Snapchain event ids use block numbers. Use the timestamp field in the event instead.
  * */
 export const extractEventTimestamp = (eventId: number): number => {
-  const binaryEventId = eventId.toString(2);
-  const binaryTimestamp = binaryEventId.slice(0, binaryEventId.length - SEQUENCE_BITS);
-  return parseInt(binaryTimestamp, 2) + FARCASTER_EPOCH;
+  return (eventId >> SEQUENCE_BITS) + FARCASTER_EPOCH;
 };
 
 /** Extracts a unix timestamp (ms resolution) from an hub event. */


### PR DESCRIPTION
…ations

## Why is this change needed?

Replace string conversion and parsing with more efficient bitwise right shift operation in extractEventTimestamp function. This change improves performance by eliminating unnecessary string operations while maintaining the exact same functionality

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the `extractEventTimestamp` function in `time.ts` to improve efficiency by replacing the conversion of `eventId` to a binary string and slicing it with a bitwise right shift operation.

### Detailed summary
- Changed the implementation of `extractEventTimestamp`.
- Replaced the conversion of `eventId` to a binary string with a bitwise right shift (`eventId >> SEQUENCE_BITS`).
- Removed the intermediate variable `binaryEventId` and `binaryTimestamp`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->