### PR TITLE
add changeset for snapchain signers

### DIFF
--- a/.changeset/neyn-10555-signers-and-scopes-protos.md
+++ b/.changeset/neyn-10555-signers-and-scopes-protos.md
@@ -1,0 +1,34 @@
+---
+"@farcaster/core": patch
+"@farcaster/hub-nodejs": patch
+"@farcaster/hub-web": patch
+---
+
+feat: pull in snapchain V16 protos (signers and scopes / gasless signers)
+
+Regenerates protobuf bindings against snapchain `e8e89a3`, the client
+surface for engine version V16 (`LATEST_PROTOCOL_VERSION` 10 → 11;
+`ProtocolFeature::GaslessSigners` gate). V16 activates testnet
+2026-04-28 20:00 UTC and mainnet 2026-05-07 17:00 UTC.
+
+- `MESSAGE_TYPE_KEY_ADD` (16) and `MESSAGE_TYPE_KEY_REMOVE` (17) on
+  `MessageType`, plus `KeyAddBody` / `KeyRemoveBody` and corresponding
+  `KeyAddData` / `KeyAddMessage` / `KeyRemoveData` / `KeyRemoveMessage`
+  type narrowings and `isKeyAdd*` / `isKeyRemove*` typeguards in `core`.
+- Backfills the previously-missing `isLendStorageData` /
+  `isLendStorageMessage` typeguards.
+- New unified signer surface in RPC: `GetSigner` and `GetSignersByFid`
+  return both on-chain and off-chain (gasless) keys via `SignerResponse`
+  and `SignersByFidResponse`. The pre-existing `GetOnChainSigner` and
+  `GetOnChainSignersByFid` are now marked deprecated; existing callers
+  are unaffected. The `Signer` proto message is re-exported from `core`
+  as `SignerInfo` to disambiguate from the existing cryptographic
+  `Signer` interface.
+- `GetSignersByFid` accepts a `SignersByFidRequest` so callers can
+  request current per-FID nonce counters (`current_user_nonce`,
+  `requester_fid_nonces`).
+- `BlocksRequest.shard_id` is removed (server already ignored it; field
+  number `1` is `reserved` on the wire).
+
+Adds `LendStorage*`, `KeyAdd*`, and `KeyRemove*` factories plus runtime
+tests for the new typeguards.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the protobuf bindings for the snapchain V16 protocol, introducing new features related to signers and scopes, and deprecating some existing RPC calls.

### Detailed summary
- Introduces snapchain V16 protos for signers and scopes.
- Regenerates protobuf bindings for engine version V16.
- Adds `MESSAGE_TYPE_KEY_ADD` and `MESSAGE_TYPE_KEY_REMOVE` to `MessageType`.
- Introduces `KeyAddBody`, `KeyRemoveBody`, and their related types.
- Implements `isKeyAdd*` and `isKeyRemove*` typeguards in `core`.
- Adds `GetSigner` and `GetSignersByFid` RPC methods for on-chain and gasless keys.
- Deprecates `GetOnChainSigner` and `GetOnChainSignersByFid`.
- Re-exports `Signer` as `SignerInfo` from `core`.
- Allows `GetSignersByFid` to accept `SignersByFidRequest` for nonce counters.
- Removes `BlocksRequest.shard_id` as it was ignored by the server.
- Adds factories and runtime tests for `LendStorage*`, `KeyAdd*`, and `KeyRemove*` types.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->