### PR TITLE
feat(shuttle): make onDbMessage optional and allow filtering message types in reconciliation

### DIFF
--- a/.changeset/shuttle-optional-on-db-message.md
+++ b/.changeset/shuttle-optional-on-db-message.md
@@ -1,0 +1,36 @@
+---
+"@farcaster/shuttle": minor
+---
+
+feat(shuttle): allow disabling DB-side reconciliation and filtering message types
+
+`MessageReconciliation` now lets callers opt out of the
+"DB messages missing from the hub" pass, which is useful during initial
+backfills where every DB row is missing from the hub by definition and
+streaming each one through the callback is just wasted work.
+
+- `onDbMessage` is now optional on both `reconcileMessagesForFid` and
+  `reconcileMessagesOfTypeForFid`. When omitted, the DB-side scan is
+  skipped entirely (no `allActiveDbMessagesOfTypeForFid` call) and the
+  per-message hub-hash map that the DB pass needed is no longer
+  populated, removing a per-FID memory cost on large backfills.
+- `reconcileMessagesForFid` accepts a new optional
+  `types: ReconcilableMessageType[]` parameter to restrict
+  reconciliation to a subset of message types (e.g. only `LEND_STORAGE`
+  after a hub backfill of just that type). The new
+  `RECONCILABLE_MESSAGE_TYPES` const + `ReconcilableMessageType` type
+  pin this to the message types `MessageReconciliation` actually has
+  hub-side RPCs for, so passing e.g. `CAST_REMOVE` is a compile-time
+  error instead of a runtime "Unknown message type" throw.
+- `DBMessage` is now exported so consumers can type their `onDbMessage`
+  callback without re-declaring the row shape.
+- Time-window resolution (`fromFarcasterTime` of `startTimestamp` /
+  `stopTimestamp`) now happens once up front in
+  `reconcileMessagesForFid` / `reconcileMessagesOfTypeForFid` instead
+  of per-type inside the DB pass, so input handling is consistent
+  whether or not `onDbMessage` is provided.
+- Bonus: fixes a stale `@farcaster/hub-shuttle` import in the example
+  app that would otherwise fail `tsc --noEmit`.
+
+No behavior change for existing callers that pass an `onDbMessage`
+callback.

--- a/packages/shuttle/src/example-app/db.ts
+++ b/packages/shuttle/src/example-app/db.ts
@@ -4,8 +4,7 @@ import { err, ok, Result } from "neverthrow";
 import path from "path";
 import { promises as fs } from "fs";
 import { fileURLToPath } from "node:url";
