### PR TITLE
fix(shuttle): swallow xtrim errors when the Redis connection is no longer ready

### DIFF
--- a/.changeset/shuttle-redis-shutdown-guard.md
+++ b/.changeset/shuttle-redis-shutdown-guard.md
@@ -1,0 +1,16 @@
+---
+"@farcaster/shuttle": patch
+---
+
+fix(shuttle): swallow `xtrim` errors when the Redis connection is no longer ready
+
+During process shutdown the periodic `HubEventStreamConsumer.clearOldEvents`
+timer can still fire while the underlying ioredis client is closing. The
+follow-up `xtrim` call against the closed connection produces unhandled
+promise rejections.
+
+`EventStreamConnection.trim` now wraps the `xtrim` call in a try/catch:
+if it fails *and* the client is no longer in a `"ready"` state, the
+error is swallowed (xtrim is best-effort periodic maintenance, the next
+invocation against a fresh client will catch up). Any other failure is
+rethrown so real errors stay visible.

--- a/packages/shuttle/src/shuttle/eventStream.ts
+++ b/packages/shuttle/src/shuttle/eventStream.ts
@@ -200,7 +200,15 @@ export class EventStreamConnection {
    * Does an approximate trim to reduce effort by Redis.
    */
   async trim(key: string, timestamp: Date) {
-    return await this.client.xtrim(key, "MINID", "~", timestamp.getTime());
+    try {
+      return await this.client.xtrim(key, "MINID", "~", timestamp.getTime());
+    } catch (e) {
+      // Swallow errors caused by the underlying connection being closed (e.g. during
+      // pod shutdown). `trim` is a periodic best-effort cleanup; the next invocation
+      // against a fresh client will catch up. Any other failure is real and rethrown.
+      if (this.client.status !== "ready") return 0;
+      throw e;
+    }
   }
 }
 


### PR DESCRIPTION
## Why is this change needed?

The periodic \`HubEventStreamConsumer.clearOldEvents\` timer can fire
while the underlying ioredis client is closing (e.g. during process
shutdown after \`SIGTERM\`). The follow-up \`xtrim\` call against the
closed connection produces unhandled promise rejections, which look
like uncaught exceptions to whatever's monitoring the process.

This wraps the \`xtrim\` call in \`EventStreamConnection.trim\` with a
try/catch: if it fails *and* the client is no longer in a \`"ready"\`
state, the error is swallowed. \`trim\` is best-effort periodic
maintenance and the next invocation against a fresh client will catch
up. Any other failure is rethrown so real errors stay visible.

Catching at the call site avoids the TOCTOU race a pre-check on
\`client.status\` would have - the connection can close between the
check and the \`xtrim\` call.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error handling in the `trim` method of the `EventStreamConnection` class by swallowing errors when the Redis connection is not ready, preventing unhandled promise rejections during shutdown.

### Detailed summary
- Wrapped the `xtrim` call in a `try/catch` block in the `trim` method.
- Swallowed errors if the Redis client status is not `"ready"`.
- Ensured that only genuine errors are rethrown, maintaining visibility of real issues.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->