### PR TITLE
feat(shuttle): scrub PG-uncastable chars from message body JSON

### DIFF
--- a/.changeset/scrub-pg-uncastable-chars.md
+++ b/.changeset/scrub-pg-uncastable-chars.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/shuttle": patch
+---
+
+Scrub Postgres-uncastable characters (NUL and unpaired UTF-16 surrogates) from message body JSON before insert. These pass `json` validation but throw on `body::jsonb` and on any `body->>'key'` extraction, leaving rows that look fine at INSERT and blow up at read time.

--- a/packages/shuttle/src/index.ts
+++ b/packages/shuttle/src/index.ts
@@ -1,2 +1,2 @@
 export * from "./shuttle";
-export { convertProtobufMessageBodyToJson, protocolBytesToString } from "./utils";
+export { convertProtobufMessageBodyToJson, protocolBytesToString, scrubStringFieldsForPostgresJson } from "./utils";

--- a/packages/shuttle/src/utils.test.ts
+++ b/packages/shuttle/src/utils.test.ts
@@ -1,0 +1,115 @@
+import { Message, MessageType, UserDataType } from "@farcaster/hub-nodejs";
+import { convertProtobufMessageBodyToJson, scrubStringFieldsForPostgresJson } from "./utils";
+
+// Constructs a barely-valid Message-shaped object for routing through the
+// body builder. We don't go through protobuf encode/decode here: protobuf's
+// own string handling is what introduced the bad bytes upstream, and the
+// only thing we're testing is what `convertProtobufMessageBodyToJson` does
+// once a JS string with bad chars is in hand. Casting to Message is
+// sufficient because the function only inspects `message.data`.
+function userDataAddMessage(value: string, subtype: UserDataType = UserDataType.BIO): Message {
+  return {
+    data: {
+      type: MessageType.USER_DATA_ADD,
+      userDataBody: { type: subtype, value },
+    },
+  } as unknown as Message;
+}
+
+function castAddMessage(text: string): Message {
+  return {
+    data: {
+      type: MessageType.CAST_ADD,
+      castAddBody: {
+        embeds: [],
+        mentions: [],
+        mentionsPositions: [],
+        text,
+        parentCastId: undefined,
+        parentUrl: undefined,
+        type: 0,
+      },
+    },
+  } as unknown as Message;
+}
+
+describe("scrubStringFieldsForPostgresJson", () => {
+  test("strips NUL bytes from plain strings", () => {
+    expect(scrubStringFieldsForPostgresJson("hello\u0000world")).toBe("helloworld");
+  });
+
+  test("strips lone high surrogates", () => {
+    expect(scrubStringFieldsForPostgresJson("a\uD800b")).toBe("ab");
+  });
+
+  test("strips lone low surrogates", () => {
+    expect(scrubStringFieldsForPostgresJson("a\uDC00b")).toBe("ab");
+  });
+
+  test("preserves paired surrogates (astral characters)", () => {
+    // U+1F600 = "😀" = "😀"
+    expect(scrubStringFieldsForPostgresJson("emoji 😀 ok")).toBe("emoji 😀 ok");
+  });
+
+  test("walks into nested objects", () => {
+    const input = { a: "x\u0000y", nested: { b: ["safe", "z\uD800"] } };
+    expect(scrubStringFieldsForPostgresJson(input)).toEqual({
+      a: "xy",
+      nested: { b: ["safe", "z"] },
+    });
+  });
+
+  test("walks into arrays", () => {
+    expect(scrubStringFieldsForPostgresJson(["a\u0000", { c: "b\uDC00" }])).toEqual(["a", { c: "b" }]);
+  });
+
+  test("leaves non-string scalars untouched", () => {
+    expect(scrubStringFieldsForPostgresJson(42)).toBe(42);
+    expect(scrubStringFieldsForPostgresJson(true)).toBe(true);
+    expect(scrubStringFieldsForPostgresJson(null)).toBe(null);
+  });
+
+  test("is idempotent", () => {
+    const dirty = { a: "x\u0000y\uD800z\uDC00", arr: ["safe", "p\u0000q"] };
+    const once = scrubStringFieldsForPostgresJson(dirty);
+    const twice = scrubStringFieldsForPostgresJson(once);
+    expect(twice).toEqual(once);
+  });
+
+  test("scrubbed output is castable through PG-shaped round-trip", () => {
+    // The actual end-to-end constraint we care about: anything we emit
+    // must survive JSON.stringify + JSON.parse without introducing
+    // sequences that PG's `jsonb` parser will later reject. This catches
+    // any future regression where the scrub leaves a half-cleaned surrogate.
+    const dirty = { v: "lone-low \uDC00 and nul \u0000 here" };
+    const clean = scrubStringFieldsForPostgresJson(dirty);
+    const serialized = JSON.stringify(clean);
+    expect(serialized).not.toMatch(/\\u0000/);
+    expect(serialized).not.toMatch(/\\uD[89ABab][0-9A-Fa-f]{2}/);
+    expect(serialized).not.toMatch(/\\uD[CDEFcdef][0-9A-Fa-f]{2}/);
+  });
+});
+
+describe("convertProtobufMessageBodyToJson applies scrub", () => {
+  test("USER_DATA_ADD strips NUL from value", () => {
+    const body = convertProtobufMessageBodyToJson(userDataAddMessage("bio\u0000text"));
+    expect(body).toEqual({ type: UserDataType.BIO, value: "biotext" });
+  });
+
+  test("USER_DATA_ADD strips lone surrogates", () => {
+    const body = convertProtobufMessageBodyToJson(userDataAddMessage("a\uD800b\uDC00c"));
+    expect(body).toEqual({ type: UserDataType.BIO, value: "abc" });
+  });
+
+  test("CAST_ADD strips NUL from text", () => {
+    const body = convertProtobufMessageBodyToJson(castAddMessage("hello\u0000"));
+    // biome-ignore lint/suspicious/noExplicitAny: structural assertion against the body union
+    expect((body as any).text).toBe("hello");
+  });
+
+  test("CAST_ADD preserves paired surrogates (emoji)", () => {
+    const body = convertProtobufMessageBodyToJson(castAddMessage("hi 😀"));
+    // biome-ignore lint/suspicious/noExplicitAny: structural assertion against the body union
+    expect((body as any).text).toBe("hi 😀");
+  });
+});

