### PR TITLE
bugfix(shuttle): correct EventStreamHubSubscriber param order in App.cre…

### DIFF
--- a/packages/shuttle/src/example-app/app.ts
+++ b/packages/shuttle/src/example-app/app.ts
@@ -101,7 +101,7 @@ export class App implements MessageHandler {
       shardKey,
       log,
       null,
-      connectionTimeout: SUBSCRIBE_RPC_TIMEOUT,
+      SUBSCRIBE_RPC_TIMEOUT,
     );
     const streamConsumer = new HubEventStreamConsumer(hub, eventStreamForRead, shardKey);
 


### PR DESCRIPTION
…ate()

* Pass shardIndex as the 3rd arg (per ctor signature)
* Move eventStreamForWrite, redis, shardKey, log to their correct positions
* Drop stray totalShards (not in constructor)
* Map SUBSCRIBE_RPC_TIMEOUT to connectionTimeout

## Why is this change needed?

Fix parameter order when instantiating `EventStreamHubSubscriber` in example-app's `App.create()`. 

Mis-ordered args caused `redis` to receive the `shardKey` string and `log` to be `undefined`, leading to a startup crash on `getLastProcessedEvent`.


Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the parameters passed to the `HubEventStreamConsumer` constructor in the `app.ts` file, specifically by adding a new parameter and removing an existing one related to shard handling.

### Detailed summary
- Added `shardIndex` to the parameters of the `HubEventStreamConsumer`.
- Removed `totalShards` and `shardIndex` from the parameters list.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->