### PR TITLE
feat: add new function to calculate storage unit expiry timestamp

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/core
 
+## 0.18.6
+
+### Patch Changes
+
+- feat: Create a new function to calculate storage unit expiry timestamp
+
 ## 0.18.5
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.18.5",
+  "version": "0.18.6",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/core/src/limits.test.ts
+++ b/packages/core/src/limits.test.ts
@@ -1,4 +1,11 @@
-import { getDefaultStoreLimit, getStoreLimit, getStoreLimits } from "./limits";
+import {
+  getDefaultStoreLimit,
+  getStorageExpiryTimestampFromBlockTimestamp,
+  getStoreLimit,
+  getStoreLimits,
+  LEGACY_STORAGE_UNIT_CUTOFF_TIMESTAMP,
+  UNIT_TYPE_2024__CUTOFF_TIMESTAMP,
+} from "./limits";
 import { StorageUnitType, StoreType } from "./protobufs";
 
 describe("getDefaultStoreLimit", () => {
@@ -20,6 +27,25 @@ describe("getDefaultStoreLimit", () => {
 
     expect(getDefaultStoreLimit(StoreType.VERIFICATIONS, StorageUnitType.UNIT_TYPE_LEGACY)).toEqual(25);
     expect(getDefaultStoreLimit(StoreType.VERIFICATIONS, StorageUnitType.UNIT_TYPE_2024)).toEqual(25);
+  });
+});
+
+describe("getStorageExpiryTimestampFromBlockTimestamp", () => {
+  test("calculates correct expiry timestamp for legacy, 2024, and 2025 storage units", () => {
+    const ONE_YEAR_IN_SECONDS = 365 * 24 * 60 * 60;
+    const legacyTimestamp = LEGACY_STORAGE_UNIT_CUTOFF_TIMESTAMP - 1;
+    const unitType2024Timestamp = UNIT_TYPE_2024__CUTOFF_TIMESTAMP - 1;
+    const unitType2025Timestamp = UNIT_TYPE_2024__CUTOFF_TIMESTAMP + 1;
+
+    expect(getStorageExpiryTimestampFromBlockTimestamp(legacyTimestamp)).toEqual(
+      legacyTimestamp + ONE_YEAR_IN_SECONDS * 3,
+    );
+    expect(getStorageExpiryTimestampFromBlockTimestamp(unitType2024Timestamp)).toEqual(
+      unitType2024Timestamp + ONE_YEAR_IN_SECONDS * 2,
+    );
+    expect(getStorageExpiryTimestampFromBlockTimestamp(unitType2025Timestamp)).toEqual(
+      unitType2025Timestamp + ONE_YEAR_IN_SECONDS,
+    );
   });
 });
 

--- a/packages/core/src/limits.ts
+++ b/packages/core/src/limits.ts
@@ -92,14 +92,18 @@ export const getStorageUnitType = (event: StorageRentOnChainEvent) => {
 };
 
 export const getStorageUnitExpiry = (event: StorageRentOnChainEvent) => {
-  if (event.blockTimestamp < LEGACY_STORAGE_UNIT_CUTOFF_TIMESTAMP) {
+  return getStorageExpiryTimestampFromBlockTimestamp(event.blockTimestamp);
+};
+
+export const getStorageExpiryTimestampFromBlockTimestamp = (blockTimestamp: number) => {
+  if (blockTimestamp < LEGACY_STORAGE_UNIT_CUTOFF_TIMESTAMP) {
     // Legacy storage units expire after 2 years
-    return event.blockTimestamp + ONE_YEAR_IN_SECONDS * 3;
-  } else if (event.blockTimestamp < UNIT_TYPE_2024__CUTOFF_TIMESTAMP) {
+    return blockTimestamp + ONE_YEAR_IN_SECONDS * 3;
+  } else if (blockTimestamp < UNIT_TYPE_2024__CUTOFF_TIMESTAMP) {
     // 2024 storage units expire after 2 years
-    return event.blockTimestamp + ONE_YEAR_IN_SECONDS * 2;
+    return blockTimestamp + ONE_YEAR_IN_SECONDS * 2;
   } else {
     // 2025 storage units expire after 1 year
-    return event.blockTimestamp + ONE_YEAR_IN_SECONDS;
+    return blockTimestamp + ONE_YEAR_IN_SECONDS;
   }
 };

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @farcaster/hub-nodejs
 
+## 0.15.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @farcaster/core@0.18.6
+
 ## 0.15.5
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -20,7 +20,7 @@
     "url": "https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/hub-nodejs"
   },
   "dependencies": {
-    "@farcaster/core": "0.18.5",
+    "@farcaster/core": "0.18.6",
     "@grpc/grpc-js": "~1.11.1",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"


### PR DESCRIPTION
## Why is this change needed?

Expose a function that calculates the expiry timestamp from just the block timestamp.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `@farcaster/core` and `@farcaster/hub-nodejs` packages to version `0.18.6` and `0.15.6` respectively, along with introducing a new function for calculating storage unit expiry timestamps.

### Detailed summary
- Updated `@farcaster/core` to version `0.18.6`.
- Updated `@farcaster/hub-nodejs` to version `0.15.6`.
- Added `getStorageExpiryTimestampFromBlockTimestamp` function in `limits.ts`.
- Modified `getStorageUnitExpiry` to use the new expiry function.
- Added tests for `getStorageExpiryTimestampFromBlockTimestamp` in `limits.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->