--- a/packages/shuttle/src/utils.ts
+++ b/packages/shuttle/src/utils.ts
@@ -68,7 +68,10 @@ export function sleep(ms: number) {
 // any `body->>'key'` extraction, leaving rows that look fine at INSERT and
 // blow up at read time. Pre-cleaning here keeps every downstream consumer
 // (current `json` text-extraction, future `jsonb` migration) happy.
-type JsonValue = string | number | boolean | null | JsonValue[] | { [k: string]: JsonValue };
+// `undefined` is included for compatibility with `MessageBodyJson`'s optional
+// fields (e.g. `parent?: ...`); they serialize as absent keys but the TS type
+// admits `undefined`.
+type JsonValue = string | number | boolean | null | undefined | JsonValue[] | { [k: string]: JsonValue };
 
 export function scrubStringFieldsForPostgresJson(value: JsonValue): JsonValue {
   if (typeof value === "string") {
@@ -80,7 +83,7 @@ export function scrubStringFieldsForPostgresJson(value: JsonValue): JsonValue {
   if (Array.isArray(value)) {
     return value.map(scrubStringFieldsForPostgresJson);
   }
-  if (value !== null && typeof value === "object") {
+  if (value !== null && value !== undefined && typeof value === "object") {
     const out: Record<string, JsonValue> = {};
     for (const [k, v] of Object.entries(value)) {
       out[k] = scrubStringFieldsForPostgresJson(v);
@@ -269,7 +272,7 @@ export function convertProtobufMessageBodyToJson(message: Message): MessageBodyJ
       throw new Error(`Unknown message type ${message.data?.type}`);
   }
 
-  return scrubStringFieldsForPostgresJson(body as unknown as JsonValue) as MessageBodyJson;
+  return scrubStringFieldsForPostgresJson(body as JsonValue) as MessageBodyJson;
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: generic

--- a/packages/shuttle/src/utils.ts
+++ b/packages/shuttle/src/utils.ts
@@ -62,6 +62,36 @@ export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// Strips characters that PostgreSQL can store as a `json` escape but cannot
+// later materialize as TEXT — specifically NUL (`\u0000`) and unpaired UTF-16
+// surrogates. These pass `json` validation but throw on `body::jsonb` and on
+// any `body->>'key'` extraction, leaving rows that look fine at INSERT and
+// blow up at read time. Pre-cleaning here keeps every downstream consumer
+// (current `json` text-extraction, future `jsonb` migration) happy.
+//
+// biome-ignore lint/suspicious/noExplicitAny: recursive walk over JSON-shaped data
+export function scrubStringFieldsForPostgresJson<T>(value: T): T {
+  if (typeof value === "string") {
+    return value
+      .replace(/\u0000/g, "")
+      .replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/g, "")
+      .replace(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "") as T;
+  }
+  if (Array.isArray(value)) {
+    // biome-ignore lint/suspicious/noExplicitAny: see above
+    return value.map(scrubStringFieldsForPostgresJson) as any;
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = scrubStringFieldsForPostgresJson(v);
+    }
+    // biome-ignore lint/suspicious/noExplicitAny: see above
+    return out as any;
+  }
+  return value;
+}
+
 export function bytesToHex(value: Uint8Array): `0x${string}` {
   return `0x${Buffer.from(value).toString("hex")}`;
 }
@@ -241,7 +271,7 @@ export function convertProtobufMessageBodyToJson(message: Message): MessageBodyJ
       throw new Error(`Unknown message type ${message.data?.type}`);
   }
 
-  return body;
+  return scrubStringFieldsForPostgresJson(body);
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: generic

--- a/packages/shuttle/src/utils.ts
+++ b/packages/shuttle/src/utils.ts
@@ -68,26 +68,24 @@ export function sleep(ms: number) {
 // any `body->>'key'` extraction, leaving rows that look fine at INSERT and
 // blow up at read time. Pre-cleaning here keeps every downstream consumer
 // (current `json` text-extraction, future `jsonb` migration) happy.
-//
-// biome-ignore lint/suspicious/noExplicitAny: recursive walk over JSON-shaped data
-export function scrubStringFieldsForPostgresJson<T>(value: T): T {
+type JsonValue = string | number | boolean | null | JsonValue[] | { [k: string]: JsonValue };
+
+export function scrubStringFieldsForPostgresJson(value: JsonValue): JsonValue {
   if (typeof value === "string") {
     return value
       .replace(/\u0000/g, "")
       .replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/g, "")
-      .replace(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "") as T;
+      .replace(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "");
   }
   if (Array.isArray(value)) {
-    // biome-ignore lint/suspicious/noExplicitAny: see above
-    return value.map(scrubStringFieldsForPostgresJson) as any;
+    return value.map(scrubStringFieldsForPostgresJson);
   }
   if (value !== null && typeof value === "object") {
-    const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    const out: Record<string, JsonValue> = {};
+    for (const [k, v] of Object.entries(value)) {
       out[k] = scrubStringFieldsForPostgresJson(v);
     }
-    // biome-ignore lint/suspicious/noExplicitAny: see above
-    return out as any;
+    return out;
   }
   return value;
 }
@@ -271,7 +269,7 @@ export function convertProtobufMessageBodyToJson(message: Message): MessageBodyJ
       throw new Error(`Unknown message type ${message.data?.type}`);
   }
 
-  return scrubStringFieldsForPostgresJson(body);
+  return scrubStringFieldsForPostgresJson(body as unknown as JsonValue) as MessageBodyJson;
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: generic


### PR DESCRIPTION
## Summary

Scrub characters that PostgreSQL `json` accepts on INSERT but rejects on `body::jsonb` cast and on every `body->>'key'` extraction:

- NUL (\u0000)
- Unpaired UTF-16 surrogates (`\uD800-\uDBFF` without a paired low half, or `\uDC00-\uDFFF` without a paired high half)

These pass `json` validation, so rows containing them are stored without warning, but every downstream consumer that materializes the body as TEXT (or eventually migrates the column to `jsonb`) throws `unsupported Unicode escape sequence` / `invalid input syntax for type json`.

## Approach

Added `scrubStringFieldsForPostgresJson` in `packages/shuttle/src/utils.ts`. Applied it as a return-time deep walk in `convertProtobufMessageBodyToJson`, so every string field in every body case is cleaned in one place. Future MessageTypes get covered automatically without per-case maintenance.

Paired surrogates (valid astral characters like emoji) are preserved; only unpaired halves are stripped.

## Test plan

- Unit tests in `packages/shuttle/src/utils.test.ts` cover:
  - NUL stripped from plain strings
  - Lone high and lone low surrogates stripped
  - Paired surrogates preserved (emoji round-trips unchanged)
  - Nested objects and arrays walked recursively
  - Non-string scalars untouched
  - Idempotence
  - Serialized output is free of the offending escape patterns (the PG-shaped round-trip invariant)
- Body-builder integration covered: USER_DATA_ADD and CAST_ADD cases tested for stripping behavior and emoji preservation.

## Draft

Posting as a draft while we sort our internal patch plumbing.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new function, `scrubStringFieldsForPostgresJson`, to sanitize JSON strings by removing uncastable characters for PostgreSQL compatibility. It also updates the export statements and adds corresponding tests to ensure functionality.

### Detailed summary
- Added `scrubStringFieldsForPostgresJson` function to clean JSON strings.
- Updated export in `packages/shuttle/src/index.ts` to include the new function.
- Enhanced documentation for the new function in `packages/shuttle/src/utils.ts`.
- Added tests for `scrubStringFieldsForPostgresJson` in `packages/shuttle/src/utils.test.ts`.
- Updated `convertProtobufMessageBodyToJson` to utilize the new scrub function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->