-import { HubTables } from "@farcaster/hub-shuttle";
-import { Fid } from "../shuttle";
+import { Fid, HubTables } from "../shuttle";
 
 const createMigrator = async (db: Kysely<HubTables>, dbSchema: string, log: Logger) => {
   const currentDir = path.dirname(fileURLToPath(import.meta.url));

--- a/packages/shuttle/src/shuttle.integration.test.ts
+++ b/packages/shuttle/src/shuttle.integration.test.ts
@@ -663,6 +663,81 @@ describe("shuttle", () => {
     expect(messagesInDb.length).toBe(2);
   });
 
+  test("reconciler with no onDbMessage skips DB-side pass and only emits hub-side observations", async () => {
+    const linkAddMessage = await Factories.LinkAddMessage.create({}, { transient: { signer } });
+
+    // Persist a DB-only message that, if the DB-side pass were running, would be flagged
+    // as missingInHub. The DB-side pass should be skipped entirely when onDbMessage is undefined.
+    const dbOnlyMessage = await Factories.LinkAddMessage.create(
+      { data: { fid: linkAddMessage.data.fid, linkBody: { type: "follow", targetFid: 99999 } } },
+      { transient: { signer } },
+    );
+    await subscriber.processHubEvent(
+      HubEvent.create({ id: 1001, type: HubEventType.MERGE_MESSAGE, mergeMessageBody: { message: dbOnlyMessage } }),
+    );
+
+    const mockRPCClient = {
+      streamFetch: () => err(new HubError("unavailable", "unavailable")),
+      getAllLinkMessagesByFid: async () =>
+        ok(MessagesResponse.create({ messages: [linkAddMessage], nextPageToken: undefined })),
+      getLinkCompactStateMessageByFid: async () =>
+        ok(MessagesResponse.create({ messages: [], nextPageToken: undefined })),
+    };
+
+    const reconciler = new MessageReconciliation(mockRPCClient as unknown as HubRpcClient, db, log);
+    const dbCallCount = { count: 0 };
+    const hubObservations: Uint8Array[] = [];
+    await reconciler.reconcileMessagesOfTypeForFid(
+      linkAddMessage.data.fid,
+      MessageType.LINK_ADD,
+      async (msg) => {
+        hubObservations.push(msg.hash);
+      },
+      // onDbMessage intentionally omitted
+    );
+
+    expect(hubObservations.length).toBe(1);
+    expect(bytesToHex(hubObservations[0] as Uint8Array)).toEqual(bytesToHex(linkAddMessage.hash));
+    expect(dbCallCount.count).toBe(0);
+  });
+
+  test("reconciler `types` filter restricts the per-type RPC calls", async () => {
+    const linkAddMessage = await Factories.LinkAddMessage.create({}, { transient: { signer } });
+
+    let castCalls = 0;
+    let linkCalls = 0;
+    const mockRPCClient = {
+      streamFetch: () => err(new HubError("unavailable", "unavailable")),
+      getAllCastMessagesByFid: async () => {
+        castCalls++;
+        return ok(MessagesResponse.create({ messages: [], nextPageToken: undefined }));
+      },
+      getAllLinkMessagesByFid: async () => {
+        linkCalls++;
+        return ok(MessagesResponse.create({ messages: [linkAddMessage], nextPageToken: undefined }));
+      },
+      getLinkCompactStateMessageByFid: async () =>
+        ok(MessagesResponse.create({ messages: [], nextPageToken: undefined })),
+    };
+
+    const reconciler = new MessageReconciliation(mockRPCClient as unknown as HubRpcClient, db, log);
+    const observations: MessageType[] = [];
+    await reconciler.reconcileMessagesForFid(
+      linkAddMessage.data.fid,
+      async (msg) => {
+        if (msg.data?.type !== undefined) observations.push(msg.data.type);
+      },
+      undefined,
+      undefined,
+      undefined,
+      [MessageType.LINK_ADD],
+    );
+
+    expect(linkCalls).toBe(1);
+    expect(castCalls).toBe(0);
+    expect(observations).toEqual([MessageType.LINK_ADD]);
+  });
+
   // TODO: Skip for now, and figure out how to test that the fallback is called correctly
   xtest("reconciler lets unresponsive server requests terminate in error", async () => {
     const startTimestamp = getFarcasterTime()._unsafeUnwrap();

--- a/packages/shuttle/src/shuttle/messageReconciliation.ts
+++ b/packages/shuttle/src/shuttle/messageReconciliation.ts
@@ -16,7 +16,21 @@ import { randomUUID } from "crypto";
 
 const MAX_PAGE_SIZE = 500;
 
-type DBMessage = {
+// The "primary" message types that `MessageReconciliation` can fetch from a hub.
+// Each entry has a corresponding `getAll<...>MessagesByFid` RPC; "remove" / compact-state
+// variants are reconciled implicitly via the DB-side pass and must not be passed in here.
+export const RECONCILABLE_MESSAGE_TYPES = [
+  MessageType.CAST_ADD,
+  MessageType.REACTION_ADD,
+  MessageType.LINK_ADD,
+  MessageType.VERIFICATION_ADD_ETH_ADDRESS,
+  MessageType.USER_DATA_ADD,
+  MessageType.LEND_STORAGE,
+] as const;
+
+export type ReconcilableMessageType = typeof RECONCILABLE_MESSAGE_TYPES[number];
+
+export type DBMessage = {
   hash: Uint8Array;
   prunedAt: Date | null;
   revokedAt: Date | null;
@@ -43,33 +57,70 @@ export class MessageReconciliation {
   async reconcileMessagesForFid(
     fid: number,
     onHubMessage: (message: Message, missingInDb: boolean, prunedInDb: boolean, revokedInDb: boolean) => Promise<void>,
-    onDbMessage: (message: DBMessage, missingInHub: boolean) => Promise<void>,
+    onDbMessage?: (message: DBMessage, missingInHub: boolean) => Promise<void>,
     startTimestamp?: number,
     stopTimestamp?: number,
+    types?: ReconcilableMessageType[],
   ) {
-    for (const type of [
-      MessageType.CAST_ADD,
-      MessageType.REACTION_ADD,
-      MessageType.LINK_ADD,
-      MessageType.VERIFICATION_ADD_ETH_ADDRESS,
-      MessageType.USER_DATA_ADD,
-      MessageType.LEND_STORAGE,
-    ]) {
+    // Validate the time range exactly once up front so callers see the same input
+    // handling regardless of whether they pass `onDbMessage`. The resolved Dates are
+    // reused by the per-type DB pass so we don't re-parse on every iteration.
+    const window = this.resolveTimeWindow(startTimestamp, stopTimestamp);
+    if (window.isErr()) {
+      this.log.error({ fid, startTimestamp, stopTimestamp }, "Invalid time range provided to reconciliation");
+      return;
+    }
+
+    for (const type of types ?? RECONCILABLE_MESSAGE_TYPES) {
       this.log.debug(`Reconciling messages for FID ${fid} of type ${type}`);
-      await this.reconcileMessagesOfTypeForFid(fid, type, onHubMessage, onDbMessage, startTimestamp, stopTimestamp);
+      await this.reconcileMessagesOfTypeForFidInternal(
+        fid,
+        type,
+        onHubMessage,
+        onDbMessage,
+        startTimestamp,
+        stopTimestamp,
+        window.value,
+      );
     }
   }
 
   async reconcileMessagesOfTypeForFid(
     fid: number,
-    type: MessageType,
+    type: ReconcilableMessageType,
     onHubMessage: (message: Message, missingInDb: boolean, prunedInDb: boolean, revokedInDb: boolean) => Promise<void>,
-    onDbMessage: (message: DBMessage, missingInHub: boolean) => Promise<void>,
+    onDbMessage?: (message: DBMessage, missingInHub: boolean) => Promise<void>,
     startTimestamp?: number,
     stopTimestamp?: number,
   ) {
-    // todo: Username proofs, and on chain events
+    const window = this.resolveTimeWindow(startTimestamp, stopTimestamp);
+    if (window.isErr()) {
+      this.log.error({ fid, type, startTimestamp, stopTimestamp }, "Invalid time range provided to reconciliation");
+      return;
+    }
+    await this.reconcileMessagesOfTypeForFidInternal(
+      fid,
+      type,
+      onHubMessage,
+      onDbMessage,
+      startTimestamp,
+      stopTimestamp,
+      window.value,
+    );
+  }
 
+  private async reconcileMessagesOfTypeForFidInternal(
+    fid: number,
+    type: ReconcilableMessageType,
+    onHubMessage: (message: Message, missingInDb: boolean, prunedInDb: boolean, revokedInDb: boolean) => Promise<void>,
+    onDbMessage: ((message: DBMessage, missingInHub: boolean) => Promise<void>) | undefined,
+    startTimestamp: number | undefined,
+    stopTimestamp: number | undefined,
+    window: { startDate?: Date; stopDate?: Date },
+  ) {
+    // Only build the hash map of hub messages when we'll actually use it for the DB-side
+    // pass. For large backfills the per-FID memory cost would otherwise be wasted.
+    const trackHubMessages = onDbMessage !== undefined;
     const hubMessagesByHash: Record<string, Message> = {};
     // First, reconcile messages that are in the hub but not in the database
     for await (const messages of this.allHubMessagesOfTypeForFid(fid, type, startTimestamp, stopTimestamp)) {
@@ -94,7 +145,9 @@ export class MessageReconciliation {
 
       for (const message of messages) {
         const msgHashKey = Buffer.from(message.hash).toString("hex");
-        hubMessagesByHash[msgHashKey] = message;
+        if (trackHubMessages) {
+          hubMessagesByHash[msgHashKey] = message;
+        }
 
         const dbMessage = dbMessageHashes[msgHashKey];
         if (dbMessage === undefined) {
@@ -114,16 +167,35 @@ export class MessageReconciliation {
     }
 
     // Next, reconcile messages that are in the database but not in the hub
-    const dbMessages = await this.allActiveDbMessagesOfTypeForFid(fid, type, startTimestamp, stopTimestamp);
-    if (dbMessages.isErr()) {
-      this.log.error({ startTimestamp, stopTimestamp }, "Invalid time range provided to reconciliation");
-      return;
+    if (onDbMessage) {
+      const dbMessages = await this.allActiveDbMessagesOfTypeForFid(fid, type, window.startDate, window.stopDate);
+
+      for (const dbMessage of dbMessages) {
+        const key = Buffer.from(dbMessage.hash).toString("hex");
+        await onDbMessage(dbMessage, !hubMessagesByHash[key]);
+      }
+    }
+  }
+
+  private resolveTimeWindow(
+    startTimestamp: number | undefined,
+    stopTimestamp: number | undefined,
+  ): HubResult<{ startDate?: Date; stopDate?: Date }> {
+    let startDate: Date | undefined;
+    if (startTimestamp !== undefined) {
+      const r = fromFarcasterTime(startTimestamp);
+      if (r.isErr()) return err(r.error);
+      startDate = new Date(r.value);
     }
 
-    for (const dbMessage of dbMessages.value) {
-      const key = Buffer.from(dbMessage.hash).toString("hex");
-      await onDbMessage(dbMessage, !hubMessagesByHash[key]);
+    let stopDate: Date | undefined;
+    if (stopTimestamp !== undefined) {
+      const r = fromFarcasterTime(stopTimestamp);
+      if (r.isErr()) return err(r.error);
+      stopDate = new Date(r.value);
     }
+
+    return ok({ startDate, stopDate });
   }
 
   private async *allHubMessagesOfTypeForFid(
@@ -350,9 +422,9 @@ export class MessageReconciliation {
 
   private async allActiveDbMessagesOfTypeForFid(
     fid: number,
-    type: MessageType,
-    startTimestamp?: number,
-    stopTimestamp?: number,
+    type: ReconcilableMessageType,
+    startDate: Date | undefined,
+    stopDate: Date | undefined,
   ) {
     let typeSet: MessageType[] = [type];
     // Add remove types for messages which support them
@@ -369,26 +441,6 @@ export class MessageReconciliation {
       case MessageType.VERIFICATION_ADD_ETH_ADDRESS:
         typeSet = [...typeSet, MessageType.VERIFICATION_REMOVE];
         break;
-    }
-
-    let startDate;
-    if (startTimestamp) {
-      const startUnixTimestampResult = fromFarcasterTime(startTimestamp);
-      if (startUnixTimestampResult.isErr()) {
-        return err(startUnixTimestampResult.error);
-      }
-
-      startDate = new Date(startUnixTimestampResult.value);
-    }
-
-    let stopDate;
-    if (stopTimestamp) {
-      const stopUnixTimestampResult = fromFarcasterTime(stopTimestamp);
-      if (stopUnixTimestampResult.isErr()) {
-        return err(stopUnixTimestampResult.error);
-      }
-
-      stopDate = new Date(stopUnixTimestampResult.value);
     }
 
     const query = this.db
@@ -411,7 +463,6 @@ export class MessageReconciliation {
     const queryWithStopTime = stopDate
       ? queryWithStartTime.where("messages.timestamp", "<=", stopDate)
       : queryWithStartTime;
-    const result = await queryWithStopTime.execute();
-    return ok(result);
+    return queryWithStopTime.execute();
   }
 }


### PR DESCRIPTION
## Why is this change needed?

\`MessageReconciliation\` currently always runs both halves of reconciliation:

1. Hub messages compared to DB.
2. Active DB rows compared to the hub.

For an initial backfill where the local DB is empty (or only partially
populated for one message type), the second half is wasted work - every
row is either missing or already covered, and the hub round-trips inside
the callback have no useful effect.

This PR makes the second half opt-in:

- \`onDbMessage\` is now optional on both \`reconcileMessagesForFid\` and
  \`reconcileMessagesOfTypeForFid\`. When omitted, the
  \`allActiveDbMessagesOfTypeForFid\` scan is skipped entirely.
- \`reconcileMessagesForFid\` accepts an optional \`types: MessageType[]\`
  parameter to restrict reconciliation to a subset of message types
  (e.g. only \`LEND_STORAGE\` after a backfill of just that type).
- \`DBMessage\` is now exported so consumers can type their \`onDbMessage\`
  callback without re-declaring the row shape.

No behavior change for callers that pass an \`onDbMessage\` callback.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to the `MessageReconciliation` process, allowing for optional DB-side message handling and improved filtering of message types, which optimizes performance during backfills and adds type safety.

### Detailed summary
- Moved `HubTables` import in `db.ts`.
- Made `onDbMessage` optional in `reconcileMessagesForFid` and `reconcileMessagesOfTypeForFid`.
- Added `types` parameter to filter message types in `reconcileMessagesForFid`.
- Exported `DBMessage` type for callback typing.
- Improved time-window resolution handling.
- Added tests for new functionality in `shuttle.integration.test.ts`.
- Updated `reconcileMessagesOfTypeForFid` to handle optional `onDbMessage`.
- Removed redundant timestamp parsing in `allActiveDbMessagesOfTypeForFid`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->