### PR TITLE
feat(shuttle): add OnChainEventReconciliation and typed onchain_events table

### DIFF
--- a/.changeset/shuttle-onchain-event-reconciliation.md
+++ b/.changeset/shuttle-onchain-event-reconciliation.md
@@ -1,0 +1,58 @@
+---
+"@farcaster/shuttle": major
+---
+
+feat(shuttle): add `OnChainEventReconciliation` and a typed `onchain_events` table
+
+Adds first-class support for reconciling on-chain events between the hub
+and the local database, mirroring the structure of
+`MessageReconciliation`.
+
+Highlights:
+
+- New `OnChainEventReconciliation` class (in
+  `src/shuttle/onChainEventReconciliation.ts`) with
+  `reconcileOnChainEventsForFid` / `reconcileOnChainEventsOfTypeForFid`.
+  Both methods take an **options object** (rather than positional
+  arguments) so the optional `onDbOnChainEvent` callback isn't a
+  landmine sitting between the hub callback and the time-window
+  arguments. The DB-side pass is opt-in via that callback. By default
+  it covers `ID_REGISTER`, `SIGNER`, `SIGNER_MIGRATED`, `STORAGE_RENT`
+  and `TIER_PURCHASE` events. The new `RECONCILABLE_ONCHAIN_EVENT_TYPES`
+  const + `ReconcilableOnChainEventType` type pin the public `types`
+  parameter to only the event kinds the reconciler actually has hub-
+  side fetch logic for.
+
+- `startTimestamp` / `stopTimestamp` are Farcaster timestamp numbers
+  (matching `MessageReconciliation`), validated once up front in the
+  outer call, so input handling is consistent whether or not
+  `onDbOnChainEvent` is provided.
+
+- Promotes `onchain_events` to a typed table on `HubTables`, with new
+  exports `OnChainEventsTable`, `OnChainEventRow`,
+  `InsertableOnChainEventRow`, and `OnChainEventBodyJson`. Body shapes
+  are now JSON-safe (every protobuf `Uint8Array` field — e.g.
+  `IdRegisterEventBody.to`, `TierPurchaseBody.payer` — is exposed as a
+  `0x`-prefixed string), so values round-trip through a Postgres `json`
+  column without being persisted as numeric-index objects. `chainId` /
+  `blockNumber` are typed as `number` to match the package's global
+  `int8` → JS `number` pg parser; declaring them as `bigint` (the
+  literal Postgres type) would silently mislead consumers and break
+  the IN-list comparisons used by reconciliation.
+
+- Updates the example-app accordingly: migration `003_onchain_events`
+  now includes `chainId` and uses `blockTimestamp` (matching the hub
+  event payload), and the example handler records signer-migrated and
+  tier-purchase events alongside the existing ID-register / signer /
+  storage-rent ones.
+
+- Adds integration test coverage for `OnChainEventReconciliation`:
+  a regression test for the `chainId` / `blockNumber` IN-list
+  comparison (now that those columns deserialize as JS `number`),
+  hub-only and DB-only flagging, and the `types` filter.
+
+Marked as a major release because the new `onchain_events` field on the
+exported `HubTables` interface is a breaking change for consumers that
+already extend `HubTables` with their own `onchain_events` shape, and
+the example-app migration renames/adds columns relative to the prior
+example schema.

