### PR TITLE
fix: pre-download node-gyp headers to avoid install race condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,9 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
 
       - name: Install dependencies
-        run: yarn install
+        run: |
+          npx node-gyp install
+          yarn install
 
       - name: Run build
         run: yarn build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npx node-gyp install
+          npx node-gyp@12.2.0 install
           yarn install
 
       - name: Run build

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npx node-gyp install
+          npx node-gyp@12.2.0 install
           yarn install
 
       - name: Create Release Pull Request or Publish to npm

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -29,7 +29,9 @@ jobs:
           key: ${{ runner.os }}--node--${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies
-        run: yarn install
+        run: |
+          npx node-gyp install
+          yarn install
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,7 +45,7 @@
     "biome-config-custom": "*",
     "ethers": "^6.6.1",
     "ethers5": "npm:ethers@^5.7.0",
-    "node-gyp": "^9.4.0",
+    "node-gyp": "12.2.0",
     "prettier-config-custom": "*",
     "ts-proto": "^1.146.0"
   }


### PR DESCRIPTION
## Summary
- Adds `npx node-gyp install` before every `yarn install` in CI workflows
- This pre-downloads Node.js headers so that multiple native addon compilations during `yarn install` don't race to download the same headers simultaneously

## Files changed
- `.github/workflows/ci.yml` - added `npx node-gyp install` before `yarn install`
- `.github/workflows/release-packages.yml` - added `npx node-gyp install` before `yarn install`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the installation process for dependencies in continuous integration workflows and modifying the version of `node-gyp` used in the project.

### Detailed summary
- In `.github/workflows/ci.yml`:
  - Changed the installation command to use `npx node-gyp@12.2.0 install` before `yarn install`.
  - Updated the `node-gyp` version in `packages/core/package.json` from `^9.4.0` to `12.2.0`.
  
- In `.github/workflows/release-packages.yml`:
  - Similar changes to the installation command as in `ci.yml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->