### PR TITLE
feat(shuttle): add UsernameProofReconciliation and typed usernames table

### DIFF
--- a/.changeset/shuttle-username-proof-reconciliation.md
+++ b/.changeset/shuttle-username-proof-reconciliation.md
@@ -1,0 +1,18 @@
+---
+"@farcaster/shuttle": minor
+---
+
+feat(shuttle): add `UsernameProofReconciliation` and a typed `usernames` table
+
+Adds first-class support for reconciling username proofs (`fname`,
+`ENS L1`, basenames) between the hub and the local database, mirroring
+the structure of `MessageReconciliation`:
+
+- New `UsernameProofReconciliation` class (in
+  `src/shuttle/usernameProofReconciliation.ts`) with
+  `reconcileUsernameProofsForFid` /
+  `reconcileUsernameProofsOfTypeForFid`. The hub-side pass is always
+  run, and the DB-side pass is opt-in via an `onDbProof` callback.
+
+- Promotes `usernames` to a typed table on `HubTables`, with new
+  exports `UsernamesTable`, `UsernameRow`, `InsertableUsernameRow`.

--- a/.changeset/shuttle-username-proof-reconciliation.md
+++ b/.changeset/shuttle-username-proof-reconciliation.md
@@ -1,5 +1,5 @@
 ---
-"@farcaster/shuttle": minor
+"@farcaster/shuttle": major
 ---
 
 feat(shuttle): add `UsernameProofReconciliation` and a typed `usernames` table
@@ -16,3 +16,8 @@ the structure of `MessageReconciliation`:
 
 - Promotes `usernames` to a typed table on `HubTables`, with new
   exports `UsernamesTable`, `UsernameRow`, `InsertableUsernameRow`.
+  Adds an `004_usernames` migration to the example app.
+
+Marked as a major release because the new `usernames` field on the
+exported `HubTables` interface is a breaking change for consumers that
+already extend `HubTables` with their own `usernames` table shape.

--- a/packages/shuttle/src/example-app/db.ts
+++ b/packages/shuttle/src/example-app/db.ts
@@ -4,8 +4,7 @@ import { err, ok, Result } from "neverthrow";
 import path from "path";
 import { promises as fs } from "fs";
 import { fileURLToPath } from "node:url";