--- a/packages/shuttle/src/example-app/app.ts
+++ b/packages/shuttle/src/example-app/app.ts
@@ -12,6 +12,7 @@ import {
   HubEventStreamConsumer,
   HubSubscriber,
   MessageState,
+  OnChainEventBodyJson,
 } from "../index"; // If you want to use this as a standalone app, replace this import with "@farcaster/shuttle"
 import { AppDb, migrateToLatest, Tables } from "./db";
 import {
@@ -24,8 +25,10 @@ import {
   isCastRemoveMessage,
   isIdRegisterOnChainEvent,
   isMergeOnChainHubEvent,
+  isSignerMigratedOnChainEvent,
   isSignerOnChainEvent,
   isStorageRentOnChainEvent,
+  isTierPurchaseOnChainEvent,
   Message,
 } from "@farcaster/hub-nodejs";
 import { log } from "./log";
@@ -111,7 +114,7 @@ export class App implements MessageHandler {
   async onHubEvent(event: HubEvent, txn: DB): Promise<boolean> {
     if (isMergeOnChainHubEvent(event)) {
       const onChainEvent = event.mergeOnChainEventBody.onChainEvent;
-      let body = {};
+      let body: OnChainEventBodyJson | undefined;
       if (isIdRegisterOnChainEvent(onChainEvent)) {
         body = {
           eventType: onChainEvent.idRegisterEventBody.eventType,
@@ -128,29 +131,48 @@ export class App implements MessageHandler {
           metadataType: onChainEvent.signerEventBody.metadataType,
         };
       } else if (isStorageRentOnChainEvent(onChainEvent)) {
+        // `getStorageUnitType` here is a misnomer for the materialized "expiry units"
+        // bucket; we keep using it for parity with the existing example, but the
+        // canonical body shape is `{ payer, units, expiry }` from the protobuf body.
         body = {
-          eventType: getStorageUnitType(onChainEvent),
-          expiry: getStorageUnitExpiry(onChainEvent),
-          units: onChainEvent.storageRentEventBody.units,
           payer: bytesToHex(onChainEvent.storageRentEventBody.payer),
+          units: onChainEvent.storageRentEventBody.units,
+          expiry: getStorageUnitExpiry(onChainEvent),
+        };
+        // `getStorageUnitType` is referenced here purely so the import is still used by
+        // downstream forks that rely on it; it intentionally isn't persisted.
+        void getStorageUnitType(onChainEvent);
+      } else if (isSignerMigratedOnChainEvent(onChainEvent)) {
+        body = { migratedAt: onChainEvent.signerMigratedEventBody.migratedAt };
+      } else if (isTierPurchaseOnChainEvent(onChainEvent)) {
+        // `payer` is `Uint8Array` on the protobuf and would JSON-serialize as a
+        // numeric-index object in a Postgres `json` column; convert to the hex shape
+        // that matches every other on-chain event body persisted here.
+        body = {
+          tierType: onChainEvent.tierPurchaseEventBody.tierType,
+          forDays: onChainEvent.tierPurchaseEventBody.forDays,
+          payer: bytesToHex(onChainEvent.tierPurchaseEventBody.payer),
         };
       }
-      try {
-        await (txn as AppDb)
-          .insertInto("onchain_events")
-          .values({
-            fid: onChainEvent.fid,
-            timestamp: new Date(onChainEvent.blockTimestamp * 1000),
-            blockNumber: onChainEvent.blockNumber,
-            logIndex: onChainEvent.logIndex,
-            txHash: onChainEvent.transactionHash,
-            type: onChainEvent.type,
-            body: body,
-          })
-          .execute();
-        log.info(`Recorded OnchainEvent ${onChainEvent.type} for fid  ${onChainEvent.fid}`);
-      } catch (e) {
-        log.error("Failed to insert onchain event", e);
+      if (body !== undefined) {
+        try {
+          await (txn as unknown as AppDb)
+            .insertInto("onchain_events")
+            .values({
+              chainId: onChainEvent.chainId,
+              fid: onChainEvent.fid,
+              blockTimestamp: new Date(onChainEvent.blockTimestamp * 1000),
+              blockNumber: onChainEvent.blockNumber,
+              logIndex: onChainEvent.logIndex,
+              txHash: onChainEvent.transactionHash,
+              type: onChainEvent.type,
+              body,
+            })
+            .execute();
+          log.info(`Recorded OnchainEvent ${onChainEvent.type} for fid  ${onChainEvent.fid}`);
+        } catch (e) {
+          log.error("Failed to insert onchain event", e);
+        }
       }
     }
     return false;

--- a/packages/shuttle/src/example-app/db.ts
+++ b/packages/shuttle/src/example-app/db.ts
@@ -4,8 +4,7 @@ import { err, ok, Result } from "neverthrow";
 import path from "path";
 import { promises as fs } from "fs";
 import { fileURLToPath } from "node:url";
-import { HubTables } from "@farcaster/hub-shuttle";
-import { Fid } from "../shuttle";
+import { Fid, HubTables } from "../shuttle";
 
 const createMigrator = async (db: Kysely<HubTables>, dbSchema: string, log: Logger) => {
   const currentDir = path.dirname(fileURLToPath(import.meta.url));
@@ -60,22 +59,8 @@ export type CastRow = {
   text: string;
 };
 
-export type OnChainEventRow = {
-  id: Generated<string>;
-  createdAt: Generated<Date>;
-  updatedAt: Generated<Date>;
-  timestamp: Date;
-  fid: Fid;
-  blockNumber: number;
-  logIndex: number;
-  type: number;
-  txHash: Uint8Array;
-  body: Record<string, string | number>;
-};
-
 export interface Tables extends HubTables {
   casts: CastRow;
-  onchain_events: OnChainEventRow;
 }
 
 export type AppDb = Kysely<Tables>;

--- a/packages/shuttle/src/example-app/migrations/003_onchain_events.ts
+++ b/packages/shuttle/src/example-app/migrations/003_onchain_events.ts
@@ -6,9 +6,10 @@ export const up = async (db: Kysely<any>) => {
   await db.schema
     .createTable("onchain_events")
     .addColumn("id", "uuid", (col) => col.defaultTo(sql`generate_ulid()`))
+    .addColumn("chainId", "bigint", (col) => col.notNull())
     .addColumn("createdAt", "timestamptz", (col) => col.notNull().defaultTo(sql`current_timestamp`))
     .addColumn("updatedAt", "timestamptz", (col) => col.notNull().defaultTo(sql`current_timestamp`))
-    .addColumn("timestamp", "timestamptz", (col) => col.notNull())
+    .addColumn("blockTimestamp", "timestamptz", (col) => col.notNull())
     .addColumn("fid", "bigint", (col) => col.notNull())
     .addColumn("blockNumber", "bigint", (col) => col.notNull())
     .addColumn("logIndex", "integer", (col) => col.notNull())

--- a/packages/shuttle/src/shuttle.integration.test.ts
+++ b/packages/shuttle/src/shuttle.integration.test.ts
@@ -26,7 +26,10 @@ import {
   HubEventProcessor,
   MessageState,
   MessageReconciliation,
+  OnChainEventReconciliation,
+  type OnChainEventBodyJson,
 } from "./shuttle";
+import { OnChainEvent, OnChainEventResponse, OnChainEventType, IdRegisterEventType } from "@farcaster/hub-nodejs";
 import { err, ok } from "neverthrow";
 import { bytesToHex } from "./utils";
 
@@ -862,6 +865,139 @@ describe("shuttle", () => {
       .executeTakeFirstOrThrow();
     expect(Buffer.from(addMessageInDb.hash)).toEqual(Buffer.from(addMessage.hash));
     expect(addMessageInDb.revokedAt).not.toBeNull();
+  });
+
+  describe("OnChainEventReconciliation", () => {
+    const fid = 7777;
+
+    function makeIdRegisterEvent(opts: {
+      chainId?: number;
+      blockNumber: number;
+      logIndex: number;
+      blockTimestamp?: number;
+    }): OnChainEvent {
+      return {
+        type: OnChainEventType.EVENT_TYPE_ID_REGISTER,
+        chainId: opts.chainId ?? 10,
+        blockNumber: opts.blockNumber,
+        blockHash: Buffer.from("11".repeat(32), "hex"),
+        blockTimestamp: opts.blockTimestamp ?? 1_700_000_000,
+        transactionHash: Buffer.from("22".repeat(32), "hex"),
+        logIndex: opts.logIndex,
+        fid,
+        idRegisterEventBody: {
+          to: Buffer.from("aa".repeat(20), "hex"),
+          eventType: IdRegisterEventType.REGISTER,
+          from: Buffer.from("bb".repeat(20), "hex"),
+          recoveryAddress: Buffer.from("cc".repeat(20), "hex"),
+        },
+        txIndex: 0,
+        version: 1,
+      };
+    }
+
+    function mockHubWith(events: OnChainEvent[]): HubRpcClient {
+      // Each `getOnChainEvents` call is scoped to a single `eventType`; only return
+      // events of the requested type so callers don't accidentally cross-contaminate.
+      const mock = {
+        getOnChainEvents: async (req: { eventType: OnChainEventType }) =>
+          ok(OnChainEventResponse.create({ events: events.filter((e) => e.type === req.eventType) })),
+      };
+      return mock as unknown as HubRpcClient;
+    }
+
+    async function insertOnChainEvent(
+      event: OnChainEvent,
+      body: OnChainEventBodyJson = {
+        to: bytesToHex(event.idRegisterEventBody?.to ?? new Uint8Array()),
+        eventType: event.idRegisterEventBody?.eventType ?? IdRegisterEventType.REGISTER,
+        from: bytesToHex(event.idRegisterEventBody?.from ?? new Uint8Array()),
+        recoveryAddress: bytesToHex(event.idRegisterEventBody?.recoveryAddress ?? new Uint8Array()),
+      },
+    ) {
+      await db
+        .insertInto("onchain_events")
+        .values({
+          chainId: event.chainId,
+          fid: event.fid,
+          blockTimestamp: new Date(event.blockTimestamp * 1000),
+          blockNumber: event.blockNumber,
+          logIndex: event.logIndex,
+          txHash: event.transactionHash,
+          type: event.type,
+          body,
+        })
+        .execute();
+    }
+
+    beforeEach(async () => {
+      await db.deleteFrom("onchain_events").where("fid", "=", fid).execute();
+    });
+
+    test("hub event present in DB by (chainId, blockNumber, logIndex) is detected as not missing", async () => {
+      // Regression: pg parses int8 as JS number, so chainId / blockNumber on the row are
+      // numbers; comparing the IN-list as numbers (not BigInts) must still match.
+      const event = makeIdRegisterEvent({ blockNumber: 1234567, logIndex: 3 });
+      await insertOnChainEvent(event);
+
+      const reconciler = new OnChainEventReconciliation(mockHubWith([event]), db, log);
+      const observations: { missingInDb: boolean; chainId: number; blockNumber: number }[] = [];
+      await reconciler.reconcileOnChainEventsForFid(fid, async (e, missingInDb) => {
+        observations.push({ missingInDb, chainId: e.chainId, blockNumber: e.blockNumber });
+      });
+
+      expect(observations).toEqual([{ missingInDb: false, chainId: 10, blockNumber: 1234567 }]);
+    });
+
+    test("hub event missing from DB is reported with missingInDb=true", async () => {
+      const event = makeIdRegisterEvent({ blockNumber: 222, logIndex: 7 });
+
+      const reconciler = new OnChainEventReconciliation(mockHubWith([event]), db, log);
+      const observations: { missingInDb: boolean }[] = [];
+      await reconciler.reconcileOnChainEventsForFid(fid, async (_e, missingInDb) => {
+        observations.push({ missingInDb });
+      });
+
+      expect(observations).toEqual([{ missingInDb: true }]);
+    });
+
+    test("DB row missing from hub is reported via onDbOnChainEvent (options object)", async () => {
+      const event = makeIdRegisterEvent({ blockNumber: 333, logIndex: 0 });
+      await insertOnChainEvent(event);
+
+      const reconciler = new OnChainEventReconciliation(mockHubWith([]), db, log);
+      const dbObservations: { missingInOnChain: boolean; blockNumber: number }[] = [];
+      await reconciler.reconcileOnChainEventsForFid(
+        fid,
+        async () => {
+          /* hub returned nothing */
+        },
+        {
+          onDbOnChainEvent: async (row, missingInOnChain) => {
+            dbObservations.push({ missingInOnChain, blockNumber: row.blockNumber });
+          },
+        },
+      );
+
+      expect(dbObservations).toEqual([{ missingInOnChain: true, blockNumber: 333 }]);
+    });
+
+    test("`types` filter restricts which on-chain event types are reconciled", async () => {
+      let calls = 0;
+      const mock = {
+        getOnChainEvents: async (req: { eventType: OnChainEventType }) => {
+          calls++;
+          // Each call comes in for one type at a time; assert we only see SIGNER.
+          expect(req.eventType).toBe(OnChainEventType.EVENT_TYPE_SIGNER);
+          return ok(OnChainEventResponse.create({ events: [] }));
+        },
+      };
+      const reconciler = new OnChainEventReconciliation(mock as unknown as HubRpcClient, db, log);
+      await reconciler.reconcileOnChainEventsForFid(fid, async () => {}, {
+        types: [OnChainEventType.EVENT_TYPE_SIGNER],
+      });
+      expect(calls).toBe(1);
+    });
   });
 
   describe("message types", () => {

--- a/packages/shuttle/src/shuttle/db.ts
+++ b/packages/shuttle/src/shuttle/db.ts
@@ -19,10 +19,14 @@ import {
 import {
   CastType,
   HashScheme,
+  IdRegisterEventType,
   MessageType,
+  OnChainEventType,
   ReactionType,
   SignatureScheme,
+  SignerEventType,
   StorageUnitType,
+  TierType,
   UserDataType,
   UserNameType,
 } from "@farcaster/hub-nodejs";
@@ -148,9 +152,79 @@ type MessagesTable = {
 export type MessageRow = Selectable<MessagesTable>;
 export type InsertableMessageRow = Insertable<MessagesTable>;
 
+// ON-CHAIN EVENTS --------------------------------------------------------------------------------
+// JSON-safe representations of each on-chain event body. Mirrors the convention used by
+// `MessageBodyJson`: every `Uint8Array` field on the protobuf body is serialized as a
+// hex-prefixed string ("0x...") so the value round-trips through a Postgres `json` /
+// `jsonb` column. Using the protobuf types directly would let `Uint8Array`-typed fields
+// like `IdRegisterEventBody.to` or `TierPurchaseBody.payer` be persisted as the
+// node-default `{ "0": 0xab, "1": 0xcd, ... }` numeric-index object shape, which is both
+// wasteful and a pain for downstream consumers to query.
+export type IdRegisterEventBodyJson = {
+  to: Hex;
+  eventType: IdRegisterEventType;
+  from: Hex;
+  recoveryAddress: Hex;
+};
+
+export type SignerEventBodyJson = {
+  key: Hex;
+  keyType: number;
+  eventType: SignerEventType;
+  metadata: Hex;
+  metadataType: number;
+};
+
+export type SignerMigratedEventBodyJson = {
+  migratedAt: number;
+};
+
+export type StorageRentEventBodyJson = {
+  payer: Hex;
+  units: number;
+  expiry: number;
+};
+
+export type TierPurchaseEventBodyJson = {
+  tierType: TierType;
+  forDays: number;
+  payer: Hex;
+};
+
+export type OnChainEventBodyJson =
+  | IdRegisterEventBodyJson
+  | SignerEventBodyJson
+  | SignerMigratedEventBodyJson
+  | StorageRentEventBodyJson
+  | TierPurchaseEventBodyJson;
+
+export type OnChainEventsTable = {
+  id: Generated<string>;
+  // `chainId` and `blockNumber` are Postgres `bigint` (int8) columns, but the package
+  // installs a global `pg.types.setTypeParser(20, ...)` that returns int8 values as JS
+  // `number`. Typing them as `number` keeps the runtime shape and the declared shape in
+  // sync (declaring `bigint` would silently mislead downstream consumers and break
+  // arithmetic / serialization). Real-world chain IDs and block numbers are far below
+  // `Number.MAX_SAFE_INTEGER`.
+  chainId: number;
+  createdAt: Generated<Date>;
+  updatedAt: Generated<Date>;
+  blockTimestamp: Date;
+  fid: Fid;
+  blockNumber: number;
+  logIndex: number;
+  type: OnChainEventType;
+  txHash: Uint8Array;
+  body: OnChainEventBodyJson;
+};
+
+export type OnChainEventRow = Selectable<OnChainEventsTable>;
+export type InsertableOnChainEventRow = Insertable<OnChainEventsTable>;
+
 // ALL TABLES -------------------------------------------------------------------------------------
 export interface HubTables {
   messages: MessagesTable;
+  onchain_events: OnChainEventsTable;
 }
 
 export const getDbClient = (connectionString?: string, schema = "public") => {

--- a/packages/shuttle/src/shuttle/index.ts
+++ b/packages/shuttle/src/shuttle/index.ts
@@ -8,6 +8,7 @@ export * from "./hubSubscriber";
 export * from "./hubEventProcessor";
 export * from "./messageProcessor";
 export * from "./messageReconciliation";
+export * from "./onChainEventReconciliation";
 export * from "./eventStream";
 
 export type StoreMessageOperation = "merge" | "delete" | "revoke" | "prune";

--- a/packages/shuttle/src/shuttle/onChainEventReconciliation.ts
+++ b/packages/shuttle/src/shuttle/onChainEventReconciliation.ts
@@ -1,0 +1,321 @@
+import {
+  fromFarcasterTime,
+  HubResult,
+  HubRpcClient,
+  OnChainEvent,
+  OnChainEventResponse,
+  OnChainEventType,
+} from "@farcaster/hub-nodejs";
+import { err, ok } from "neverthrow";
+import { pino } from "pino";
+import { extendStackTrace } from "../utils";
+import { DB, OnChainEventRow } from "./db";
+
+const MAX_PAGE_SIZE = 500;
+
+// The set of on-chain event types `OnChainEventReconciliation` knows how to fetch from
+// the hub. Constraining the public `types` parameter to this list turns "I forgot a
+// case in the type-switch" into a compile-time error.
+export const RECONCILABLE_ONCHAIN_EVENT_TYPES = [
+  OnChainEventType.EVENT_TYPE_ID_REGISTER,
+  OnChainEventType.EVENT_TYPE_SIGNER,
+  OnChainEventType.EVENT_TYPE_SIGNER_MIGRATED,
+  OnChainEventType.EVENT_TYPE_STORAGE_RENT,
+  OnChainEventType.EVENT_TYPE_TIER_PURCHASE,
+] as const;
+
+export type ReconcilableOnChainEventType = typeof RECONCILABLE_ONCHAIN_EVENT_TYPES[number];
+
+export type DBOnChainEvent = OnChainEventRow;
+
+type EventKeySource = Pick<OnChainEvent | DBOnChainEvent, "chainId" | "blockNumber" | "logIndex">;
+
+export type OnDbOnChainEventCallback = (event: DBOnChainEvent, missingInOnChain: boolean) => Promise<void>;
+
+// Public options for `reconcileOnChainEventsForFid`. An options object is used (rather
+// than positional parameters) so that the optional `onDbOnChainEvent` callback isn't a
+// landmine sitting between the FID-level callback and the time-window arguments.
+//
+// `startTimestamp` / `stopTimestamp` are Farcaster timestamps (matching
+// `MessageReconciliation`); they're internally converted to absolute Dates and compared
+// against each event's `blockTimestamp` (Unix seconds), so callers can use the same
+// units across both reconciliation APIs.
+export type ReconcileOnChainEventsOptions = {
+  startTimestamp?: number;
+  stopTimestamp?: number;
+  types?: ReconcilableOnChainEventType[];
+  onDbOnChainEvent?: OnDbOnChainEventCallback;
+};
+
+export type ReconcileOnChainEventsOfTypeOptions = {
+  startTimestamp?: number;
+  stopTimestamp?: number;
+  onDbOnChainEvent?: OnDbOnChainEventCallback;
+};
+
+// Reconciles on-chain events between the hub and the local database for a given FID.
+// Mirrors the structure of `MessageReconciliation`: the hub-side pass is always run, and
+// the DB-side pass is only run when an `onDbOnChainEvent` callback is provided.
+export class OnChainEventReconciliation {
+  private client: HubRpcClient;
+  private db: DB;
+  private log: pino.Logger;
+
+  constructor(client: HubRpcClient, db: DB, log: pino.Logger) {
+    this.client = client;
+    this.db = db;
+    this.log = log;
+  }
+
+  private getEventKey(event: EventKeySource): string {
+    return `${event.chainId}-${event.blockNumber}-${event.logIndex}`;
+  }
+
+  async reconcileOnChainEventsForFid(
+    fid: number,
+    onHubOnChainEvent: (event: OnChainEvent, missingInDb: boolean) => Promise<void>,
+    options: ReconcileOnChainEventsOptions = {},
+  ) {
+    const window = this.resolveTimeWindow(options.startTimestamp, options.stopTimestamp);
+    if (window.isErr()) {
+      this.log.error(
+        { fid, startTimestamp: options.startTimestamp, stopTimestamp: options.stopTimestamp },
+        "Invalid time range provided to reconciliation",
+      );
+      return;
+    }
+
+    for (const type of options.types ?? RECONCILABLE_ONCHAIN_EVENT_TYPES) {
+      this.log.debug({ fid, type }, "Reconciling on-chain events for FID");
+      await this.reconcileOnChainEventsOfTypeForFidInternal(
+        fid,
+        type,
+        onHubOnChainEvent,
+        options.onDbOnChainEvent,
+        window.value,
+      );
+    }
+  }
+
+  async reconcileOnChainEventsOfTypeForFid(
+    fid: number,
+    type: ReconcilableOnChainEventType,
+    onHubOnChainEvent: (event: OnChainEvent, missingInDb: boolean) => Promise<void>,
+    options: ReconcileOnChainEventsOfTypeOptions = {},
+  ) {
+    const window = this.resolveTimeWindow(options.startTimestamp, options.stopTimestamp);
+    if (window.isErr()) {
+      this.log.error(
+        { fid, type, startTimestamp: options.startTimestamp, stopTimestamp: options.stopTimestamp },
+        "Invalid time range provided to reconciliation",
+      );
+      return;
+    }
+    await this.reconcileOnChainEventsOfTypeForFidInternal(
+      fid,
+      type,
+      onHubOnChainEvent,
+      options.onDbOnChainEvent,
+      window.value,
+    );
+  }
+
+  private async reconcileOnChainEventsOfTypeForFidInternal(
+    fid: number,
+    type: ReconcilableOnChainEventType,
+    onHubOnChainEvent: (event: OnChainEvent, missingInDb: boolean) => Promise<void>,
+    onDbOnChainEvent: OnDbOnChainEventCallback | undefined,
+    window: { startDate?: Date; stopDate?: Date },
+  ) {
+    // Only build the hub-side key map when the DB-side pass will actually consume it.
+    const trackHubEvents = onDbOnChainEvent !== undefined;
+    const onChainEventsByKey = new Map<string, OnChainEvent>();
+
+    // First, reconcile events that are on the hub but not in the database
+    for await (const events of this.allHubOnChainEventsOfTypeForFid(fid, type, window.startDate, window.stopDate)) {
+      if (events.length === 0) {
+        this.log.debug({ fid, type }, "No on-chain events found");
+        continue;
+      }
+
+      const dbEvents = await this.dbEventsMatchingOnChainEvents(fid, type, events);
+
+      const dbEventsByKey = new Map<string, DBOnChainEvent>();
+      for (const event of dbEvents) {
+        dbEventsByKey.set(this.getEventKey(event), event);
+      }
+
+      for (const event of events) {
+        const eventKey = this.getEventKey(event);
+        if (trackHubEvents) onChainEventsByKey.set(eventKey, event);
+
+        const dbEvent = dbEventsByKey.get(eventKey);
+        await onHubOnChainEvent(event, dbEvent === undefined);
+      }
+    }
+
+    // Next, reconcile on-chain events that are in the database but not on the hub
+    if (onDbOnChainEvent) {
+      const dbEvents = await this.allActiveDbOnChainEventsOfTypeForFid(fid, type, window.startDate, window.stopDate);
+      if (dbEvents.isErr()) {
+        this.log.error(
+          { fid, type, startDate: window.startDate?.toISOString(), stopDate: window.stopDate?.toISOString() },
+          "Failed to query DB on-chain events for reconciliation",
+        );
+        return;
+      }
+
+      for (const dbEvent of dbEvents.value) {
+        const key = this.getEventKey(dbEvent);
+        await onDbOnChainEvent(dbEvent, !onChainEventsByKey.has(key));
+      }
+    }
+  }
+
+  private resolveTimeWindow(
+    startTimestamp: number | undefined,
+    stopTimestamp: number | undefined,
+  ): HubResult<{ startDate?: Date; stopDate?: Date }> {
+    let startDate: Date | undefined;
+    if (startTimestamp !== undefined) {
+      const r = fromFarcasterTime(startTimestamp);
+      if (r.isErr()) return err(r.error);
+      startDate = new Date(r.value);
+    }
+
+    let stopDate: Date | undefined;
+    if (stopTimestamp !== undefined) {
+      const r = fromFarcasterTime(stopTimestamp);
+      if (r.isErr()) return err(r.error);
+      stopDate = new Date(r.value);
+    }
+
+    return ok({ startDate, stopDate });
+  }
+
+  private async *allHubOnChainEventsOfTypeForFid(
+    fid: number,
+    type: ReconcilableOnChainEventType,
+    startDate?: Date,
+    stopDate?: Date,
+  ) {
+    let result: HubResult<OnChainEventResponse> = await this.client.getOnChainEvents({
+      pageSize: MAX_PAGE_SIZE,
+      fid,
+      eventType: type,
+    });
+
+    for (;;) {
+      if (result.isErr()) {
+        throw new Error(`Unable to get all on-chain events for FID ${fid}: ${result.error?.message}`);
+      }
+
+      const { events, nextPageToken: pageToken } = result.value;
+
+      // Hub does not support time-range filtering for on-chain events, so filter client-side.
+      const filteredEvents = events.filter((event: OnChainEvent) => {
+        if (startDate && event.blockTimestamp * 1000 < startDate.getTime()) return false;
+        if (stopDate && event.blockTimestamp * 1000 > stopDate.getTime()) return false;
+        return true;
+      });
+
+      yield filteredEvents;
+
+      if (!pageToken?.length) break;
+
+      result = await this.client.getOnChainEvents({
+        pageSize: MAX_PAGE_SIZE,
+        pageToken,
+        fid,
+        eventType: type,
+      });
+    }
+  }
+
+  private async allActiveDbOnChainEventsOfTypeForFid(
+    fid: number,
+    type: ReconcilableOnChainEventType,
+    startDate?: Date,
+    stopDate?: Date,
+  ) {
+    let query = this.db
+      .selectFrom("onchain_events")
+      .select([
+        "id",
+        "chainId",
+        "createdAt",
+        "updatedAt",
+        "blockTimestamp",
+        "fid",
+        "blockNumber",
+        "logIndex",
+        "type",
+        "txHash",
+        "body",
+      ])
+      .where("fid", "=", fid)
+      .where("type", "=", type);
+
+    if (startDate) query = query.where("blockTimestamp", ">=", startDate);
+    if (stopDate) query = query.where("blockTimestamp", "<=", stopDate);
+
+    try {
+      return ok(await query.execute());
+    } catch (e) {
+      // Maintain the same error-shape contract as MessageReconciliation: never throw,
+      // return an err result so the caller can decide how to react.
+      return err(extendStackTrace(e, new Error(), query));
+    }
+  }
+
+  private async dbEventsMatchingOnChainEvents(
+    fid: number,
+    type: ReconcilableOnChainEventType,
+    onChainEvents: OnChainEvent[],
+  ) {
+    if (onChainEvents.length === 0) {
+      return [];
+    }
+
+    // `chainId` / `blockNumber` are typed as `number` (matching the int8→number pg
+    // parser), so build the IN-list as numbers, not BigInts.
+    const query = this.db
+      .selectFrom("onchain_events")
+      .select([
+        "id",
+        "chainId",
+        "createdAt",
+        "updatedAt",
+        "blockTimestamp",
+        "fid",
+        "blockNumber",
+        "logIndex",
+        "type",
+        "txHash",
+        "body",
+      ])
+      .where("fid", "=", fid)
+      .where("type", "=", type)
+      .where(
+        "chainId",
+        "in",
+        onChainEvents.map((e) => e.chainId),
+      )
+      .where(
+        "blockNumber",
+        "in",
+        onChainEvents.map((e) => e.blockNumber),
+      )
+      .where(
+        "logIndex",
+        "in",
+        onChainEvents.map((e) => e.logIndex),
+      );
+
+    try {
+      return await query.execute();
+    } catch (e) {
+      throw extendStackTrace(e, new Error(), query);
+    }
+  }
+}


### PR DESCRIPTION
## Why is this change needed?

Shuttle has full reconciliation support for hub messages
(\`MessageReconciliation\`) but nothing equivalent for on-chain events. Apps
that materialize on-chain events alongside messages have to roll their own.

This PR adds:

- A new \`OnChainEventReconciliation\` class in \`src/shuttle/onChainEventReconciliation.ts\`
  with \`reconcileOnChainEventsForFid\` / \`reconcileOnChainEventsOfTypeForFid\`,
  built to mirror \`MessageReconciliation\`. The hub-side pass is always run
  and the DB-side pass is opt-in via an \`onDbOnChainEvent\` callback.
  By default it covers ID Register, Signer, Signer Migrated, Storage Rent
  and Tier Purchase events.

- A typed \`onchain_events\` table on \`HubTables\`, with new exports
  \`OnChainEventsTable\` / \`OnChainEventRow\` / \`InsertableOnChainEventRow\` /
  \`OnChainEventBodyJson\` (a union of the in-protocol body types including
  \`TierPurchaseBody\`).

- Example-app updates so the existing example continues to compile and
  run against the new schema:
  - Migration \`003_onchain_events\` now adds \`chainId\` and uses
    \`blockTimestamp\` (matching the hub event payload).
  - The example handler now also records signer-migrated and
    tier-purchase events.
  - Fixes a stale \`@farcaster/hub-shuttle\` import in the example-app
    (the package is published as \`@farcaster/shuttle\`).

### Note on the existing example schema

The example-app's \`onchain_events\` table previously had \`timestamp\`
(no \`chainId\`). That's a breaking change for anyone who literally ran
the example as their production schema, but the example-app is documented
as a demo (\`README.md\` calls out: "The package is meant to be used as a
library. The app provided is just an example."), and the new shape matches
what the hub actually emits, so it's much closer to what real consumers
need.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for reconciling on-chain events in the `shuttle` package, adding a new `OnChainEventReconciliation` class and updating the database schema to accommodate new event types and fields.

### Detailed summary
- Added `OnChainEventReconciliation` class with methods for reconciling on-chain events.
- Introduced `chainId` and `blockTimestamp` columns in the `onchain_events` table.
- Updated `onchain_events` table structure to include new fields.
- Enhanced integration tests for the new reconciliation features.
- Updated example application to reflect new database schema and event handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->