### PR TITLE
explicitly bump shuttle since it's a dependent

### DIFF
--- a/.changeset/neyn-10555-shuttle-bump.md
+++ b/.changeset/neyn-10555-shuttle-bump.md
@@ -1,0 +1,8 @@
+---
+"@farcaster/shuttle": patch
+---
+
+chore: rebuild against `@farcaster/hub-nodejs@0.15.11` so the rolled-up
+`.d.ts` re-exports the new V16 types (`KeyAddMessage` / `KeyRemoveMessage` /
+`SignerInfo` / `SignersByFidRequest` / etc.) for consumers importing them
+through `@farcaster/shuttle`. No source change.


### PR DESCRIPTION
## Why is this change needed?

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `@farcaster/shuttle` package to ensure compatibility with the latest types from `@farcaster/hub-nodejs@0.15.11`. This update allows consumers to access new TypeScript definitions without any changes to the source code.

### Detailed summary
- Bump `@farcaster/shuttle` to a patch version.
- Rebuild against `@farcaster/hub-nodejs@0.15.11`.
- Update `.d.ts` re-exports to include new V16 types:
  - `KeyAddMessage`
  - `KeyRemoveMessage`
  - `SignerInfo`
  - `SignersByFidRequest`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->