### PR TITLE
feat(shuttle): rewind event stream on restart (Issue #2172)

### DIFF
--- a/.changeset/add-shuttle-rewind-config.md
+++ b/.changeset/add-shuttle-rewind-config.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+feat(shuttle): add configurable event stream rewind on restart to prevent missing out-of-order events (Issue #2172)

--- a/packages/shuttle/src/example-app/app.ts
+++ b/packages/shuttle/src/example-app/app.ts
@@ -44,6 +44,9 @@ import {
   TOTAL_SHARDS,
   USE_STREAMING_RPCS_FOR_BACKFILL,
   SUBSCRIBE_RPC_TIMEOUT,
+      {
+        rewindSeconds: HUB_REWIND_SECONDS,
+      },
 } from "./env";
 import * as process from "node:process";
 import url from "node:url";
@@ -102,6 +105,9 @@ export class App implements MessageHandler {
       log,
       undefined,
       SUBSCRIBE_RPC_TIMEOUT,
+      {
+        rewindSeconds: HUB_REWIND_SECONDS,
+      },
     );
     const streamConsumer = new HubEventStreamConsumer(hub, eventStreamForRead, shardKey);
 

--- a/packages/shuttle/src/example-app/env.ts
+++ b/packages/shuttle/src/example-app/env.ts
@@ -23,4 +23,5 @@ export const STATSD_METRICS_PREFIX = process.env["STATSD_METRICS_PREFIX"] || "sh
 
 export const CONCURRENCY = parseInt(process.env["CONCURRENCY"] || "2");
 export const USE_STREAMING_RPCS_FOR_BACKFILL = process.env["USE_STREAMING_RPCS_FOR_BACKFILL"] === "true" ? true : false;
+export const HUB_REWIND_SECONDS = parseInt(process.env["HUB_REWIND_SECONDS"] || "0");
 export const SUBSCRIBE_RPC_TIMEOUT = parseInt(process.env["SUBSCRIBE_RPC_TIMEOUT"] || "30000");


### PR DESCRIPTION
Implements a configurable rewind (default 0s, recommended 1-5s) for the Hub Shuttle event stream on startup. This ensures that any events emitted slightly out of order just before a shutdown are not missed.

Fixes #2172

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a configurable rewind feature for event streams in the `shuttle` application, allowing users to prevent missing out-of-order events by rewinding to a specified timestamp on restart.

### Detailed summary
- Added `HUB_REWIND_SECONDS` environment variable to configure rewind duration.
- Modified `App` class to include `rewindSeconds` in its configuration.
- Updated `BaseHubSubscriber` to accept and store `rewindSeconds`.
- Implemented rewind logic in `BaseHubSubscriber` to fetch events from a target timestamp.
- Enhanced `EventStreamHubSubscriber` to pass `rewindSeconds` to its superclass.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->