### PR TITLE
chore: Client release for profile tokens

### DIFF
--- a/.changeset/hungry-beers-ring.md
+++ b/.changeset/hungry-beers-ring.md
@@ -1,7 +1,0 @@
----
-"@farcaster/hub-nodejs": patch
-"@farcaster/hub-web": patch
-"@farcaster/core": patch
----
-
-Update protobufs to pick up new types (support profile tokens)

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @farcaster/core
 
+## 0.18.7
+
+### Patch Changes
+
+- e640c6c4: Update protobufs to pick up new types (support profile tokens)
+
 ## 0.18.6
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/core",
-  "version": "0.18.6",
+  "version": "0.18.7",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hub-nodejs/CHANGELOG.md
+++ b/packages/hub-nodejs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hub-nodejs
 
+## 0.15.7
+
+### Patch Changes
+
+- e640c6c4: Update protobufs to pick up new types (support profile tokens)
+- Updated dependencies [e640c6c4]
+  - @farcaster/core@0.18.7
+
 ## 0.15.6
 
 ### Patch Changes

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-nodejs",
-  "version": "0.15.6",
+  "version": "0.15.7",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -20,7 +20,7 @@
     "url": "https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/hub-nodejs"
   },
   "dependencies": {
-    "@farcaster/core": "0.18.6",
+    "@farcaster/core": "0.18.7",
     "@grpc/grpc-js": "~1.11.1",
     "@noble/hashes": "^1.3.0",
     "neverthrow": "^6.0.0"

--- a/packages/hub-web/CHANGELOG.md
+++ b/packages/hub-web/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/hub-web
 
+## 0.11.5
+
+### Patch Changes
+
+- e640c6c4: Update protobufs to pick up new types (support profile tokens)
+- Updated dependencies [e640c6c4]
+  - @farcaster/core@0.18.7
+
 ## 0.11.4
 
 ### Patch Changes

--- a/packages/hub-web/package.json
+++ b/packages/hub-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hub-web",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -32,7 +32,7 @@
     "ts-proto": "^1.146.0"
   },
   "dependencies": {
-    "@farcaster/core": "^0.18.5",
+    "@farcaster/core": "^0.18.7",
     "@improbable-eng/grpc-web": "^0.15.0",
     "rxjs": "^7.8.0"
   }


### PR DESCRIPTION
## Why is this change needed?

Release client versions for https://github.com/farcasterxyz/hub-monorepo/pull/2648

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of the `@farcaster/core` package and its dependencies, along with corresponding changelog updates to reflect these changes.

### Detailed summary
- Updated `@farcaster/core` version from `0.18.6` to `0.18.7`.
- Added changelog entries for versions `0.18.7`, `0.11.5`, and `0.15.7` with details on protobuf updates.
- Updated `@farcaster/core` dependency version in `packages/hub-web` and `packages/hub-nodejs` from `0.18.6` to `0.18.7`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->