-import { HubTables } from "@farcaster/hub-shuttle";
-import { Fid } from "../shuttle";
+import { Fid, HubTables } from "../shuttle";
 
 const createMigrator = async (db: Kysely<HubTables>, dbSchema: string, log: Logger) => {
   const currentDir = path.dirname(fileURLToPath(import.meta.url));

--- a/packages/shuttle/src/example-app/migrations/004_usernames.ts
+++ b/packages/shuttle/src/example-app/migrations/004_usernames.ts
@@ -1,0 +1,28 @@
+import { type Kysely, sql } from "kysely";
+
+// biome-ignore lint/suspicious/noExplicitAny: legacy code, avoid using ignore for new code
+export const up = async (db: Kysely<any>) => {
+  await db.schema
+    .createTable("usernames")
+    .addColumn("id", "uuid", (col) => col.defaultTo(sql`generate_ulid()`))
+    .addColumn("createdAt", "timestamptz", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("updatedAt", "timestamptz", (col) => col.notNull().defaultTo(sql`current_timestamp`))
+    .addColumn("deletedAt", "timestamptz")
+    .addColumn("fid", "bigint", (col) => col.notNull())
+    .addColumn("username", "text", (col) => col.notNull())
+    .addColumn("custodyAddress", "bytea")
+    .addColumn("proofTimestamp", "timestamptz", (col) => col.notNull())
+    .addColumn("type", "integer", (col) => col.notNull())
+    .execute();
+
+  // Partial unique index: for each (fid, type), only one live username row at a time.
+  // Use sql.ref so the predicate column lookup is unconstrained by the columns() narrowing,
+  // and goes through Kysely's identifier handling so the schema set by WithSchemaPlugin sticks.
+  await db.schema
+    .createIndex("usernames_fid_type_username_unique")
+    .on("usernames")
+    .columns(["fid", "type", "username"])
+    .where(sql.ref("deletedAt"), "is", null)
+    .unique()
+    .execute();
+};

--- a/packages/shuttle/src/shuttle.integration.test.ts
+++ b/packages/shuttle/src/shuttle.integration.test.ts
@@ -26,7 +26,9 @@ import {
   HubEventProcessor,
   MessageState,
   MessageReconciliation,
+  UsernameProofReconciliation,
 } from "./shuttle";
+import { UserNameProof, UserNameType, UsernameProofsResponse } from "@farcaster/hub-nodejs";
 import { err, ok } from "neverthrow";
 import { bytesToHex } from "./utils";
 
@@ -862,6 +864,97 @@ describe("shuttle", () => {
       .executeTakeFirstOrThrow();
     expect(Buffer.from(addMessageInDb.hash)).toEqual(Buffer.from(addMessage.hash));
     expect(addMessageInDb.revokedAt).not.toBeNull();
+  });
+
+  describe("UsernameProofReconciliation", () => {
+    const fid = 4242;
+
+    function makeProof(name: string, owner: string, type: UserNameType, timestamp: number): UserNameProof {
+      return {
+        timestamp,
+        name: Buffer.from(name, "utf8"),
+        owner: Buffer.from(owner.replace(/^0x/, ""), "hex"),
+        signature: Buffer.from([]),
+        fid,
+        type,
+      };
+    }
+
+    function mockHubWith(proofs: UserNameProof[]): HubRpcClient {
+      const mock = {
+        getUserNameProofsByFid: async (_request: { fid: number }) => ok(UsernameProofsResponse.create({ proofs })),
+      };
+      return mock as unknown as HubRpcClient;
+    }
+
+    beforeEach(async () => {
+      await db.deleteFrom("usernames").where("fid", "=", fid).execute();
+    });
+
+    test("hub proof present in DB by readable username is detected (regression: IN-clause used hex bytes)", async () => {
+      const ownerHex = "0xaaaabbbbccccddddeeeeffff0000111122223333";
+      const proof = makeProof("alice", ownerHex, UserNameType.USERNAME_TYPE_FNAME, 1_700_000_000);
+
+      // The DB stores the readable username, not the hex of the protobuf bytes.
+      await db
+        .insertInto("usernames")
+        .values({
+          fid,
+          username: "alice",
+          custodyAddress: Buffer.from(ownerHex.slice(2), "hex"),
+          proofTimestamp: new Date(proof.timestamp * 1000),
+          type: UserNameType.USERNAME_TYPE_FNAME,
+        })
+        .execute();
+
+      const reconciler = new UsernameProofReconciliation(mockHubWith([proof]), db, log);
+      const observations: { name: string; missingInDb: boolean }[] = [];
+      await reconciler.reconcileUsernameProofsForFid(fid, async (p, missingInDb) => {
+        observations.push({ name: Buffer.from(p.name).toString("utf8"), missingInDb });
+      });
+
+      expect(observations).toEqual([{ name: "alice", missingInDb: false }]);
+    });
+
+    test("hub proof missing from DB is reported with missingInDb=true", async () => {
+      const proof = makeProof("bob", `0x${"11".repeat(20)}`, UserNameType.USERNAME_TYPE_FNAME, 1_700_000_001);
+
+      const reconciler = new UsernameProofReconciliation(mockHubWith([proof]), db, log);
+      const observations: { name: string; missingInDb: boolean }[] = [];
+      await reconciler.reconcileUsernameProofsForFid(fid, async (p, missingInDb) => {
+        observations.push({ name: Buffer.from(p.name).toString("utf8"), missingInDb });
+      });
+
+      expect(observations).toEqual([{ name: "bob", missingInDb: true }]);
+    });
+
+    test("DB row missing from hub is reported with missingInHub=true when onDbProof is provided", async () => {
+      const ownerHex = `0x${"22".repeat(20)}`;
+      await db
+        .insertInto("usernames")
+        .values({
+          fid,
+          username: "carol",
+          custodyAddress: Buffer.from(ownerHex.slice(2), "hex"),
+          proofTimestamp: new Date(1_700_000_002 * 1000),
+          type: UserNameType.USERNAME_TYPE_FNAME,
+        })
+        .execute();
+
+      const reconciler = new UsernameProofReconciliation(mockHubWith([]), db, log);
+      const dbObservations: { name: string; missingInHub: boolean }[] = [];
+      await reconciler.reconcileUsernameProofsForFid(
+        fid,
+        async () => {
+          /* hub returned nothing */
+        },
+        async (p, missingInHub) => {
+          dbObservations.push({ name: Buffer.from(p.name).toString("utf8"), missingInHub });
+        },
+      );
+
+      expect(dbObservations).toEqual([{ name: "carol", missingInHub: true }]);
+    });
   });
 
   describe("message types", () => {

--- a/packages/shuttle/src/shuttle/db.ts
+++ b/packages/shuttle/src/shuttle/db.ts
@@ -148,9 +148,26 @@ type MessagesTable = {
 export type MessageRow = Selectable<MessagesTable>;
 export type InsertableMessageRow = Insertable<MessagesTable>;
 
+// USERNAMES --------------------------------------------------------------------------------------
+export type UsernamesTable = {
+  id: Generated<string>;
+  createdAt: Generated<Date>;
+  updatedAt: Generated<Date>;
+  deletedAt: Date | null;
+  fid: Fid;
+  username: string;
+  custodyAddress: Uint8Array | null;
+  proofTimestamp: Date;
+  type: UserNameType;
+};
+
+export type UsernameRow = Selectable<UsernamesTable>;
+export type InsertableUsernameRow = Insertable<UsernamesTable>;
+
 // ALL TABLES -------------------------------------------------------------------------------------
 export interface HubTables {
   messages: MessagesTable;
+  usernames: UsernamesTable;
 }
 
 export const getDbClient = (connectionString?: string, schema = "public") => {

--- a/packages/shuttle/src/shuttle/index.ts
+++ b/packages/shuttle/src/shuttle/index.ts
@@ -8,6 +8,7 @@ export * from "./hubSubscriber";
 export * from "./hubEventProcessor";
 export * from "./messageProcessor";
 export * from "./messageReconciliation";
+export * from "./usernameProofReconciliation";
 export * from "./eventStream";
 
 export type StoreMessageOperation = "merge" | "delete" | "revoke" | "prune";

--- a/packages/shuttle/src/shuttle/usernameProofReconciliation.ts
+++ b/packages/shuttle/src/shuttle/usernameProofReconciliation.ts
@@ -3,6 +3,17 @@ import { err, ok, Result } from "neverthrow";
 import { pino } from "pino";
 import { DB } from "./db";
 
+// `UserNameProof.name` on the wire is the username's UTF-8 bytes (e.g. "alice" -> [0x61,...]).
+// The `usernames` table on `HubTables` stores `username` as the human-readable string, so any
+// time we cross the wire<->row boundary we need to round-trip through UTF-8, not hex.
+function nameBytesToUsername(name: Uint8Array): string {
+  return Buffer.from(name).toString("utf8");
+}
+
+function usernameToNameBytes(username: string): Uint8Array {
+  return Buffer.from(username, "utf8");
+}
+
 // Reconciles username proofs between the hub and the local database for a given FID.
 // Mirrors the structure of MessageReconciliation: the hub-side pass is always run, and
 // the DB-side pass is only run when an onDbProof callback is provided.
@@ -155,17 +166,20 @@ export class UsernameProofReconciliation {
       if (stopDate) query = query.where("proofTimestamp", "<", stopDate);
 
       if (hubProofs) {
+        // The `username` column stores the human-readable name, not hex of the bytes,
+        // so build the IN list with the UTF-8 decoding of each hub proof's name. Building
+        // it from `bytesToHexString(p.name)` (a "0x..." string) would never match anything.
         query = query.where(
           "username",
           "in",
-          hubProofs.map((p) => bytesToHexString(p.name)._unsafeUnwrap()),
+          hubProofs.map((p) => nameBytesToUsername(p.name)),
         );
       }
 
       const results = await query.execute();
 
       const proofs = results.map((row) => ({
-        name: Buffer.from(row.username),
+        name: usernameToNameBytes(row.username),
         type: row.type,
         fid: row.fid,
         timestamp: Math.floor(row.proofTimestamp.getTime() / 1000),

--- a/packages/shuttle/src/shuttle/usernameProofReconciliation.ts
+++ b/packages/shuttle/src/shuttle/usernameProofReconciliation.ts
@@ -1,0 +1,217 @@
+import { bytesToHexString, fromFarcasterTime, HubRpcClient, UserNameProof, UserNameType } from "@farcaster/hub-nodejs";
+import { err, ok, Result } from "neverthrow";
+import { pino } from "pino";
+import { DB } from "./db";
+
+// Reconciles username proofs between the hub and the local database for a given FID.
+// Mirrors the structure of MessageReconciliation: the hub-side pass is always run, and
+// the DB-side pass is only run when an onDbProof callback is provided.
+export class UsernameProofReconciliation {
+  private readonly hubClient: HubRpcClient;
+  private readonly db: DB;
+  private readonly log: pino.Logger;
+
+  constructor(hubClient: HubRpcClient, db: DB, log: pino.Logger) {
+    this.hubClient = hubClient;
+    this.db = db;
+    this.log = log;
+  }
+
+  async reconcileUsernameProofsForFid(
+    fid: number,
+    onHubProof: (proof: UserNameProof, missingInDb: boolean) => Promise<void>,
+    onDbProof?: (proof: UserNameProof, missingInHub: boolean) => Promise<void>,
+    startTimestamp?: number,
+    stopTimestamp?: number,
+    types?: UserNameType[],
+  ) {
+    let startDate: Date | undefined;
+    if (startTimestamp) {
+      const startUnixTimestampResult = fromFarcasterTime(startTimestamp);
+      if (startUnixTimestampResult.isErr()) {
+        this.log.error({ fid, types, startTimestamp, stopTimestamp }, "Invalid time range provided to reconciliation");
+        return;
+      }
+
+      startDate = new Date(startUnixTimestampResult.value);
+    }
+
+    let stopDate: Date | undefined;
+    if (stopTimestamp) {
+      const stopUnixTimestampResult = fromFarcasterTime(stopTimestamp);
+      if (stopUnixTimestampResult.isErr()) {
+        this.log.error({ fid, types, startTimestamp, stopTimestamp }, "Invalid time range provided to reconciliation");
+        return;
+      }
+
+      stopDate = new Date(stopUnixTimestampResult.value);
+    }
+
+    for (const proofType of types ?? [
+      UserNameType.USERNAME_TYPE_FNAME,
+      UserNameType.USERNAME_TYPE_ENS_L1,
+      UserNameType.USERNAME_TYPE_BASENAME,
+    ]) {
+      this.log.debug({ fid, proofType, startTimestamp, stopTimestamp }, "Reconciling username proofs for FID");
+      await this.reconcileUsernameProofsOfTypeForFid(fid, proofType, onHubProof, onDbProof, startDate, stopDate);
+    }
+  }
+
+  async reconcileUsernameProofsOfTypeForFid(
+    fid: number,
+    proofType: UserNameType,
+    onHubProof: (proof: UserNameProof, missingInDb: boolean) => Promise<void>,
+    onDbProof?: (proof: UserNameProof, missingInHub: boolean) => Promise<void>,
+    startDate?: Date,
+    stopDate?: Date,
+  ): Promise<void> {
+    const hubProofsByKey = new Map<string, UserNameProof>();
+
+    // First, reconcile proofs that are in the hub but not in the database
+    for await (const proofs of this.allHubUsernameProofsOfTypeForFid(fid, proofType, startDate, stopDate)) {
+      if (proofs.length === 0) {
+        this.log.debug(
+          { fid, proofType, startDate: startDate?.toISOString(), stopDate: stopDate?.toISOString() },
+          "No username proofs found in hub",
+        );
+        continue;
+      }
+
+      const dbProofs = await this.dbProofsMatchingHubProofs(fid, proofType, startDate, stopDate, proofs);
+      if (dbProofs.isErr()) {
+        throw dbProofs.error;
+      }
+
+      const dbProofsByKey = new Map<string, UserNameProof>();
+      for (const proof of dbProofs.value) {
+        dbProofsByKey.set(this.getProofKey(proof), proof);
+      }
+
+      for (const proof of proofs) {
+        const proofKey = this.getProofKey(proof);
+        hubProofsByKey.set(proofKey, proof);
+        await onHubProof(proof, !dbProofsByKey.has(proofKey));
+      }
+    }
+
+    // Next, reconcile proofs that are in the database but not in the hub
+    if (onDbProof) {
+      const dbProofs = await this.allActiveDbProofsOfTypeForFid(fid, proofType, startDate, stopDate);
+      if (dbProofs.isErr()) {
+        this.log.error(
+          { fid, proofType, startDate: startDate?.toISOString(), stopDate: stopDate?.toISOString() },
+          "Failed to query DB username proofs for reconciliation",
+        );
+        return;
+      }
+
+      for (const dbProof of dbProofs.value) {
+        const key = this.getProofKey(dbProof);
+        await onDbProof(dbProof, !hubProofsByKey.has(key));
+      }
+    }
+  }
+
+  private async getProofsFromHub(
+    fid: number,
+    proofType: UserNameType,
+    startDate?: Date,
+    stopDate?: Date,
+  ): Promise<Result<UserNameProof[], Error>> {
+    const result = await this.hubClient.getUserNameProofsByFid({ fid });
+    if (result.isErr()) {
+      return err(new Error(`Unable to get username proofs for FID ${fid}`, { cause: result.error }));
+    }
+
+    let proofs = result.value.proofs.filter((proof) => proof.type === proofType);
+
+    if (startDate || stopDate) {
+      proofs = proofs.filter((proof) => {
+        if (startDate !== undefined && proof.timestamp * 1000 < startDate.getTime()) return false;
+        if (stopDate !== undefined && proof.timestamp * 1000 > stopDate.getTime()) return false;
+        return true;
+      });
+    }
+
+    return ok(proofs);
+  }
+
+  private async getProofsFromDb(
+    fid: number,
+    proofType: UserNameType,
+    startDate?: Date,
+    stopDate?: Date,
+    hubProofs?: UserNameProof[],
+  ): Promise<Result<UserNameProof[], Error>> {
+    try {
+      let query = this.db
+        .selectFrom("usernames")
+        .select(["username", "fid", "proofTimestamp", "custodyAddress", "type"])
+        .where("fid", "=", fid)
+        .where("type", "=", proofType)
+        .where("deletedAt", "is", null);
+
+      if (startDate) query = query.where("proofTimestamp", ">", startDate);
+      if (stopDate) query = query.where("proofTimestamp", "<", stopDate);
+
+      if (hubProofs) {
+        query = query.where(
+          "username",
+          "in",
+          hubProofs.map((p) => bytesToHexString(p.name)._unsafeUnwrap()),
+        );
+      }
+
+      const results = await query.execute();
+
+      const proofs = results.map((row) => ({
+        name: Buffer.from(row.username),
+        type: row.type,
+        fid: row.fid,
+        timestamp: Math.floor(row.proofTimestamp.getTime() / 1000),
+        signature: Buffer.from([]),
+        owner: row.custodyAddress ? Buffer.from(row.custodyAddress) : Buffer.from([]),
+      }));
+
+      return ok(proofs);
+    } catch (e) {
+      return err(new Error(`Failed to get username proofs from DB for FID ${fid}`, { cause: e }));
+    }
+  }
+
+  private async *allHubUsernameProofsOfTypeForFid(
+    fid: number,
+    proofType: UserNameType,
+    startDate?: Date,
+    stopDate?: Date,
+  ): AsyncGenerator<UserNameProof[]> {
+    const hubProofsResult = await this.getProofsFromHub(fid, proofType, startDate, stopDate);
+    if (hubProofsResult.isErr()) {
+      throw hubProofsResult.error;
+    }
+
+    yield hubProofsResult.value;
+  }
+
+  private async allActiveDbProofsOfTypeForFid(fid: number, proofType: UserNameType, startDate?: Date, stopDate?: Date) {
+    return this.getProofsFromDb(fid, proofType, startDate, stopDate);
+  }
+
+  private async dbProofsMatchingHubProofs(
+    fid: number,
+    proofType: UserNameType,
+    startDate?: Date,
+    stopDate?: Date,
+    hubProofs?: UserNameProof[],
+  ) {
+    return this.getProofsFromDb(fid, proofType, startDate, stopDate, hubProofs);
+  }
+
+  private getProofKey(proof: UserNameProof): string {
+    // Identifying fields only (name, owner, fid, type) - timestamp is intentionally excluded
+    // so that re-issued proofs for the same name+owner+fid+type are treated as the same proof.
+    const nameHex = bytesToHexString(proof.name)._unsafeUnwrap();
+    const ownerHex = bytesToHexString(proof.owner)._unsafeUnwrap();
+    return `${nameHex}-${proof.fid}-${ownerHex}-${proof.type}`;
+  }
+}


### PR DESCRIPTION
## Why is this change needed?

Shuttle has full reconciliation support for hub messages
(\`MessageReconciliation\`) but nothing equivalent for username proofs
(\`fname\`, ENS L1, basename). Apps that materialize usernames have to
roll their own.

This PR adds:

- A new \`UsernameProofReconciliation\` class in
  \`src/shuttle/usernameProofReconciliation.ts\` with
  \`reconcileUsernameProofsForFid\` /
  \`reconcileUsernameProofsOfTypeForFid\`, built to mirror
  \`MessageReconciliation\`. The hub-side pass is always run and the
  DB-side pass is opt-in via an \`onDbProof\` callback. By default it
  covers \`USERNAME_TYPE_FNAME\`, \`USERNAME_TYPE_ENS_L1\` and
  \`USERNAME_TYPE_BASENAME\`.

- A typed \`usernames\` table on \`HubTables\`, with new exports
  \`UsernamesTable\` / \`UsernameRow\` / \`InsertableUsernameRow\`.

This PR stacks neatly on top of the existing reconciliation patterns and
does not depend on
[#2705](https://github.com/farcasterxyz/hub-monorepo/pull/2705)
(on-chain event reconciliation), but they share the same overall design,
so reviewing them together may be useful.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR includes [documentation](https://github.com/farcasterxyz/hub-monorepo/blob/main/CONTRIBUTING.md#32-writing-docs) if necessary.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `UsernameProofReconciliation` class and a new `usernames` table, enhancing the system's ability to reconcile username proofs between the hub and the local database. It includes breaking changes and a migration for the new table.

### Detailed summary
- Added `UsernameProofReconciliation` class in `src/shuttle/usernameProofReconciliation.ts`.
- Introduced `usernames` table with types: `UsernamesTable`, `UsernameRow`, `InsertableUsernameRow`.
- Updated `HubTables` interface to include `usernames`.
- Created migration script `004_usernames` for the new table.
- Added tests for `UsernameProofReconciliation` functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->